### PR TITLE
Add flag for ITSI style authoring [#95539464]

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -506,42 +506,43 @@ ul.quiet_list {
     background: #fef7e0;
   }
 }
-form.edit_lightweight_activity {
+form.edit_lightweight_activity,
+form.new_lightweight_activity {
   fieldset {
     clear: left;
-   	margin-top: 20px;
+     margin-top: 20px;
   }
   legend {
-   	font-weight: bold;
+     font-weight: bold;
   }
   .submit {
-	text-align: right;
-	width: 100%;
+  text-align: right;
+  width: 100%;
   }
 }
 
 #menu {
- 	float: right;
- 	list-style-type: none;
- 	h2 {
- 		font-weight: bold;
- 		margin-bottom: 10px;
-	}
+   float: right;
+   list-style-type: none;
+   h2 {
+     font-weight: bold;
+     margin-bottom: 10px;
+  }
   .sortable-list {
- 		clear: both;
- 		float: none;
- 		list-style-type: none;
- 		margin: 0;
- 		padding: 0;
+     clear: both;
+     float: none;
+     list-style-type: none;
+     margin: 0;
+     padding: 0;
     .item {
- 			border-bottom: dashed 1px #6fc5d8;
- 			clear: both;
- 			margin: 0 0 .5em;
- 			padding: 5px 3px;
+       border-bottom: dashed 1px #6fc5d8;
+       clear: both;
+       margin: 0 0 .5em;
+       padding: 5px 3px;
       min-height: 15px;
     }
     .menu {
-			float: right;
+      float: right;
       li {
         display: inline;
         border: none;
@@ -553,11 +554,11 @@ form.edit_lightweight_activity {
   }
 }
 #pages, #activities {
-	background: #c9e9e6;
-	padding: 15px;
-	-moz-border-radius: 8px;
-	-webkit-border-radius: 8px;
-	border-radius: 8px;
+  background: #c9e9e6;
+  padding: 15px;
+  -moz-border-radius: 8px;
+  -webkit-border-radius: 8px;
+  border-radius: 8px;
     width: 100%;
   li#add {
     margin-top: 10px;
@@ -567,7 +568,7 @@ form.edit_lightweight_activity {
       color: #333;
       height: 14px;
       padding-left: 18px;
-   		text-decoration: none;
+       text-decoration: none;
     }
   }
   li a {
@@ -583,7 +584,7 @@ form.edit_lightweight_activity {
   }
 }
 ul#new {
- 	margin-top: 1em;
+   margin-top: 1em;
   li#add a {
     background: transparent url(/assets/icons/add.png) 0 0 no-repeat;
     background-size: 14px;
@@ -704,18 +705,18 @@ div.block-empty {
   margin-top: 15px;
   background-color:#dcf1f5;
   padding: 1px 2px 2px 2px;
-  
+
   input {
     position: relative;
     top: 1px;
     margin: 1px;
     padding: 0;
   }
-  
+
   label {
     margin-right: 30px;
   }
-  
+
   label:last-child {
     margin-right: 0;
   }

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -69,6 +69,21 @@ class InteractivePagesController < ApplicationController
   def edit
     authorize! :update, @page
     @all_pages = @activity.pages
+
+    @editor_mode = @activity.editor_mode
+    if params[:mode] && current_user.admin?
+      @editor_mode = case params[:mode]
+        when "itsi" then LightweightActivity::ITSI_EDITOR_MODE
+        when "itsi-dev" then LightweightActivity::ITSI_WIP_EDITOR_MODE
+        else LightweightActivity::STANDARD_EDITOR_MODE
+      end
+    end
+
+    if @editor_mode == LightweightActivity::ITSI_WIP_EDITOR_MODE
+      render :itsi_edit
+    else
+      render :edit
+    end
   end
 
   def update

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -8,10 +8,18 @@ class LightweightActivity < ActiveRecord::Base
     ['Multi-page', LAYOUT_MULTI_PAGE],
     ['Single-page', LAYOUT_SINGLE_PAGE]
   ]
+  STANDARD_EDITOR_MODE = 0
+  ITSI_EDITOR_MODE = 1
+  ITSI_WIP_EDITOR_MODE = 2 # this is just for development of the React edit template - it will be removed once that work is done
+  EDITOR_MODE_OPTIONS = [
+    ['Standard', STANDARD_EDITOR_MODE],
+    ['ITSI', ITSI_EDITOR_MODE],
+    ['ITSI (Development)', ITSI_WIP_EDITOR_MODE]
+  ]
 
   attr_accessible :name, :user_id, :pages, :related, :description,
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :theme_id, :project_id,
-                  :portal_run_count, :layout
+                  :portal_run_count, :layout, :editor_mode
 
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
@@ -87,7 +95,8 @@ class LightweightActivity < ActiveRecord::Base
       theme_id: theme_id,
       thumbnail_url: thumbnail_url,
       notes: notes,
-      layout:layout
+      layout: layout,
+      editor_mode: editor_mode
     }
   end
 
@@ -118,7 +127,8 @@ class LightweightActivity < ActiveRecord::Base
                                         :theme_id,
                                         :thumbnail_url,
                                         :notes,
-                                        :layout])
+                                        :layout,
+                                        :editor_mode])
     activity_json[:pages] = []
     self.pages.each do |p|
       activity_json[:pages] << p.export
@@ -138,7 +148,8 @@ class LightweightActivity < ActiveRecord::Base
       theme_id: activity_json_object[:theme_id],
       thumbnail_url: activity_json_object[:thumbnail_url],
       time_to_complete: activity_json_object[:time_to_complete],
-      layout: activity_json_object[:layout]
+      layout: activity_json_object[:layout],
+      editor_mode: activity_json_object[:editor_mode]
     }
 
   end

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -40,6 +40,10 @@
   %h1.title
     = @activity.name
 
+  - if @editor_mode == LightweightActivity::ITSI_EDITOR_MODE
+    %div{ :style => "font-weight: bold; margin: 10px 0; background-color: #cff204; padding: 10px;" }
+      This page will use the ITSI editor mode once it is completed.
+
   %h2.question
     = editable_field @page, :name, {:use_trigger => true, :edit_string => 'Edit', :submit => 'Save', :cancel => 'Cancel', :onblur => 'ignore', :placeholder => 'page title'}
     %span.preview
@@ -50,7 +54,7 @@
       = f.select :embeddable_display_mode, InteractivePage::EMBEDDABLE_DISPLAY_OPTIONS, {}, { :onchange => 'this.form.submit();', :title => 'Display of embeddables: stacked for scrolling, or carousel for sequential display' }
       %p.page-section-controls#page-section-controls
         %label
-          = f.check_box :show_introduction, :onchange => 'this.form.submit();' 
+          = f.check_box :show_introduction, :onchange => 'this.form.submit();'
           Page introduction
         %label
           = f.check_box :show_info_assessment, :onchange => 'this.form.submit();'

--- a/app/views/interactive_pages/itsi_edit.html.haml
+++ b/app/views/interactive_pages/itsi_edit.html.haml
@@ -1,0 +1,51 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :title do
+  = "Edit #{@page.name}"
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li
+        \/
+        = link_to 'All Activities', activities_path
+      %li
+        \/
+        = link_to @activity.name, edit_activity_path(@activity)
+      %li
+        \/
+        = @page.name
+
+%div{:class => ["content", "editing", @page.layout.match(/^r-/) ? "stacked-right" : nil]}
+  .page-nav
+    - if @page.higher_item
+      %a{:class => 'previous', :href => edit_activity_page_path(@activity, @page.higher_item)}
+        ! &nbsp;
+    - else
+      %a{:class => 'previous disabled'}
+        ! &nbsp;
+    - page_counter = 1
+    - @activity.pages.each do |p|
+      = link_to page_counter, edit_activity_page_path(@activity, p), :class => (p === @page) ? 'active' : ''
+      - page_counter = page_counter + 1
+    = link_to '+', new_activity_page_path(@activity), {:title => "Add another page to #{@activity.name}"}
+    - if @page.lower_item
+      %a{:class => 'next', :href => edit_activity_page_path(@activity, @page.lower_item)}
+        ! &nbsp;
+    - else
+      %a{:class => 'next disabled'}
+        ! &nbsp;
+
+  %h1.title
+    = @activity.name
+
+  %div#itsi_editor
+    The ITSI editor will be rendered here... Stay tuned!
+
+:javascript
+  $(function() {
+    if ((navigator.userAgent.indexOf("MSIE"))!=-1){
+      $('#page-section-controls').removeAttr("id");
+    }
+  });

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -12,7 +12,7 @@
         = link_to 'All Activities', activities_path
       %li= "/ #{@activity.name}".html_safe
 
-%h1.title 
+%h1.title
   Edit activity
   %span.preview
     = link_to "Preview", preview_activity_path(@activity), :target => 'new'
@@ -68,6 +68,9 @@
       .field
         = f.label :layout, "Activity layout"
         = f.select :layout, options_for_select(LightweightActivity::LAYOUT_OPTIONS, @activity.layout)
+      .field
+        = f.label :editor_mode, "Authoring Mode"
+        = f.select :editor_mode, options_for_select(LightweightActivity::EDITOR_MODE_OPTIONS, @activity.editor_mode)
       .field
         = f.label :notes,  'Notes'
         .hint The notes area is for storing information for other authors, e.g. source material or usage restrictions, and is not intended to be displayed in the runtime.

--- a/app/views/lightweight_activities/new.html.haml
+++ b/app/views/lightweight_activities/new.html.haml
@@ -52,6 +52,8 @@
     = f.text_field :thumbnail_url
   = field_set_tag 'Activity layout' do
     = f.select :layout, options_for_select(LightweightActivity::LAYOUT_OPTIONS, @activity.layout)
+  = field_set_tag "Authoring Mode" do
+    = f.select :editor_mode, options_for_select(LightweightActivity::EDITOR_MODE_OPTIONS, @activity.editor_mode)
   = field_set_tag 'Notes' do
     The notes area is for storing information for other authors, e.g. source material or usage restrictions, and is not intended to be displayed in the runtime.
     = f.text_area :notes

--- a/db/migrate/20150609202753_add_editor_mode_to_lightweight_activities.rb
+++ b/db/migrate/20150609202753_add_editor_mode_to_lightweight_activities.rb
@@ -1,0 +1,5 @@
+class AddEditorModeToLightweightActivities < ActiveRecord::Migration
+  def change
+    add_column :lightweight_activities, :editor_mode, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150602204447) do
+ActiveRecord::Schema.define(:version => 20150609202753) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -338,6 +338,7 @@ ActiveRecord::Schema.define(:version => 20150602204447) do
     t.integer  "project_id"
     t.integer  "portal_run_count",   :default => 0
     t.integer  "layout",             :default => 0
+    t.integer  "editor_mode",        :default => 0
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 describe LightweightActivity do
   let(:thumbnail_url) { "http://fake.url.com/image" }
   let(:author)        { FactoryGirl.create(:author) }
-  let(:activity)      { 
+  let(:activity)      {
     activity = FactoryGirl.create(:activity, :thumbnail_url => thumbnail_url)
     activity.user = author
     activity.save
     activity
   }
-  let(:valid)         { 
-    activity = FactoryGirl.build(:activity) 
+  let(:valid)         {
+    activity = FactoryGirl.build(:activity)
     activity.user = author
     activity.save
     activity
   }
-  
+
   it 'should have valid attributes' do
     expect(activity.name).not_to be_blank
     expect(activity.publication_status).to eq("hidden")
@@ -153,7 +153,7 @@ describe LightweightActivity do
 
   describe '#to_hash' do
     it 'returns a hash with relevant values for activity duplication' do
-      expected = { name: activity.name, related: activity.related, description: activity.description, time_to_complete: activity.time_to_complete, project_id: activity.project_id, theme_id: activity.theme_id, thumbnail_url: activity.thumbnail_url, notes: activity.notes, layout: activity.layout }
+      expected = { name: activity.name, related: activity.related, description: activity.description, time_to_complete: activity.time_to_complete, project_id: activity.project_id, theme_id: activity.theme_id, thumbnail_url: activity.thumbnail_url, notes: activity.notes, layout: activity.layout, editor_mode: activity.editor_mode }
       expect(activity.to_hash).to eq(expected)
     end
   end
@@ -161,7 +161,7 @@ describe LightweightActivity do
   describe '#export' do
       it 'returns json of an activity' do
         expect(activity.export[:pages].length).to eq(activity.pages.count)
-    end 
+    end
   end
 
   describe '#duplicate' do
@@ -226,7 +226,7 @@ describe LightweightActivity do
   describe '#serialize_for_portal' do
     let(:simple_portal_hash) do
       url = "http://test.host/activities/#{activity.id}"
-      { 
+      {
         "type"          =>"Activity",
         "name"          => activity.name,
         "description"   => activity.description,


### PR DESCRIPTION
Adds a select for a new editor_mode integer field on the lightweight_activities model.  The select is shown both on the new and edit pages.

The style.scss changes are a side fix to share the the edit_lightweight_activity styles with the unstyled new_lightweight_activity.

Per the meeting I also added a mode query parameter to the edit page so that admins can override the edit mode.