### PR TITLE
An author can hide pages in an activity.

### DIFF
--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -4,6 +4,7 @@ class InteractivePagesController < ApplicationController
   before_filter :set_page, :except => [:new, :create]
   before_filter :set_run_key, :only => [:show, :preview]
   before_filter :set_sequence, :only => [:show]
+  before_filter :check_if_hidden, :only => [:show, :preview]
 
   before_filter :enable_js_logger, :only => [:show, :preview]
 
@@ -204,6 +205,11 @@ class InteractivePagesController < ApplicationController
   end
 
   private
+
+  def check_if_hidden
+    raise ActiveRecord::RecordNotFound if @page.is_hidden
+  end
+
   def set_page
     if params[:activity_id]
       @activity = LightweightActivity.find(params[:activity_id], :include => :pages)
@@ -217,7 +223,6 @@ class InteractivePagesController < ApplicationController
   end
 
   def setup_show
-    raise ActiveRecord::RecordNotFound if @page.is_hidden
     current_theme
     current_project
     setup_global_interactive_state_data

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -217,6 +217,7 @@ class InteractivePagesController < ApplicationController
   end
 
   def setup_show
+    raise ActiveRecord::RecordNotFound if @page.is_hidden
     current_theme
     current_project
     setup_global_interactive_state_data

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -37,7 +37,7 @@ class LightweightActivitiesController < ApplicationController
     if @activity.layout == LightweightActivity::LAYOUT_SINGLE_PAGE
       redirect_to activity_single_page_with_response_path(@activity, @run.key) and return
     end
-    if @run.last_page && !params[:show_index]
+    if @run.last_page && !@run.last_page.is_hidden && !params[:show_index]
       # TODO: If the Page isn't in this activity... Then we need to log that as an error,
       # and do the best we can to get back to the right page...
       if @activity != @run.last_page.lightweight_activity

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -1,6 +1,6 @@
 class InteractivePage < ActiveRecord::Base
   attr_accessible :lightweight_activity, :name, :position, :text, :layout, :sidebar, :show_introduction, :show_sidebar,
-                  :show_interactive, :show_info_assessment, :embeddable_display_mode, :sidebar_title,
+                  :show_interactive, :show_info_assessment, :embeddable_display_mode, :sidebar_title, :is_hidden,
                   :additional_sections
 
   serialize :additional_sections

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -132,11 +132,11 @@ class InteractivePage < ActiveRecord::Base
   end
 
   def first_visible?
-    prev_visible_page == nil
+    !is_hidden && prev_visible_page == nil
   end
 
   def last_visible?
-    next_visible_page == nil
+    !is_hidden && next_visible_page == nil
   end
 
   def visible_sections

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -123,6 +123,22 @@ class InteractivePage < ActiveRecord::Base
     end
   end
 
+  def next_visible_page
+    lightweight_activity.visible_pages.where('position > ?', position).first
+  end
+
+  def prev_visible_page
+    lightweight_activity.visible_pages.where('position < ?', position).last
+  end
+
+  def first_visible?
+    prev_visible_page == nil
+  end
+
+  def last_visible?
+    next_visible_page == nil
+  end
+
   def visible_sections
     return [] unless additional_sections
     self.class.registered_additional_sections.select { |s| additional_sections[s[:name]] }

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -154,6 +154,7 @@ class InteractivePage < ActiveRecord::Base
       position: position,
       text: text,
       layout: layout,
+      is_hidden: is_hidden,
       sidebar: sidebar,
       sidebar_title: sidebar_title,
       show_introduction: show_introduction,
@@ -195,11 +196,11 @@ class InteractivePage < ActiveRecord::Base
   end
   
   def export
-
     page_json = self.as_json(only: [:name, 
                                     :position, 
                                     :text, 
-                                    :layout, 
+                                    :layout,
+                                    :is_hidden,
                                     :sidebar, 
                                     :sidebar_title, 
                                     :show_introduction, 
@@ -246,6 +247,7 @@ class InteractivePage < ActiveRecord::Base
       position: page_json_object[:position],
       text: page_json_object[:text],
       layout: page_json_object[:layout],
+      is_hidden: page_json_object[:is_hidden],
       sidebar: page_json_object[:sidebar],
       sidebar_title: page_json_object[:sidebar_title],
       show_introduction: page_json_object[:show_introduction],

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -33,15 +33,15 @@ class LightweightActivity < ActiveRecord::Base
   # validates_length_of :name, :maximum => 50
   validates :description, :related, :html => true
 
-  # Just a way of getting self.pages with the embeddables eager-loaded
-  def pages_with_embeddables
-    return InteractivePage.includes(:interactive_items, :page_items => :embeddable).where(:lightweight_activity_id => self.id)
+  # Just a way of getting self.visible_pages with the embeddables eager-loaded
+  def visible_pages_with_embeddables
+    InteractivePage.includes(:interactive_items, :page_items => :embeddable).where(:lightweight_activity_id => self.id, :is_hidden => false)
   end
 
   # Returns an array of embeddables which are questions (i.e. Open Response or Multiple Choice)
   def questions
     q = []
-    pages_with_embeddables.each do |p|
+    visible_pages_with_embeddables.each do |p|
       p.embeddables.each do |e|
         if QUESTION_TYPES.include? e.class
           q << e

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -183,6 +183,8 @@ class LightweightActivity < ActiveRecord::Base
 
     pages = []
     self.pages.each do |page|
+      # Don't publish hidden pages.
+      next if page.is_hidden
       elements = []
       (page.embeddables + page.interactives).each do |embeddable|
         # skip item if hidden

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -35,7 +35,10 @@ class LightweightActivity < ActiveRecord::Base
 
   # Just a way of getting self.visible_pages with the embeddables eager-loaded
   def visible_pages_with_embeddables
-    InteractivePage.includes(:interactive_items, :page_items => :embeddable).where(:lightweight_activity_id => self.id, :is_hidden => false)
+    InteractivePage
+      .includes(:interactive_items, :page_items => :embeddable)
+      .where(:lightweight_activity_id => self.id, :is_hidden => false)
+      .order(:position)
   end
 
   # Returns an array of embeddables which are questions (i.e. Open Response or Multiple Choice)

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -17,6 +17,9 @@ class LightweightActivity < ActiveRecord::Base
   belongs_to :changed_by, :class_name => 'User'
 
   has_many :pages, :foreign_key => 'lightweight_activity_id', :class_name => 'InteractivePage', :order => :position
+  has_many :visible_pages, :foreign_key => 'lightweight_activity_id', :class_name => 'InteractivePage', :order => :position,
+             :conditions => {interactive_pages: {is_hidden: false}}
+
   has_many :lightweight_activities_sequences, :dependent => :destroy
   has_many :sequences, :through => :lightweight_activities_sequences
   has_many :runs, :foreign_key => 'activity_id'

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -48,6 +48,11 @@
     = form_for @page do |f|
       = f.select :layout, options_for_select(InteractivePage::LAYOUT_OPTIONS.map { |l| [l[:name], l[:class_val]] }, @page.layout), {},  { :onchange => 'this.form.submit();', :title => 'Page layout' }
       = f.select :embeddable_display_mode, InteractivePage::EMBEDDABLE_DISPLAY_OPTIONS, {}, { :onchange => 'this.form.submit();', :title => 'Display of embeddables: stacked for scrolling, or carousel for sequential display' }
+      %label
+        -# There is no typical :onchange => 'this.form.submit();' handler, as we also need confirmation dialog.
+        -# It's handled separately in the JavaScript block at the end of this partial.
+        = f.check_box :is_hidden, :id => 'hide-page-checkbox'
+        Hidden
       %p.page-section-controls#page-section-controls
         %label
           = f.check_box :show_introduction, :onchange => 'this.form.submit();' 
@@ -102,4 +107,19 @@
     if ((navigator.userAgent.indexOf("MSIE"))!=-1){
       $('#page-section-controls').removeAttr("id");
     }
+
+    // Hide page checkbox handling.
+    var confirmHideMessage = "Are you sure you want to hide this page? You will lose data from #{pluralize(@activity.active_runs, "learner")} that have run this activity.";
+    var activeRuns = #{@activity.active_runs};
+    $('#hide-page-checkbox').on('change', function(e) {
+      if (this.checked && activeRuns > 0) {
+        if (confirm(confirmHideMessage)) {
+          this.form.submit();
+        } else {
+          this.checked = false;
+        }
+      } else {
+        this.form.submit();
+      }
+    });
   });

--- a/app/views/interactive_pages/show.html.haml
+++ b/app/views/interactive_pages/show.html.haml
@@ -11,23 +11,23 @@
 
 .bottom-buttons
   - next_activity = @sequence.next_activity(@page.lightweight_activity) if @sequence
-  - unless @page.first?
+  - unless @page.first_visible?
     .button-left
       .last-page
-        %a{ :href => runnable_activity_page_path(@page.lightweight_activity, @page.higher_item), :class => 'prev' }
+        %a{ :href => runnable_activity_page_path(@page.lightweight_activity, @page.prev_visible_page), :class => 'prev' }
           %input{ :class => 'button', :type => 'submit', :value => t("BACK") }
-  - if @page.last?
+  - if @page.last_visible?
     .button-center
       .submit.report
         %a{ :href => summary_with_response_path(@page.lightweight_activity, @session_key), :class => 'gen-report', :target => 'new' }
           %input{ :class => 'button', :type => 'submit', :value => t("GENERATE_A_REPORT") }
-  - if @page.last? && next_activity
+  - if @page.last_visible? && next_activity
     .button-right
       .next-page
         %a{ :href => sequence_activity_path(@sequence, next_activity), :title => next_activity.name, :class => 'next forward_nav'}
           %input{ :class => 'button next forward_nav', :type => 'submit', :value => t("BEGIN_NEXT_ACTIVITY") }
-  - elsif @page.lower_item
+  - elsif @page.next_visible_page
     .button-right
       .next-page
-        %a{ :href => runnable_activity_page_path(@page.lightweight_activity, @page.lower_item), :class => 'next forward_nav' }
+        %a{ :href => runnable_activity_page_path(@page.lightweight_activity, @page.next_visible_page), :class => 'next forward_nav' }
           %input{ :class => 'button next forward_nav', :type => 'submit', :value => t("NEXT")}

--- a/app/views/shared/_activity_nav.html.haml
+++ b/app/views/shared/_activity_nav.html.haml
@@ -41,7 +41,7 @@
             %a{:href=> runnable_activity_path(@activity, :show_index => true),:class => classes}
               %i.fa.fa-home
           - page_counter = 1
-          - @activity.pages.each do |p|
+          - @activity.visible_pages.each do |p|
             .pagination-item
               - classes = 'pagination-link'
               - if @page
@@ -52,12 +52,12 @@
       -if @page
         %td.activity-nav
           .prev_and_next
-            - next_href = @page.lower_item.nil? ? nil : runnable_activity_page_path(@page.lightweight_activity, @page.lower_item)
-            - previous_href = @page.higher_item.nil? ? nil : runnable_activity_page_path(@page.lightweight_activity, @page.higher_item)
+            - next_href = @page.next_visible_page.nil? ? nil : runnable_activity_page_path(@page.lightweight_activity, @page.next_visible_page)
+            - previous_href = @page.prev_visible_page.nil? ? nil : runnable_activity_page_path(@page.lightweight_activity, @page.prev_visible_page)
             - prev_classes  = 'pagination-link prev'
             - next_classes  = 'pagination-link next forward_nav'
-            - prev_classes << ' disabled' if @page.higher_item.nil?
-            - next_classes << ' disabled' if @page.lower_item.nil?
+            - prev_classes << ' disabled' if @page.prev_visible_page.nil?
+            - next_classes << ' disabled' if @page.next_visible_page.nil?
             %a{ :class => prev_classes, :href => previous_href }
               %i.fa.fa-arrow-left
             %a{ :class => next_classes, :href => next_href }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,9 +28,6 @@ LightweightStandalone::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
-
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 

--- a/db/migrate/20150610120725_add_is_hidden_to_interactive_pages.rb
+++ b/db/migrate/20150610120725_add_is_hidden_to_interactive_pages.rb
@@ -1,0 +1,5 @@
+class AddIsHiddenToInteractivePages < ActiveRecord::Migration
+  def change
+    add_column :interactive_pages, :is_hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150602204447) do
+ActiveRecord::Schema.define(:version => 20150610120725) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -62,12 +62,12 @@ ActiveRecord::Schema.define(:version => 20150602204447) do
   add_index "c_rater_feedback_submissions", ["interactive_page_id", "run_id"], :name => "c_rater_fed_submission_page_run_idx"
 
   create_table "c_rater_item_settings", :force => true do |t|
-    t.string   "item_id"
     t.integer  "score_mapping_id"
     t.integer  "provider_id"
     t.string   "provider_type"
     t.datetime "created_at",       :null => false
     t.datetime "updated_at",       :null => false
+    t.string   "item_id"
   end
 
   add_index "c_rater_item_settings", ["provider_id", "provider_type"], :name => "c_rat_set_prov_idx"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(:version => 20150602204447) do
     t.integer  "image_question_id"
     t.datetime "created_at",                                                   :null => false
     t.datetime "updated_at",                                                   :null => false
-    t.text     "annotation",          :limit => 2147483647
+    t.text     "annotation",          :limit => 4294967294
     t.string   "annotated_image_url"
     t.boolean  "is_dirty",                                  :default => false
     t.boolean  "is_final",                                  :default => false
@@ -235,7 +235,6 @@ ActiveRecord::Schema.define(:version => 20150602204447) do
     t.boolean  "is_prediction",            :default => false
     t.boolean  "give_prediction_feedback", :default => false
     t.text     "prediction_feedback"
-    t.string   "default_text"
     t.boolean  "is_hidden",                :default => false
   end
 
@@ -304,6 +303,7 @@ ActiveRecord::Schema.define(:version => 20150602204447) do
     t.string   "embeddable_display_mode", :default => "stacked"
     t.string   "sidebar_title",           :default => "Did you know?"
     t.text     "additional_sections"
+    t.boolean  "is_hidden",               :default => false
   end
 
   add_index "interactive_pages", ["lightweight_activity_id", "position"], :name => "interactive_pages_by_activity_idx"
@@ -368,13 +368,13 @@ ActiveRecord::Schema.define(:version => 20150602204447) do
 
   create_table "mw_interactives", :force => true do |t|
     t.string   "name"
-    t.text     "url"
-    t.datetime "created_at",                        :null => false
-    t.datetime "updated_at",                        :null => false
+    t.text     "url",            :limit => 2048
+    t.datetime "created_at",                                        :null => false
+    t.datetime "updated_at",                                        :null => false
     t.integer  "native_width"
     t.integer  "native_height"
-    t.boolean  "save_state",     :default => false
-    t.boolean  "has_report_url", :default => false
+    t.boolean  "save_state",                     :default => false
+    t.boolean  "has_report_url",                 :default => false
     t.boolean  "click_to_play"
     t.string   "image_url"
   end
@@ -394,12 +394,12 @@ ActiveRecord::Schema.define(:version => 20150602204447) do
 
   create_table "portal_publications", :force => true do |t|
     t.string   "portal_url"
-    t.text     "response",         :limit => 255
+    t.text     "response"
     t.boolean  "success"
     t.integer  "publishable_id"
     t.string   "publishable_type"
-    t.datetime "created_at",                      :null => false
-    t.datetime "updated_at",                      :null => false
+    t.datetime "created_at",       :null => false
+    t.datetime "updated_at",       :null => false
   end
 
   create_table "projects", :force => true do |t|

--- a/spec/controllers/lightweight_activity_controller_spec.rb
+++ b/spec/controllers/lightweight_activity_controller_spec.rb
@@ -54,6 +54,7 @@ describe LightweightActivitiesController do
         mock_model(Run, {
           :last_page => page,
           :key => "4875ade4-8529-46b2-bb34-b87158f265ae",
+          :activity => act,
           :sequence => seq,
           :sequence_run => seq_run,
           :increment_run_count! => nil
@@ -66,6 +67,15 @@ describe LightweightActivitiesController do
       it "should redirect to the run page" do
         # page_with_response_path(@activity.id, @run.last_page.id, @run)
         expect(subject).to redirect_to(page_with_response_path(act.id, page.id, run.key))
+      end
+
+      describe "when the run page is hidden" do
+        let(:page) { act.pages.create!(:name => "Page 1", :text => "This page is hidden.", :is_hidden => true) }
+        subject { get :show, :id => act.id}
+        it "should not redirect to the run page" do
+          expect(subject).not_to redirect_to(page_with_response_path(act.id, page.id, run.key))
+          expect(response).to render_template('lightweight_activities/show')
+        end
       end
       
       describe "when the run page is for a different activity" do

--- a/spec/factories/lightweight_activities.rb
+++ b/spec/factories/lightweight_activities.rb
@@ -20,6 +20,17 @@ FactoryGirl.define do
     pages { [FactoryGirl.create(:page)] }
   end
 
+  factory :activity_with_pages, :class => LightweightActivity do
+    ignore do
+      pages_count 3
+    end
+    name { generate(:name) }
+    publication_status 'public'
+    related { generate(:related) }
+    description { generate(:description) }
+    pages { pages_count.times.map { FactoryGirl.create(:page) } }
+  end
+
   factory :activity_with_page_and_or, :class => LightweightActivity do
     name { generate(:name) }
     publication_status 'public'

--- a/spec/factories/lightweight_activities.rb
+++ b/spec/factories/lightweight_activities.rb
@@ -28,7 +28,9 @@ FactoryGirl.define do
     publication_status 'public'
     related { generate(:related) }
     description { generate(:description) }
-    pages { pages_count.times.map { FactoryGirl.create(:page) } }
+    after(:create) do |act, evaluator|
+      FactoryGirl.create_list(:page, evaluator.pages_count, lightweight_activity: act)
+    end
   end
 
   factory :activity_with_page_and_or, :class => LightweightActivity do

--- a/spec/features/hide_show_page_spec.rb
+++ b/spec/features/hide_show_page_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'uri'
+
+feature 'Activity page can be hidden', :js => true do
+  let(:user)                   { FactoryGirl.create(:admin) }
+  before :each do
+    login_as user, :scope => :user
+  end
+
+  feature 'marking page as visible or hidden' do
+    let(:activity) { FactoryGirl.create(:activity_with_page_and_or) }
+    let(:activity_page)          { activity.pages.first }
+    let(:edit_activity_page_url) { edit_activity_page_path(activity, activity_page) }
+    let(:activity_page_url)      { activity_page_path(activity, activity_page) }
+
+    scenario 'page can be marked as hidden' do
+      visit activity_page_url
+      expect(page.status_code).to eq(200)
+
+      visit edit_activity_page_url
+      expect(page).to have_unchecked_field 'hide-page-checkbox'
+      check 'hide-page-checkbox'
+
+      visit activity_page_url
+      expect(page.status_code).to eq(404)
+    end
+
+    scenario 'page can be marked as visible' do
+      activity_page.update_attributes!(is_hidden: true)
+
+      visit edit_activity_page_url
+      expect(page).to have_checked_field 'hide-page-checkbox'
+      uncheck 'hide-page-checkbox'
+
+      visit activity_page_url
+      expect(page.status_code).to eq(200)
+    end
+  end
+
+  feature 'the last visible page is considered as the end of the activity' do
+    let (:activity)        { FactoryGirl.create(:activity_with_pages, pages_count: 3) }
+    let (:third_page)      { activity.pages[2] }
+    let(:edit_activity_page_url) { edit_activity_page_path(activity, third_page) }
+    let (:second_page_url) { activity_page_path(activity, activity.pages[1]) }
+
+    scenario 'user can' do
+      visit second_page_url
+      expect(page).not_to have_button 'Generate a report'
+
+      third_page.update_attributes!(is_hidden: true)
+      visit second_page_url
+      # it should look like the last one now
+      expect(page).to have_button 'Generate a report'
+    end
+  end
+end

--- a/spec/features/hide_show_page_spec.rb
+++ b/spec/features/hide_show_page_spec.rb
@@ -22,6 +22,7 @@ feature 'Activity page can be hidden', :js => true do
       check 'hide-page-checkbox'
 
       visit activity_page_url
+      # this requires action_dispatch.show_exceptions = true otheriwse a 500 is returned
       expect(page.status_code).to eq(404)
     end
 

--- a/spec/features/hide_show_page_spec.rb
+++ b/spec/features/hide_show_page_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 require 'uri'
 
 feature 'Activity page can be hidden', :js => true do
-  let(:user)                   { FactoryGirl.create(:admin) }
+  let(:user) { FactoryGirl.create(:admin) }
   before :each do
     login_as user, :scope => :user
   end
 
   feature 'marking page as visible or hidden' do
-    let(:activity) { FactoryGirl.create(:activity_with_page_and_or) }
+    let(:activity)               { FactoryGirl.create(:activity_with_page_and_or) }
     let(:activity_page)          { activity.pages.first }
     let(:edit_activity_page_url) { edit_activity_page_path(activity, activity_page) }
     let(:activity_page_url)      { activity_page_path(activity, activity_page) }
@@ -38,12 +38,12 @@ feature 'Activity page can be hidden', :js => true do
   end
 
   feature 'the last visible page is considered as the end of the activity' do
-    let (:activity)        { FactoryGirl.create(:activity_with_pages, pages_count: 3) }
-    let (:third_page)      { activity.pages[2] }
-    let(:edit_activity_page_url) { edit_activity_page_path(activity, third_page) }
-    let (:second_page_url) { activity_page_path(activity, activity.pages[1]) }
+    let (:activity)               { FactoryGirl.create(:activity_with_pages, pages_count: 3) }
+    let (:third_page)             { activity.pages[2] }
+    let (:edit_activity_page_url) { edit_activity_page_path(activity, third_page) }
+    let (:second_page_url)        { activity_page_path(activity, activity.pages[1]) }
 
-    scenario 'user can' do
+    scenario 'when the last page is marked as hidden, the previous one looks like the end of activity' do
       visit second_page_url
       expect(page).not_to have_button 'Generate a report'
 

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -136,6 +136,7 @@ describe InteractivePage do
         position: page.position,
         text: page.text,
         layout: page.layout,
+        is_hidden: page.is_hidden,
         sidebar: page.sidebar,
         sidebar_title: page.sidebar_title,
         show_introduction: page.show_introduction,
@@ -154,6 +155,7 @@ describe InteractivePage do
       page_json = page.export.as_json
       expect(page_json['interactives'].length).to eq(page.interactives.count)
       expect(page_json['embeddables'].length).to eq(page.embeddables.count)
+      expect(page_json['is_hidden']).to eq(page.is_hidden)
     end
   end
 
@@ -163,6 +165,7 @@ describe InteractivePage do
       expect(dupe).to be_a(InteractivePage)
       expect(dupe.name).to eq(page.name)
       expect(dupe.text).to eq(page.text)
+      expect(dupe.is_hidden).to eq(page.is_hidden)
       expect(dupe.sidebar_title).to eq(page.sidebar_title)
     end
 

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -129,6 +129,40 @@ describe InteractivePage do
     expect(page.embeddables.last.name).to eq("Embeddable 4")
   end
 
+  describe 'helpers related to order of pages should respect is_hidden value' do
+    let (:activity) { FactoryGirl.create(:activity_with_pages, pages_count: 4) }
+
+    context 'when no pages are hidden' do
+      it 'order is based on pages position' do
+        expect(activity.pages[0].first_visible?).to be_truthy
+        expect(activity.pages[0].prev_visible_page).to be_nil
+        expect(activity.pages[1].first_visible?).to be_falsey
+        expect(activity.pages[1].prev_visible_page).to eql(activity.pages[0])
+        expect(activity.pages[2].last_visible?).to be_falsey
+        expect(activity.pages[2].next_visible_page).to eql(activity.pages[3])
+        expect(activity.pages[3].next_visible_page).to be_nil
+        expect(activity.pages[3].last_visible?).to be_truthy
+      end
+    end
+
+    context 'when some pages are hidden' do
+      before(:each) do
+        activity.pages.first.update_attributes!(is_hidden: true)
+        activity.pages.last.update_attributes!(is_hidden: true)
+      end
+      it 'order is based on pages position and is_hidden values' do
+        expect(activity.pages[0].first_visible?).to be_falsey
+        expect(activity.pages[0].prev_visible_page).to be_nil
+        expect(activity.pages[1].first_visible?).to be_truthy
+        expect(activity.pages[1].prev_visible_page).to be_nil
+        expect(activity.pages[2].last_visible?).to be_truthy
+        expect(activity.pages[2].next_visible_page).to be_nil
+        expect(activity.pages[3].next_visible_page).to be_nil
+        expect(activity.pages[3].last_visible?).to be_falsey
+      end
+    end
+  end
+
   describe '#to_hash' do
     it 'has values from the source instance' do
       expected = {

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -87,8 +87,25 @@ describe LightweightActivity do
   end
 
   describe '#questions' do
-    it 'returns an array of Embeddables which are MultipleChoice or OpenResponse' do
-      expect(activity.questions).to eq([])
+    let (:page1) { FactoryGirl.create(:interactive_page_with_or) }
+    let (:page2) { FactoryGirl.create(:interactive_page_with_or) }
+    before(:each) do
+      activity.pages << page1
+      activity.pages << page2
+    end
+
+    it 'returns an array of embeddables' do
+      expect(activity.questions.length).to eql(2)
+      expect(activity.questions).to eql([page1.embeddables[0], page2.embeddables[0]])
+    end
+
+    context 'when some pages are hidden' do
+      let (:page2) { FactoryGirl.create(:interactive_page_with_or, is_hidden: true) }
+
+      it 'returns an array of visible embeddables' do
+        expect(activity.questions.length).to eql(1)
+        expect(activity.questions).to eql(page1.embeddables)
+      end
     end
   end
 
@@ -291,5 +308,4 @@ describe LightweightActivity do
       end
     end
   end
-
 end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -87,8 +87,8 @@ describe LightweightActivity do
   end
 
   describe '#questions' do
-    let (:page1) { FactoryGirl.create(:interactive_page_with_or) }
-    let (:page2) { FactoryGirl.create(:interactive_page_with_or) }
+    let (:page1) { FactoryGirl.create(:interactive_page_with_or, position: 1) }
+    let (:page2) { FactoryGirl.create(:interactive_page_with_or, position: 2) }
     before(:each) do
       activity.pages << page1
       activity.pages << page2

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -242,6 +242,22 @@ describe LightweightActivity do
     it 'returns a simple hash that can be consumed by the Portal' do
       expect(activity.serialize_for_portal('http://test.host')).to eq(simple_portal_hash)
     end
+
+    describe 'pages section' do
+      before(:each) do
+        activity.pages << FactoryGirl.create(:page, name: 'page 1', position: 0)
+        activity.pages << FactoryGirl.create(:page, name: 'page 2', position: 1)
+        activity.pages << FactoryGirl.create(:page, name: 'hidden page', is_hidden: true, position: 2)
+        activity.reload
+      end
+
+      it 'returns only visible pages' do
+        pages = activity.serialize_for_portal('http://test.host')['sections'][0]['pages']
+        expect(pages.length).to eql(2)
+        expect(pages[0]['name']).to eql('page 1')
+        expect(pages[1]['name']).to eql('page 2')
+      end
+    end
   end
 
   describe "named scopes" do


### PR DESCRIPTION
I've added a new checkbox to the top section of page edit form that let authors hide the page.
Hidden page is not displayed in the runtime (404 if user tries to get there via direct URL) and question numbers should respect visibility of pages. Also, when the first or last page is hidden, navigation buttons visible on the pages between them handle that. So, for example user will still see "Generate a report button" on the last visible page, there will be no "Next >" button if the last page is hidden and so on.