### PR TITLE
publish with the correct authentication_token

### DIFF
--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -35,7 +35,7 @@ module Publishable
     end
 
     self.update_attribute('publication_status','public')
-    self.portal_publish_with_token(user.authentication_token,auth_portal,self_url)
+    self.portal_publish_with_token(user.authentication_token(auth_portal.strategy_name),auth_portal,self_url)
   end
 
   def republish_for_portal(auth_portal,self_url,json=nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,9 +41,10 @@ class User < ActiveRecord::Base
     # TODO: token expiration
     auth = nil
     if provider
-      auth = authentications.find_by_provider provider
+      auth = authentications.find_last_by_provider provider
+    else
+      auth = most_recent_authentication
     end
-    auth ||= most_recent_authentication
     auth ? auth.token : nil
   end
 

--- a/spec/models/publishable_spec.rb
+++ b/spec/models/publishable_spec.rb
@@ -9,10 +9,10 @@ describe Publishable do
   let (:authentication_token ) { "fake token" }
   let (:user) { double(:authentication_token => "fake token") }
   let (:portal_url) { "fake portal url" }
-  let (:portal) { double }
+  let (:portal) { double(:strategy_name => 'fake strategy') }
   let (:self_url) { "fake self url"}
   describe "#portal_publish" do
-  	it "should handle strings" do
+  	it "should handle a portal url string argument" do
   	  is_expected.to receive(:update_attribute)
       expect(Concord::AuthPortal).to receive(:portal_for_url).with(portal_url).and_return( portal )
   	  is_expected.to receive(:portal_publish_with_token).with(authentication_token, portal, self_url)


### PR DESCRIPTION
Without this, the wrong authentication toke was being used when a user
was logging into two different portal and then trying to add the material
to the first portal.
[#99167076]