### PR TITLE
C-Rater integration

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -237,7 +237,7 @@ button.disabled, .btn-primary.disabled, span.edit_trigger.disabled {
   color: #75a643 !important;
   font: 500 1.5em 'Lato', georgia, 'times new roman', serif;
 }
-.questions .embeddable, .authorable_open_response, .authorable_multiple_choice, .authorable_image_question {
+.questions .embeddable, .authorable {
   background: #eee;
   margin-bottom: 1em;
   padding: 3%;
@@ -685,27 +685,32 @@ div.block-empty {
   height: 20px;
   width: 20px;
   background-position: 2px 2px;
+  visibility: hidden;
+
+  #sort_embeddables & {
+    visibility: visible;
+  }
 }
 /* These are unique to the edit view */
-#page-section-controls,.page-section-controls{
-  float : right;
-  margin-right: 15px;
+#page-section-controls, .page-section-controls {
+  display: inline-block;
+  margin-top: 15px;
   background-color:#dcf1f5;
   padding: 1px 2px 2px 2px;
   
-  input{
+  input {
     position: relative;
     top: 1px;
     margin: 1px;
-    padding: 0px;
+    padding: 0;
   }
   
   label {
     margin-right: 30px;
   }
   
-  label#page_sidebar{
-    margin-right: 0px;
+  label:last-child {
+    margin-right: 0;
   }
 }
 #page-section-controls{
@@ -775,6 +780,7 @@ fieldset {
   /* Info/assessment block */
   div.questions {
     border: 1px solid #6fc5d8;
+    margin-bottom: 15px;
     padding: 5px;
     position: relative;
     h2 {
@@ -786,11 +792,14 @@ fieldset {
       padding: 5px; /* Gives the head itself some padding */
       font: 500 1.3em 'Lato', georgia, 'times new roman', serif;
     }
-    form.embeddables-form {
+    .embeddables-form {
       position: absolute;
       top: 3px;
       right: 5px;
       text-align: right;
+      form {
+        display: inline-block;
+      }
     }
     .embeddable_tools {
       text-align: right;
@@ -803,7 +812,7 @@ fieldset {
         float: left;
       }
     }
-    #sort_embeddables>div {
+    .embeddables_list > div {
       .embeddable_tools {
         background-color: #b5e3ef;
         padding: 5px;

--- a/app/controllers/c_rater/argumentation_blocks_controller.rb
+++ b/app/controllers/c_rater/argumentation_blocks_controller.rb
@@ -1,0 +1,51 @@
+class CRater::ArgumentationBlocksController < ApplicationController
+  before_filter :set_page_and_authorize
+
+  def create_embeddables
+    create_arg_block_embeddables(@page)
+    redirect_to(:back)
+  end
+
+  def remove_embeddables
+    @page.page_items.where(section: CRater::ARG_SECTION_NAME).destroy_all
+    redirect_to(:back)
+  end
+
+  private
+
+  def set_page_and_authorize
+    @page = InteractivePage.find(params[:page_id])
+    @activity = @page.lightweight_activity
+    authorize! :update, @page
+    update_activity_changed_by
+  end
+
+  def create_arg_block_embeddables(page)
+    mc1 = Embeddable::MultipleChoice.create(custom: true)
+    mc1.create_default_choices
+    page.add_embeddable(mc1, 0, CRater::ARG_SECTION_NAME)
+
+    or1 = Embeddable::OpenResponse.create(prompt: 'Explain your answer.')
+    page.add_embeddable(or1, 1, CRater::ARG_SECTION_NAME)
+
+    or1_c_rater_settings = CRater::Settings.new(item_id: 'HENRY001')
+    or1_c_rater_settings.provider = or1
+    or1_c_rater_settings.save!
+
+    mc2 = Embeddable::MultipleChoice.create(prompt: 'How certain are you about your claim based on your explanation?',
+                                            show_as_menu: true)
+    mc2.add_choice('(1) Not at all certain')
+    mc2.add_choice('(2)')
+    mc2.add_choice('(3)')
+    mc2.add_choice('(4)')
+    mc2.add_choice('(5) Very certain')
+    page.add_embeddable(mc2, 2, CRater::ARG_SECTION_NAME)
+
+    or2 = Embeddable::OpenResponse.create(prompt: 'Explain what influenced your certainty rating.')
+    page.add_embeddable(or2, 3, CRater::ARG_SECTION_NAME)
+
+    or2_c_rater_settings = CRater::Settings.create(item_id: 'HENRY001')
+    or2_c_rater_settings.provider = or2
+    or2_c_rater_settings.save!
+  end
+end

--- a/app/controllers/c_rater/settings_controller.rb
+++ b/app/controllers/c_rater/settings_controller.rb
@@ -1,0 +1,22 @@
+class CRater::SettingsController < ApplicationController
+  before_filter :set_settings
+
+  def edit
+    respond_with_edit_form
+  end
+
+  def update
+    if @settings.update_attributes(params[:c_rater_settings])
+      flash[:notice] = "C-Rater settings were successfully updated."
+      redirect_to(:back)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_settings
+    @settings = CRater::Settings.find(params[:id])
+  end
+end

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -168,6 +168,7 @@ class InteractivePagesController < ApplicationController
     @all_pages = @activity.pages
     @run.update_attribute(:page, @page)
     finder = Embeddable::AnswerFinder.new(@run)
-    @modules = @page.embeddables.map { |e| finder.find_answer(e) }
+    # Limit embeddables to ones that do not belong to any section.
+    @main_section_answers = @page.main_embeddables.map { |e| finder.find_answer(e) }
   end
 end

--- a/app/helpers/c_rater/authoring_helper.rb
+++ b/app/helpers/c_rater/authoring_helper.rb
@@ -1,0 +1,10 @@
+module CRater::AuthoringHelper
+
+  def arg_block_authorables(page)
+    embeddables = page.section_embeddables(CRater::ARG_SECTION_NAME)
+    # Return list of embeddables + C-Rater settings if available.
+    embeddables.map { |e|
+      e.respond_to?(:c_rater_settings) && e.c_rater_settings ? [e, e.c_rater_settings] : e
+    }.flatten
+  end
+end

--- a/app/models/c_rater.rb
+++ b/app/models/c_rater.rb
@@ -1,4 +1,9 @@
 module CRater
+  # Argumentation block metadata.
+  ARG_SECTION_NAME  = 'arg_block'
+  ARG_SECTION_LABEL = 'Argumentation Block'
+  ARG_SECTION_DIR   = 'c_rater/argumentation_block'
+
   def self.table_name_prefix
     'c_rater_'
   end

--- a/app/models/c_rater.rb
+++ b/app/models/c_rater.rb
@@ -1,0 +1,5 @@
+module CRater
+  def self.table_name_prefix
+    'c_rater_'
+  end
+end

--- a/app/models/c_rater/feedback_functionality.rb
+++ b/app/models/c_rater/feedback_functionality.rb
@@ -1,5 +1,4 @@
 # Mixin. Expects that target class implements:
-#  - id
 #  - answer_text (returns string)
 #  - c_rater_settings (should point to CRaterSettings instance if feedback should be obtained, nil otherwise)
 
@@ -27,28 +26,17 @@ module CRater::FeedbackFunctionality
 
   def get_c_rater_feedback
     return unless c_rater_enabled?
-    feedback = CRater::FeedbackItem.new(
+    feedback_item = CRater::FeedbackItem.new(
       status: 'requested',
       # Save both answer text and item id to prevent context loss - these values can be changed later by user.
       answer_text: answer_text,
       item_id: c_rater_settings.item_id
     )
-    feedback.answer = self
-    feedback.save!
-    response = request_feedback
-    if response[:success]
-      feedback.status = 'success'
-      feedback.score = response[:score]
-      # TODO: score -> text mapping
-      # feedback.feedback_text = ...
-    else
-      feedback.status = 'error'
-    end
-    feedback.response_info = response[:response_info]
-    feedback.save!
+    feedback_item.answer = self
+    feedback_item.save!
+    continue_feedback_processing(feedback_item)
   end
-  handle_asynchronously :get_c_rater_feedback
-
+  
   private
 
   def c_rater_configured?
@@ -56,11 +44,27 @@ module CRater::FeedbackFunctionality
     !!config[:client_id] && !!config[:username] && !!config[:password]
   end
 
-  def request_feedback
+  def issue_c_rater_request(feedback_item)
     config = c_rater_config
     crater = CRater::APIWrapper.new(config[:client_id], config[:username], config[:password], config[:url])
-    item_id = c_rater_settings.item_id
     # Use answer.id (as answer class includes this module) as response_id provided to C-Rater.
-    crater.get_feedback(item_id, id, answer_text)
+    crater.get_feedback(feedback_item.item_id, id, feedback_item.answer_text)
   end
+
+  def continue_feedback_processing(feedback_item)
+    feedback_item.status = 'started'
+    feedback_item.save!
+    response = issue_c_rater_request(feedback_item)
+    if response[:success]
+      feedback_item.status = 'success'
+      feedback_item.score = response[:score]
+      # TODO: score -> text mapping
+      # feedback.feedback_text = ...
+    else
+      feedback_item.status = 'error'
+    end
+    feedback_item.response_info = response[:response_info]
+    feedback_item.save!
+  end 
+  handle_asynchronously :continue_feedback_processing
 end

--- a/app/models/c_rater/feedback_functionality.rb
+++ b/app/models/c_rater/feedback_functionality.rb
@@ -62,6 +62,7 @@ module CRater::FeedbackFunctionality
       # feedback.feedback_text = ...
     else
       feedback_item.status = 'error'
+      feedback_item.feedback_text = response[:error]
     end
     feedback_item.response_info = response[:response_info]
     feedback_item.save!

--- a/app/models/c_rater/feedback_functionality.rb
+++ b/app/models/c_rater/feedback_functionality.rb
@@ -1,0 +1,66 @@
+# Mixin. Expects that target class implements:
+#  - id
+#  - answer_text (returns string)
+#  - c_rater_settings (should point to CRaterSettings instance if feedback should be obtained, nil otherwise)
+
+# Each time an instance is updated, new C-Rater feedback will be obtained.
+
+module CRater::FeedbackFunctionality
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :c_rater_feedback_items, as: :answer, class_name: 'CRater::FeedbackItem'
+  end
+
+  def c_rater_config
+    {
+      client_id: ENV['C_RATER_CLIENT_ID'],
+      username:  ENV['C_RATER_USERNAME'],
+      password:  ENV['C_RATER_PASSWORD'],
+      url:       ENV['C_RATER_URL'] # optional, APIWrapper will use default URL if not provided.
+    }
+  end
+
+  def c_rater_enabled?
+    !!c_rater_configured? && !!c_rater_settings && !!c_rater_settings.item_id
+  end
+
+  def get_c_rater_feedback
+    return unless c_rater_enabled?
+    feedback = CRater::FeedbackItem.new(
+      status: 'requested',
+      # Save both answer text and item id to prevent context loss - these values can be changed later by user.
+      answer_text: answer_text,
+      item_id: c_rater_settings.item_id
+    )
+    feedback.answer = self
+    feedback.save!
+    response = request_feedback
+    if response[:success]
+      feedback.status = 'success'
+      feedback.score = response[:score]
+      # TODO: score -> text mapping
+      # feedback.feedback_text = ...
+    else
+      feedback.status = 'error'
+    end
+    feedback.response_info = response[:response_info]
+    feedback.save!
+  end
+  handle_asynchronously :get_c_rater_feedback
+
+  private
+
+  def c_rater_configured?
+    config = c_rater_config
+    !!config[:client_id] && !!config[:username] && !!config[:password]
+  end
+
+  def request_feedback
+    config = c_rater_config
+    crater = CRater::APIWrapper.new(config[:client_id], config[:username], config[:password], config[:url])
+    item_id = c_rater_settings.item_id
+    # Use answer.id (as answer class includes this module) as response_id provided to C-Rater.
+    crater.get_feedback(item_id, id, answer_text)
+  end
+end

--- a/app/models/c_rater/feedback_item.rb
+++ b/app/models/c_rater/feedback_item.rb
@@ -1,0 +1,5 @@
+class CRater::FeedbackItem < ActiveRecord::Base
+  attr_accessible :answer_id, :answer_type, :answer_text, :item_id, :status, :score, :feedback_text, :response_info
+
+  belongs_to :answer, polymorphic: true
+end

--- a/app/models/c_rater/feedback_item.rb
+++ b/app/models/c_rater/feedback_item.rb
@@ -1,5 +1,6 @@
 class CRater::FeedbackItem < ActiveRecord::Base
   attr_accessible :answer_id, :answer_type, :answer_text, :item_id, :status, :score, :feedback_text, :response_info
+  serialize :response_info
 
   belongs_to :answer, polymorphic: true
 end

--- a/app/models/c_rater/score_mapping.rb
+++ b/app/models/c_rater/score_mapping.rb
@@ -1,0 +1,3 @@
+class CRater::ScoreMapping < ActiveRecord::Base
+  attr_accessible :mapping
+end

--- a/app/models/c_rater/settings.rb
+++ b/app/models/c_rater/settings.rb
@@ -1,5 +1,5 @@
 class CRater::Settings < ActiveRecord::Base
   belongs_to :provider, polymorphic: true
   belongs_to :score_mapping
-  attr_accessible :item_id
+  attr_accessible :item_id, :score_mapping_id
 end

--- a/app/models/c_rater/settings.rb
+++ b/app/models/c_rater/settings.rb
@@ -1,0 +1,5 @@
+class CRater::Settings < ActiveRecord::Base
+  belongs_to :provider, polymorphic: true
+  belongs_to :score_mapping
+  attr_accessible :item_id
+end

--- a/app/models/c_rater/settings_provider_functionality.rb
+++ b/app/models/c_rater/settings_provider_functionality.rb
@@ -1,0 +1,6 @@
+module CRater::SettingsProviderFunctionality
+  extend ActiveSupport::Concern
+  included do
+    has_one :c_rater_settings, as: :provider, class_name: 'CRater::Settings'
+  end
+end

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -1,15 +1,13 @@
 module Embeddable
   class OpenResponse < ActiveRecord::Base
-    attr_accessible :name, :prompt, :is_prediction,
-      :give_prediction_feedback, :prediction_feedback
-
     include Embeddable
+    include CRater::SettingsProviderFunctionality
 
+    attr_accessible :name, :prompt, :is_prediction, :give_prediction_feedback, :prediction_feedback
+
+    # PageItem instances are join models, so if the embeddable is gone the join should go too.
     has_many :page_items, :as => :embeddable, :dependent => :destroy
-    # PageItem instances are join models, so if the embeddable is gone
-    # the join should go too.
     has_many :interactive_pages, :through => :page_items
-
     has_many :answers,
       :class_name  => 'Embeddable::OpenResponseAnswer',
       :foreign_key => 'open_response_id'

--- a/app/models/embeddable/open_response_answer.rb
+++ b/app/models/embeddable/open_response_answer.rb
@@ -12,7 +12,6 @@ module Embeddable
 
     after_update :send_to_portal
     after_update :propagate_to_collaborators
-    after_update :get_c_rater_feedback
 
     def self.by_question(q)
       where(:open_response_id => q.id)

--- a/app/models/embeddable/open_response_answer.rb
+++ b/app/models/embeddable/open_response_answer.rb
@@ -1,17 +1,18 @@
 module Embeddable
   class OpenResponseAnswer < ActiveRecord::Base
-    include Answer # Common methods for Answer models
+    include Answer
+    include CRater::FeedbackFunctionality
 
     attr_accessible :answer_text, :run, :question, :is_dirty, :is_final
 
     belongs_to :question,
       :class_name => 'Embeddable::OpenResponse',
       :foreign_key => "open_response_id"
-
     belongs_to :run
 
     after_update :send_to_portal
     after_update :propagate_to_collaborators
+    after_update :get_c_rater_feedback
 
     def self.by_question(q)
       where(:open_response_id => q.id)
@@ -35,6 +36,10 @@ module Embeddable
 
     def blank?
       self.answer_text.blank?
+    end
+
+    def c_rater_settings
+      question && question.c_rater_settings
     end
   end
 end

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -1,5 +1,9 @@
 class InteractivePage < ActiveRecord::Base
-  attr_accessible :lightweight_activity, :name, :position, :text, :layout, :sidebar, :show_introduction, :show_sidebar, :show_interactive, :show_info_assessment, :embeddable_display_mode, :sidebar_title
+  attr_accessible :lightweight_activity, :name, :position, :text, :layout, :sidebar, :show_introduction, :show_sidebar,
+                  :show_interactive, :show_info_assessment, :embeddable_display_mode, :sidebar_title,
+                  :additional_sections
+
+  serialize :additional_sections
 
   belongs_to :lightweight_activity, :class_name => 'LightweightActivity', :touch => true
 
@@ -16,6 +20,7 @@ class InteractivePage < ActiveRecord::Base
   INTERACTIVE_TYPES = [{ :name => 'Image',  :class_name => 'ImageInteractive' },
                        { :name => 'Iframe', :class_name => 'MwInteractive' },
                        { :name => 'Video',  :class_name => 'VideoInteractive' }]
+
   validates :sidebar_title, presence: true
   validates :layout, :inclusion => { :in => LAYOUT_OPTIONS.map { |l| l[:class_val] } }
   validates :embeddable_display_mode, :inclusion => { :in => EMBEDDABLE_DISPLAY_OPTIONS }
@@ -23,23 +28,74 @@ class InteractivePage < ActiveRecord::Base
   # Reject invalid HTML inputs
   # See https://www.pivotaltracker.com/story/show/60459320
   validates :text, :sidebar, :html => true
-  # validates :sidebar, :html => true
 
-  has_many :interactive_items, :order => :position, :dependent => :destroy, :include => [:interactive]
   # InteractiveItem is a join model; if this is deleted, it should go too
+  has_many :interactive_items, :order => :position, :dependent => :destroy, :include => [:interactive]
+
+  # Like InteractiveItems, PageItems are join models, so they should not
+  # survive the deletion of associated instances of InteractivePage.
+  has_many :page_items, :order => :position, :dependent => :destroy, :include => [:embeddable]
+
+  # Interactive page can register additional page sections:
+  #
+  #  InteractivePage.register_page_section({name: 'FooBar', dir: 'foo_bar', label: 'Foo Bar'})
+  #
+  # Each section is required to provide two partials:
+  # - #{dir}/_author.html.haml
+  # - #{dir}/_runtime.html.haml
+  #
+  # Note that content of the section is totally flexible.
+  # If you want to display some embeddables in section, you can provide 'section' argument to
+  # .add_embeddable method and then obtain section embeddables using .section_embeddables method.
+  @registered_additional_sections = []
+  def self.registered_additional_sections
+    @registered_additional_sections
+  end
+
+  def self.register_additional_section(s)
+    @registered_additional_sections.push(s)
+    # Let client code use .update_attributes methods (and similar) to set show_<section_name>.
+    attr_accessible "show_#{s[:name]}"
+    # show_<section_name> getter:
+    define_method("show_#{s[:name]}") do
+      additional_sections && additional_sections[s[:name]]
+    end
+    # show_<section_name> setter:
+    define_method("show_#{s[:name]}=") do |v|
+      self.additional_sections ||= {}
+      # Handle parameter values from Rails forms.
+      if v == "1" || v == 1 || v == true
+        additional_sections[s[:name]] = true
+      else
+        additional_sections.delete(s[:name])
+      end
+    end
+  end
+
+  # Register additional sections of interactive page.
+  # This code could (or should) to some config file or initializer, but as we
+  # have only one additional section at the moment, let's keep it here.
+  InteractivePage.register_additional_section({name:  CRater::ARG_SECTION_NAME,
+                                               dir:   CRater::ARG_SECTION_DIR,
+                                               label: CRater::ARG_SECTION_LABEL})
 
   # This is a sort of polymorphic has_many :through.
   def interactives
     self.interactive_items.collect{|ii| ii.interactive}
   end
 
-  has_many :page_items, :order => :position, :dependent => :destroy, :include => [:embeddable]
-  # Like InteractiveItems, PageItems are join models, so they should not
-  # survive the deletion of associated instances of InteractivePage.
-
   # This is a sort of polymorphic has_many :through.
   def embeddables
-    self.page_items.collect{|qi| qi.embeddable}
+    self.page_items.collect{ |qi| qi.embeddable }
+  end
+
+  def section_embeddables(section)
+    self.page_items.where(section: section).collect{ |qi| qi.embeddable }
+  end
+
+  def main_embeddables
+    # Embeddables that do not have section specified (nil section).
+    section_embeddables(nil)
   end
 
   def add_interactive(interactive, position = nil, validate = true)
@@ -59,11 +115,17 @@ class InteractivePage < ActiveRecord::Base
     end
   end
 
-  def add_embeddable(embeddable, position = nil)
-    join = PageItem.create!(:interactive_page => self, :embeddable => embeddable, :position => position)
+  def add_embeddable(embeddable, position = nil, section = nil)
+    join = PageItem.create!(:interactive_page => self, :embeddable => embeddable,
+                            :position => position, :section => section)
     unless position
       join.move_to_bottom
     end
+  end
+
+  def visible_sections
+    return [] unless additional_sections
+    self.class.registered_additional_sections.select { |s| additional_sections[s[:name]] }
   end
 
   def to_hash

--- a/app/models/page_item.rb
+++ b/app/models/page_item.rb
@@ -1,5 +1,5 @@
 class PageItem < ActiveRecord::Base
-  attr_accessible :interactive_page, :position, :embeddable
+  attr_accessible :interactive_page, :position, :section, :embeddable
   acts_as_list :scope => :interactive_page
 
   belongs_to :interactive_page

--- a/app/views/c_rater/argumentation_block/_author.html.haml
+++ b/app/views/c_rater/argumentation_block/_author.html.haml
@@ -1,0 +1,13 @@
+.questions
+  %h2
+    = section_label
+    .embeddables-form
+      = button_to "Create", c_rater_arg_block_create_embeddables_path(page), :method => :post
+      - activity = page.lightweight_activity
+      - confirm_message = "Are you sure you want to delete these elements? You will lose data from #{pluralize(activity.active_runs, "learner")} that have answered these questions."
+      = button_to "Remove", c_rater_arg_block_remove_embeddables_path(page), :method => :post, :data => {:confirm => (activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
+
+  .embeddables_list
+    - arg_block_authorables(page).each do |e|
+      - e_type = e.class.name.underscore
+      = render :partial => "#{e_type.pluralize}/author", :locals => { :embeddable => e, :page => page }

--- a/app/views/c_rater/settings/_author.html.haml
+++ b/app/views/c_rater/settings/_author.html.haml
@@ -1,0 +1,11 @@
+.authorable
+  .embeddable_tools
+    .drag_handle
+    = link_to "edit", edit_c_rater_setting_path(embeddable), :remote => true, :id => "edit-embed-iq-#{embeddable.id}"
+
+  %p
+    C-Rater Item ID:
+    = embeddable.item_id
+  %p
+    C-Rater score mapping:
+    = embeddable.score_mapping_id

--- a/app/views/c_rater/settings/edit.html.haml
+++ b/app/views/c_rater/settings/edit.html.haml
@@ -1,0 +1,14 @@
+= form_for @settings do |f|
+  .errors
+    = f.error_messages
+  %p
+    = f.label 'C-Rater Item ID'
+  %p
+    = f.text_field :item_id
+  %p
+    = f.label 'C-Rater score mapping ID'
+  %p
+    = f.text_field :score_mapping_id
+
+  = f.submit "Cancel", :class => 'close'
+  = f.submit "Save", :class => 'embeddable-save'

--- a/app/views/embeddable/multiple_choices/_author.html.haml
+++ b/app/views/embeddable/multiple_choices/_author.html.haml
@@ -1,4 +1,4 @@
-.authorable_multiple_choice{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
+.authorable{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
   .embeddable_tools
     .drag_handle
     = link_to "edit", edit_embeddable_multiple_choice_path(embeddable), :remote => true, :id => "edit-embed-mc-#{embeddable.id}"

--- a/app/views/embeddable/open_responses/_author.html.haml
+++ b/app/views/embeddable/open_responses/_author.html.haml
@@ -1,4 +1,4 @@
-.authorable_open_response{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
+.authorable{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
   .embeddable_tools
     .drag_handle
     = link_to "edit", edit_embeddable_open_response_path(embeddable), :remote => true, :id => "edit-embed-or-#{embeddable.id}"

--- a/app/views/embeddable/xhtmls/_author.html.haml
+++ b/app/views/embeddable/xhtmls/_author.html.haml
@@ -1,4 +1,4 @@
-.xhtml.authorable_xhtml{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
+.xhtml.authorable{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
   .embeddable_tools
     .drag_handle
     = link_to "edit", edit_embeddable_xhtml_path(embeddable), :remote => true, :id => "edit-embed-xhtml-#{embeddable.id}"

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -1,5 +1,5 @@
 .embeddables
-  - unless @modules.blank?
-    - @modules.each do |m|
+  - unless @main_section_answers.blank?
+    - @main_section_answers.each do |m|
       .question{ :class => m.kind_of?(Embeddable::Xhtml) ? 'challenge' : '' }
         = render :partial => "#{m.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => m}

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -45,22 +45,27 @@
     %span.preview
       = link_to "Preview", preview_activity_page_path(@activity, @page), :target => 'new'
   %div.edit_interactive_page
-    = form_for @page, :remote => true do |f|
+    = form_for @page do |f|
       = f.select :layout, options_for_select(InteractivePage::LAYOUT_OPTIONS.map { |l| [l[:name], l[:class_val]] }, @page.layout), {},  { :onchange => 'this.form.submit();', :title => 'Page layout' }
       = f.select :embeddable_display_mode, InteractivePage::EMBEDDABLE_DISPLAY_OPTIONS, {}, { :onchange => 'this.form.submit();', :title => 'Display of embeddables: stacked for scrolling, or carousel for sequential display' }
-      %span.page-section-controls#page-section-controls     
-        %label{:id => 'page_intro',:for => "interactive_page_show_introduction"}    
+      %p.page-section-controls#page-section-controls
+        %label
           = f.check_box :show_introduction, :onchange => 'this.form.submit();' 
           Page introduction
-        %label{:id => 'info_block',:for => "interactive_page_show_info_assessment"}
+        %label
           = f.check_box :show_info_assessment, :onchange => 'this.form.submit();'
           Info/Assessment block
-        %label{:id => 'interactive_box',:for => "interactive_page_show_interactive"}
+        %label
           = f.check_box :show_interactive, :onchange => 'this.form.submit();'
           Interactive box
-        %label{:id => 'page_sidebar',:for => "interactive_page_show_sidebar"}
+        %label
           = f.check_box :show_sidebar, :onchange => 'this.form.submit();'
-          Page sidebar text  
+          Page sidebar text
+        - InteractivePage.registered_additional_sections.each do |s|
+          %label
+            = f.check_box "show_#{s[:name]}", :onchange => 'this.form.submit();'
+            = s[:label]
+
   - if @page.show_introduction
     .instructions{:class => @page.text.blank? ? 'block-empty' : '' }
       %h2 Introduction
@@ -72,10 +77,13 @@
         = form_tag add_embeddable_activity_page_path(@activity, @page), :class => 'embeddables-form' do
           = embeddable_selector
           = submit_tag 'Add Embeddable'
-        #sort_embeddables
-          - @page.embeddables.each do |e|
+        #sort_embeddables.embeddables_list
+          - @page.section_embeddables(nil).each do |e|
             - e_type = e.class.name.underscore
             = render :partial => "#{e_type.pluralize}/author", :locals => { :embeddable => e, :page => @page }
+    -# Additional sections are dynamically loaded, based on .visible_sections value:
+    - @page.visible_sections.each do |s|
+      = render :partial => "#{s[:dir]}/author", :locals => { :page => @page, :section_name => s[:name], :section_label => s[:label] }
   - if @page.show_interactive
     %div{:class => (@page.show_info_assessment ? 'other' : 'other full-width')}
       = form_tag add_interactive_activity_page_path(@activity, @page), :class => 'interactives-form' do

--- a/config/app_environment_variables.sample.rb
+++ b/config/app_environment_variables.sample.rb
@@ -15,4 +15,7 @@ ENV['CONCORD_DRAWING_TOOL']              ||= 'drawing-tool'
 ENV['SHUTTERBUG_URI']                    ||= "//snapshot.concord.org/shutterbug"
 ENV['LOGGER_URI']                        ||= '//cc-log-manager.herokuapp.com/api/logs'
 ENV['LOGGER_APPLICATION_NAME']           ||= 'LARA-log-poc'
+ENV['C_RATER_CLIENT_ID']                 ||= 'XXXXXXX'
+ENV['C_RATER_USERNAME']                  ||= 'XXXXXXX'
+ENV['C_RATER_PASSWORD']                  ||= 'XXXXXXX'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,12 @@ LightweightStandalone::Application.routes.draw do
     resources :multiple_choice_answers
   end
 
+  namespace :c_rater do
+    resources :settings, :only => [:edit, :update]
+    post "/argumentation_blocks/:page_id/create_embeddables" => 'argumentation_blocks#create_embeddables', :as => 'arg_block_create_embeddables'
+    post "/argumentation_blocks/:page_id/remove_embeddables" => 'argumentation_blocks#remove_embeddables', :as => 'arg_block_remove_embeddables'
+  end
+
   namespace :admin do
     resources :users
   end

--- a/db/migrate/20150129111233_create_c_rater_score_mappings.rb
+++ b/db/migrate/20150129111233_create_c_rater_score_mappings.rb
@@ -1,0 +1,9 @@
+class CreateCRaterScoreMappings < ActiveRecord::Migration
+  def change
+    create_table :c_rater_score_mappings do |t|
+      t.text :mapping
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150129111335_create_c_rater_settings.rb
+++ b/db/migrate/20150129111335_create_c_rater_settings.rb
@@ -1,0 +1,13 @@
+class CreateCRaterSettings < ActiveRecord::Migration
+  def change
+    create_table :c_rater_settings do |t|
+      t.integer :item_id
+      t.references :score_mapping
+      t.references :provider, polymorphic: true
+
+      t.timestamps
+    end
+    add_index :c_rater_settings, :score_mapping_id
+    add_index :c_rater_settings, [:provider_id, :provider_type]
+  end
+end

--- a/db/migrate/20150129112555_create_c_rater_feedback_items.rb
+++ b/db/migrate/20150129112555_create_c_rater_feedback_items.rb
@@ -1,0 +1,16 @@
+class CreateCRaterFeedbackItems < ActiveRecord::Migration
+  def change
+    create_table :c_rater_feedback_items do |t|
+      t.text :answer_text
+      t.references :answer, polymorphic: true
+      t.integer :item_id
+      t.string :status
+      t.integer :score
+      t.text :feedback_text
+      t.text :response_info
+
+      t.timestamps
+    end
+    add_index :c_rater_feedback_items, [:answer_id, :answer_type]
+  end
+end

--- a/db/migrate/20150202182852_change_item_id_in_c_rater_settings.rb
+++ b/db/migrate/20150202182852_change_item_id_in_c_rater_settings.rb
@@ -1,0 +1,22 @@
+class ChangeItemIdInCRaterSettings < ActiveRecord::Migration
+  def up
+    # Index name too long issue...
+    remove_index :c_rater_settings, [:provider_id, :provider_type]
+    add_index :c_rater_settings, [:provider_id, :provider_type], name: 'c_rat_set_prov_idx'
+    remove_index :c_rater_feedback_items, [:answer_id, :answer_type]
+    add_index :c_rater_feedback_items, [:answer_id, :answer_type], name: 'c_rat_feed_it_answer_idx'
+
+    change_column :c_rater_settings, :item_id, :string
+    change_column :c_rater_feedback_items, :item_id, :string
+  end
+
+  def down
+    change_column :c_rater_settings, :item_id, :integer
+    change_column :c_rater_feedback_items, :item_id, :integer
+
+    remove_index :c_rater_feedback_items, name: 'c_rat_feed_it_answer_idx'
+    add_index :c_rater_feedback_items, [:answer_id, :answer_type]
+    remove_index :c_rater_settings, name: 'c_rat_set_prov_idx'
+    add_index :c_rater_settings, [:provider_id, :provider_type]
+  end
+end

--- a/db/migrate/20150203174736_add_section_to_page_items.rb
+++ b/db/migrate/20150203174736_add_section_to_page_items.rb
@@ -1,0 +1,5 @@
+class AddSectionToPageItems < ActiveRecord::Migration
+  def change
+    add_column :page_items, :section, :string
+  end
+end

--- a/db/migrate/20150204154523_add_additional_sections_to_interactive_page.rb
+++ b/db/migrate/20150204154523_add_additional_sections_to_interactive_page.rb
@@ -1,0 +1,5 @@
+class AddAdditionalSectionsToInteractivePage < ActiveRecord::Migration
+  def change
+    add_column :interactive_pages, :additional_sections, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150129112555) do
+ActiveRecord::Schema.define(:version => 20150202182852) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(:version => 20150129112555) do
     t.text     "answer_text"
     t.integer  "answer_id"
     t.string   "answer_type"
-    t.integer  "item_id"
+    t.string   "item_id"
     t.string   "status"
     t.integer  "score"
     t.text     "feedback_text"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(:version => 20150129112555) do
     t.datetime "updated_at",    :null => false
   end
 
-  add_index "c_rater_feedback_items", ["answer_id", "answer_type"], :name => "index_c_rater_feedback_items_on_answer_id_and_answer_type"
+  add_index "c_rater_feedback_items", ["answer_id", "answer_type"], :name => "c_rat_feed_it_answer_idx"
 
   create_table "c_rater_score_mappings", :force => true do |t|
     t.text     "mapping"
@@ -55,15 +55,15 @@ ActiveRecord::Schema.define(:version => 20150129112555) do
   end
 
   create_table "c_rater_settings", :force => true do |t|
-    t.integer  "item_id"
     t.integer  "score_mapping_id"
     t.integer  "provider_id"
     t.string   "provider_type"
     t.datetime "created_at",       :null => false
     t.datetime "updated_at",       :null => false
+    t.string   "item_id"
   end
 
-  add_index "c_rater_settings", ["provider_id", "provider_type"], :name => "index_c_rater_settings_on_provider_id_and_provider_type"
+  add_index "c_rater_settings", ["provider_id", "provider_type"], :name => "c_rat_set_prov_idx"
   add_index "c_rater_settings", ["score_mapping_id"], :name => "index_c_rater_settings_on_score_mapping_id"
 
   create_table "collaboration_runs", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141126144838) do
+ActiveRecord::Schema.define(:version => 20150129112555) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -32,6 +32,39 @@ ActiveRecord::Schema.define(:version => 20141126144838) do
 
   add_index "authentications", ["uid", "provider"], :name => "index_authentications_on_uid_and_provider", :unique => true
   add_index "authentications", ["user_id", "provider"], :name => "index_authentications_on_user_id_and_provider", :unique => true
+
+  create_table "c_rater_feedback_items", :force => true do |t|
+    t.text     "answer_text"
+    t.integer  "answer_id"
+    t.string   "answer_type"
+    t.integer  "item_id"
+    t.string   "status"
+    t.integer  "score"
+    t.text     "feedback_text"
+    t.text     "response_info"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
+  end
+
+  add_index "c_rater_feedback_items", ["answer_id", "answer_type"], :name => "index_c_rater_feedback_items_on_answer_id_and_answer_type"
+
+  create_table "c_rater_score_mappings", :force => true do |t|
+    t.text     "mapping"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "c_rater_settings", :force => true do |t|
+    t.integer  "item_id"
+    t.integer  "score_mapping_id"
+    t.integer  "provider_id"
+    t.string   "provider_type"
+    t.datetime "created_at",       :null => false
+    t.datetime "updated_at",       :null => false
+  end
+
+  add_index "c_rater_settings", ["provider_id", "provider_type"], :name => "index_c_rater_settings_on_provider_id_and_provider_type"
+  add_index "c_rater_settings", ["score_mapping_id"], :name => "index_c_rater_settings_on_score_mapping_id"
 
   create_table "collaboration_runs", :force => true do |t|
     t.integer  "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150202182852) do
+ActiveRecord::Schema.define(:version => 20150204154523) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -236,6 +236,7 @@ ActiveRecord::Schema.define(:version => 20150202182852) do
     t.string   "layout",                  :default => "l-6040"
     t.string   "embeddable_display_mode", :default => "stacked"
     t.string   "sidebar_title",           :default => "Did you know?"
+    t.text     "additional_sections"
   end
 
   add_index "interactive_pages", ["lightweight_activity_id", "position"], :name => "interactive_pages_by_activity_idx"
@@ -315,6 +316,7 @@ ActiveRecord::Schema.define(:version => 20150202182852) do
     t.integer  "position"
     t.datetime "created_at",          :null => false
     t.datetime "updated_at",          :null => false
+    t.string   "section"
   end
 
   add_index "page_items", ["embeddable_id", "embeddable_type"], :name => "index_page_items_on_embeddable_id_and_embeddable_type"

--- a/lib/c_rater.rb
+++ b/lib/c_rater.rb
@@ -1,0 +1,80 @@
+require 'builder'
+
+class CRater
+  # Pilot environment has been recommended by ETS.
+  C_RATER_URI = 'https://nlp-pilot.ets.org/crater/scoring/internal/CraterScoringServlet'
+  # C-Rater supports only ISO-8859-1 encoding.
+  ENCODING = 'iso-8859-1'
+
+  def initialize(client_id, username, password, url = nil)
+    @client_id = client_id
+    @username  = username
+    @password  = password
+    @url       = url || C_RATER_URI
+  end
+
+  def request_xml(item_id, response_id, response_text)
+    builder = Builder::XmlMarkup.new
+    xml = builder.tag!('crater-request', includeRNS: 'N') do |b|
+      b.client(id: @client_id)
+      b.items do
+        b.item(id: item_id) do
+          b.responses do
+            b.response(id: response_id) do
+              b.cdata!(response_text)
+            end
+          end
+        end
+      end
+    end
+    xml.encode(ENCODING)
+  end
+
+  def get_feedback(item_id, response_id, response_text)
+    xml = request_xml(item_id, response_id, response_text)
+    resp = HTTParty.post(@url, request_options(xml))
+    score = get_score_from_resp(resp.parsed_response)
+    result = if resp.code == 200 && score
+               {
+                 success: true,
+                 score: score
+               }
+             else
+               {
+                 success: false
+               }
+             end
+    # Always include debug information in response (code, unparsed body and headers).
+    result.merge({
+      code: resp.code,
+      headers: resp.headers,
+      body: resp.body
+    })
+  end
+
+  private
+
+  def request_options(body)
+    {
+      headers: {
+        'Content-Type' => "application/xml; charset=#{ENCODING}"
+      },
+      basic_auth: {
+        username: @username,
+        password: @password
+      },
+      body: body
+    }
+  end
+
+  def get_score_from_resp(parsed_response)
+    return nil unless parsed_response.respond_to?(:fetch) # hash expected
+    score = parsed_response.fetch('crater_results', {})
+                           .fetch('items', {})
+                           .fetch('item', {})
+                           .fetch('responses', {})
+                           .fetch('response', {})
+                           .fetch('score', nil)
+    score.nil? ? nil : score.to_i
+  end
+end

--- a/lib/c_rater/api_wrapper.rb
+++ b/lib/c_rater/api_wrapper.rb
@@ -33,6 +33,9 @@ class CRater::APIWrapper
   def get_feedback(item_id, response_id, response_text)
     xml = request_xml(item_id, response_id, response_text)
     resp = HTTParty.post(@url, request_options(xml))
+    # C-Rater API seems to always return HTTP 200 and error message provided in XML body.
+    # This code assumes that there is only one XML structure that is correct for us (that includes score)
+    # and everything else will be treated as error.
     score = get_score_from_resp(resp.parsed_response)
     result = if resp.code == 200 && score
                {
@@ -48,7 +51,7 @@ class CRater::APIWrapper
     result.merge({
       response_info: {
         code: resp.code,
-        headers: resp.headers,
+        headers: resp.headers.to_hash,
         body: resp.body
       }
     })

--- a/lib/c_rater/api_wrapper.rb
+++ b/lib/c_rater/api_wrapper.rb
@@ -1,6 +1,6 @@
 require 'builder'
 
-class CRater
+class CRater::APIWrapper
   # Pilot environment has been recommended by ETS.
   C_RATER_URI = 'https://nlp-pilot.ets.org/crater/scoring/internal/CraterScoringServlet'
   # C-Rater supports only ISO-8859-1 encoding.
@@ -46,9 +46,11 @@ class CRater
              end
     # Always include debug information in response (code, unparsed body and headers).
     result.merge({
-      code: resp.code,
-      headers: resp.headers,
-      body: resp.body
+      response_info: {
+        code: resp.code,
+        headers: resp.headers,
+        body: resp.body
+      }
     })
   end
 

--- a/spec/controllers/c_rater/argumentation_blocks_controller_spec.rb
+++ b/spec/controllers/c_rater/argumentation_blocks_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe CRater::ArgumentationBlocksController do
+  let(:user) { FactoryGirl.create(:author) }
+  let(:act)  { FactoryGirl.create(:activity_with_page, user: user) }
+  let(:page) { act.pages.first }
+  let(:prev_page) { 'http://prev.page.com' }
+
+  before(:each) do
+    sign_in user
+    @request.env['HTTP_REFERER'] = prev_page
+  end
+
+  describe '#create_embeddables' do
+    it 'should create argumentation block embeddables' do
+      post :create_embeddables, page_id: page.id
+      expect(page.embeddables.length).to eql(4)
+      expect(response).to redirect_to(prev_page)
+    end
+  end
+
+  describe '#remove_embeddables' do
+    let (:open_response1) { FactoryGirl.create(:open_response) }
+    let (:open_response2) { FactoryGirl.create(:open_response) }
+    before(:each) do
+      page.add_embeddable(open_response1)
+      page.add_embeddable(open_response1, nil, CRater::ARG_SECTION_NAME)
+    end
+    it 'should remove *only* argumentation block embeddables' do
+      post :remove_embeddables, page_id: page.id
+      expect(page.embeddables.length).to eql(1)
+      expect(response).to redirect_to(prev_page)
+    end
+  end
+end

--- a/spec/libs/c_rarter_spec.rb
+++ b/spec/libs/c_rarter_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe CRater do
+  let(:client_id)     { 'concord' }
+  let(:username)      { 'cc' }
+  let(:password)      { 'password' }
+  let(:protocol)      { 'https://'}
+  let(:url)           { 'c-rater.fake.url.org' }
+  let(:item_id)       { 'fake_item_id' }
+  let(:response_id)   { 123 }
+  let(:response_text) { 'response abc xyz' }
+  let(:score)         { 2 }
+  let(:xml_req_spec) do
+    xml = <<-EOS
+      <crater-request includeRNS="N">
+        <client id="#{client_id}"/>
+        <items>
+          <item id="#{item_id}">
+            <responses>
+              <response id="#{response_id}">
+                <![CDATA[#{response_text}]]>
+              </response>
+            </responses>
+          </item>
+        </items>
+      </crater-request>
+    EOS
+    process_xml(xml)
+  end
+  let(:xml_resp_spec) do
+    xml = <<-EOS
+      <crater-results>
+        <tracking id="12345"/>
+        <client id="#{client_id}"/>
+        <items>
+          <item id="#{item_id}">
+            <responses>
+              <response id="#{response_id}" score="#{score}" concepts="3,6" realNumberScore="2.62039"
+                confidenceMeasure="0.34574">
+                <advisorylist>
+                  <advisorycode>101</advisorycode>
+                </advisorylist>
+              </response>
+            </responses>
+          </item>
+        </items>
+      </crater-results>
+    EOS
+    process_xml(xml)
+  end
+
+  let(:crater) { CRater.new(client_id, username, password, "#{protocol}#{url}") }
+
+  def process_xml(xml_string)
+    # Remove new lines and unnecessary whitespaces
+    xml_string.squish.gsub('> <', '><')
+  end
+
+  describe '#request_xml' do
+    subject { crater.request_xml(item_id, response_id, response_text) }
+    # Yes, this test isn't flexible at all. However it should be good enough, as it's very unlikely we ever change
+    # form of the request.
+    it { is_expected.to eql(xml_req_spec) }
+  end
+
+  describe '#get_feedback' do
+    subject { crater.get_feedback(item_id, response_id, response_text) }
+
+    describe 'when C-Rater service works as expected' do
+      before do
+        stub_request(:post, "#{protocol}#{username}:#{password}@#{url}").
+          with(:body => xml_req_spec,
+               :headers => {'Content-Type'=>'application/xml; charset=iso-8859-1'}).
+          to_return(:status => 200, :body => xml_resp_spec,
+                    :headers => {'Content-Type'=>'application/xml; charset=iso-8859-1'})
+      end
+
+      it "returns score and additional information" do
+        expect(subject[:success]).to be true
+        expect(subject[:score]).to eql(score)
+        expect(subject[:code]).to eql(200)
+        expect(subject[:body]).to eql(xml_resp_spec)
+        expect(subject[:headers]).not_to be_nil
+      end
+    end
+
+    describe 'when C-Rater service is unavailable' do
+      before do
+        stub_request(:post, "#{protocol}#{username}:#{password}@#{url}").
+          with(:body => xml_req_spec,
+               :headers => {'Content-Type'=>'application/xml; charset=iso-8859-1'}).
+          to_return(:status => 404, :body => 'Page not found')
+      end
+
+      it "returns only debug information" do
+        expect(subject[:success]).to be false
+        expect(subject[:score]).to be_nil
+        expect(subject[:code]).to eql(404)
+        expect(subject[:body]).to eql('Page not found')
+        expect(subject[:headers]).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/libs/c_rater/api_wrapper_spec.rb
+++ b/spec/libs/c_rater/api_wrapper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CRater do
+describe CRater::APIWrapper do
   let(:client_id)     { 'concord' }
   let(:username)      { 'cc' }
   let(:password)      { 'password' }
@@ -49,7 +49,7 @@ describe CRater do
     process_xml(xml)
   end
 
-  let(:crater) { CRater.new(client_id, username, password, "#{protocol}#{url}") }
+  let(:crater) { CRater::APIWrapper.new(client_id, username, password, "#{protocol}#{url}") }
 
   def process_xml(xml_string)
     # Remove new lines and unnecessary whitespaces
@@ -78,9 +78,9 @@ describe CRater do
       it "returns score and additional information" do
         expect(subject[:success]).to be true
         expect(subject[:score]).to eql(score)
-        expect(subject[:code]).to eql(200)
-        expect(subject[:body]).to eql(xml_resp_spec)
-        expect(subject[:headers]).not_to be_nil
+        expect(subject[:response_info][:code]).to eql(200)
+        expect(subject[:response_info][:body]).to eql(xml_resp_spec)
+        expect(subject[:response_info][:headers]).not_to be_nil
       end
     end
 
@@ -95,9 +95,9 @@ describe CRater do
       it "returns only debug information" do
         expect(subject[:success]).to be false
         expect(subject[:score]).to be_nil
-        expect(subject[:code]).to eql(404)
-        expect(subject[:body]).to eql('Page not found')
-        expect(subject[:headers]).not_to be_nil
+        expect(subject[:response_info][:code]).to eql(404)
+        expect(subject[:response_info][:body]).to eql('Page not found')
+        expect(subject[:response_info][:headers]).not_to be_nil
       end
     end
   end

--- a/spec/models/c_rater/feedback_functionality_spec.rb
+++ b/spec/models/c_rater/feedback_functionality_spec.rb
@@ -116,6 +116,7 @@ describe CRater::FeedbackFunctionality do
             expect(answer.c_rater_feedback_items.count).to eql(1)
             feedback = answer.c_rater_feedback_items.last
             expect(feedback.status).to eql('error')
+            expect(feedback.feedback_text).to eql(err_resp)
             expect(feedback.response_info[:body]).to eql(err_resp)
           end
         end

--- a/spec/models/c_rater/feedback_functionality_spec.rb
+++ b/spec/models/c_rater/feedback_functionality_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe CRater::FeedbackFunctionality do
+  class FeedbackFunctionalityTestClass < ActiveRecord::Base
+    # Well, it's not pretty, but I don't have idea how to solve that better. The goal is to test FeedbackFunctionality
+    # isolated from the class that includes it.
+    self.table_name = :embeddable_open_response_answers
+    include CRater::FeedbackFunctionality
+  end
+
+  let(:answer) do
+    ans = FeedbackFunctionalityTestClass.create
+    # Stub interface required by feedback functionality:
+    allow(ans).to receive(:answer_text).and_return(ans_text)
+    allow(ans).to receive(:c_rater_settings).and_return(settings)
+    ans
+  end
+
+  let(:ans_text) { 'foobar' }
+  let(:item_id) { 123 }
+  let(:settings) { CRater::Settings.new(item_id: item_id) }
+
+  describe 'instance of class that includes feedback functionality' do
+    subject { answer }
+
+    it { is_expected.to respond_to(:c_rater_enabled?) }
+    it { is_expected.to respond_to(:c_rater_config) }
+    it { is_expected.to respond_to(:get_c_rater_feedback) }
+
+    it 'should have access to C-Rater settings' do
+      expect(answer.c_rater_settings).to be_a(CRater::Settings)
+    end
+
+    context 'C-Rater not configured' do
+      before(:each) do
+        allow(answer).to receive(:c_rater_config).and_return(client_id: nil,
+                                                             username: nil,
+                                                             password: nil)
+      end
+      describe '#c_rater_enabled?' do
+        subject { answer.c_rater_enabled? }
+        it { is_expected.to be false }
+      end
+      describe '#get_c_rater_feedback' do
+        it 'should do nothing' do
+          # WebMock raises an error if any web request is issued.
+          answer.save
+          answer.get_c_rater_feedback
+        end
+      end
+    end
+
+    context 'C-Rater configured' do
+      let(:client_id) { 'cc' }
+      let(:username) { 'concord' }
+      let(:password) { 'password' }
+      let(:protocol) { 'https://' }
+      let(:url) { 'fake.c-rater.api/api/v1' }
+      let(:score) { 2 }
+      let(:response) do
+        <<-EOS
+          <crater-results>
+            <tracking id="12345"/>
+            <client id="#{client_id}"/>
+            <items>
+              <item id="123">
+                <responses>
+                  <response id="#{answer.id}" score="#{score}" concepts="3,6" realNumberScore="2.62039"
+                    confidenceMeasure="0.34574">
+                    <advisorylist>
+                      <advisorycode>101</advisorycode>
+                    </advisorylist>
+                  </response>
+                </responses>
+              </item>
+            </items>
+          </crater-results>
+        EOS
+      end
+      before(:each) do
+        allow(answer).to receive(:c_rater_config).and_return(client_id: client_id,
+                                                             username: username,
+                                                             password: password,
+                                                             url: "#{protocol}#{url}")
+        stub_request(:post, "#{protocol}#{username}:#{password}@#{url}").
+          to_return(:status => 200, :body => response,
+                    :headers => {'Content-Type'=>'application/xml; charset=iso-8859-1'})
+      end
+
+      describe '#c_rater_enabled?' do
+        subject { answer.c_rater_enabled? }
+        it { is_expected.to be true }
+      end
+
+      describe '#get_c_rater_feedback' do
+        it 'creates feedback entry in DB' do
+          expect(answer.c_rater_feedback_items.count).to eql(0)
+          answer.get_c_rater_feedback
+          expect(answer.c_rater_feedback_items.count).to eql(1)
+          feedback = answer.c_rater_feedback_items.last
+          expect(feedback.status).to eql('success')
+          expect(feedback.score).to eql(score)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/embeddable/open_response_answer_spec.rb
+++ b/spec/models/embeddable/open_response_answer_spec.rb
@@ -58,14 +58,11 @@ describe Embeddable::OpenResponseAnswer do
   end
 
   describe "C-Rater functionality" do
-    it "should implement required interface" do
-      expect(answer).to respond_to(:answer_text)
-      expect(answer).to respond_to(:c_rater_settings)
-    end
-    it "should get C-Rater feedback after answer is updated" do
-      expect(answer).to receive(:get_c_rater_feedback)
-      answer.answer_text = 'foobar'
-      answer.save
+    subject { answer }
+    it { is_expected.to respond_to(:get_c_rater_feedback) }
+    describe "required interface" do
+      it { is_expected.to respond_to(:answer_text) }
+      it { is_expected.to respond_to(:c_rater_settings) }
     end
   end
 end

--- a/spec/models/embeddable/open_response_answer_spec.rb
+++ b/spec/models/embeddable/open_response_answer_spec.rb
@@ -57,4 +57,15 @@ describe Embeddable::OpenResponseAnswer do
     end
   end
 
+  describe "C-Rater functionality" do
+    it "should implement required interface" do
+      expect(answer).to respond_to(:answer_text)
+      expect(answer).to respond_to(:c_rater_settings)
+    end
+    it "should get C-Rater feedback after answer is updated" do
+      expect(answer).to receive(:get_c_rater_feedback)
+      answer.answer_text = 'foobar'
+      answer.save
+    end
+  end
 end

--- a/spec/models/embeddable/open_response_spec.rb
+++ b/spec/models/embeddable/open_response_spec.rb
@@ -19,4 +19,9 @@ describe Embeddable::OpenResponse do
       expect(open_response.duplicate).to be_a_new(Embeddable::OpenResponse).with( name: open_response.name, prompt: open_response.prompt )
     end
   end
+
+  describe 'C-Rater functionality' do
+    subject { open_response }
+    it { is_expected.to respond_to(:c_rater_settings) }
+  end
 end

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -211,4 +211,17 @@ describe InteractivePage do
       end
     end
   end
+
+  describe 'InteractivePage#register_additional_section' do
+    before(:all) do
+      InteractivePage.register_additional_section({name:  'test_section',
+                                                   dir:   'dir',
+                                                   label: 'label'})
+    end
+    it 'should add new methods (show_<secion_name_)' do
+      expect(page).not_to respond_to(:show_unexisting_section)
+      expect(page).to respond_to(:show_test_section)
+      expect(page).to respond_to(:show_test_section=)
+    end
+  end
 end


### PR DESCRIPTION
@scytacki, @knowuh, I'm creating a pull request so you can take a look at this code.
It's pretty big, so summary:

- All C-Rater-specific functionality is provided in CRater module.
- I'm quite happy about core functionality related to C-Rater like its API wrapper, FeedbackFunctionality, FeedbackItem, FeedbackSettings etc. To enable C-Rater feedback it's enough to include some mixins. Tests coverage is hopefully quite good.
- I'm less happy about argumentation block and changes to InteractivePage model. I've added "additional section" concept to avoid adding yet another `show_<something>` column to this model and hardcoding things in views. Although it includes some weird meta-programming and this concept pretends to be generic, while it clearly addresses argumentation block needs. 
- Filtering of embeddables by section is also pretty specific. I've only added `section` column to PageItem model. Obviously section could be modelled better (probably it should belong to page and consist of page items etc.), but the current approach doesn't require risky migrations that restructure all activities. It's also easy to remove in the future.

Contact point between existing code and C-Rater code:
- OpenResponse and OpenResponseAnswer include CRater modules (2 lines).
- InteractivePage registers argumentation block section (1 line, but of course first I had to add "additional section" feature).
- A few new routes.

I didn't modify existing code too much, but mostly tried to provide new one that is clearly scoped to C-Rater. Unfortunately this new code code is spread across the whole codebase (models, controllers, views, helpers, lib), but should be easy to identify it due to CRater module and/or directories.