### PR TITLE
Fix sorting of embeddable question types

### DIFF
--- a/app/views/c_rater/item_settings/_author.html.haml
+++ b/app/views/c_rater/item_settings/_author.html.haml
@@ -1,19 +1,18 @@
-.authorable
-  .embeddable_tools
-    .drag_handle
-    = link_to "edit", edit_c_rater_item_setting_path(embeddable), :remote => true, :id => "edit-embed-iq-#{embeddable.id}"
+.embeddable_tools
+  .drag_handle
+  = link_to "edit", edit_c_rater_item_setting_path(embeddable), :remote => true, :id => "edit-embed-iq-#{embeddable.id}"
 
-  %p
-    C-Rater Item ID:
-    %span.value
-      = embeddable.item_id
-  %p
-    C-Rater score mapping:
-    %span.value
-      - mapping = embeddable.score_mapping
-      = mapping && mapping.description || "<no mapping selected>"
+%p
+  C-Rater Item ID:
+  %span.value
+    = embeddable.item_id
+%p
+  C-Rater score mapping:
+  %span.value
+    - mapping = embeddable.score_mapping
+    = mapping && mapping.description || "<no mapping selected>"
 
-:scss
+:css
   .value {
     font-weight: bold;
   }

--- a/app/views/embeddable/image_questions/_author.html.haml
+++ b/app/views/embeddable/image_questions/_author.html.haml
@@ -1,24 +1,23 @@
-.authorable_image_question{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
-  .embeddable_tools
-    .drag_handle
-    = link_to "edit", edit_embeddable_image_question_path(embeddable), :remote => true, :id => "edit-embed-iq-#{embeddable.id}"
-    |
-    - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
-    = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
+.embeddable_tools
+  .drag_handle
+  = link_to "edit", edit_embeddable_image_question_path(embeddable), :remote => true, :id => "edit-embed-iq-#{embeddable.id}"
+  |
+  - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
+  = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
 
-    - if params[:edit_embed_iq].to_i == embeddable.id
-      :javascript
-        $("a[id^=edit-embed-iq-#{embeddable.id}]").click()
+  - if params[:edit_embed_iq].to_i == embeddable.id
+    :javascript
+      $("a[id^=edit-embed-iq-#{embeddable.id}]").click()
 
-  .prompt
-    = embeddable.drawing_prompt.html_safe unless embeddable.drawing_prompt.blank?
-    = image_tag embeddable.bg_url, { :style => "width: 100%;" } unless embeddable.bg_url.blank?
-    = embeddable.prompt.html_safe unless embeddable.prompt.blank?
-  - if embeddable.is_shutterbug?
-    %button.image_question.button{:type => 'submit', :id => 'image_snapshot_button'}
-      %i.fa.fa-camera
-      Take snapshot
-  - elsif embeddable.is_drawing?
-    %button.image_question.button{:type => 'submit', :id => 'image_drawing_button'}
-      %i.fa.fa-pencil
-      Make drawing
+.prompt
+  = embeddable.drawing_prompt.html_safe unless embeddable.drawing_prompt.blank?
+  = image_tag embeddable.bg_url, { :style => "width: 100%;" } unless embeddable.bg_url.blank?
+  = embeddable.prompt.html_safe unless embeddable.prompt.blank?
+- if embeddable.is_shutterbug?
+  %button.image_question.button{:type => 'submit', :id => 'image_snapshot_button'}
+    %i.fa.fa-camera
+    Take snapshot
+- elsif embeddable.is_drawing?
+  %button.image_question.button{:type => 'submit', :id => 'image_drawing_button'}
+    %i.fa.fa-pencil
+    Make drawing

--- a/app/views/embeddable/labbooks/_author.html.haml
+++ b/app/views/embeddable/labbooks/_author.html.haml
@@ -1,16 +1,15 @@
-.authorable
-  .embeddable_tools
-    .drag_handle
-    = link_to "edit", edit_embeddable_labbook_path(embeddable), remote: true,  id: "edit-embed-lb-#{embeddable.id}"
-    |
-    - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
-    = link_to "remove", page_remove_embeddable_path(page, embeddable), method: :post, data: {confirm: (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
-  %p
-    = embeddable.name
-  .prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
-  %button.button{type: 'submit'}
-    %i.fa.fa-camera
-    = embeddable.action_label
+.embeddable_tools
+  .drag_handle
+  = link_to "edit", edit_embeddable_labbook_path(embeddable), remote: true,  id: "edit-embed-lb-#{embeddable.id}"
+  |
+  - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
+  = link_to "remove", page_remove_embeddable_path(page, embeddable), method: :post, data: {confirm: (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
+%p
+  = embeddable.name
+.prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
+%button.button{type: 'submit'}
+  %i.fa.fa-camera
+  = embeddable.action_label
 
 - if params[:edit_embed_lb].to_i == embeddable.id
   :javascript

--- a/app/views/embeddable/multiple_choices/_author.html.haml
+++ b/app/views/embeddable/multiple_choices/_author.html.haml
@@ -1,25 +1,24 @@
-.authorable{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
-  .embeddable_tools
-    .drag_handle
-    = link_to "edit", edit_embeddable_multiple_choice_path(embeddable), :remote => true, :id => "edit-embed-mc-#{embeddable.id}"
-    |
-    - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that #{"has".pluralize(@activity.active_runs)} answered this question."
-    = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
-    - if params[:edit_embed_mc].to_i == embeddable.id
-      :javascript
-        $("a[id^=edit-embed-mc-#{embeddable.id}]").click()
-  .prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
-  - if embeddable.show_as_menu
-    = select embeddable, :answers, options_from_collection_for_select(embeddable.choices, 'id', 'choice', embeddable.answers.last), { :include_blank => "Pick one" }
-  - else
-    - embeddable.choices.each do |choice|
-      - control_name = "questions[embeddable__#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}]"
-      - control_id = "embeddable__#{choice.class.to_s.demodulize.underscore}_#{choice.id}"
-      %label{:for => control_id}
-        - if embeddable.multi_answer
-          = check_box_tag control_name, choice.id, false, :id => control_id
-        - else
-          %input{:type => 'radio', :name => control_name, :id => control_id, :value => control_id}
-        = choice.choice
-  - if embeddable.enable_check_answer
-    %button= "Check answer"
+.embeddable_tools
+  .drag_handle
+  = link_to "edit", edit_embeddable_multiple_choice_path(embeddable), :remote => true, :id => "edit-embed-mc-#{embeddable.id}"
+  |
+  - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that #{"has".pluralize(@activity.active_runs)} answered this question."
+  = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
+  - if params[:edit_embed_mc].to_i == embeddable.id
+    :javascript
+      $("a[id^=edit-embed-mc-#{embeddable.id}]").click()
+.prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
+- if embeddable.show_as_menu
+  = select embeddable, :answers, options_from_collection_for_select(embeddable.choices, 'id', 'choice', embeddable.answers.last), { :include_blank => "Pick one" }
+- else
+  - embeddable.choices.each do |choice|
+    - control_name = "questions[embeddable__#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}]"
+    - control_id = "embeddable__#{choice.class.to_s.demodulize.underscore}_#{choice.id}"
+    %label{:for => control_id}
+      - if embeddable.multi_answer
+        = check_box_tag control_name, choice.id, false, :id => control_id
+      - else
+        %input{:type => 'radio', :name => control_name, :id => control_id, :value => control_id}
+      = choice.choice
+- if embeddable.enable_check_answer
+  %button= "Check answer"

--- a/app/views/embeddable/open_responses/_author.html.haml
+++ b/app/views/embeddable/open_responses/_author.html.haml
@@ -1,12 +1,11 @@
-.authorable{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
-  .embeddable_tools
-    .drag_handle
-    = link_to "edit", edit_embeddable_open_response_path(embeddable), :remote => true, :id => "edit-embed-or-#{embeddable.id}"
-    |
-    - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
-    = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
-    - if params[:edit_embed_or].to_i == embeddable.id
-      :javascript
-        $("a[id^=edit-embed-or-#{embeddable.id}]").click()
-  .prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
-  %textarea{:name => "questions[embeddable__#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}]"}
+.embeddable_tools
+  .drag_handle
+  = link_to "edit", edit_embeddable_open_response_path(embeddable), :remote => true, :id => "edit-embed-or-#{embeddable.id}"
+  |
+  - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
+  = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
+  - if params[:edit_embed_or].to_i == embeddable.id
+    :javascript
+      $("a[id^=edit-embed-or-#{embeddable.id}]").click()
+.prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
+%textarea{:name => "questions[embeddable__#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}]"}

--- a/app/views/embeddable/xhtmls/_author.html.haml
+++ b/app/views/embeddable/xhtmls/_author.html.haml
@@ -1,15 +1,14 @@
-.xhtml.authorable{:id => "embeddable_#{embeddable.id}.#{embeddable.class.to_s}"}
-  .embeddable_tools
-    .drag_handle
-    = link_to "edit", edit_embeddable_xhtml_path(embeddable), :remote => true, :id => "edit-embed-xhtml-#{embeddable.id}"
-    |
-    - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
-    = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
-    - if params[:edit_embed_xhtml].to_i == embeddable.id
-      :javascript
-        $("a[id^=edit-embed-xhtml-#{embeddable.id}]").click()
-  - if embeddable.content.blank?
-    .xhtml
-      Embeddable text will go here.
-  - else
-    .xhtml= embeddable.content.html_safe
+.embeddable_tools
+  .drag_handle
+  = link_to "edit", edit_embeddable_xhtml_path(embeddable), :remote => true, :id => "edit-embed-xhtml-#{embeddable.id}"
+  |
+  - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have answered this question."
+  = link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'}
+  - if params[:edit_embed_xhtml].to_i == embeddable.id
+    :javascript
+      $("a[id^=edit-embed-xhtml-#{embeddable.id}]").click()
+- if embeddable.content.blank?
+  .xhtml
+    Embeddable text will go here.
+- else
+  .xhtml= embeddable.content.html_safe

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -79,8 +79,8 @@
           = submit_tag 'Add Embeddable'
         #sort_embeddables.embeddables_list
           - @page.section_embeddables(nil).each do |e|
-            - e_type = e.class.name.underscore
-            = render :partial => "#{e_type.pluralize}/author", :locals => { :embeddable => e, :page => @page }
+            .authorable{:id => "embeddable_#{e.id}.#{e.class.to_s}"}
+              = render :partial => "#{e.class.name.underscore.pluralize}/author", :locals => { :embeddable => e, :page => @page }
     -# Additional sections are dynamically loaded, based on .visible_sections value:
     - @page.visible_sections.each do |s|
       = render :partial => "#{s[:dir]}/author", :locals => { :page => @page, :section_name => s[:name], :section_label => s[:label] }


### PR DESCRIPTION
Fixes sorting of Labbook embeddable item. Labbook dom element wasn't defining necessary ID.
I extracted `.authorable{:id => "embeddable_#{e.id}.#{e.class.to_s}"}` div from all partials and moved it one lever higher, so it'll be more difficult to make similar mistake in the future.