### PR TITLE
Remove its-dev editor links [#97499816]

### DIFF
--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -6,7 +6,7 @@ class LightweightActivitiesController < ApplicationController
   before_filter :set_activity, :except => [:index, :new, :create]
   before_filter :set_run_key,  :only   => [:summary, :show, :preview, :resubmit_answers, :single_page]
   before_filter :set_sequence, :only   => [:summary, :show, :single_page]
-  
+
   before_filter :enable_js_logger, :only => [:summary, :show, :preview, :single_page]
 
   layout :set_layout
@@ -110,12 +110,11 @@ class LightweightActivitiesController < ApplicationController
     if params[:mode] && current_user.admin?
       @editor_mode = case params[:mode]
                        when "itsi" then LightweightActivity::ITSI_EDITOR_MODE
-                       when "itsi-dev" then LightweightActivity::ITSI_WIP_EDITOR_MODE
                        else LightweightActivity::STANDARD_EDITOR_MODE
                      end
     end
 
-    if @editor_mode == LightweightActivity::ITSI_WIP_EDITOR_MODE
+    if @editor_mode == LightweightActivity::ITSI_EDITOR_MODE
       # Data assigned to `gon` variable will be available for JavaScript code in `window.gon` object.
       gon.ITSIEditor = ITSIAuthoring::Editor.new(@activity).to_json
       render :itsi_edit
@@ -170,7 +169,7 @@ class LightweightActivitiesController < ApplicationController
       redirect_to activities_path
     end
   end
-  
+
   def show_status
     @message = params[:message] || ''
     respond_to do |format|
@@ -178,13 +177,13 @@ class LightweightActivitiesController < ApplicationController
       format.html
     end
   end
-  
+
   def export
     authorize! :export, @activity
     lightweight_activity_json = @activity.export.to_json
     send_data lightweight_activity_json, type: :json, disposition: "attachment", filename: "#{@activity.name}_version_1.json"
   end
-  
+
   def move_up
     authorize! :update, @activity
     @page = @activity.pages.find(params[:id])

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -10,11 +10,9 @@ class LightweightActivity < ActiveRecord::Base
   ]
   STANDARD_EDITOR_MODE = 0
   ITSI_EDITOR_MODE = 1
-  ITSI_WIP_EDITOR_MODE = 2 # this is just for development of the React edit template - it will be removed once that work is done
   EDITOR_MODE_OPTIONS = [
     ['Standard', STANDARD_EDITOR_MODE],
-    ['ITSI', ITSI_EDITOR_MODE],
-    ['ITSI (Development)', ITSI_WIP_EDITOR_MODE]
+    ['ITSI', ITSI_EDITOR_MODE]
   ]
 
   attr_accessible :name, :user_id, :pages, :related, :description,

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -40,10 +40,6 @@
   %h1.title
     = @activity.name
 
-  - if @editor_mode == LightweightActivity::ITSI_EDITOR_MODE
-    %div{ :style => "font-weight: bold; margin: 10px 0; background-color: #cff204; padding: 10px;" }
-      This page will use the ITSI editor mode once it is completed.
-
   %h2.question
     = editable_field @page, :name, {:use_trigger => true, :edit_string => 'Edit', :submit => 'Save', :cancel => 'Cancel', :onblur => 'ignore', :placeholder => 'page title'}
     %span.preview

--- a/app/views/lightweight_activities/_edit_header.html.haml
+++ b/app/views/lightweight_activities/_edit_header.html.haml
@@ -4,11 +4,9 @@
     = link_to "Preview", preview_activity_path(@activity), :target => 'new'
   - if current_user.is_admin
     %span.preview
-      = link_to "Mode: Standard", "#{edit_activity_path(@activity)}?mode=standard"
+      = link_to "Edit in Standard Mode", "#{edit_activity_path(@activity)}?mode=standard"
     %span.preview
-      = link_to "Mode: ITSI", "#{edit_activity_path(@activity)}?mode=itsi"
-    %span.preview
-      = link_to "Mode: ITSI (Development)", "#{edit_activity_path(@activity)}?mode=itsi-dev"
+      = link_to "Edit in ITSI Mode", "#{edit_activity_path(@activity)}?mode=itsi"
 
 = render :partial => "publications/publication_details", :locals =>{ :publication => @activity}
 - if @activity.active_runs > 0


### PR DESCRIPTION
NOTE: Once this is live the existing itsi-dev marked activities with edit as standard mode.  You'll need to set the edit mode to ITSI.  Since this was internal I didn't think a migration was needed.