### PR TITLE
duplicate can publish back to a portal

### DIFF
--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -158,6 +158,7 @@ class LightweightActivitiesController < ApplicationController
     end
   end
 
+  # FIXME this should really be something other than a GET since it has side effects
   def duplicate
     authorize! :duplicate, @activity
     @new_activity = @activity.duplicate(current_user)
@@ -167,6 +168,12 @@ class LightweightActivitiesController < ApplicationController
     end
 
     if @new_activity.save(:validations => false) # In case the old activity was invalid
+      # check if we should publish this new activity somewhere
+      if params['add_to_portal']
+        req_url = "#{request.protocol}#{request.host_with_port}"
+        # this might take a little time so it might be better do this in the background
+        @new_activity.portal_publish(current_user,params['add_to_portal'],req_url)
+      end
       redirect_to edit_activity_path(@new_activity)
     else
       flash[:warning] = "Copy failed"

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -30,6 +30,10 @@ module Publishable
   alias_method :last_publication, :find_portal_publication
 
   def portal_publish(user,auth_portal,self_url)
+    if auth_portal.is_a? String
+      auth_portal = Concord::AuthPortal.portal_for_url(auth_portal)
+    end
+
     self.update_attribute('publication_status','public')
     self.portal_publish_with_token(user.authentication_token,auth_portal,self_url)
   end

--- a/spec/controllers/lightweight_activity_controller_spec.rb
+++ b/spec/controllers/lightweight_activity_controller_spec.rb
@@ -412,16 +412,26 @@ describe LightweightActivitiesController do
   end
 
   describe '#duplicate' do
+    let (:duplicate_act) {  FactoryGirl.build(:activity) }
+
     it "should call 'duplicate' on the activity" do
+      allow(LightweightActivity).to receive(:find).and_return(act)
+      expect(act).to receive(:duplicate).and_return(duplicate_act)
       get :duplicate, { :id => act.id }
-      expect(assigns(:new_activity)).to be_a(LightweightActivity)
-      expect(assigns(:new_activity).name).to match /^Copy of #{assigns(:activity).name[0..30]}/
-      expect(assigns(:new_activity).user).to eq(@user)
     end
 
     it 'should redirect to edit the new activity' do
       get :duplicate, { :id => act.id }
       expect(response).to redirect_to(edit_activity_url(assigns(:new_activity)))
+    end
+
+    let (:portal_url) { "https://fake.portal.com" }
+
+    it "should publish the new activity if asked to do so" do
+      allow(LightweightActivity).to receive(:find).and_return(act)
+      allow(act).to receive(:duplicate).and_return(duplicate_act)
+      expect(duplicate_act).to receive(:portal_publish).with(@user, portal_url, "#{request.protocol}#{request.host_with_port}")
+      get :duplicate, { :id => act.id, :add_to_portal => portal_url }
     end
   end
 

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -210,6 +210,7 @@ describe LightweightActivity do
       expect(dup.time_to_complete).to eq(activity.time_to_complete)
       expect(dup.layout).to eq(activity.layout)
       expect(dup.editor_mode).to eq(activity.editor_mode)
+      expect(dup.name).to match /^Copy of #{activity.name[0..30]}/
     end
     describe "for itsi activities" do
       let(:edit_mode) { LightweightActivity::ITSI_EDITOR_MODE   }

--- a/spec/models/publishable_spec.rb
+++ b/spec/models/publishable_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Publishable do
+  subject(:instance) do
+  	# fake included for now
+    allow(Publishable).to receive(:included) { "NO OP"}
+    Class.new { include Publishable }.new
+  end
+  let (:authentication_token ) { "fake token" }
+  let (:user) { double(:authentication_token => "fake token") }
+  let (:portal_url) { "fake portal url" }
+  let (:portal) { double }
+  let (:self_url) { "fake self url"}
+  describe "#portal_publish" do
+  	it "should handle strings" do
+  	  is_expected.to receive(:update_attribute)
+      expect(Concord::AuthPortal).to receive(:portal_for_url).with(portal_url).and_return( portal )
+  	  is_expected.to receive(:portal_publish_with_token).with(authentication_token, portal, self_url)
+      instance.portal_publish(user, portal_url, self_url )
+  	end
+  end
+end


### PR DESCRIPTION
When passed a URL like:
http://localhost:3000/activities/8/duplicate?domain=http://portal.local/&domain_uid=2&add_to_portal=http://portal.local/

LARA will first log in the user in the portal, then duplicate the activity, and then publish it back to the portal.  This pull request also includes a few changes to some existing spec tests of the duplicate code.

[#97737250]