### PR TITLE
Preserve hidden attributes on embeddables and interactives on copy & export

### DIFF
--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -33,7 +33,8 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
       bg_url: bg_url,
       is_prediction: is_prediction,
       give_prediction_feedback: give_prediction_feedback,
-      prediction_feedback: prediction_feedback
+      prediction_feedback: prediction_feedback,
+      is_hidden: is_hidden
     }
   end
 
@@ -49,7 +50,8 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
                               :bg_url,
                               :is_prediction,
                               :give_prediction_feedback,
-                              :prediction_feedback])
+                              :prediction_feedback,
+                              :is_hidden])
   end
   
   def self.import(import_hash)

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -77,7 +77,8 @@ module Embeddable
         action_type: action_type,
         name: name,
         prompt: prompt,
-        custom_action_label: custom_action_label
+        custom_action_label: custom_action_label,
+        is_hidden: is_hidden
       }
     end
 
@@ -86,7 +87,13 @@ module Embeddable
     end
 
     def export
-      return self.as_json(only: [:action_type, :name, :prompt, :custom_action_label])
+      return self.as_json(only: [
+        :action_type,
+        :name,
+        :prompt,
+        :custom_action_label,
+        :is_hidden
+      ])
     end
 
     def self.import(import_hash)

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -19,7 +19,7 @@ module Embeddable
       :class_name => 'Embeddable::MultipleChoiceAnswer',
       :foreign_key => 'multiple_choice_id'
 
-    attr_accessible :name, :prompt, :custom, :choices_attributes, 
+    attr_accessible :name, :prompt, :custom, :choices_attributes,
       :enable_check_answer, :multi_answer, :show_as_menu, :is_prediction,
       :give_prediction_feedback, :prediction_feedback, :layout, :is_hidden
     accepts_nested_attributes_for :choices, :allow_destroy => true
@@ -87,7 +87,8 @@ module Embeddable
         is_prediction: is_prediction,
         give_prediction_feedback: give_prediction_feedback,
         prediction_feedback: prediction_feedback,
-        layout: layout
+        layout: layout,
+        is_hidden: is_hidden
       }
     end
 
@@ -109,8 +110,9 @@ module Embeddable
                                 :is_prediction,
                                 :give_prediction_feedback,
                                 :prediction_feedback,
-                                :layout])
-      
+                                :layout,
+                                :is_hidden])
+
       mc_export[:choices] = []
       
       self.choices.each do |choice|

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -21,7 +21,8 @@ module Embeddable
         is_prediction: is_prediction,
         give_prediction_feedback: give_prediction_feedback,
         prediction_feedback: prediction_feedback,
-        default_text: default_text
+        default_text: default_text,
+        is_hidden: is_hidden
       }
     end
 
@@ -47,7 +48,8 @@ module Embeddable
                                 :is_prediction,
                                 :give_prediction_feedback,
                                 :prediction_feedback,
-                                :default_text])
+                                :default_text,
+                                :is_hidden])
     end
 
     def self.import (import_hash)

--- a/app/models/embeddable/xhtml.rb
+++ b/app/models/embeddable/xhtml.rb
@@ -15,18 +15,19 @@ module Embeddable
     def to_hash
       {
         name: name,
-        content: content
+        content: content,
+        is_hidden: is_hidden
       }
     end
 
     def duplicate
       return Embeddable::Xhtml.new(self.to_hash)
     end
-    
+
     def export
-      self.as_json(only:[:name, :content])
+      self.as_json(only:[:name, :content, :is_hidden])
     end
-    
+
     def self.import(import_hash)
       return self.new(import_hash)
     end

--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -16,7 +16,8 @@ class ImageInteractive < ActiveRecord::Base
       url: url,
       caption: caption,
       credit: credit,
-      credit_url: credit_url
+      credit_url: credit_url,
+      is_hidden: is_hidden
     }
   end
 
@@ -29,14 +30,15 @@ class ImageInteractive < ActiveRecord::Base
     return html_credit if self.credit_url.blank?
     return "<a href='#{self.credit_url}' target='_blank'>#{self.credit}</a>".html_safe
   end
-  
+
   def export
-    return self.as_json(only:[:caption, 
-                              :url, 
-                              :credit, 
-                              :credit_url])
+    return self.as_json(only:[:caption,
+                              :url,
+                              :credit,
+                              :credit_url,
+                              :is_hidden])
   end
-  
+
   def self.import(import_hash)
     return self.new(import_hash)
   end

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -45,7 +45,8 @@ class MwInteractive < ActiveRecord::Base
       save_state: save_state,
       has_report_url: has_report_url,
       click_to_play: click_to_play,
-      image_url: image_url
+      image_url: image_url,
+      is_hidden: is_hidden
     }
   end
 
@@ -65,16 +66,17 @@ class MwInteractive < ActiveRecord::Base
       "#{interactive_page.lightweight_activity.id}_#{interactive_page.id}_#{id}_#{self.class.to_s.underscore.gsub(/\//, '_')}"
     end
   end
-  
+
   def export
-    return self.as_json(only:[:name, 
-                              :url, 
-                              :native_width, 
+    return self.as_json(only:[:name,
+                              :url,
+                              :native_width,
                               :native_height,
                               :save_state,
                               :has_report_url,
                               :click_to_play,
-                              :image_url])
+                              :image_url,
+                              :is_hidden])
   end
   
   def self.import(import_hash)

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -48,7 +48,8 @@ class VideoInteractive < ActiveRecord::Base
       caption: caption,
       credit: credit,
       height: height,
-      width: width
+      width: width,
+      is_hidden: is_hidden
     }
   end
 
@@ -59,12 +60,13 @@ class VideoInteractive < ActiveRecord::Base
   end
   
   def export
-    video_interactive_export = self.as_json(only:[:poster_url, 
-                                                  :caption, 
+    video_interactive_export = self.as_json(only:[:poster_url,
+                                                  :caption,
                                                   :credit,
                                                   :height,
-                                                  :width])
-    
+                                                  :width,
+                                                  :is_hidden])
+
     video_interactive_export[:sources] =  []
     
     self.sources.each do |source|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -240,8 +240,8 @@ ActiveRecord::Schema.define(:version => 20150706174054) do
     t.boolean  "is_prediction",            :default => false
     t.boolean  "give_prediction_feedback", :default => false
     t.text     "prediction_feedback"
-    t.boolean  "is_hidden",                :default => false
     t.string   "default_text"
+    t.boolean  "is_hidden",                :default => false
   end
 
   create_table "embeddable_xhtmls", :force => true do |t|
@@ -404,12 +404,12 @@ ActiveRecord::Schema.define(:version => 20150706174054) do
 
   create_table "portal_publications", :force => true do |t|
     t.string   "portal_url"
-    t.text     "response",         :limit => 255
+    t.text     "response"
     t.boolean  "success"
     t.integer  "publishable_id"
     t.string   "publishable_type"
-    t.datetime "created_at",                      :null => false
-    t.datetime "updated_at",                      :null => false
+    t.datetime "created_at",                     :null => false
+    t.datetime "updated_at",                     :null => false
     t.string   "publication_hash", :limit => 40
   end
 

--- a/spec/factories/labbooks.rb
+++ b/spec/factories/labbooks.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :labbook, :class => Embeddable::Labbook do
+    name        { generate(:name) }
+    prompt      { generate(:prompt) }
+    action_type { Embeddable::Labbook::SNAPSHOT_ACTION }
+    is_hidden   { false }
+  end
+end

--- a/spec/models/embeddable/image_question_spec.rb
+++ b/spec/models/embeddable/image_question_spec.rb
@@ -18,9 +18,19 @@ describe Embeddable::ImageQuestion do
         bg_url: image_question.bg_url,
         is_prediction: image_question.is_prediction,
         give_prediction_feedback: image_question.give_prediction_feedback,
-        prediction_feedback: image_question.prediction_feedback
+        prediction_feedback: image_question.prediction_feedback,
+        is_hidden: image_question.is_hidden
       }
       expect(image_question.to_hash).to eq(expected)
+    end
+  end
+
+  describe "export" do
+    let(:json){ emb.export.as_json }
+    let(:emb) { image_question }
+    it 'preserves is_hidden' do
+      emb.is_hidden = true
+      expect(json['is_hidden']).to eq true
     end
   end
 

--- a/spec/models/embeddable/labbook_spec.rb
+++ b/spec/models/embeddable/labbook_spec.rb
@@ -7,8 +7,25 @@ describe Embeddable::Labbook do
     it 'is implemented' do
       expect(labbook).to respond_to(:to_hash)
     end
+    it 'has interesting attributes' do
+      expected = {
+        action_type: labbook.action_type,
+        name: labbook.name,
+        prompt: labbook.prompt,
+        custom_action_label: labbook.custom_action_label,
+        is_hidden: labbook.is_hidden
+      }
+      expect(labbook.to_hash).to eq(expected)
+    end
   end
-
+  describe "export" do
+    let(:json){ emb.export.as_json }
+    let(:emb) { labbook}
+    it 'preserves is_hidden' do
+      emb.is_hidden = true
+      expect(json['is_hidden']).to eq true
+    end
+  end
   describe '#duplicate' do
     it 'returns a new instance with copied attributes' do
       expect(labbook.duplicate).to be_a_new(Embeddable::Labbook)

--- a/spec/models/embeddable/multiple_choice_spec.rb
+++ b/spec/models/embeddable/multiple_choice_spec.rb
@@ -109,21 +109,40 @@ describe Embeddable::MultipleChoice do
 
   describe '#to_hash' do
     it 'returns a hash with copied attributes' do
-      expected = { name: multichoice.name, prompt: multichoice.prompt, custom: multichoice.custom, enable_check_answer: multichoice.enable_check_answer, multi_answer: multichoice.multi_answer, show_as_menu: multichoice.show_as_menu, is_prediction: multichoice.is_prediction, give_prediction_feedback: multichoice.give_prediction_feedback, prediction_feedback: multichoice.prediction_feedback, layout: multichoice.layout }
+      expected = {
+        name: multichoice.name,
+        prompt: multichoice.prompt,
+        custom: multichoice.custom,
+        enable_check_answer: multichoice.enable_check_answer,
+        multi_answer: multichoice.multi_answer,
+        show_as_menu: multichoice.show_as_menu,
+        is_prediction: multichoice.is_prediction,
+        give_prediction_feedback: multichoice.give_prediction_feedback,
+        prediction_feedback: multichoice.prediction_feedback,
+        layout: multichoice.layout,
+        is_hidden: multichoice.is_hidden
+      }
       expect(multichoice.to_hash).to eq(expected)
     end
   end
 
   describe '#export' do
+    let(:multichoice_json) { multichoice.export.as_json }
     it 'returns json of a multiple choice question' do
-      multichoice_json = multichoice.export.as_json
       expect(multichoice_json['choices'].length).to eq(multichoice.choices.count)
-    end 
+    end
+    it 'preserves is_hidden' do
+      multichoice.is_hidden = true
+      expect(multichoice_json['is_hidden']).to eq true
+    end
   end
 
   describe '#duplicate' do
     it 'returns a new instance with copied attributes' do
-      expect(multichoice.duplicate).to be_a_new(Embeddable::MultipleChoice).with( name: multichoice.name, prompt: multichoice.prompt )
+      expect(multichoice.duplicate).to be_a_new(Embeddable::MultipleChoice).with({
+        name: multichoice.name,
+        prompt: multichoice.prompt
+      })
     end
 
     it 'copies choices' do

--- a/spec/models/embeddable/open_response_spec.rb
+++ b/spec/models/embeddable/open_response_spec.rb
@@ -9,8 +9,25 @@ describe Embeddable::OpenResponse do
 
   describe '#to_hash' do
     it 'has interesting attributes' do
-      expected = { name: open_response.name, prompt: open_response.prompt, is_prediction: open_response.is_prediction, give_prediction_feedback: open_response.give_prediction_feedback, prediction_feedback: open_response.prediction_feedback, default_text: open_response.default_text }
+      expected = {
+        name: open_response.name,
+        prompt: open_response.prompt,
+        is_prediction: open_response.is_prediction,
+        give_prediction_feedback: open_response.give_prediction_feedback,
+        prediction_feedback: open_response.prediction_feedback,
+        default_text: open_response.default_text,
+        is_hidden: open_response.is_hidden
+      }
       expect(open_response.to_hash).to eq(expected)
+    end
+  end
+
+  describe "export" do
+    let(:json){ emb.export.as_json }
+    let(:emb) { open_response}
+    it 'preserves is_hidden' do
+      emb.is_hidden = true
+      expect(json['is_hidden']).to eq true
     end
   end
 

--- a/spec/models/embeddable/xhtml_spec.rb
+++ b/spec/models/embeddable/xhtml_spec.rb
@@ -14,9 +14,22 @@ describe Embeddable::Xhtml do
     end
   end
 
+  describe "export" do
+    let(:json){ emb.export.as_json }
+    let(:emb) { xhtml }
+    it 'preserves is_hidden' do
+      emb.is_hidden = true
+      expect(json['is_hidden']).to eq true
+    end
+  end
+
   describe '#to_hash' do
     it 'returns useful attributes' do
-      expected = { name: xhtml.name, content: xhtml.content }
+      expected = {
+        name: xhtml.name,
+        content: xhtml.content,
+        is_hidden: xhtml.is_hidden
+      }
       expect(xhtml.to_hash).to eq(expected)
     end
   end

--- a/spec/models/image_interactive_spec.rb
+++ b/spec/models/image_interactive_spec.rb
@@ -19,14 +19,26 @@ describe ImageInteractive do
 
   describe '#to_hash' do
     it 'has useful values' do
-      expected = { url: image_interactive.url, caption: image_interactive.caption, credit: image_interactive.credit, credit_url: image_interactive.credit_url}
+      expected = {
+        url: image_interactive.url,
+        caption: image_interactive.caption,
+        credit: image_interactive.credit,
+        credit_url: image_interactive.credit_url,
+        is_hidden: image_interactive.is_hidden
+      }
       expect(image_interactive.to_hash).to eq(expected)
     end
   end
 
   describe '#duplicate' do
     it 'is a new instance of ImageInteractive with values' do
-      expect(image_interactive.duplicate).to be_a_new(ImageInteractive).with( url: image_interactive.url, caption: image_interactive.caption, credit: image_interactive.credit )
+      image_interactive.is_hidden = true
+      expect(image_interactive.duplicate).to be_a_new(ImageInteractive).with({
+        url: image_interactive.url,
+        caption: image_interactive.caption,
+        credit: image_interactive.credit,
+        is_hidden: image_interactive.is_hidden
+        })
     end
   end
 
@@ -34,7 +46,7 @@ describe ImageInteractive do
     let(:credit)     { nil }
     let(:credit_url) { nil }
     let(:parms)      { {:credit => credit, :credit_url => credit_url } }
-    let(:link)       { ImageInteractive.new(parms).credit_with_link  } 
+    let(:link)       { ImageInteractive.new(parms).credit_with_link  }
     describe "With nil values" do
       it "should return an empty string" do
         expect(link).to be_blank

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -249,47 +249,89 @@ describe InteractivePage do
       it "the page itself should not be valid" do
         expect(page).not_to be_valid
       end
-      it 'has copies of the original interactives' do
-        dupe = page.duplicate
-        # dupe.reload.interactives.length.should be(page.interactives.length)
-      end
-
-      it 'has copies of the original embeddables' do
-        # Note that this only confirms that there are the same number of embeddables. Page starts with 3.
+      it "should have the same number of embeddables" do
         expect(page.duplicate.embeddables.length).to be(page.embeddables.length)
       end
+      it "should have the same number of interactives as the original" do
+        expect(page.duplicate.interactives.length).to be(page.interactives.length)
+      end
+    end
 
-      describe "copying a labbook with a reference to an interactive" do
-        before(:each) do
-          page.add_embeddable labbook
+    describe 'copies of the original interactives' do
+      let(:hidden_image)    { FactoryGirl.create(:image_interactive, is_hidden: true)}
+      let(:hidden_mw)       { FactoryGirl.create(:mw_interactive, is_hidden: true)}
+      let(:hidden_video)    { FactoryGirl.create(:video_interactive, is_hidden: true)}
+      let(:dupe)            { page.duplicate.reload}
+      before(:each) do
+        page.add_interactive hidden_image
+        page.add_interactive hidden_mw
+        page.add_interactive hidden_video
+        page.reload
+      end
+      it "should have the same number of interactives as the original" do
+        dupe.interactives.length.should be(page.interactives.length)
+      end
+
+      it "should have copies of interactives with the same visibility" do
+        page.interactives.each_with_index do |original,i|
+          interactive_copy = dupe.interactives[i]
+          expect(original.is_hidden?).to eq interactive_copy.is_hidden?
         end
+      end
+    end
 
-        let(:args)              { {interactive: page_interactive}  }
-        let(:labbook)           { Embeddable::Labbook.new(args)    }
+    describe 'has copies of the original embeddables' do
+      let(:hidden_text)    { FactoryGirl.create(:xhtml, is_hidden: true)}
+      let(:hidden_labbook) { FactoryGirl.create(:labbook, is_hidden: true)}
+      let(:dupe)           { page.duplicate.reload}
+      before(:each) do
+        page.add_embeddable hidden_labbook
+        page.add_embeddable hidden_text
+      end
 
-        let(:dupe)              { page.duplicate       }
-        let(:page_interactive)  { page.interactives[0] }
-        let(:dupe_interactive)  { dupe.interactives[0] }
+      it "should have the same number of embeddables" do
+        expect(dupe.embeddables.length).to be(page.embeddables.length)
+      end
 
-        let(:page_labbook) { find_labbook(page) }
-        let(:dupe_labbook) { find_labbook(dupe) }
-
-        describe "the original page" do
-          it "should have a labbook" do
-            expect(page_labbook).not_to be_nil
-          end
-
-          it "the labbook should point at the interactive" do
-            expect(page_labbook.interactive).to eql (page_interactive)
-          end
+      it "should have embeddables of the same visibility as the original" do
+        page.embeddables.each_with_index do |original,i|
+          copy_emb = dupe.embeddables[i]
+          expect(original.is_hidden?).to eq copy_emb.is_hidden?
         end
-        describe "the duplcate after a copy" do
-          it "should have a labook" do
-            expect(dupe_labbook).not_to be_nil
-          end
-          it "the labook should point at the new interactive" do
-            expect(dupe_labbook.interactive).to eql (dupe_interactive)
-          end
+      end
+    end
+
+
+    describe "copying a labbook with a reference to an interactive" do
+      before(:each) do
+        page.add_embeddable labbook
+      end
+
+      let(:args)              { {interactive: page_interactive}  }
+      let(:labbook)           { Embeddable::Labbook.new(args)    }
+
+      let(:dupe)              { page.duplicate       }
+      let(:page_interactive)  { page.interactives[0] }
+      let(:dupe_interactive)  { dupe.interactives[0] }
+
+      let(:page_labbook) { find_labbook(page) }
+      let(:dupe_labbook) { find_labbook(dupe) }
+
+      describe "the original page" do
+        it "should have a labbook" do
+          expect(page_labbook).not_to be_nil
+        end
+        it "the labbook should point at the interactive" do
+          expect(page_labbook.interactive).to eql (page_interactive)
+        end
+      end
+
+      describe "the duplcate after a copy" do
+        it "should have a labook" do
+          expect(dupe_labbook).not_to be_nil
+        end
+        it "the labook should point at the new interactive" do
+          expect(dupe_labbook.interactive).to eql (dupe_interactive)
         end
       end
     end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -233,6 +233,25 @@ describe LightweightActivity do
       end
     end
 
+    it 'has hidden pages that are hidden in the source' do
+      3.times do |n|
+        activity.pages << FactoryGirl.create(:page, is_hidden: true)
+        activity.pages << FactoryGirl.create(:page, is_hidden: false)
+      end
+      duplicate = activity.duplicate(owner)
+      hidden_count = 0
+      visibile_count = 0
+      duplicate.pages.each do |p|
+        if p.is_hidden?
+          hidden_count = hidden_count + 1
+        else
+          visibile_count = visibile_count + 1
+        end
+      end
+      expect(hidden_count).to eq 3
+      expect(visibile_count).to eq 3
+    end
+    
     describe "when a page in the activity fails validation" do
       let(:bad_content)   {"</p> no closing div tag"}
 

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -32,14 +32,33 @@ describe MwInteractive do
 
   describe '#to_hash' do
     it 'has useful values' do
-      expected = { name: interactive.name, url: interactive.url, native_width: interactive.native_width, native_height: interactive.native_height, save_state: interactive.save_state, has_report_url: interactive.has_report_url, click_to_play: interactive.click_to_play, image_url: interactive.image_url }
+      expected = {
+        name: interactive.name,
+        url: interactive.url,
+        native_width: interactive.native_width,
+        native_height: interactive.native_height,
+        save_state: interactive.save_state,
+        has_report_url: interactive.has_report_url,
+        click_to_play: interactive.click_to_play,
+        image_url: interactive.image_url,
+        is_hidden: interactive.is_hidden
+       }
       expect(interactive.to_hash).to eq(expected)
     end
   end
 
   describe '#duplicate' do
     it 'is a new instance of MwInteractive with values' do
-      expect(interactive.duplicate).to be_a_new(MwInteractive).with( name: "Copy of #{interactive.name}", url: interactive.url, native_width: interactive.native_width, native_height: interactive.native_height, click_to_play: interactive.click_to_play, image_url: interactive.image_url )
+      interactive.is_hidden = true
+      expect(interactive.duplicate).to be_a_new(MwInteractive).with({
+        name: "Copy of #{interactive.name}",
+        url: interactive.url,
+        native_width: interactive.native_width,
+        native_height: interactive.native_height,
+        click_to_play: interactive.click_to_play,
+        image_url: interactive.image_url,
+        is_hidden: interactive.is_hidden
+      })
     end
   end
 end

--- a/spec/models/video_interactive_spec.rb
+++ b/spec/models/video_interactive_spec.rb
@@ -44,7 +44,14 @@ describe VideoInteractive do
 
   describe '#to_hash' do
     it 'has useful values' do
-      expected = { poster_url: video_interactive.poster_url, caption: video_interactive.caption, credit: video_interactive.credit, width: video_interactive.width, height: video_interactive.height }
+      expected = {
+        poster_url: video_interactive.poster_url,
+        caption: video_interactive.caption,
+        credit: video_interactive.credit,
+        width: video_interactive.width,
+        height: video_interactive.height,
+        is_hidden: video_interactive.is_hidden
+      }
       expect(video_interactive.to_hash).to eq(expected)
     end
   end
@@ -53,12 +60,19 @@ describe VideoInteractive do
     it 'returns json of a video interactive' do
       video_interactive_json = video_interactive.export.as_json
       expect(video_interactive_json['sources'].length).to eq(video_interactive.sources.count)
-    end 
+    end
   end
 
   describe '#duplicate' do
     it 'is a new instance of VideoInteractive with values' do
-      expect(video_interactive.duplicate).to be_a_new(VideoInteractive).with( poster_url: video_interactive.poster_url, caption: video_interactive.caption, credit: video_interactive.credit, width: video_interactive.width, height: video_interactive.height )
+      video_interactive.is_hidden = true
+      expect(video_interactive.duplicate).to be_a_new(VideoInteractive).with({
+        poster_url: video_interactive.poster_url,
+        caption: video_interactive.caption,
+        credit: video_interactive.credit,
+        width: video_interactive.width,
+        height: video_interactive.height,
+        is_hidden: video_interactive.is_hidden})
     end
   end
 end


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/98560552 

Note:  We need to factor-out common attributes for
embeddables and interactives.

Also we need to unify serialization methods: duplicate, export,  to_hash, serialize_for_portal (!)

Making this small change for serializing visibility cut across too many files and too many specs.

I was tempted to address, but ran out of time.
