### PR TITLE
Abstract iframe-phone in LARA so every interactive has an iframe-phone

### DIFF
--- a/app/assets/javascripts/iframe-phone-manager.coffee
+++ b/app/assets/javascripts/iframe-phone-manager.coffee
@@ -1,0 +1,62 @@
+# Manager of the iframe phone instances.
+# Do not use iframePhone module directly, use this class instead.
+
+class IframePhoneManager
+  IFRAMES_SEL = 'iframe.interactive'
+
+  @_instance = null
+
+  # PUBLIC
+  # Only class methods are designed to be public.
+  @getPhone: (iframeEl, afterConnectedCallback) ->
+    @_getInstance()._getPhone(iframeEl, afterConnectedCallback)
+
+  @getRpcEndpoint: (iframeEl, namespace) ->
+    @_getInstance()._getRpcEndpoint(iframeEl, namespace)
+
+  @_getInstance: ->
+    @_instance = new IframePhoneManager() unless @_instance
+    @_instance
+
+  # PRIVATE
+  # Instance methods are not intented to be used externally, not even constructor, they are all private.
+  constructor: ->
+    @_iframeData = {}
+    @_processAllIframes()
+
+  _getPhone: (iframeEl, afterConnectedCallback) ->
+    data = @_iframeData[iframeEl]
+    return null unless data
+
+    if afterConnectedCallback
+      if data.phoneAnswered
+        # Ensure that callback is *always* executed in an async way.
+        setTimeout (-> afterConnectedCallback()), 1
+      else
+        data.phoneAnsweredCallbacks.push afterConnectedCallback
+
+    data.phone
+
+  _getRpcEndpoint: (iframeEl, namespace) ->
+    data = @_iframeData[iframeEl]
+    return null unless data
+
+    unless data.rpcEndpoints[namespace]
+      data.rpcEndpoints[namespace] = new iframePhone.IframePhoneRpcEndpoint phone: data.phone, namespace: namespace
+
+    data.rpcEndpoints[namespace]
+
+  _processAllIframes: ->
+    $(IFRAMES_SEL).each (idx, iframeEl) =>
+      @_iframeData[iframeEl] =
+        phoneAnswered: false
+        phoneAnsweredCallbacks: []
+        phone: new iframePhone.ParentEndpoint iframeEl, => @_phoneAnswered(iframeEl)
+        rpcEndpoints: {}
+
+  _phoneAnswered: (iframeEl) ->
+    data = @_iframeData[iframeEl]
+    data.phoneAnswered = true
+    callback() for callback in data.phoneAnsweredCallbacks
+
+window.IframePhoneManager = IframePhoneManager

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -67,10 +67,7 @@ class IFrameSaver
       @load_interactive =>
         @set_autosave_enabled(true)
 
-    @iframePhone = new iframePhone.ParentEndpoint($iframe[0], phone_answered)
-    @iframePhoneRpc = new iframePhone.IframePhoneRpcEndpoint
-      phone: @iframePhone
-      namespace: 'lara-logging'
+    @iframePhone = IframePhoneManager.getPhone($iframe[0], phone_answered)
 
   @default_success: ->
     console.log "saved"
@@ -143,7 +140,8 @@ class IFrameSaver
           if interactive
             @saved_state = interactive
             @iframePhone.post({type: 'loadInteractive', content: interactive})
-            @iframePhoneRpc.call message: 'lara-logging-present'
+            # Lab logging needs to be re-enabled after interactive is (re)loaded.
+            LoggerUtils.enableLabLogging @$iframe[0]
             @$delete_button.show() if @should_show_delete == null or @should_show_delete
       error: (jqxhr, status, error) =>
         @error("couldn't load interactive")

--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -14,6 +14,7 @@
 //= require fabric
 //= require hammerjs
 //= require eventemitter2
+//= require iframe-phone-manager
 //= require drawing-tool
 //= require shutterbug
 //= require api-urls

--- a/spec/javascripts/iframe_saver_spec.coffee
+++ b/spec/javascripts/iframe_saver_spec.coffee
@@ -12,7 +12,7 @@ describe 'IFrameSaver', () ->
   fake_save_indicator = jasmine.createSpyObj('SaveIndicator',['showSaved','showSaving', 'showSaveFailed'])
 
   beforeEach () ->
-    window.iframePhone.ParentEndpoint = () ->
+    window.IframePhoneManager.getPhone = () ->
       return fake_phone
     loadFixtures "iframe-saver.html"
 


### PR DESCRIPTION
The main change is that the client code shouldn't use iframe phone module directly, but `IframePhoneManager` instead. It ensures that there is only once instance of the iframe phone connected to given iframe (and RPC endpoint for a given namespace). Also, each client can specify its own `afterConnectedCallback`.

It doesn't solve `IframePhone` issues - it's still possible that some messages will get lost if message handlers are added too late. It just makes the code more sane - we don't store iframe phone instances in `Logger` and `IframeSaver` classes, there is less coupling between them and generally we delegate iframe-phone related tasks to a new tool.