### PR TITLE
Add option for "preflighting" an iframe interactive

### DIFF
--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -59,6 +59,15 @@ class IFrameSaver
             else
               @$delete_button.hide()
 
+        # A preflight url is a url which should be loaded in a popup window. This allows sites that require cookies
+        # to be able to initialize in browsers that require you to visit a page in a full browser window before they
+        # will allow the site to access cookies when embedded in an iframe.
+        if opts.preflight_url?
+          @$iframe.data('preflight_url', opts.preflight_url)
+          ctp = @$iframe.siblings('.click_to_play')
+          ctp.addClass('shown')
+          ctp.show()
+
       @iframePhone.post('getExtendedSupport')
       @iframePhone.post('getLearnerUrl')
 

--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -80,4 +80,26 @@ module InteractiveRunHelper
     end
   end
 
+  def click_to_play_barrier(interactive)
+    opts = {
+      :id => dom_id_for(interactive, :click_to_play),
+      :class => 'click_to_play'
+    }
+
+    if interactive.click_to_play
+      opts[:class] += ' shown'
+    else
+      opts[:style] = 'display: none;'
+    end
+
+    capture_haml do
+      haml_tag 'div', opts do
+        haml_tag '.background'
+        haml_tag '.text' do
+          haml_concat "Click here to start the interactive."
+        end
+      end
+    end
+  end
+
 end

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -35,11 +35,28 @@
 
 :javascript
   $(document).ready(function() {
-    $('##{dom_id_for(interactive, :click_to_play)}').click(function() {
-      $(this).css('display','none');
-      $(this).removeClass('shown')
+    var loadIframe = function(component) {
+      $(component).css('display','none');
+      $(component).removeClass('shown')
       $('##{dom_id_for(interactive, :interactive_image)}').css('display','none');
       $('#interactive_#{interactive.id}').attr('src','#{interactive.url}');
-      InteractiveManager.register($(this).parent('.interactive-container'))
+      InteractiveManager.register($(component).parent('.interactive-container'));
+    };
+    $('##{dom_id_for(interactive, :click_to_play)}').click(function() {
+      var component = this,
+          preflight_url = $('#interactive_#{interactive.id}').data('preflight_url');
+      if (preflight_url) {
+        // pop up a pre-flight window. When it closes itself, load the iframe.
+        var win = window.open(preflight_url, 'preflight_window', 'height=120,width=120,location=0,menubar=0,resizable=0,scrollbars=0,status=0,titlebar=0,toolbar=0');
+        win.blur(); // pop under the main window
+        var poller = setInterval(function() {
+          if (win.closed !== false) {
+            clearInterval(poller);
+            loadIframe(component);
+          }
+        }, 200);
+      } else {
+        loadIframe(component);
+      }
     })
   })

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -10,23 +10,12 @@
         See :-
         =link_to "#{interactive.url}","#{interactive.url}"
 
-  - if interactive.click_to_play
-    .click_to_play.shown{:id => dom_id_for(interactive, :click_to_play)}
-      .background
-      .text= "Click here to start the interactive."
+  = click_to_play_barrier(interactive)
+  = interactive_iframe_tag(interactive, @run, !interactive.click_to_play) do
 
-    = interactive_iframe_tag(interactive, @run,false) do
-
-      Your browser does not support inline frames, or is currently not configured to display inline frames.
-      Content can be viewed at the actual source page:
-      = link_to interactive.url, interactive.url
-
-  - else
-    = interactive_iframe_tag(interactive, @run) do
-
-      Your browser does not support inline frames, or is currently not configured to display inline frames.
-      Content can be viewed at the actual source page:
-      = link_to interactive.url, interactive.url
+    Your browser does not support inline frames, or is currently not configured to display inline frames.
+    Content can be viewed at the actual source page:
+    = link_to interactive.url, interactive.url
 
   - if interactive.save_state
     .below_interactive


### PR DESCRIPTION
Certain browsers (IE and Safari) won't load cookies for a third-party
domain within in iframe unless the user has been to that domain in a
normal browser window. Pre-flighting pops up a window with a specific
url under that domain which initializes cookies for that domain and then
closes itself. Once that is complete, the iframe can be loaded and
cookies will work as expected.

[#96215356]
[#92480624]
