### PR TITLE
Add after_update observable to publishable models [#98300886]

### DIFF
--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -66,4 +66,16 @@ module Publishable
       self.republish_for_portal(portal,self_url)
     end
   end
+
+  ## auto publishing methods
+
+  def self.included(clazz)
+    clazz.class_eval do
+      after_update :auto_publish_to_portal
+    end
+  end
+
+  def auto_publish_to_portal
+    logger.debug "TODO: Autopublish #{self}"
+  end
 end


### PR DESCRIPTION
This turned out to be very simple.  The model associations for the page and page_items child and grandchildren objects trigger the after_update callback in the lightweight activity for any updates to its contained models.  The "trigger a stubbed something" mentioned in the PT story just outputs a log line.  This will be fleshed out when the auto publishing queuing story is completed.