### PR TITLE
change response type to text from string

### DIFF
--- a/db/migrate/20140313155919_change_response_string_to_text.rb
+++ b/db/migrate/20140313155919_change_response_string_to_text.rb
@@ -1,0 +1,13 @@
+class ChangeResponseStringToText < ActiveRecord::Migration
+  def up
+    change_table :portal_publications do |t|
+      t.change :response, :text
+    end
+  end
+
+  def down
+    change_table :portal_publications do |t|
+      t.change :response, :string
+    end
+  end
+end


### PR DESCRIPTION
Publication responses can be too long to fit into a varchar(255) column. This migration changes the column type to text in order to store the responses.
