### PR TITLE
Add simple metadata editor to ITSI authoring page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
 
 gem 'rails', '~> 3.2.19'
 gem "jquery-rails"
@@ -22,8 +21,11 @@ gem 'omniauth-oauth2', :git => 'https://github.com/intridea/omniauth-oauth2.git'
 gem 'default_value_for'
 
 # Rails assets:
-gem 'rails-assets-drawing-tool', '1.3.2'
-gem 'rails-assets-shutterbug', '0.5.4'
+source 'https://rails-assets.org' do
+  gem 'rails-assets-drawing-tool', '1.3.2'
+  gem 'rails-assets-shutterbug', '0.5.4'
+  gem 'rails-assets-modulejs', '1.6.0'
+end
 
 # Easy (or at least easier) database dumps and reloads
 # Have to use a fork to cope with a bug: https://github.com/ludicast/yaml_db/issues/31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,7 @@ GEM
     rails-assets-fabric (1.5.0)
     rails-assets-hammerjs (2.0.4)
     rails-assets-jquery (2.1.4)
+    rails-assets-modulejs (1.6.0)
     rails-assets-shutterbug (0.5.4)
       rails-assets-jquery (>= 1.10.1)
     railties (3.2.19)
@@ -533,8 +534,9 @@ DEPENDENCIES
   pry-stack_explorer
   rack-environmental
   rails (~> 3.2.19)
-  rails-assets-drawing-tool (= 1.3.2)
-  rails-assets-shutterbug (= 0.5.4)
+  rails-assets-drawing-tool (= 1.3.2)!
+  rails-assets-modulejs (= 1.6.0)!
+  rails-assets-shutterbug (= 0.5.4)!
   rb-fsevent
   react-rails (~> 1.0)
   request-log-analyzer

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,10 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 // N.B. will need to load specific jquery-ui modules for production
+//= require modulejs
+//= require react
+//= require react_ujs
+//= require components
 //= require jquery
 //= require jquery-ajax-csrf
 //= require jquery_ujs

--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -1,0 +1,1 @@
+//= require_tree ./components

--- a/app/assets/javascripts/components/itsi_authoring/editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/editor.js.coffee
@@ -1,0 +1,12 @@
+{div} = React.DOM
+
+modulejs.define 'components/itsi_authoring/editor',
+['components/itsi_authoring/metadata_editor'],
+(MetadataEditor) ->
+  MetadataEditor = React.createFactory MetadataEditor
+
+  React.createClass
+    render: ->
+      (div {className: 'ia-editor'},
+        (MetadataEditor initialData: @props.metadata, updateUrl: @props.paths.activity)
+      )

--- a/app/assets/javascripts/components/itsi_authoring/form_mixin.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/form_mixin.js.coffee
@@ -1,0 +1,29 @@
+{div} = React.DOM
+
+# Component that includes this mixin needs to define @updateUrl property.
+modulejs.define 'components/itsi_authoring/form_mixin', ->
+  getInitialState: ->
+    changedData: {}
+
+  handleFormChange: (e) ->
+    changedData = @state.changedData
+    changedData[e.target.name] = e.target.value
+    @setState changedData: changedData
+
+  submitForm: ->
+    formData = @state.changedData
+    # Don't issue request if nothing has been updated.
+    return if $.isEmptyObject formData
+    # Rails-specific approach to PUT requests.
+    formData._method = 'PUT'
+    $.ajax
+      url: @props.updateUrl
+      data: formData
+      type: 'POST',
+      success: ->
+        console.log 'component updated'
+      error: ->
+        console.log 'component update failed'
+
+  renderSaveButton: ->
+    (div {className: 'ia-save-btn', onClick: @submitForm}, 'Save')

--- a/app/assets/javascripts/components/itsi_authoring/metadata_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/metadata_editor.js.coffee
@@ -1,0 +1,20 @@
+{div, input, textarea} = React.DOM
+
+modulejs.define 'components/itsi_authoring/metadata_editor',
+['components/itsi_authoring/form_mixin'],
+(FormMixin) ->
+
+  React.createClass
+    mixins: [FormMixin]
+
+    render: ->
+      data = @props.initialData
+      (div {className: 'ia-metadata-editor'},
+        (div {className: 'ia-label'}, 'Activity name')
+        (input type: 'text', name: 'lightweight_activity[name]', defaultValue: data.name, onChange: @handleFormChange)
+        (div {className: 'ia-label'}, 'Activity description')
+        (textarea name: 'lightweight_activity[description]', defaultValue: data.description, onChange: @handleFormChange)
+        (div {className: 'ia-label'},
+          @renderSaveButton()
+        )
+      )

--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -10,6 +10,7 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
+//= require modulejs
 //= require jquery-ajax-csrf
 //= require fabric
 //= require hammerjs

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,5 +24,6 @@
  *= require bad_browser
  *= require dirty_runs
  *= require run_detail_report
- *= require c_rater/score_mapping 
+ *= require c_rater/score_mapping
+ *= require components/itsi_authoring
  */

--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -1,0 +1,25 @@
+.ia-editor {
+  margin: 20px;
+}
+
+.ia-save-btn {
+  font-size: 12px;
+  display: inline-block;
+  height: 16px;
+  color: white;
+  cursor: pointer;
+  padding: 2px 10px;
+  border-radius: 12px;
+  background: #f3951d;
+}
+
+.ia-metadata-editor {
+  .ia-label {
+    font-size: 16px;
+    font-weight: bold;
+    margin-bottom: 3px;
+  }
+  input, textarea {
+    margin-bottom: 10px;
+  }
+}

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -116,6 +116,8 @@ class LightweightActivitiesController < ApplicationController
     end
 
     if @editor_mode == LightweightActivity::ITSI_WIP_EDITOR_MODE
+      # Data assigned to `gon` variable will be available for JavaScript code in `window.gon` object.
+      gon.ITSIEditor = ITSIAuthoring::Editor.new(@activity).to_json
       render :itsi_edit
     else
       render :edit

--- a/app/services/itsi_authoring/editor.rb
+++ b/app/services/itsi_authoring/editor.rb
@@ -1,0 +1,36 @@
+class ITSIAuthoring::Editor
+  include LightweightStandalone::Application.routes.url_helpers
+
+  def initialize(activity)
+    @activity = activity
+  end
+
+  def to_json
+    {
+      paths: paths_json,
+      metadata: metadata_json,
+      sections: sections_json
+    }
+  end
+
+  private
+
+  def paths_json
+    {
+      activity: activity_path(@activity)
+    }
+  end
+
+  def metadata_json
+    {
+      name: @activity.name,
+      description: @activity.description
+    }
+  end
+
+  def sections_json
+    @activity.pages.each do |p|
+      {}
+    end
+  end
+end

--- a/app/views/lightweight_activities/itsi_edit.html.haml
+++ b/app/views/lightweight_activities/itsi_edit.html.haml
@@ -21,4 +21,8 @@
   %p.active-runs
     = "This activity has been used by #{pluralize(@activity.active_runs, "learner")}. Editing may cause problems with results data. If you make changes, please publish this activity and any associated sequences as soon as possible."
 
-The ITSI editor will be rendered here... Stay tuned!
+#itsi-editor
+
+:javascript
+  ITSIEditor = React.createElement(modulejs.require('components/itsi_authoring/editor'), gon.ITSIEditor);
+  React.render(ITSIEditor, $('#itsi-editor')[0]);

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150609202753) do
+ActiveRecord::Schema.define(:version => 20150610120725) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -62,12 +62,12 @@ ActiveRecord::Schema.define(:version => 20150609202753) do
   add_index "c_rater_feedback_submissions", ["interactive_page_id", "run_id"], :name => "c_rater_fed_submission_page_run_idx"
 
   create_table "c_rater_item_settings", :force => true do |t|
-    t.string   "item_id"
     t.integer  "score_mapping_id"
     t.integer  "provider_id"
     t.string   "provider_type"
     t.datetime "created_at",       :null => false
     t.datetime "updated_at",       :null => false
+    t.string   "item_id"
   end
 
   add_index "c_rater_item_settings", ["provider_id", "provider_type"], :name => "c_rat_set_prov_idx"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(:version => 20150609202753) do
     t.integer  "image_question_id"
     t.datetime "created_at",                                                   :null => false
     t.datetime "updated_at",                                                   :null => false
-    t.text     "annotation",          :limit => 2147483647
+    t.text     "annotation",          :limit => 4294967294
     t.string   "annotated_image_url"
     t.boolean  "is_dirty",                                  :default => false
     t.boolean  "is_final",                                  :default => false
@@ -235,8 +235,8 @@ ActiveRecord::Schema.define(:version => 20150609202753) do
     t.boolean  "is_prediction",            :default => false
     t.boolean  "give_prediction_feedback", :default => false
     t.text     "prediction_feedback"
-    t.string   "default_text"
     t.boolean  "is_hidden",                :default => false
+    t.string   "default_text"
   end
 
   create_table "embeddable_xhtmls", :force => true do |t|
@@ -304,6 +304,7 @@ ActiveRecord::Schema.define(:version => 20150609202753) do
     t.string   "embeddable_display_mode", :default => "stacked"
     t.string   "sidebar_title",           :default => "Did you know?"
     t.text     "additional_sections"
+    t.boolean  "is_hidden",               :default => false
   end
 
   add_index "interactive_pages", ["lightweight_activity_id", "position"], :name => "interactive_pages_by_activity_idx"
@@ -369,13 +370,13 @@ ActiveRecord::Schema.define(:version => 20150609202753) do
 
   create_table "mw_interactives", :force => true do |t|
     t.string   "name"
-    t.text     "url"
-    t.datetime "created_at",                        :null => false
-    t.datetime "updated_at",                        :null => false
+    t.text     "url",            :limit => 2048
+    t.datetime "created_at",                                        :null => false
+    t.datetime "updated_at",                                        :null => false
     t.integer  "native_width"
     t.integer  "native_height"
-    t.boolean  "save_state",     :default => false
-    t.boolean  "has_report_url", :default => false
+    t.boolean  "save_state",                     :default => false
+    t.boolean  "has_report_url",                 :default => false
     t.boolean  "click_to_play"
     t.string   "image_url"
   end


### PR DESCRIPTION
This PR adds a simple activity editor to the ITSI authoring page. It also adds and uses `ModuleJS`. Features are pretty trivial, but it's more about setting some structure and approach.

It's not production ready, so to speak, but we are working on the page that is marked as WIP anyway, so I think we can merge this kind of pull requests to master. Otherwise, we can keep this branch around and create PR against it instead of master.

@dougmartin, feel free to modify this code if you feel so. React forms were actually something new to me, so I'm not sure if that's the best approach.