### PR TITLE
Add auto publishing job queue [#98301172]

### DIFF
--- a/app/models/pending_portal_publication.rb
+++ b/app/models/pending_portal_publication.rb
@@ -1,0 +1,5 @@
+class PendingPortalPublication < ActiveRecord::Base
+  attr_accessible :portal_publication_id
+
+  belongs_to :portal_publication
+end

--- a/app/models/portal_publication.rb
+++ b/app/models/portal_publication.rb
@@ -1,6 +1,6 @@
 class PortalPublication < ActiveRecord::Base
 
-  attr_accessible :portal_url, :response, :success, :publishable, :publication_hash
+  attr_accessible :portal_url, :response, :success, :publishable, :publication_hash, :publication_time
   # Assuming portals aren't a first-class model - representing them by their URLs
 
   # What got published - usually one of these, not both

--- a/app/models/process_pending_portal_publication.rb
+++ b/app/models/process_pending_portal_publication.rb
@@ -1,0 +1,40 @@
+class ProcessPendingPortalPublication < Struct.new(:pending_portal_publication_id, :auto_publish_url, :backoff)
+  def perform
+    # immediately find and remove the pending publication so that new publications can be queued
+    pending_portal_publication = PendingPortalPublication.find(pending_portal_publication_id)
+    return if pending_portal_publication.nil?
+    pending_portal_publication.delete
+
+    # get shorter local references
+    portal_publication = pending_portal_publication.portal_publication
+    return if portal_publication.nil?
+    publishable = portal_publication.publishable
+    return if publishable.nil?
+    portal = Concord::AuthPortal.portal_for_publishing_url(portal_publication.portal_url)
+    last_portal_publication = publishable.last_publication(portal)
+    return if last_portal_publication.nil?
+
+    # if the portal publication is not the latest one another job has published behind us so we are done
+    return if portal_publication.id != last_portal_publication.id
+
+    # skip autopublish if the hash hasn't changed since the last publish
+    json = publishable.serialize_for_portal(auto_publish_url).to_json
+    return if last_portal_publication.publication_hash == Digest::SHA1.hexdigest(json)
+
+    # publish to the portal
+    response = publishable.republish_for_portal(portal, auto_publish_url, json)
+    unless response.code == 201
+
+      # if it fails requeue with an exponentially increased backoff time with a max of 3 hours or 10800 seconds
+      # will actually stop at (2^11)*5=10240 seconds or 2.84 hours
+      new_backoff = backoff * 2
+      if new_backoff * publishable.auto_publish_delay < 3*60*60
+        publishable.queue_auto_publish_to_portal(auto_publish_url, new_backoff)
+      end
+    end
+  end
+
+  def debug(text)
+    Delayed::Worker.logger.add(Logger::DEBUG, text) if Delayed::Worker.logger
+  end
+end

--- a/app/models/process_pending_portal_publication.rb
+++ b/app/models/process_pending_portal_publication.rb
@@ -11,7 +11,7 @@ class ProcessPendingPortalPublication < Struct.new(:pending_portal_publication_i
     publishable = portal_publication.publishable
     return if publishable.nil?
     portal = Concord::AuthPortal.portal_for_publishing_url(portal_publication.portal_url)
-    last_portal_publication = publishable.last_publication(portal)
+    last_portal_publication = publishable.last_successful_publication(portal)
     return if last_portal_publication.nil?
 
     # if the portal publication is not the latest one another job has published behind us so we are done

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -26,6 +26,11 @@ module Publishable
     self.portal_publications.where('portal_url' => concord_auth_portal.publishing_url).last
   end
   alias_method :last_publication, :find_portal_publication
+
+  def last_successful_publication(concord_auth_portal)
+    self.portal_publications.where('portal_url' => concord_auth_portal.publishing_url, 'success' => true).last
+  end
+
   def portal_publish(user,auth_portal,self_url)
     self.update_attribute('publication_status','public')
     self.portal_publish_with_token(user.authentication_token,auth_portal,self_url)

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -2,9 +2,12 @@ require 'digest/sha1'
 
 module Publishable
 
+  class AutoPublishIncomplete < StandardError; end
+
   def latest_publication_portals
     counts = portal_publications.group(:portal_url).count
-    rows = portal_publications.select("portal_url, success, created_at, publication_hash").where(["id IN (SELECT MAX(id) FROM portal_publications GROUP BY portal_url)"])
+    group_select = "id IN (SELECT MAX(id) FROM portal_publications WHERE publishable_id = ? AND publishable_type = ? GROUP BY portal_url)"
+    rows = portal_publications.select("portal_url, success, created_at, publication_hash").where([group_select, self.id, self.class.name])
     portals = []
     rows.each do |row|
       portals << {
@@ -20,7 +23,7 @@ module Publishable
   end
 
   def find_portal_publication(concord_auth_portal)
-    self.portal_publications.where('portal_url' =>  concord_auth_portal.publishing_url).last
+    self.portal_publications.where('portal_url' => concord_auth_portal.publishing_url).last
   end
   alias_method :last_publication, :find_portal_publication
   def portal_publish(user,auth_portal,self_url)
@@ -28,8 +31,8 @@ module Publishable
     self.portal_publish_with_token(user.authentication_token,auth_portal,self_url)
   end
 
-  def republish_for_portal(auth_portal,self_url)
-    portal_publish_with_token(auth_portal.secret,auth_portal,self_url,true)
+  def republish_for_portal(auth_portal,self_url,json=nil)
+    portal_publish_with_token(auth_portal.secret,auth_portal,self_url,true,json)
   end
 
   def publication_details
@@ -47,26 +50,33 @@ module Publishable
     return return_vals
   end
 
-  def portal_publish_with_token(token,auth_portal,self_url,republish=false)
+  def portal_publish_with_token(token,auth_portal,self_url,republish=false,json=nil)
     # TODO: better error handling
     raise "#{self.class.name} is Not Publishable" unless self.respond_to?(:serialize_for_portal)
     url = auth_portal.publishing_url
     url = auth_portal.republishing_url if republish
     Rails.logger.info "Attempting to publish #{self.class.name} #{self.id} to #{auth_portal.url}."
     auth_token = 'Bearer %s' % token
-    json = self.serialize_for_portal(self_url).to_json
+
+    start_time = Time.now.to_f
+
+    json = json || self.serialize_for_portal(self_url).to_json
     hash = Digest::SHA1.hexdigest(json)
     response = HTTParty.post(url,
       :body => json,
       :headers => {"Authorization" => auth_token, "Content-Type" => 'application/json'})
 
+    end_time = Time.now.to_f
+
+    Rails.logger.info "Response Time: #{end_time - start_time}"
     Rails.logger.info "Response: #{response.inspect}"
     self.portal_publications.create({
       portal_url: auth_portal.publishing_url,
       response: response.inspect,
       success: ( response.code == 201 ) ? true : false,
       publishable: self,
-      publication_hash: hash
+      publication_hash: hash,
+      publication_time: (end_time - start_time) * 1000
     })
 
     self.publication_hash = hash
@@ -96,12 +106,47 @@ module Publishable
 
   def self.included(clazz)
     clazz.class_eval do
-      after_update :auto_publish_to_portal
+
       has_many :portal_publications, :as => :publishable, :order => :updated_at
+
+      # all changes will be queued for auto publishing
+      after_update :queue_auto_publish_to_portal
+
+      def auto_publish_delay
+        return 5
+      end
+
+      def queue_auto_publish_to_portal(auto_publish_url=nil, backoff=1)
+
+        urls = self.portal_publications.where(:success => true).pluck(:portal_url).uniq
+        urls.map { |url| Concord::AuthPortal.portal_for_publishing_url(url)}.each do |portal|
+          # no portals are defined in test mode
+          return if portal.nil?
+
+          # get the last time it was published (sucessfully or not)
+          last_portal_publication = self.portal_publications.where('portal_url' => portal.publishing_url).last
+
+          # skip auto publishing if never initially published
+          return if last_portal_publication.nil?
+
+          # create a new pending publication pointing at the last publication
+          pending_portal_publication = PendingPortalPublication.new :portal_publication_id => last_portal_publication.id
+
+          # try to save it - if there is an existing pending publication for this item it will throw ActiveRecord::StatementInvalid
+          # because of the unique index constraint on the table
+          begin
+            pending_portal_publication.save!
+
+            # if the job saved then process it
+            auto_publish_url ||= Thread.current[:auto_publish_url]
+            Delayed::Job.enqueue(ProcessPendingPortalPublication.new(pending_portal_publication.id, auto_publish_url, backoff), 0, (auto_publish_delay * backoff).seconds.from_now)
+
+          rescue ActiveRecord::StatementInvalid => e
+            raise e unless /Duplicate entry/.match(e.to_s)
+          end
+        end
+      end
     end
   end
 
-  def auto_publish_to_portal
-    logger.debug "TODO: Autopublish #{self}"
-  end
 end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,1 +1,4 @@
 Delayed::Worker.delay_jobs = Rails.env.production? || !!ENV['DELAYEDJOB']
+if Rails.env.development?
+  Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
+end

--- a/db/migrate/20150707193908_create_pending_portal_publications.rb
+++ b/db/migrate/20150707193908_create_pending_portal_publications.rb
@@ -1,0 +1,12 @@
+class CreatePendingPortalPublications < ActiveRecord::Migration
+  def change
+    create_table :pending_portal_publications do |t|
+      t.integer :portal_publication_id
+      t.timestamps
+    end
+
+    add_index :pending_portal_publications, :portal_publication_id, unique: true, name: 'unique_publications_per_portal'
+
+    add_column :portal_publications, :publication_time, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150706174054) do
+ActiveRecord::Schema.define(:version => 20150707193908) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -402,6 +402,14 @@ ActiveRecord::Schema.define(:version => 20150706174054) do
   add_index "page_items", ["embeddable_id", "embeddable_type"], :name => "index_page_items_on_embeddable_id_and_embeddable_type"
   add_index "page_items", ["interactive_page_id"], :name => "index_page_items_on_interactive_page_id"
 
+  create_table "pending_portal_publications", :force => true do |t|
+    t.integer  "portal_publication_id"
+    t.datetime "created_at",            :null => false
+    t.datetime "updated_at",            :null => false
+  end
+
+  add_index "pending_portal_publications", ["portal_publication_id"], :name => "unique_publications_per_portal", :unique => true
+
   create_table "portal_publications", :force => true do |t|
     t.string   "portal_url"
     t.text     "response",         :limit => 255
@@ -411,6 +419,7 @@ ActiveRecord::Schema.define(:version => 20150706174054) do
     t.datetime "created_at",                      :null => false
     t.datetime "updated_at",                      :null => false
     t.string   "publication_hash", :limit => 40
+    t.integer  "publication_time"
   end
 
   create_table "projects", :force => true do |t|


### PR DESCRIPTION
This adds a new table that contains queued auto publishing jobs.  The table has a unique index on the portal_url + publishable_id + publishable_type so that only one auto publishing job per (portal, publishable) tuple is allowed.  When at least one new record is successfully added a delayed job is invoked to process the queue.

NOTES:
1. To build the host url for the serialized data in the model the url is stored in the thread when the application starts.
2. This code assumes that the jobs are not processed in parallel by delayed job.
3. The host url is passed to the delayed job.  This works locally since jobs are not delayed in development mode.  Looking at the docs it looks like the params are serialized into the delayed_jobs table but I was not able to test that locally. 