### PR TITLE
Iframe phone mock

### DIFF
--- a/app/assets/javascripts/iframe-phone-manager.coffee
+++ b/app/assets/javascripts/iframe-phone-manager.coffee
@@ -56,8 +56,11 @@ class IframePhoneManager
     @_phoneData[phoneId] =
       phoneAnswered: false
       phoneAnsweredCallbacks: []
-      phone: new iframePhone.ParentEndpoint iframeEl, => @_phoneAnswered(iframeEl)
       rpcEndpoints: {}
+
+    # Make sure that phone data is created before we create phone itself. It lets us support case when
+    # afterConnectedCallback is executed synchronously right away in constructor (useful for tests).
+    @_phoneData[phoneId].phone = new iframePhone.ParentEndpoint iframeEl, => @_phoneAnswered(iframeEl)
 
     phoneId
 
@@ -65,5 +68,6 @@ class IframePhoneManager
     data = @_iframePhoneData iframeEl
     data.phoneAnswered = true
     callback() for callback in data.phoneAnsweredCallbacks
+    undefined
 
 window.IframePhoneManager = IframePhoneManager

--- a/spec/javascripts/fixtures/global-iframe-saver.html
+++ b/spec/javascripts/fixtures/global-iframe-saver.html
@@ -1,0 +1,3 @@
+<iframe src="" class="interactive"></iframe>
+<iframe src="" class="interactive"></iframe>
+<iframe src="" class="interactive"></iframe>

--- a/spec/javascripts/global_state_saver_spec.coffee
+++ b/spec/javascripts/global_state_saver_spec.coffee
@@ -1,0 +1,57 @@
+describe 'GlobalIframeSaver', ->
+  beforeEach ->
+    loadFixtures "global-iframe-saver.html" # just 3 iframes
+    jasmine.Ajax.install()
+    jasmine.mockIframePhone.install()
+    @saveUrl = 'https://lara.url/global_state_endpoint'
+    @globalState = {key: 'val'}
+
+  afterEach ->
+    jasmine.Ajax.uninstall()
+    jasmine.mockIframePhone.uninstall()
+
+  it 'should broadcast global state if it is provided in config', ->
+    @globalSaver = new GlobalIframeSaver save_url: @saveUrl, raw_data: JSON.stringify(@globalState)
+    expect(jasmine.mockIframePhone.messages.count()).toEqual 3
+    $('iframe').each (idx, iframeEl) =>
+      expect(jasmine.mockIframePhone.messages.at(idx)).toEqual
+        source: window
+        target: iframeEl
+        message:
+          type: 'loadInteractiveGlobal'
+          content: @globalState
+
+  describe 'when "interactiveStateGlobal" message is received from iframe', ->
+    beforeEach ->
+      @globalSaver = new GlobalIframeSaver save_url: @saveUrl
+      jasmine.mockIframePhone.postMessageFrom $('iframe')[0], {type: 'interactiveStateGlobal', content: @globalState}
+
+    it 'should broadcast "loadInteractiveGlobal" to other iframes', ->
+      expect(jasmine.mockIframePhone.messages.count()).toEqual 3
+      # Initial message.
+      expect(jasmine.mockIframePhone.messages.at(0)).toEqual
+        source: $('iframe')[0]
+        target: window
+        message:
+          type: 'interactiveStateGlobal'
+          content: @globalState
+      # Messages posted by GlobalIframeSaver:
+      expect(jasmine.mockIframePhone.messages.at(1)).toEqual
+        source: window
+        target: $('iframe')[1]
+        message:
+          type: 'loadInteractiveGlobal'
+          content: @globalState
+      expect(jasmine.mockIframePhone.messages.at(2)).toEqual
+        source: window
+        target: $('iframe')[2]
+        message:
+          type: 'loadInteractiveGlobal'
+          content: @globalState
+
+    it 'should send state to LARA server', ->
+      request = jasmine.Ajax.requests.mostRecent()
+      expect(request.url).toBe @saveUrl
+      expect(request.method).toBe 'POST'
+      # No idea why raw data needs to be wrapped in array - caused by jQuery or MockAjax?
+      expect(request.data()).toEqual raw_data: [JSON.stringify(@globalState)]

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -11,3 +11,6 @@
 // });
 
 jasmine.getFixtures().fixturesPath = '__spec__/fixtures'
+
+// Setup empty Gon data to avoid JS errors.
+window.gon = {};

--- a/spec/javascripts/helpers/mock-iframe-phone.js
+++ b/spec/javascripts/helpers/mock-iframe-phone.js
@@ -1,0 +1,157 @@
+// Mock iframe phone implementation. Supports jasmine, but can be easily adapted to another test framework.
+// See mock_iframe_phone_spec.coffee for example of use.
+
+(function(global) {
+
+  var mockIframePhoneManager = null;
+
+  function MockIframePhoneManager() {
+    this._realIframePhoneModule = global.iframePhone;
+
+    this._iframeEndpointInstance = null;
+    this._phones = {};
+    this._phonesCount = 0;
+
+    // Messages object allows to inspect all recorded fake post messages.
+    this.messages = {
+      _messages: [],
+      all: function() {
+        return this._messages;
+      },
+      at: function(idx) {
+        return this._messages[idx];
+      },
+      count: function() {
+        return this._messages.length;
+      },
+      reset: function() {
+        this._messages = [];
+      },
+      _add: function(msg) {
+        this._messages.push(msg);
+      }
+    };
+  }
+
+  // Call it before your test (e.g. beforeEach).
+  MockIframePhoneManager.prototype.install = function() {
+    // Mock iframePhone module.
+    global.iframePhone = {
+      ParentEndpoint: MockPhone,
+      getIFrameEndpoint: function () {
+        if (!this._iframeEndpointInstance) {
+          this._iframeEndpointInstance = new MockPhone(window.parent);
+        }
+        return this._iframeEndpointInstance;
+      }
+    };
+  };
+
+  // Call it after your test (e.g. afterEach).
+  MockIframePhoneManager.prototype.uninstall = function() {
+    // Restore iframePhone module.
+    global.iframePhone = this._realIframePhoneModule;
+
+    this.messages.reset();
+    this._phones = {};
+    this._phonesCount = 0;
+    this._iframeEndpointInstance = null;
+  };
+
+  MockIframePhoneManager.prototype.withMock = function(closure) {
+    this.install();
+    try {
+      closure();
+    } finally {
+      this.uninstall();
+    }
+  };
+
+  // Posts fake message from given element (e.g. iframe). Current window is the receiver.
+  // If there is a mock iframe phones connected to source element, it will be notified.
+  MockIframePhoneManager.prototype.postMessageFrom = function(source, message) {
+    this.messages._add({source: source, target: window, message: message});
+    var id = $(source).data('mock-iframe-phone-id');
+    if (typeof id === 'undefined') {
+      // There was no iframe phone registered for this element.
+      return;
+    }
+    this._phones[id]._handleMessage(message);
+  };
+
+  MockIframePhoneManager.prototype._registerPhone = function(element, phone) {
+    var id = this._phonesCount++;
+    // Save ID.
+    $(element).data('mock-iframe-phone-id', id);
+    this._phones[id] = phone;
+  };
+
+  // Mock iframe phone, implements interface of both ParentEndpoint and IframeEndpoint.
+  function MockPhone(targetElement, targetOrigin, afterConnectedCallback) {
+    mockIframePhoneManager._registerPhone(targetElement, this);
+    this._listeners = {};
+    this._targetElement = targetElement;
+    this._targetOrigin = targetOrigin;
+    if (afterConnectedCallback) {
+      afterConnectedCallback();
+    }
+  }
+
+  MockPhone.prototype.post = function(type, content) {
+    var message;
+    // Message object can be constructed from 'type' and 'content' arguments or it can be passed
+    // as the first argument.
+    if (arguments.length === 1 && typeof type === 'object' && typeof type.type === 'string') {
+      message = type;
+    } else {
+      message = {
+        type: type,
+        content: content
+      };
+    }
+    mockIframePhoneManager.messages._add({source: window, target: this._targetElement, message: message});
+  };
+
+  MockPhone.prototype.addListener = function(type, fn) {
+    this._listeners[type] = fn;
+  };
+
+  MockPhone.prototype.removeListener = function(type) {
+    this._listeners[messageName] = null;
+  };
+
+  MockPhone.prototype.removeAllListeners = function() {
+    this._listeners = {};
+  };
+
+  MockPhone.prototype.getListenerNames = function() {
+    return Object.keys(this._listeners);
+  };
+
+  MockPhone.prototype.getTargetWindow = function() {
+    return this._targetElement;
+  };
+
+  MockPhone.prototype.targetOrigin = function() {
+    return this._targetOrigin;
+  };
+
+  MockPhone.prototype._handleMessage = function(message) {
+    if (this._listeners[message.type]) {
+      this._listeners[message.type](message.content);
+    }
+  };
+
+  MockPhone.prototype.initialize = function() {
+    // noop
+  };
+
+  MockPhone.prototype.disconnect = function() {
+    // noop
+  };
+
+  // Initialize MockIframePhoneManager and make it available in Jasmine tests.
+  mockIframePhoneManager = new MockIframePhoneManager(window);
+  jasmine.mockIframePhone = mockIframePhoneManager;
+
+}(typeof window === 'undefined' && typeof exports === 'object' ? exports : window));

--- a/spec/javascripts/iframe_phone_manager_spec.coffee
+++ b/spec/javascripts/iframe_phone_manager_spec.coffee
@@ -1,0 +1,47 @@
+describe 'IframePhoneManager', ->
+  beforeEach ->
+    setFixtures '<iframe src="http://test.com"></iframe>'
+    @iframeEl = $('iframe')[0]
+
+  it 'is available in global namespace', ->
+    expect(IframePhoneManager).toEqual jasmine.anything()
+
+  describe '#getPhone', ->
+    it 'returns the same phone even if called multiple times', ->
+      phone1 = IframePhoneManager.getPhone @iframeEl
+      phone2 = IframePhoneManager.getPhone @iframeEl
+      expect(phone1).toBe phone2
+
+    it 'executes all provided afterConnectedCallbacks (async!)', (done) ->
+      jasmine.mockIframePhone.withMock =>
+        jasmine.mockIframePhone.autoConnect = false
+
+        callback = jasmine.createSpy 'callback'
+        IframePhoneManager.getPhone @iframeEl, callback
+        phone = IframePhoneManager.getPhone @iframeEl, callback
+        expect(callback).not.toHaveBeenCalled()
+        setTimeout =>
+          phone.fakeConnection()
+          # Callbacks added before connection was initialized should be executed right away when it happens
+          # (in real world it's async).
+          expect(callback).toHaveBeenCalled()
+          expect(callback.calls.count()).toEqual 2
+          # Callbacks added after connection was initialized should be executed asynchronously in the future
+          # (so we're consistent and we always simulate async connection to an iframe).
+          callback.calls.reset()
+          IframePhoneManager.getPhone @iframeEl, callback
+          expect(callback).not.toHaveBeenCalled()
+          # Test passes only if done is called within next 5 seconds.
+          IframePhoneManager.getPhone @iframeEl, done
+        , 1
+
+    describe '#getRpcEndpoint', ->
+      it 'returns the same RPC endpoint even if called multiple times', ->
+        rpc1 = IframePhoneManager.getRpcEndpoint @iframeEl, 'test-namespace'
+        rpc2 = IframePhoneManager.getRpcEndpoint @iframeEl, 'test-namespace'
+        expect(rpc1).toBe rpc2
+
+      it 'returns different RPC endpoint for different namespaces', ->
+        rpc1 = IframePhoneManager.getRpcEndpoint @iframeEl, 'test-namespace-1'
+        rpc2 = IframePhoneManager.getRpcEndpoint @iframeEl, 'test-namespace-2'
+        expect(rpc1).not.toBe rpc2

--- a/spec/javascripts/mock_iframe_phone_spec.coffee
+++ b/spec/javascripts/mock_iframe_phone_spec.coffee
@@ -1,0 +1,106 @@
+describe 'MockIframePhone', ->
+  describe 'when installed', ->
+    beforeEach ->
+      jasmine.mockIframePhone.install()
+      $('<iframe>').appendTo 'body'
+      @iframeEl = $('iframe')[0]
+      # Test both types of endpoints.
+      @parentEndpoint = new iframePhone.ParentEndpoint  @iframeEl
+      @iframeEndpoint = new iframePhone.getIFrameEndpoint()
+      @phones = [@parentEndpoint, @iframeEndpoint]
+
+    afterEach ->
+      jasmine.mockIframePhone.uninstall()
+      $('iframe').remove()
+
+    it 'should provide iframePhone module that mimics the original one', ->
+      @phones.forEach (phone) ->
+        expect(phone).toEqual jasmine.anything()
+
+    it 'should provide #postMessageFrom function', ->
+      expect(typeof jasmine.mockIframePhone.postMessageFrom).toEqual 'function'
+
+    it 'should provide #messages object', ->
+      expect(typeof jasmine.mockIframePhone.messages).toEqual 'object'
+
+    describe 'when fake message is posted *to* iframe phone', ->
+      beforeEach ->
+        @parentListener = jasmine.createSpy 'parentListener'
+        @parentEndpoint.addListener 'testMsg', @parentListener
+        jasmine.mockIframePhone.postMessageFrom @iframeEl, {type: 'testMsg', content: 'foobar'}
+
+        @iframeListener = jasmine.createSpy 'iframeListener'
+        @iframeEndpoint.addListener 'testMsg', @iframeListener
+        jasmine.mockIframePhone.postMessageFrom window.parent, {type: 'testMsg', content: 'barfoo'}
+
+      it 'listeners should be called', ->
+        expect(@parentListener).toHaveBeenCalledWith 'foobar'
+        expect(@parentListener.calls.count()).toEqual 1
+        expect(@iframeListener).toHaveBeenCalledWith 'barfoo'
+        expect(@iframeListener.calls.count()).toEqual 1
+
+      it 'should be recorded', ->
+        expect(jasmine.mockIframePhone.messages.count()).toEqual 2
+        expect(jasmine.mockIframePhone.messages.at(0)).toEqual
+          source: @iframeEl
+          target: window
+          message:
+            type: 'testMsg'
+            content: 'foobar'
+        expect(jasmine.mockIframePhone.messages.at(1)).toEqual
+          source: window.parent
+          target: window
+          message:
+            type: 'testMsg'
+            content: 'barfoo'
+
+    describe 'when fake message is posted *from* iframe phone', ->
+      beforeEach ->
+        @parentEndpoint.post 'testMsgFromParentEndpoint', {key: 'value'}
+        @iframeEndpoint.post 'testMsgFromIframeEndpoint', {param: 'test'}
+
+      it 'it should be recorded', ->
+        expect(jasmine.mockIframePhone.messages.count()).toEqual 2
+        expect(jasmine.mockIframePhone.messages.at(0)).toEqual
+          source: window
+          target: @iframeEl
+          message:
+            type: 'testMsgFromParentEndpoint'
+            content: {key: 'value'}
+        expect(jasmine.mockIframePhone.messages.at(1)).toEqual
+          source: window
+          target: window.parent
+          message:
+            type: 'testMsgFromIframeEndpoint'
+            content: {param: 'test'}
+
+    describe '#messages object', ->
+      beforeEach ->
+        jasmine.mockIframePhone.postMessageFrom window.parent, {type: 'testMsg1', content: 'barfoo'}
+        jasmine.mockIframePhone.postMessageFrom @iframeEl, {type: 'testMsg2', content: 'foobar'}
+
+      it 'should allow to count recorded messages', ->
+        expect(jasmine.mockIframePhone.messages.count()).toEqual 2
+
+      it 'should allow to get all messages', ->
+        expect(jasmine.mockIframePhone.messages.all().length).toEqual 2
+
+      it 'should allow to get specific message', ->
+        expect(jasmine.mockIframePhone.messages.at(0)).toEqual jasmine.mockIframePhone.messages.all()[0]
+        expect(jasmine.mockIframePhone.messages.at(0)).toEqual
+          source: window.parent
+          target: window
+          message:
+            type: 'testMsg1'
+            content: 'barfoo'
+        expect(jasmine.mockIframePhone.messages.at(1)).toEqual jasmine.mockIframePhone.messages.all()[1]
+        expect(jasmine.mockIframePhone.messages.at(1)).toEqual
+          source: @iframeEl
+          target: window.parent
+          message:
+            type: 'testMsg2'
+            content: 'foobar'
+
+      it 'should allow to reset recorded messages', ->
+        jasmine.mockIframePhone.messages.reset()
+        expect(jasmine.mockIframePhone.messages.count()).toEqual 0

--- a/spec/javascripts/mock_iframe_phone_spec.coffee
+++ b/spec/javascripts/mock_iframe_phone_spec.coffee
@@ -106,17 +106,36 @@ describe 'MockIframePhone', ->
         expect(jasmine.mockIframePhone.messages.count()).toEqual 0
 
     describe 'MockPhone afterConnectedCallback support', ->
-      it '(fake) connection is automatically initialized right after the parent endpoint is created (sync!)', ->
-        afterConnectedCallback = jasmine.createSpy 'afterConnectedCallback'
-        parentEndpoint = new iframePhone.ParentEndpoint @iframeEl, afterConnectedCallback
-        expect(afterConnectedCallback).toHaveBeenCalled
-        expect(afterConnectedCallback.calls.count()).toEqual 1
+      describe 'when jasmine.mockIframePhone.autoConnect is set to true (default)', ->
+        it '(fake) connection is automatically initialized', ->
+          afterConnectedCallback = jasmine.createSpy 'afterConnectedCallback'
+          parentEndpoint = new iframePhone.ParentEndpoint @iframeEl, afterConnectedCallback
+          expect(afterConnectedCallback).toHaveBeenCalled()
+          expect(afterConnectedCallback.calls.count()).toEqual 1
+          # Test different constructor too.
+          afterConnectedCallback.calls.reset()
+          parentEndpoint = new iframePhone.ParentEndpoint @iframeEl, 'origin', afterConnectedCallback
+          expect(afterConnectedCallback).toHaveBeenCalled
+          expect(afterConnectedCallback.calls.count()).toEqual 1
 
-        # Test different constructor too.
-        afterConnectedCallback.calls.reset()
-        parentEndpoint = new iframePhone.ParentEndpoint @iframeEl, 'origin', afterConnectedCallback
-        expect(afterConnectedCallback).toHaveBeenCalled
-        expect(afterConnectedCallback.calls.count()).toEqual 1
+      describe 'when jasmine.mockIframePhone.autoConnect is set to false', ->
+        beforeEach ->
+          jasmine.mockIframePhone.autoConnect = false
+
+        it '(fake) connection needs to be manually initialized', ->
+          afterConnectedCallback = jasmine.createSpy 'afterConnectedCallback'
+          parentEndpoint = new iframePhone.ParentEndpoint @iframeEl, afterConnectedCallback
+          expect(afterConnectedCallback).not.toHaveBeenCalled()
+          parentEndpoint.fakeConnection()
+          expect(afterConnectedCallback).toHaveBeenCalled()
+          expect(afterConnectedCallback.calls.count()).toEqual 1
+          # Test different constructor too.
+          afterConnectedCallback.calls.reset()
+          parentEndpoint = new iframePhone.ParentEndpoint @iframeEl, 'origin', afterConnectedCallback
+          expect(afterConnectedCallback).not.toHaveBeenCalled()
+          parentEndpoint.fakeConnection()
+          expect(afterConnectedCallback).toHaveBeenCalled()
+          expect(afterConnectedCallback.calls.count()).toEqual 1
 
     describe 'MockPhone#targetOrigin', ->
       describe 'of parent endpoint', ->


### PR DESCRIPTION
Iframe phone mock implements complete iframe phone interface, but ignores origin check (I don't think it's important for the client code in most cases, but if we find it useful, we can obviously add it). There is no RPC support, as I don't think it's worth it at the moment (I don't think we're going to continue using it after recent discussions).

It lets us test LARA iframe API using Jasmine (or any other JS test framework). I was also considering another approach - we could add a real iframe with a real iframe phone and then use JS API to trigger real messages (as both parent and iframe page would be hosted from the same domain, so they have access to each other's context). However that doesn't seem easy in Jasmine tests (as it would be more like an integration test, not unit) and the initial setup would be probably much more painful. I hope the full mock is more convenient (just `.install()` call, no spies necessary etc.).

I've added two specs:
- specs of mock iframe phone itself, so it's tested and we have an example of use
- specs of global interactive state JS code (real world use case)

BTW, I'm wondering if we should extract this code and add it to iframe phone repository.