### PR TITLE
Added portal publication status checker [#98301304]

### DIFF
--- a/app/assets/javascripts/components/itsi_authoring/editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/editor.js.coffee
@@ -5,16 +5,19 @@ modulejs.define 'components/itsi_authoring/editor',
   'components/itsi_authoring/metadata_editor',
   'components/itsi_authoring/section_editor',
   'components/itsi_authoring/alert',
+  'components/itsi_authoring/publication_details',
 ],
 (
   MetadataEditorClass,
   SectionEditorClass,
-  AlertClass
+  AlertClass,
+  PublicationDetailsClass
 ) ->
 
   MetadataEditor = React.createFactory MetadataEditorClass
   SectionEditor = React.createFactory SectionEditorClass
   Alert = React.createFactory AlertClass
+  PublicationDetails = React.createFactory PublicationDetailsClass
 
   React.createClass
 
@@ -48,6 +51,7 @@ modulejs.define 'components/itsi_authoring/editor',
     render: ->
       (div {className: 'ia-editor'},
         (Alert {alert: @state.alert}) if @state.alert
+        (PublicationDetails {publicationDetails: @props.publication_details})
         (MetadataEditor {metadata: @props.metadata, alert: @alert})
         (div {className: 'ia-editor-sections'},
           for section, i in @props.sections

--- a/app/assets/javascripts/components/itsi_authoring/publication_details.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/publication_details.js.coffee
@@ -1,0 +1,55 @@
+{div, ul, li, span, a} = React.DOM
+
+POLL_INTERVAL = 5000
+
+modulejs.define 'components/itsi_authoring/publication_details',
+->
+  React.createClass
+
+    getInitialState: ->
+      last_publication_hash: @props.publicationDetails.last_publication_hash
+      latest_publication_portals: @props.publicationDetails.latest_publication_portals
+      polling: false
+
+    componentDidMount: ->
+      @poller = setInterval @pollForChanges, 5000
+
+    componentWillUnmount: ->
+      clearInterval @poller
+
+    pollForChanges: ->
+      $.ajax
+        url: @props.publicationDetails.poll_url
+        type: 'GET',
+        success: (data) =>
+          if data
+            @setState
+              last_publication_hash: data.last_publication_hash
+              latest_publication_portals: data.latest_publication_portals
+
+    render: ->
+      numPortals = @state.latest_publication_portals.length
+      plural = if numPortals > 1 then 's' else ''
+
+      (div {className: 'publication_details'},
+        (div {className: 'summary'},
+          if numPortals > 0
+            "This item has been published to #{numPortals} portal#{plural}. Any changes will automatically be published to the portal#{plural} below."
+          else
+            "This item is not published to any of the portals. Click on the publish button to publish this item."
+        )
+        (ul {className: 'details', style: {marginTop: 10}},
+          for portal in @state.latest_publication_portals
+            debugTitle = "Activity: #{@state.last_publication_hash} => Portal: #{portal.publication_hash}"
+            (li {className: 'detail', key: portal.url},
+              (span {className: 'detail'}, portal.domain)
+              (span {className: 'detail'}, " : (#{portal.count} time#{if portal.count is 1 then '' else 's'}) - ")
+              (span {className: 'detail'}, portal.date)
+              if portal.success
+                (span {className: 'message success-message', title: debugTitle}, if @state.last_publication_hash is portal.publication_hash then 'published' else 'publishing')
+              else
+                (span {className: 'message error-message', title: debugTitle}, 'not published!')
+            )
+        )
+        (a {href: @props.publicationDetails.publish_url, className: 'btn btn-primary', 'data-remote': true}, 'Manually Publish')
+      )

--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -43,7 +43,22 @@
     font-size: 13px;
   }
 
-
+  .publication_details {
+    span.message {
+      color: #fff;
+      padding: 2px 5px;
+      margin-left: 10px;
+      -webkit-border-radius: 5px;
+      -moz-border-radius: 5px;
+      border-radius: 5px;
+    }
+    span.success-message {
+      background-color: #18a73b;
+    }
+    span.error-message {
+      background-color: #f00;
+    }
+  }
 
   .ia-editor {
     margin: 20px;

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -38,13 +38,21 @@ class PublicationsController < ApplicationController
       @portal.url
     end
   end
-  
+
   def show_status
     @message = params[:message] || ''
     respond_to do |format|
       format.js { render :json => { :html => render_to_string('show_status')}, :content_type => 'text/json' }
       format.html
     end
+  end
+
+  def autopublishing_status
+    status = {
+      :last_publication_hash => @publishable.publication_hash,
+      :latest_publication_portals => @publishable.latest_publication_portals
+    }
+    render :json => status, :content_type => 'text/json'
   end
 
   def remove_portal

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -18,7 +18,7 @@ class LightweightActivity < ActiveRecord::Base
 
   attr_accessible :name, :user_id, :pages, :related, :description,
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :theme_id, :project_id,
-                  :portal_run_count, :layout, :editor_mode
+                  :portal_run_count, :layout, :editor_mode, :publication_hash
 
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'

--- a/app/models/portal_publication.rb
+++ b/app/models/portal_publication.rb
@@ -1,5 +1,6 @@
 class PortalPublication < ActiveRecord::Base
-  attr_accessible :portal_url, :response, :success, :publishable
+
+  attr_accessible :portal_url, :response, :success, :publishable, :publication_hash
   # Assuming portals aren't a first-class model - representing them by their URLs
 
   # What got published - usually one of these, not both
@@ -8,4 +9,5 @@ class PortalPublication < ActiveRecord::Base
   def portal_domain
     URI.parse(self.portal_url).host
   end
+
 end

--- a/app/models/publication_status.rb
+++ b/app/models/publication_status.rb
@@ -20,8 +20,6 @@ module PublicationStatus
       scope :official,  where(:is_official => true)
       scope :community, where(:is_official => false)
 
-      has_many :portal_publications, :as => :publishable, :order => :updated_at
-
       # * Find all activities for one user (regardless of publication status)
       def self.my(user)
         where(:user_id => user.id)

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -103,7 +103,6 @@ module Publishable
   end
 
   def auto_publish_to_portal
-    hash =
     logger.debug "TODO: Autopublish #{self}"
   end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,6 +1,6 @@
 class Sequence < ActiveRecord::Base
   attr_accessible :description, :title, :theme_id, :project_id,
-    :user_id, :logo, :display_title, :thumbnail_url, :abstract
+    :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash
   include Publishable # defines methods to publish to portals
   include PublicationStatus # defines publication status scopes and helpers
   has_many :lightweight_activities_sequences, :order => :position, :dependent => :destroy

--- a/app/services/itsi_authoring/editor.rb
+++ b/app/services/itsi_authoring/editor.rb
@@ -9,7 +9,13 @@ class ITSIAuthoring::Editor
     {
       metadata: metadata_json,
       sections: @activity.pages.map { |p| section_json(p) },
-      active_runs: @activity.active_runs
+      active_runs: @activity.active_runs,
+      publication_details: {
+        :last_publication_hash => @activity.publication_hash,
+        :latest_publication_portals => @activity.latest_publication_portals,
+        :publish_url => publication_publish_path(@activity.class, @activity.id),
+        :poll_url => publication_autopublishing_status_path(@activity.class, @activity.id)
+      }
     }
   end
 

--- a/app/views/lightweight_activities/_edit_header.html.haml
+++ b/app/views/lightweight_activities/_edit_header.html.haml
@@ -8,7 +8,8 @@
     %span.preview
       = link_to "Edit in ITSI Mode", "#{edit_activity_path(@activity)}?mode=itsi"
 
-= render :partial => "publications/publication_details", :locals =>{ :publication => @activity}
+- if show_publication_details
+  = render :partial => "publications/publication_details", :locals =>{ :publication => @activity}
 - if @activity.active_runs > 0
   %p.active-runs
     = "This activity has been used by #{pluralize(@activity.active_runs, "learner")}. Editing may cause problems with results data. If you make changes, please publish this activity and any associated sequences as soon as possible."

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -12,7 +12,7 @@
         = link_to 'All Activities', activities_path
       %li= "/ #{@activity.name}".html_safe
 
-= render :partial => "edit_header"
+= render :partial => "edit_header", locals: {show_publication_details: true}
 
 #leftcol
   .sequence_form

--- a/app/views/lightweight_activities/itsi_edit.html.haml
+++ b/app/views/lightweight_activities/itsi_edit.html.haml
@@ -5,7 +5,7 @@
   = "Edit #{@activity.name}"
 = content_for :container_css_classes, 'itsi-edit'
 
-= render :partial => "edit_header"
+= render :partial => "edit_header", locals: {show_publication_details: false}
 
 #itsi-editor
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ LightweightStandalone::Application.routes.draw do
       get :contact_us
     end
   end
-  
+
 
   resources :themes
 
@@ -135,6 +135,7 @@ LightweightStandalone::Application.routes.draw do
   end
 
   match "/publications/show_status/:publishable_type/:publishable_id"=> 'publications#show_status', :as => 'publication_show_status'
+  match "/publications/autopublishing_status/:publishable_type/:publishable_id"=> 'publications#autopublishing_status', :as => 'publication_autopublishing_status'
   match "/publications/add/:publishable_type/:publishable_id"=> 'publications#add_portal', :as => 'publication_add_portal'
   match "/publications/publish/:publishable_type/:publishable_id"=> 'publications#publish', :as => 'publication_publish'
   match "/import" => 'import#import_status', :as => 'import_status', :via => 'get'

--- a/db/migrate/20150706174054_enable_auto_publishing.rb
+++ b/db/migrate/20150706174054_enable_auto_publishing.rb
@@ -1,0 +1,7 @@
+class EnableAutoPublishing < ActiveRecord::Migration
+  def change
+    add_column :portal_publications, :publication_hash, :string, limit: 40
+    add_column :lightweight_activities, :publication_hash, :string, limit: 40
+    add_column :sequences, :publication_hash, :string, limit: 40
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150624175249) do
+ActiveRecord::Schema.define(:version => 20150706174054) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -329,23 +329,24 @@ ActiveRecord::Schema.define(:version => 20150624175249) do
   create_table "lightweight_activities", :force => true do |t|
     t.string   "name"
     t.integer  "user_id"
-    t.string   "publication_status", :default => "private"
-    t.datetime "created_at",                                :null => false
-    t.datetime "updated_at",                                :null => false
+    t.string   "publication_status",               :default => "private"
+    t.datetime "created_at",                                              :null => false
+    t.datetime "updated_at",                                              :null => false
     t.integer  "offerings_count"
     t.text     "related"
     t.text     "description"
     t.integer  "changed_by_id"
-    t.boolean  "is_official",        :default => false
+    t.boolean  "is_official",                      :default => false
     t.integer  "time_to_complete"
-    t.boolean  "is_locked",          :default => false
+    t.boolean  "is_locked",                        :default => false
     t.text     "notes"
     t.string   "thumbnail_url"
     t.integer  "theme_id"
     t.integer  "project_id"
-    t.integer  "portal_run_count",   :default => 0
-    t.integer  "layout",             :default => 0
-    t.integer  "editor_mode",        :default => 0
+    t.integer  "portal_run_count",                 :default => 0
+    t.integer  "layout",                           :default => 0
+    t.integer  "editor_mode",                      :default => 0
+    t.string   "publication_hash",   :limit => 40
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -409,6 +410,7 @@ ActiveRecord::Schema.define(:version => 20150624175249) do
     t.string   "publishable_type"
     t.datetime "created_at",                      :null => false
     t.datetime "updated_at",                      :null => false
+    t.string   "publication_hash", :limit => 40
   end
 
   create_table "projects", :force => true do |t|
@@ -466,17 +468,18 @@ ActiveRecord::Schema.define(:version => 20150624175249) do
   create_table "sequences", :force => true do |t|
     t.string   "title"
     t.text     "description"
-    t.datetime "created_at",                                :null => false
-    t.datetime "updated_at",                                :null => false
+    t.datetime "created_at",                                              :null => false
+    t.datetime "updated_at",                                              :null => false
     t.integer  "user_id"
     t.integer  "theme_id"
     t.integer  "project_id"
     t.text     "logo"
-    t.string   "publication_status", :default => "private"
-    t.boolean  "is_official",        :default => false
+    t.string   "publication_status",               :default => "private"
+    t.boolean  "is_official",                      :default => false
     t.string   "display_title"
     t.string   "thumbnail_url"
     t.text     "abstract"
+    t.string   "publication_hash",   :limit => 40
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"


### PR DESCRIPTION
This adds/changes the following:

1. Adds publication_hash (sha1) to the portal_publications, lightweight_activities and lightweight_activity_sequences tables to track the version of the activity/sequence published.
2. Moves the portal_publications has_many association from publication_status.rb to publishable.rb
3. Adds a json endpoint to poll for autopublishing information
4. Adds a React component to the ITSI editor that displays the initial autopublishing information and then polls every 5 seconds for updates to that information.