### PR TITLE
Editing page looks like the ITSI editing page.  [#97209594]

### DIFF
--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -1,122 +1,161 @@
-.ia-editor {
-  margin: 20px;
-}
 
-.ia-save-btn {
-  font-size: 12px;
-  display: inline-block;
-  height: 16px;
-  color: white;
-  cursor: pointer;
-  padding: 2px 10px;
-  border-radius: 12px;
-  background: #f3951d;
-}
-
-.ia-metadata-editor {
-  .ia-label {
-    font-size: 16px;
-    font-weight: bold;
-    margin-bottom: 3px;
+#container.itsi-edit {
+  background-color: #fee9aa;
+  font-family: Arial, Helvetica, sans-serif;
+  #content {
+    background: #f3f2ed
   }
-  input, textarea {
-    margin-bottom: 10px;
-    width: 100%;
+
+  h1 {
+    margin-left: 0.5em;
   }
-  textarea {
-    height: 100px;
-  }
-}
-
-.ia-editor-sections {
-
-  margin-top: 20px;
-
-  .ia-section-editor {
-    margin: 10px 0;
-
-    .ia-section-editor-title {
-      font-weight: bold;
+  a {
+    color: #479492;
+    text-decoration: none;
+    &:visited {
+      color: #479492;
+      text-decoration: none;
     }
+    &:hover {
+      color: darkorange;
+    }
+  }
 
-    .ia-section-editor-elements {
-      margin: 10px 0 10px 30px;
+  p { margin-bottom: 1em; }
 
-      .ia-section-editor-element {
-        margin: 10px 0;
-        background-color: #eee;
-        padding: 5px 10px;
+  input, textarea {
+    border: 1px solid #a1d2d1;
+    padding: 0.3em 5px;
+    font-size: 13px;
+  }
 
-        .ia-section-editor-edit {
-          float: right;
-        }
 
-        .ia-section-editor-buttons {
-          margin: 5px 0;
 
-          a {
-            margin-left: 10px;
+  .ia-editor {
+    margin: 20px;
+    background: #f3f2ed
+  }
+
+  .ia-save-btn {
+    font-size: 12px;
+    display: inline-block;
+    height: 16px;
+    color: white;
+    cursor: pointer;
+    padding: 2px 10px;
+    border-radius: 12px;
+    background: #f3951d;
+  }
+
+  .ia-metadata-editor {
+    .ia-label {
+      font-size: 16px;
+      font-weight: bold;
+      margin-bottom: 3px;
+    }
+    input, textarea {
+      margin-bottom: 10px;
+      width: 100%;
+    }
+    textarea {
+      height: 100px;
+    }
+  }
+
+  .ia-editor-sections {
+
+    margin-top: 20px;
+
+    .ia-section-editor {
+      margin: 10px 0;
+      font-size: 14px;
+      padding-left: 30px;
+      .ia-section-editor-title {
+        font-weight: bold;
+      }
+
+      .ia-section-editor-elements {
+        margin: 10px 0 10px 30px;
+
+        .ia-section-editor-element {
+          margin: 5px;
+          padding: 5px;
+          padding-left: 30px;
+          background-color: #eee;
+          &:hover {
+            background-color: white;
           }
-        }
+          .ia-section-editor-edit {
+            float: right;
+          }
 
-        .ia-section-editor-form {
+          .ia-section-editor-buttons {
+            margin: 5px 0;
 
-        }
+            a {
+              margin-left: 10px;
+            }
+          }
 
-        .ia-section-text {
-          margin: 10px 0;
-        }
-        .ia-section-text-value {
-          min-height: 10px;
-          margin: 5px 0;
-        }
+          .ia-section-editor-form {
 
-        .ia-section-default-drawing-tool {
-          background: url('/assets/drawing_tool.png') no-repeat;
-          width: 767px;
-          height: 606px;
-        }
+          }
 
-        textarea, input[type=text] {
-          width: 90%;
-        }
+          .ia-section-text {
+            margin: 10px 0;
+          }
+          .ia-section-text-value {
+            min-height: 10px;
+            margin: 5px 0;
+            margin-right: 30px;
+          }
 
-        label {
-          display: block;
-          font-weight: bold;
-          margin: 10px 0 5px 0;
+          .ia-section-default-drawing-tool {
+            background: url('/assets/drawing_tool.png') no-repeat;
+            width: 767px;
+            height: 606px;
+          }
+
+          textarea, input[type=text] {
+            width: 90%;
+          }
+
+          label {
+            display: block;
+            font-weight: bold;
+            margin: 10px 0 5px 0;
+          }
         }
       }
     }
   }
-}
 
-.ia-alert-pill {
-  position: fixed;
-  top: 10px;
-  right: 10px;
-  padding: 5px;
-  -webkit-border-radius: 10px;
-  -moz-border-radius: 10px;
-  border-radius: 10px;
-  color: #fff;
+  .ia-alert-pill {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    padding: 5px;
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+    color: #fff;
+  }
+  .ia-alert-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 5px;
+    color: #fff;
+    text-align: center;
+  }
+  .ia-alert-info {
+    background-color: #228B22;
+  }
+  .ia-alert-warn {
+    background-color: darkorange;
+  }
+  .ia-alert-error {
+    background-color: #f00;
+  }
 }
-.ia-alert-bar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  padding: 5px;
-  color: #fff;
-  text-align: center;
-}
-.ia-alert-info {
-  background-color: #228B22;
-}
-.ia-alert-warn {
-  background-color: darkorange;
-}
-.ia-alert-error {
-  background-color: #f00;
-}
-

--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -5,7 +5,11 @@
   #content {
     background: #f3f2ed
   }
-
+  #session {
+    box-sizing: border-box;
+    padding: 0.5em 1em 0.5em 0.25em;
+    width: 100%
+  }
   h1 {
     margin-left: 0.5em;
   }
@@ -18,6 +22,16 @@
     }
     &:hover {
       color: darkorange;
+    }
+    &.btn {
+      font-size: 12px;
+      display: inline-block;
+      height: 16px;
+      color: white;
+      cursor: pointer;
+      padding: 2px 10px;
+      border-radius: 12px;
+      background: #f3951d;
     }
   }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 <%- else -%>
   <body class="right <%= request.original_fullpath.split('/').join(' ') %>">
 <%- end -%>
-<div id="container">
+<div id="container" class="<%= content_for :container_css_classes %>">
   <div id="header">
     <div>
       <%= link_to image_tag("mw-logo.png", :alt => "Molecular Workbench", :id => 'mw-logo'), 'http://mw.concord.org/nextgen', :title => 'Molecular Workbench' %>

--- a/app/views/lightweight_activities/itsi_edit.html.haml
+++ b/app/views/lightweight_activities/itsi_edit.html.haml
@@ -3,6 +3,7 @@
     = render :partial => 'shared/session'
 = content_for :title do
   = "Edit #{@activity.name}"
+= content_for :container_css_classes, 'itsi-edit'
 = content_for :nav do
   .breadcrumbs
     %ul


### PR DESCRIPTION
Small CSS changes to make ITSI editing look like it does in the portal.
https://www.pivotaltracker.com/story/show/97209594

The main change is conditionally adding a the `itsi-edit` css class to the top level `#container` -- and adding several styles matching the `#container.itsi-edit >` selector so that the form matches `template_edit` in the portal. eg: http://itsi-aws.staging.concord.org/activities/3275/template_edit
