### PR TITLE
Add trigger the autopublishing of sequences when activities change [#99005644]

### DIFF
--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -152,6 +152,11 @@ module Publishable
             raise e unless (e.is_a? ActiveRecord::RecordNotUnique) or /Duplicate entry/.match(e.to_s)
           end
         end
+
+        # changes to activities should trigger auto publishing of their associated sequences
+        if self.respond_to?(:sequences)
+          self.sequences.each { |sequence| sequence.queue_auto_publish_to_portal() }
+        end
       end
     end
   end


### PR DESCRIPTION
The :touch option does not work for has_many associations so I had to do it manually in the queing code.