### PR TITLE
Add feedback element for ITSI editor saves [#97298198]

### DIFF
--- a/app/assets/javascripts/components/itsi_authoring/alert.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/alert.js.coffee
@@ -1,0 +1,11 @@
+{div} = React.DOM
+
+modulejs.define 'components/itsi_authoring/alert',
+->
+  React.createClass
+
+    render: ->
+      if @props.alert
+        (div {className: "ia-alert-#{@props.alert.layout} ia-alert-#{@props.alert.type}"}, @props.alert.text)
+      else
+        (div {}, null)

--- a/app/assets/javascripts/components/itsi_authoring/drawing_response_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/drawing_response_editor.js.coffee
@@ -22,13 +22,13 @@ modulejs.define 'components/itsi_authoring/drawing_response_editor',
 
     # maps form names to @props.data keys
     dataMap:
-      'embeddable_image_question[bg_url]': 'bg_url'  # TODO: add bg_url to JSON export
+      'embeddable_image_question[bg_url]': 'bg_url'
 
     initialEditState: ->
       false
 
     render: ->
-      (SectionEditorElement {data: @props.data, title: 'Drawing Response', toHide: 'embeddable_image_question[is_hidden]', onEdit: @edit},
+      (SectionEditorElement {data: @props.data, title: 'Drawing Response', toHide: 'embeddable_image_question[is_hidden]', onEdit: @edit, alert: @props.alert},
         if @state.edit
           (SectionEditorForm {onSave: @save, onCancel: @cancel},
             (label {}, 'Background Image')

--- a/app/assets/javascripts/components/itsi_authoring/editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/editor.js.coffee
@@ -3,26 +3,50 @@
 modulejs.define 'components/itsi_authoring/editor',
 [
   'components/itsi_authoring/metadata_editor',
-  'components/itsi_authoring/section_editor'
+  'components/itsi_authoring/section_editor',
+  'components/itsi_authoring/alert',
 ],
 (
   MetadataEditorClass,
-  SectionEditorClass
+  SectionEditorClass,
+  AlertClass
 ) ->
 
   MetadataEditor = React.createFactory MetadataEditorClass
   SectionEditor = React.createFactory SectionEditorClass
+  Alert = React.createFactory AlertClass
 
   React.createClass
 
+    componentWillMount: ->
+      @alerts = []
+
+    getInitialState: ->
+      alert: null
+
+    _processAlertQueue: ->
+      if @alerts.length > 0
+        @setState alert: @alerts.shift()
+        setTimeout (=> @_processAlertQueue()), 1000
+      else
+        @setState alert: null
+
+    alert: (type, text, layout='bar') ->  # other layout option is 'pill'
+      @alerts.push
+        type: type
+        text: text
+        layout: layout
+      @_processAlertQueue() if @alerts.length is 1
+
     render: ->
       (div {className: 'ia-editor'},
-        (MetadataEditor {metadata: @props.metadata})
+        (Alert {alert: @state.alert}) if @state.alert
+        (MetadataEditor {metadata: @props.metadata, alert: @alert})
         (div {className: 'ia-editor-sections'},
           for section, i in @props.sections
             # ignore the 'Test page'
             if section.name isnt 'Test page'
               title = if name is 'Second Career STEM Question' then 'Concluding Career STEM Question' else section.name
-              (SectionEditor {section: section, title: title, key: i})
+              (SectionEditor {section: section, title: title, key: i, alert: @alert})
         )
       )

--- a/app/assets/javascripts/components/itsi_authoring/form_mixin.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/form_mixin.js.coffee
@@ -13,17 +13,20 @@ modulejs.define 'components/itsi_authoring/form_mixin', ->
   submitForm: ->
     formData = @state.changedData
     # Don't issue request if nothing has been updated.
-    return if $.isEmptyObject formData
+    if $.isEmptyObject formData
+      @props.alert 'warn', 'No changes to save'
+      return
     # Rails-specific approach to PUT requests.
     formData._method = 'PUT'
     $.ajax
       url: @updateUrl()
       data: formData
       type: 'POST',
-      success: ->
-        console.log 'component updated'
-      error: ->
-        console.log 'component update failed'
+      success: =>
+        @props.alert 'info', 'Saved'
+        @setState changedData: {}
+      error: =>
+        @props.alert 'error', 'Save Failed!'
 
   input: (props) ->
     props.onChange = @handleFormChange

--- a/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
@@ -63,7 +63,7 @@ modulejs.define 'components/itsi_authoring/model_editor',
       @edit()
 
     render: ->
-      (SectionEditorElement {data: @props.data, title: 'Model', toHide: 'mw_interactive[is_hidden]', onEdit: @switchToEditMode},
+      (SectionEditorElement {data: @props.data, title: 'Model', toHide: 'mw_interactive[is_hidden]', onEdit: @switchToEditMode, alert: @props.alert},
         if @state.edit
           (SectionEditorForm {onSave: @save, onCancel: @cancel},
             (label {}, 'Model')

--- a/app/assets/javascripts/components/itsi_authoring/open_response_question_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/open_response_question_editor.js.coffee
@@ -29,7 +29,7 @@ modulejs.define 'components/itsi_authoring/open_response_question_editor',
       (@props.data.prompt?.length or 0) is 0
 
     render: ->
-      (SectionEditorElement {data: @props.data, title: 'Open Response Question', toHide: 'embeddable_open_response[is_hidden]', onEdit: @edit},
+      (SectionEditorElement {data: @props.data, title: 'Open Response Question', toHide: 'embeddable_open_response[is_hidden]', onEdit: @edit, alert: @props.alert},
         if @state.edit
           (SectionEditorForm {onSave: @save, onCancel: @cancel},
             (label {}, 'Question prompt')

--- a/app/assets/javascripts/components/itsi_authoring/prediction_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/prediction_editor.js.coffee
@@ -68,7 +68,7 @@ modulejs.define 'components/itsi_authoring/prediction_editor',
       @edit()
 
     render: ->
-      (SectionEditorElement {data: @props.data, title: 'Sensor', toHide: 'mw_interactive[is_hidden]', onEdit: @switchToEditMode},
+      (SectionEditorElement {data: @props.data, title: 'Sensor', toHide: 'mw_interactive[is_hidden]', onEdit: @switchToEditMode, alert: @props.alert},
         if @state.edit
           (SectionEditorForm {onSave: @save, onCancel: @cancel},
             (label {}, 'Sensor')

--- a/app/assets/javascripts/components/itsi_authoring/section_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/section_editor.js.coffee
@@ -39,6 +39,10 @@ modulejs.define 'components/itsi_authoring/section_editor',
           _method: 'PUT'
           interactive_page:
             is_hidden: if selected then 0 else 1
+        success: =>
+          @props.alert 'info', 'Saved'
+        error: =>
+          @props.alert 'error', 'Save Failed!'
       @setState selected: selected
 
     getEditorForInteractiveElement: (element) ->
@@ -64,16 +68,16 @@ modulejs.define 'components/itsi_authoring/section_editor',
           (span {className: 'ia-section-editor-title'}, @props.title)
         )
         (div {className: 'ia-section-editor-elements', style: {display: if @state.selected then 'block' else 'none'}},
-          (TextEditor {data: @props.section})
+          (TextEditor {data: @props.section, alert: @props.alert})
           for interactive, i in @props.section.interactives
             editor = @getEditorForInteractiveElement interactive
             if editor
-              (editor {key: "interactive#{i}", data: interactive})
+              (editor {key: "interactive#{i}", data: interactive, alert: @props.alert})
 
           for embeddable, i in @props.section.embeddables
             editor = @getEditorForEmbeddedElement embeddable
             if editor
-              (editor {key: "embeddable#{i}", data: embeddable})
+              (editor {key: "embeddable#{i}", data: embeddable, alert: @props.alert})
         )
       )
 

--- a/app/assets/javascripts/components/itsi_authoring/section_editor_element.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/section_editor_element.js.coffee
@@ -18,6 +18,10 @@ modulejs.define 'components/itsi_authoring/section_editor_element',
         url: "#{@props.data.update_url}.json"
         type: 'POST'
         data: postData
+        success: =>
+          @props.alert 'info', 'Saved'
+        error: =>
+          @props.alert 'error', 'Save Failed!'
       @setState selected: selected
 
     edit: (e) ->

--- a/app/assets/javascripts/components/itsi_authoring/section_element_editor_mixin.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/section_element_editor_mixin.js.coffee
@@ -48,7 +48,9 @@ modulejs.define 'components/itsi_authoring/section_element_editor_mixin',
       defaultValues: defaultValues
 
     # Don't issue request if nothing has been updated.
-    return if $.isEmptyObject @state.changedValues
+    if $.isEmptyObject @state.changedValues
+      @props.alert 'warn', 'No changes to save'
+      return
 
     # Rails-specific approach to PUT requests.
     @state.changedValues._method = 'PUT'
@@ -56,10 +58,11 @@ modulejs.define 'components/itsi_authoring/section_element_editor_mixin',
       url: "#{@props.data.update_url}.json"
       data: @state.changedValues
       type: 'POST',
-      success: ->
-        console.log 'component updated'
-      error: ->
-        console.log 'component update failed'
+      success: =>
+        @props.alert 'info', 'Saved'
+        @setState changedValues: {}
+      error: =>
+        @props.alert 'error', 'Save Failed!'
 
   valueChanged: (key, value) ->
     @state.values[key] = value

--- a/app/assets/javascripts/components/itsi_authoring/sensor_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/sensor_editor.js.coffee
@@ -13,7 +13,7 @@ modulejs.define 'components/itsi_authoring/sensor_editor',
   React.createClass
 
     render: ->
-      (SectionEditorElement {data: @props.data, title: 'Sensor', toHide: 'mw_interactive[is_hidden]'},
+      (SectionEditorElement {data: @props.data, title: 'Sensor', toHide: 'mw_interactive[is_hidden]', alert: @props.alert},
         (div {className: 'ia-section-text'},
           (div {},
             (div {}, 'Data Collector')

--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -91,3 +91,32 @@
   }
 }
 
+.ia-alert-pill {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  padding: 5px;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  border-radius: 10px;
+  color: #fff;
+}
+.ia-alert-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 5px;
+  color: #fff;
+  text-align: center;
+}
+.ia-alert-info {
+  background-color: #228B22;
+}
+.ia-alert-warn {
+  background-color: darkorange;
+}
+.ia-alert-error {
+  background-color: #f00;
+}
+

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -75,24 +75,26 @@ class InteractivePagesController < ApplicationController
   def update
     authorize! :update, @page
     update_activity_changed_by
-    if request.xhr?
-      if @page.update_attributes(params[:interactive_page])
-        # *** respond with the new value ***
-        render :text => params[:interactive_page].values.first and return
-      else
-        # *** respond with the old value ***
-        render :text => @page[params[:interactive_page].keys.first] and return
-      end
-    end
     respond_to do |format|
-      format.html do
+      if request.xhr?
         if @page.update_attributes(params[:interactive_page])
-          @page.reload # In case it's the name we updated
-          flash[:notice] = "Page #{@page.name} was updated."
+          # *** respond with the new value ***
+          format.html { render :text => params[:interactive_page].values.first }
         else
-          flash[:warning] = "There was a problem updating Page #{@page.name}."
+          # *** respond with the old value ***
+          format.html { render :text => @page[params[:interactive_page].keys.first] }
         end
-        redirect_to edit_activity_page_path(@activity, @page) and return
+        format.json { render :json => @page.to_json }
+      else
+        format.html do
+          if @page.update_attributes(params[:interactive_page])
+            @page.reload # In case it's the name we updated
+            flash[:notice] = "Page #{@page.name} was updated."
+          else
+            flash[:warning] = "There was a problem updating Page #{@page.name}."
+          end
+          redirect_to edit_activity_page_path(@activity, @page) and return
+        end
       end
     end
   end


### PR DESCRIPTION
This also updates interactive_pages_controller.rb so that it returns properly formatted json on xhr json updates (otherwise the save of the page text shows that it fails with these new alerts).

If the default alert bar seems to intrusive there is also a 'pill' option available that can be used as the default.  It places a rounded "pill" in the top right corner instead of adding an entire bar at the top of the page.