### PR TITLE
Add Function.bind polyfill so JS code works in PhantomJS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,10 +11,10 @@
 // GO AFTER THE REQUIRES BELOW.
 //
 // N.B. will need to load specific jquery-ui modules for production
+//= require bind-polyfill
 //= require modulejs
 //= require react
 //= require react_ujs
-//= require components
 //= require jquery
 //= require jquery-ajax-csrf
 //= require jquery_ujs
@@ -34,6 +34,7 @@
 //= require edit_sequence
 //= require login_menu
 //= require chosen-jquery
-//= require application-init
 //= require tablesorter
 //= require c_rater/score_mapping
+//= require components
+//= require application-init

--- a/app/assets/javascripts/bind-polyfill.js
+++ b/app/assets/javascripts/bind-polyfill.js
@@ -1,0 +1,24 @@
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
+
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+      fToBind = this,
+      fNOP    = function() {},
+      fBound  = function() {
+        return fToBind.apply(this instanceof fNOP
+            ? this
+            : oThis,
+          aArgs.concat(Array.prototype.slice.call(arguments)));
+      };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}

--- a/app/assets/javascripts/bind-polyfill.js
+++ b/app/assets/javascripts/bind-polyfill.js
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain. http://creativecommons.org/publicdomain/zero/1.0/
+// source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill
+// license info: https://developer.mozilla.org/en-US/docs/MDN/About#Copyrights_and_licenses
 if (!Function.prototype.bind) {
   Function.prototype.bind = function(oThis) {
     if (typeof this !== 'function') {

--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -10,6 +10,7 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
+//= require bind-polyfill
 //= require modulejs
 //= require jquery-ajax-csrf
 //= require fabric


### PR DESCRIPTION
Failing tests were caused by the fact that Phantom 1.x doesn't support `Function.prototype.bind` and React is using it. 

We can either upgrade PhantomJS everywhere to 2.x or simply add polyfill. I've done the latter, as it's simpler. TravisCI has Phantom 1.x preinstalled. You can install PhantomJS 2.x there:
https://mediocre.com/forum/topics/phantomjs-2-and-travis-ci-we-beat-our-heads-against-a-wall-so-you-dont-have-to
but I'm not sure if it's worth it yet. Perhaps sooner or later TravisCI will migrate and homebrew will support 2.x. :wink: