### PR TITLE
Remove banner from itsi editor when iframed and adjust height [#97848200] [#99173350]

### DIFF
--- a/app/assets/javascripts/iframed_site_manager.js
+++ b/app/assets/javascripts/iframed_site_manager.js
@@ -1,0 +1,45 @@
+// add iframe class to html before body loads completely - this must be run after the body tag in application.html.erb
+try {
+  if (window.self !== window.top) {
+    // add body class to hide elements (inserted before because body class gets mangled in application.html.erb)
+    document.body.className = "iframed " + document.body.className;
+
+    // wait until the full body loads
+    $(function () {
+      var $document = $(document),
+          sendMessage= function (message) {
+            window.parent.postMessage({iframed_site_manager: message}, '*');
+          };
+
+      // wait until the parent tells us it needs the iframed-site-manager
+      $(window).on('message', function (e) {
+        var data = e.originalEvent.data ? e.originalEvent.data.iframed_site_manager : null;
+        if (!data) {
+          return;
+        }
+
+        // start the height poller if needed
+        if (data.need_height_poller) {
+          var lastHeight = $document.height(),
+              sendHeight, heightPoller;
+
+          sendHeight = function (iframeHeight) {
+            sendMessage({iframe_height: iframeHeight});
+          };
+          sendHeight(lastHeight);
+
+          heightPoller = function () {
+            var newHeight = $document.height();
+            if (newHeight !== lastHeight) {
+              sendHeight(newHeight);
+              lastHeight = newHeight;
+            }
+          };
+          setInterval(heightPoller, 100);
+        }
+
+        // other iframe site services go here...
+      })
+    });
+  }
+} catch (e) {}

--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -1,4 +1,3 @@
-
 #container.itsi-edit {
   background-color: #fee9aa;
   font-family: Arial, Helvetica, sans-serif;
@@ -67,7 +66,7 @@
     }
     input, textarea {
       margin-bottom: 10px;
-      width: 100%;
+      width: 90%;
     }
     textarea {
       height: 100px;

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -1006,3 +1006,22 @@ ul#new-menu {
       color: red;
     }
 }
+
+body.iframed {
+  #container {
+    margin-top: -13px;
+    #header {
+      display: none;
+      height: 0;
+    }
+    #content {
+      #session, h1, nav {
+        display: none;
+      }
+    }
+  }
+  #footer {
+    display: none;
+  }
+}
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,11 +8,13 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 </head>
+<%- @body_class = request.original_fullpath.split('/').join(' ') -%>
 <%- if @session_key -%>
-  <body class="right <%= request.original_fullpath.split('/').join(' ') %>" data-session-key="<%= @session_key %>">
+  <body class="right <%= @body_class %>" data-session-key="<%= @session_key %>">
 <%- else -%>
-  <body class="right <%= request.original_fullpath.split('/').join(' ') %>">
+  <body class="right <%= @body_class %>">
 <%- end -%>
+<%= javascript_include_tag "iframed_site_manager" %>
 <div id="container" class="<%= content_for :container_css_classes %>">
   <div id="header">
     <div>


### PR DESCRIPTION
This runs Javascript right after the body tag is defined in application.html.erb that addes an 'iframed' class to the body if the page is not the top document.  The body.iframed class then removes unneeded elements from the page like the header and footer.  It then waits for the parent document to announce it needs iframe_site_manager services via PostMessage and then handles those requests.  Currently the only requests are the the iframe height  [#99173350] but other stories in the current PT may require other types of lara-iframed communication.

