### PR TITLE
Replaced answer#question_index with template loop variable

### DIFF
--- a/app/views/c_rater/argumentation_block/_runtime.html.haml
+++ b/app/views/c_rater/argumentation_block/_runtime.html.haml
@@ -27,7 +27,7 @@
 
     - embeddables.each_with_index do |m,index|
       .question
-        = render :partial => "#{m.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => m}
+        = render :partial => "#{m.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => m, :question_index => index + 1}
         - fb = m.get_saved_feedback
         - fb_visible = fb && !fb.feedback_text.blank?
         - fb_dirty = fb && fb.outdated?
@@ -65,7 +65,7 @@
           %tr
             %td
               .ab-robot-figure{:id => 'ab-robot-image'}
-            %td         
+            %td
               %div
                 = t('ARG_BLOCK.FEEDBACK_ON_FEEDBACK')
                 - CRater::FeedbackSubmission.usefulness_score_names.each do |value, label|
@@ -77,7 +77,7 @@
            :value => submission_count > 0 ? t('ARG_BLOCK.RESUBMIT') : t('ARG_BLOCK.SUBMIT'),
            'data-href' => c_rater_arg_block_save_feedback_path(page),
            'data-page_id' => page.id}
-    %div.ab-submit-prompt       
+    %div.ab-submit-prompt
 
 :javascript
   $(function() {
@@ -115,14 +115,14 @@
     border: 1px solid #eee;
     padding: 12px 22px;
   }
-  
+
   .ab-robot-wrap {
     margin:0 auto;
     td {
       padding: 0 10px;
       vertical-align: middle;
     }
-    
+
     .ab-robot-figure {
       width: 85px;
       height: 109px;
@@ -137,11 +137,11 @@
     border: 1px solid #eee;
     border-radius: 10px;
     padding: 5px 5px 5px 5px;
-    
+
     .ab-feedback-text {
-      
+
       margin:10px 0 0 0;
-      
+
       table {
         td {
           padding: 0 10px;
@@ -179,7 +179,7 @@
       background: rgba(255, 0, 0, 0.2);
     }
   }
-  
+
   .ab-openresponseanswer-1, .ab-openresponseanswer-3{
     .ab-robot-scale{
       background-repeat: no-repeat;
@@ -192,7 +192,7 @@
       width: 330px;
     }
   }
- 
+
   .ab-score-error {
     .ab-openresponseanswer-1 {
       .ab-robot-scale {

--- a/app/views/embeddable/image_question_answers/_lightweight.html.haml
+++ b/app/views/embeddable/image_question_answers/_lightweight.html.haml
@@ -1,2 +1,2 @@
 - partial_name = ENV["CONCORD_DRAWING_TOOL"] == 'drawing-tool'  ? "lightweight_drawing_tool" : "lightweight_svg_edit"
-= render :partial => "embeddable/image_question_answers/#{partial_name}", :locals => { :embeddable => embeddable }
+= render :partial => "embeddable/image_question_answers/#{partial_name}", :locals => { :embeddable => embeddable, :question_index => question_index }

--- a/app/views/embeddable/image_question_answers/_lightweight_drawing_tool.html.haml
+++ b/app/views/embeddable/image_question_answers/_lightweight_drawing_tool.html.haml
@@ -1,5 +1,5 @@
 .question-hdr
-  %h5.h5= "#{t("QUESTION")} ##{embeddable.question_index}"
+  %h5.h5= "#{t("QUESTION")} ##{question_index}"
 .question-bd
   .question-txt
     != embeddable.drawing_prompt

--- a/app/views/embeddable/image_question_answers/_lightweight_svg_edit.html.haml
+++ b/app/views/embeddable/image_question_answers/_lightweight_svg_edit.html.haml
@@ -1,5 +1,5 @@
 .question-hdr
-  %h5.h5= "#{t("QUESTION")} ##{embeddable.question_index}"
+  %h5.h5= "#{t("QUESTION")} ##{question_index}"
 .question-bd
   .question-txt
     != embeddable.drawing_prompt

--- a/app/views/embeddable/labbook_answers/_lightweight.html.haml
+++ b/app/views/embeddable/labbook_answers/_lightweight.html.haml
@@ -1,6 +1,6 @@
 - embeddable_dom_id = "#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"
 .question-hdr
-  %h5.h5= "#{t('LABBOOK_ALBUM')} ##{embeddable.question_index}"
+  %h5.h5= "#{t('LABBOOK_ALBUM')} ##{question_index}"
 .question-bd.labbook{id: embeddable_dom_id,
                     'data-labbook-url' => embeddable.class.labbook_provider,
                     'data-lara-update-url' => embeddable_labbook_answer_path(embeddable),

--- a/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
+++ b/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
@@ -1,7 +1,7 @@
 - embeddable_string = "#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"
 - check_button_string = "check_button_#{embeddable_string}"
 .question-hdr
-  %h5.h5= "#{t("QUESTION")} ##{embeddable.question_index}"
+  %h5.h5= "#{t("QUESTION")} ##{question_index}"
 .question-bd{ :id => embeddable_string }
   .question-txt
     != embeddable.prompt

--- a/app/views/embeddable/open_response_answers/_lightweight.html.haml
+++ b/app/views/embeddable/open_response_answers/_lightweight.html.haml
@@ -1,6 +1,6 @@
 - embeddable_string = "#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"
 .question-hdr
-  %h5.h5= "#{t("QUESTION")} ##{embeddable.question_index}"
+  %h5.h5= "#{t("QUESTION")} ##{question_index}"
 .question-bd{ :id => embeddable_string }
   .question-txt
     != embeddable.prompt

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -1,6 +1,6 @@
 .embeddables
   - unless embeddables.blank?
-    - embeddables.each do |e|
+    - embeddables.each_with_index do |e, index|
       - is_likert = e.kind_of?(Embeddable::MultipleChoiceAnswer) && e.is_likert
       .question{ :class => e.kind_of?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : "" }
-        = render :partial => "#{e.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => e}
+        = render :partial => "#{e.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => e, :question_index => index + 1}


### PR DESCRIPTION
This fixes the missing question numbers in single page activities.  I tracked this reversion down to this commit inside of Piotr's hide page PR:

https://github.com/concord-consortium/lara/commit/e81b63a2c2a549b1a6138e79cae30f260b055098

Before this commit the question numbers show, after it they are blank.

Each of the lightweight embedded partials use the answer#question_index method to find its 1-based index in the list of questions for the page.  With the above commit the answer.question was no longer being found in the list of activity.questions so it was returning nil which rendered as an empty string in the template.  After looking at the code and reading the "DANGER TODO" comment (see below) above the method I saw that the method call could be replaced by a simple template loop variable in the partials.  I thought this would be the safest way to fix the problem.

    # DANGER TODO:  This memoization isn't going to work
    # the way the author intended, because that instance var is going
    # to be shared by every class that includes this module.
    @question_index = nil
    def question_index(skip_cache=false)

NOTE: This fixes the question number issue but I'm concerned there may be other problems, for instance in reporting, related to the anwer.question not being the the list of activity.questions.  I left the anwer#question_index code in so that we could add a failing test for it and track down a fix in a separate PR.