### PR TITLE
Associate a Labbook with an Interactive. 

### DIFF
--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -79,7 +79,7 @@ class LightweightActivitiesController < ApplicationController
     if !params[:response_key]
       redirect_to summary_with_response_path(@activity, @session_key) and return
     end
-    @answers = @activity.answers(@run).select { |a| a.show_in_report }
+    @answers = @activity.answers(@run).select { |a| a.show_in_report? }
   end
 
   # The remaining actions are all authoring actions.

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -41,5 +41,8 @@ module Embeddable
       "#{interactive_pages.first.lightweight_activity.id}_#{interactive_pages.first.id}_#{id}_#{self.class.to_s.underscore.gsub(/\//, '_')}"
     end
   end
-
+  
+  def show_in_runtime?
+    true
+  end
 end

--- a/app/models/embeddable/answer.rb
+++ b/app/models/embeddable/answer.rb
@@ -90,7 +90,11 @@ module Embeddable::Answer
     update_column(:is_dirty, false)
   end
 
-  def show_in_report
+  def show_in_report?
+    true
+  end
+
+  def show_in_runtime?
     true
   end
 

--- a/app/models/embeddable/answer.rb
+++ b/app/models/embeddable/answer.rb
@@ -9,6 +9,8 @@ module Embeddable::Answer
       delegate :is_prediction,            :to => :question
       delegate :give_prediction_feedback, :to => :question
       delegate :prediction_feedback,      :to => :question
+      delegate :show_in_runtime?,         :to => :question
+
       def self.by_run(r)
         where(:run_id => r.id)
       end
@@ -93,10 +95,5 @@ module Embeddable::Answer
   def show_in_report?
     true
   end
-
-  def show_in_runtime?
-    true
-  end
-
 
 end

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -11,10 +11,12 @@ module Embeddable
       ['Snapshot', SNAPSHOT_ACTION]
     ]
 
-    attr_accessible :action_type, :name, :prompt, :custom_action_label, :is_hidden
+    attr_accessible :action_type, :name, :prompt, :custom_action_label, :is_hidden, :interactive_type, :interactive_id, :interactive
 
     has_many :page_items, :as => :embeddable, :dependent => :destroy
     has_many :interactive_pages, :through => :page_items
+
+    belongs_to :interactive, :polymorphic => true
 
     # "Answer" isn't the best word probably, but it fits the rest of names and convention.
     # LabbookAnswer is an instance related to particular activity run and user.
@@ -89,7 +91,7 @@ module Embeddable
       action_type == SNAPSHOT_ACTION
     end
 
-    def interactive
+    def find_interactive
       # Return first interactive available on the page (note that in practice it's impossible that this model has more
       # than one page, even though it's many-to-many association).
       # In the future we can let authors explicitly select which interactive Labbook album is connected to.
@@ -106,5 +108,14 @@ module Embeddable
           I18n.t('TAKE_SNAPSHOT')
       end
     end
+
+    def is_connected?
+      !interactive.nil?
+    end
+
+    def show_in_runtime?
+      is_connected?
+    end
+
   end
 end

--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -5,6 +5,7 @@ class ImageInteractive < ActiveRecord::Base
   # InteractiveItem is a join model; if this is deleted, that instance should go too
 
   has_one :interactive_page, :through => :interactive_item
+  has_one :labbook, :as => :interactive
 
   def self.string_name
     "image interactive"

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -67,7 +67,7 @@ class InteractiveRunState < ActiveRecord::Base
     arg ? original_json(arg) : answer_json
   end
 
-  def show_in_report
+  def show_in_report?
     interactive.respond_to?('save_state') && interactive.save_state && interactive.respond_to?('has_report_url') && interactive.has_report_url
   end
 
@@ -84,7 +84,7 @@ class InteractiveRunState < ActiveRecord::Base
     def prompt
       question.prompt
     end
-    def show_in_report
+    def show_in_report?
       false
     end
   end

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -14,6 +14,8 @@ class MwInteractive < ActiveRecord::Base
   has_one :interactive_page, :through => :interactive_item
   has_many :interactive_run_states, :as => :interactive
 
+  has_one :labbook, :as => :interactive
+
   def self.string_name
     "iframe interactive"
   end

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -6,6 +6,8 @@ class VideoInteractive < ActiveRecord::Base
            :foreign_key => 'video_interactive_id',
            :dependent => :destroy # If we delete this video we should dump its sources
 
+  has_one :labbook, :as => :interactive
+
   attr_accessible :poster_url, :caption, :credit, :height, :width, :sources_attributes, :is_hidden
 
   accepts_nested_attributes_for :sources, :allow_destroy => true

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -1,6 +1,9 @@
 .embeddables
   - unless embeddables.blank?
     - embeddables.each do |e|
-      - is_likert = e.kind_of?(Embeddable::MultipleChoiceAnswer) && e.is_likert
-      .question{ :class => e.kind_of?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : "" }
-        = render :partial => "#{e.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => e}
+      - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
+      - css_class = e.is_a?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : ""
+      - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
+      - if e.show_in_runtime?
+        .question{ class: css_class }
+          = render(partial: partial_name, locals: { embeddable: e })

--- a/db/migrate/20150624175249_add_interactive_to_labbook.rb
+++ b/db/migrate/20150624175249_add_interactive_to_labbook.rb
@@ -1,0 +1,16 @@
+class AddInteractiveToLabbook < ActiveRecord::Migration
+  def up
+     change_table :embeddable_labbooks do |t|
+       t.references :interactive, :polymorphic => true
+     end
+     add_index :embeddable_labbooks, :interactive_id,   name: "labbook_interactive_i_idx"
+     add_index :embeddable_labbooks, :interactive_type, name: "labbook_interactive_t_idx"
+   end
+
+  def down
+     change_table :embeddable_labbooks do |t|
+       t.remove_references :interactive, :polymorphic => true, index: true
+     end
+     # column indexes are removed when columns are removed.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150623154510) do
+ActiveRecord::Schema.define(:version => 20150624175249) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -172,7 +172,12 @@ ActiveRecord::Schema.define(:version => 20150623154510) do
     t.text     "prompt"
     t.string   "custom_action_label"
     t.boolean  "is_hidden",           :default => false
+    t.integer  "interactive_id"
+    t.string   "interactive_type"
   end
+
+  add_index "embeddable_labbooks", ["interactive_id"], :name => "labbook_interactive_i_idx"
+  add_index "embeddable_labbooks", ["interactive_type"], :name => "labbook_interactive_t_idx"
 
   create_table "embeddable_multiple_choice_answers", :force => true do |t|
     t.integer  "run_id"

--- a/spec/models/embeddable/labbook_answer_spec.rb
+++ b/spec/models/embeddable/labbook_answer_spec.rb
@@ -5,7 +5,7 @@ describe Embeddable::LabbookAnswer do
 
   let(:labbook) { Embeddable::Labbook.create }
   let(:run) { Run.new }
-  let(:labbok_answer) { Embeddable::LabbookAnswer.create(question: labbook, run: run) }
+  let(:labbook_answer) { Embeddable::LabbookAnswer.create(question: labbook, run: run) }
 
   describe '#portal_hash' do
     let(:expected_hash) do
@@ -13,13 +13,13 @@ describe Embeddable::LabbookAnswer do
         type:          'external_link',
         question_type: 'iframe interactive',
         question_id:   labbook.portal_id,
-        answer:        labbok_answer.report_url,
+        answer:        labbook_answer.report_url,
         is_final:      false
       }
     end
 
     it 'matches the expected hash' do
-      expect(labbok_answer.portal_hash).to eq(expected_hash)
+      expect(labbook_answer.portal_hash).to eq(expected_hash)
     end
   end
 
@@ -30,29 +30,29 @@ describe Embeddable::LabbookAnswer do
     before(:each) do
       stub_request(:post, labbook_replace_url).
          with(body: {dst_source: Embeddable::LabbookAnswer::SOURCE_ID,
-                     dst_user_id: labbok_answer.labbook_user_id,
+                     dst_user_id: labbook_answer.labbook_user_id,
                      src_source: Embeddable::LabbookAnswer::SOURCE_ID,
                      src_user_id: another_answer.labbook_user_id}).
          to_return(:status => 200, :body => "", :headers => {})
     end
 
     it 'should fire off a web request to replace album snapshots' do
-      labbok_answer.copy_answer!(another_answer)
+      labbook_answer.copy_answer!(another_answer)
       expect(a_request(:post, labbook_replace_url)).to have_been_made.once
     end
   end
 
   describe '#show_in_runtime?' do
-    describe 'with a disabled labbok' do
+    describe 'with a disabled labbook' do
       let(:labbook) { stub_model(Embeddable::Labbook, show_in_runtime?: false) }
       it "should return false" do
-        expect(labbok_answer.show_in_runtime?).to eql(false)
+        expect(labbook_answer.show_in_runtime?).to eql(false)
       end
     end
-    describe 'with an enabled labbok' do
+    describe 'with an enabled labbook' do
       let(:labbook) { stub_model(Embeddable::Labbook, show_in_runtime?: true) }
       it "should return false" do
-        expect(labbok_answer.show_in_runtime?).to eql(true)
+        expect(labbook_answer.show_in_runtime?).to eql(true)
       end
     end
   end

--- a/spec/models/embeddable/labbook_answer_spec.rb
+++ b/spec/models/embeddable/labbook_answer_spec.rb
@@ -41,4 +41,19 @@ describe Embeddable::LabbookAnswer do
       expect(a_request(:post, labbook_replace_url)).to have_been_made.once
     end
   end
+
+  describe '#show_in_runtime?' do
+    describe 'with a disabled labbok' do
+      let(:labbook) { stub_model(Embeddable::Labbook, show_in_runtime?: false) }
+      it "should return false" do
+        expect(labbok_answer.show_in_runtime?).to eql(false)
+      end
+    end
+    describe 'with an enabled labbok' do
+      let(:labbook) { stub_model(Embeddable::Labbook, show_in_runtime?: true) }
+      it "should return false" do
+        expect(labbok_answer.show_in_runtime?).to eql(true)
+      end
+    end
+  end
 end

--- a/spec/models/embeddable/labbook_spec.rb
+++ b/spec/models/embeddable/labbook_spec.rb
@@ -39,4 +39,34 @@ describe Embeddable::Labbook do
       end
     end
   end
+  describe 'its interactive' do
+    let(:args)    { {} }
+    let(:labbook) { Embeddable::Labbook.new args }
+    describe 'when it is not associated with an interactive' do
+      it 'should have no interactive' do
+        expect(labbook.interactive).to eql(nil)
+      end
+      it 'should be marked as disconnected' do
+        expect(labbook.is_connected?).to eql(false)
+      end
+
+      it 'it should not show up in the runtime' do
+        expect(labbook.show_in_runtime?).to eql(false)
+      end
+    end
+    describe 'when it has an interactive' do
+      let(:interactive) { MwInteractive.new  }
+      let(:args) { {interactive: interactive}}
+      it 'should have an interactive' do
+        expect(labbook.interactive).to eql(interactive)
+      end
+      it 'should be marked as connected' do
+        expect(labbook.is_connected?).to eql(true)
+      end
+
+      it 'it should show up in the runtime' do
+        expect(labbook.show_in_runtime?).to eql(true)
+      end
+    end
+  end
 end

--- a/spec/views/embeddable/labbook_answers/_lightweight.html.haml_spec.rb
+++ b/spec/views/embeddable/labbook_answers/_lightweight.html.haml_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe "rendering labbook answer partial" do
+  def data_attribute(name,value)
+    "[data-#{name}='#{value}']"
+  end
+
+  let(:run)             { Run.new }
+  let(:interactive_id)  { 7 }
+  let(:interactive)     { stub_model(ImageInteractive, id: 7 ) }
+  let(:labbook)         { stub_model(Embeddable::Labbook, interactive: interactive) }
+  let(:labbook_answer)  { Embeddable::LabbookAnswer.create(question: labbook, run: run) }
+
+  it "displays the partial for a labbook" do
+    render :partial => "embeddable/labbook_answers/lightweight.html.haml", :locals => {embeddable: labbook_answer}
+    expect(rendered).to have_css('.question-bd.labbook')
+  end
+
+  it "includes data-binding attributes" do
+    render :partial => "embeddable/labbook_answers/lightweight.html.haml", :locals => {embeddable: labbook_answer}
+    expected_css = data_attribute('interactive-id', interactive_id)
+    expect(rendered).to have_css(expected_css)
+  end
+end

--- a/spec/views/interactive_pages/_list_embeddables.html.haml_spec.rb
+++ b/spec/views/interactive_pages/_list_embeddables.html.haml_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+
+describe "interactive_pages/_list_embeddables.html.haml" do
+  let(:run)             { Run.new }
+  let(:interactive_id)  { 7 }
+  let(:interactive)     { stub_model(ImageInteractive, id: 7 ) }
+  let(:labbook)         { stub_model(Embeddable::Labbook) }
+  let(:labbook_answer)  { Embeddable::LabbookAnswer.create(question: labbook, run: run) }
+  let(:embeddables)     { [labbook_answer] }
+
+  describe "Displaying labbook answers" do
+    describe "when the labbook doesn't have an interactive" do
+      it "should not be shown" do
+        expect(rendered).not_to have_css('.question-bd.labbook')
+      end
+    end
+    describe "when the labbook has an interactive" do
+      let(:labbook)         { stub_model(Embeddable::Labbook, interactive: interactive) }
+      it "should show the labbook answer" do
+        render :partial => "interactive_pages/list_embeddables.html.haml", :locals => {embeddables: embeddables}
+        expect(rendered).to have_css('.question-bd.labbook')
+      end
+    end
+  end
+end
+
+
+# /Users/npaessel/lab/cc/lara/app/views/interactive_pages/_list_embeddables.html.haml


### PR DESCRIPTION
For the first part of this story:  https://www.pivotaltracker.com/story/show/97734786

Next step is:
> In standard mode authoring show the user which interactive a LabBook is associated with.

@dougmartin if you get a chance.