### PR TITLE
Autopublish part-2

### DIFF
--- a/app/models/process_pending_portal_publication.rb
+++ b/app/models/process_pending_portal_publication.rb
@@ -22,9 +22,9 @@ class ProcessPendingPortalPublication < Struct.new(:pending_portal_publication_i
     end
 
     portal = Concord::AuthPortal.portal_for_publishing_url(portal_publication.portal_url)
-    last_portal_publication = publishable.last_successful_publication(portal)
+    last_portal_publication = publishable.last_publication(portal)
     if last_portal_publication.nil?
-      info "no successful previous publication"
+      info "no previous publication"
     end
 
     # if the portal publication is not the latest one another job has published behind us so we are done

--- a/app/models/process_pending_portal_publication.rb
+++ b/app/models/process_pending_portal_publication.rb
@@ -53,10 +53,13 @@ class ProcessPendingPortalPublication < Struct.new(:pending_portal_publication_i
     end
   end
 
-  def debug(text)
-    Delayed::Worker.logger.add(Logger::DEBUG, text) if Delayed::Worker.logger
-  end
+  # if you want to seperately monitor the log statments from Jobs
+  # first make sure you are running a seperate delayed_job process see:
+  #    config/initializers/delayed_job_config.rb
+  # then filter the messages in your log file
+  #    tail -f log/development.log | grep "\[Job"
+  # this is possible because of lib/delayed_job_tagged_logging.rb
   def info(text)
-    Delayed::Worker.logger.add(Logger::INFO, text) if Delayed::Worker.logger
+    Rails.logger.info text
   end
 end

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -80,8 +80,10 @@ module Publishable
       publication_time: (end_time - start_time) * 1000
     })
 
-    self.publication_hash = hash
-    self.save!
+    # update_column is necessary so this change doesn't trigger update_after
+    # if update_after is triggered then a new Job will be queued and we don't need
+    # to do that. This also means that updated_at column won't be changed by this
+    self.update_column(:publication_hash, hash)
 
     return response
   end

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -27,10 +27,6 @@ module Publishable
   end
   alias_method :last_publication, :find_portal_publication
 
-  def last_successful_publication(concord_auth_portal)
-    self.portal_publications.where('portal_url' => concord_auth_portal.publishing_url, 'success' => true).last
-  end
-
   def portal_publish(user,auth_portal,self_url)
     self.update_attribute('publication_status','public')
     self.portal_publish_with_token(user.authentication_token,auth_portal,self_url)

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -147,7 +147,9 @@ module Publishable
             Delayed::Job.enqueue(ProcessPendingPortalPublication.new(pending_portal_publication.id, auto_publish_url, backoff), 0, (auto_publish_delay * backoff).seconds.from_now)
 
           rescue ActiveRecord::StatementInvalid => e
-            raise e unless /Duplicate entry/.match(e.to_s)
+            # Perhaps there is a better way, at least on SQLite the exception type is: ActiveRecord::RecordNotUnique
+            # if it is on MySQL then we can simplify this a bit
+            raise e unless (e.is_a? ActiveRecord::RecordNotUnique) or /Duplicate entry/.match(e.to_s)
           end
         end
       end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,4 +1,4 @@
+require 'delayed_job_tagged_logging'
+Delayed::Worker.plugins << Delayed::Plugins::TaggedLogging
+
 Delayed::Worker.delay_jobs = Rails.env.production? || !!ENV['DELAYEDJOB']
-if Rails.env.development?
-  Delayed::Worker.logger = Logger.new(File.join(Rails.root, 'log', 'delayed_job.log'))
-end

--- a/lib/delayed_job_tagged_logging.rb
+++ b/lib/delayed_job_tagged_logging.rb
@@ -1,0 +1,26 @@
+module Delayed
+  module Plugins
+    class TaggedLogging < Delayed::Plugin
+      Delayed::Worker.logger = Rails.logger
+
+      callbacks do |lifecycle|
+        lifecycle.around(:execute) do |worker, *args, &block|
+          if worker.name_prefix
+            name = worker.name_prefix.strip
+          else
+            name = "unknown"
+          end
+          Rails.logger.tagged "Worker:#{name}" do
+            block.call(worker, *args)
+          end
+        end
+
+        lifecycle.around(:invoke_job) do |job, *args, &block|
+          Rails.logger.tagged "Job:#{job.id}" do
+            block.call(job, *args)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This includes 3 fixes:
- support for using SQLite
- reverting my mistake with 'successful publications'
- fixing an issue that causes a Job to be requeued which then failed after a successful publish

It also modifies the logging when in delayed job.  I'm not really happy with the logging changes, but I needed to stop.

I might just go ahead and merge this because what is on staging right now is broken

cc @dougmartin 