### PR TITLE
Added json response to unauthorized ajax calls

### DIFF
--- a/app/controllers/c_rater/score_mappings_controller.rb
+++ b/app/controllers/c_rater/score_mappings_controller.rb
@@ -1,15 +1,16 @@
 class CRater::ScoreMappingsController < ApplicationController
-  
+
   def index
     if current_user && current_user.admin?
       @filter = CollectionFilter.new(current_user, CRater::ScoreMapping, params[:filter] || {})
       @score_mappings = @filter.collection.includes(:user)
     else
-      render :partial => "shared/unauthorized", :locals => {:action => "no_action",:resource=> "no_resource"},:status => 403
+      response_data = unauthorized_response_data("no_action", "no_resource")
+      render :partial => "shared/unauthorized", :locals => {:message => response_data[:message]}, :status => 403
       return
     end
   end
-  
+
   def new
     @score_mapping = CRater::ScoreMapping.new()
     respond_to do |format|
@@ -17,7 +18,7 @@ class CRater::ScoreMappingsController < ApplicationController
       format.html
     end
   end
-  
+
   def create
     score_mapping = { mapping: params[:c_rater_score_mapping].slice(:score0,:score1,:score2,:score3,:score4,:score5,:score6)}
     @score_mapping = CRater::ScoreMapping.create(score_mapping)
@@ -27,7 +28,7 @@ class CRater::ScoreMappingsController < ApplicationController
     @score_mapping.save
     redirect_to(:back)
   end
-  
+
   def edit
     @score_mapping = CRater::ScoreMapping.find(params[:id])
     respond_to do |format|
@@ -35,7 +36,7 @@ class CRater::ScoreMappingsController < ApplicationController
       format.html
     end
   end
-  
+
   def update
     @score_mapping = CRater::ScoreMapping.find(params[:id])
     score_mapping = { mapping: params[:c_rater_score_mapping].slice(:score0,:score1,:score2,:score3,:score4,:score5,:score6)}
@@ -45,7 +46,7 @@ class CRater::ScoreMappingsController < ApplicationController
     @score_mapping.save!
     redirect_to(:back)
   end
-  
+
   def destroy
     @score_mapping = CRater::ScoreMapping.find(params[:id])
     @score_mapping.destroy

--- a/app/views/shared/_unauthorized.html.haml
+++ b/app/views/shared/_unauthorized.html.haml
@@ -1,13 +1,3 @@
-- if current_user
-  - user = session[:portal_username] || current_user.email
--else
-  - user = "Anonymous"  
-
-- if resource.class.name == "LightweightActivity" || resource.class.name == "Sequence"
-  - message = "#{user}, you don't have permission to #{action} the #{resource.class.name} with id : #{resource.id}"
-- else
-  - message = "#{user}, you don't have permission to access this page."
-  
 %body{:style => 'background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif;' }
   .unauthorized_message{:style=>'width: 20em;padding: 0 4em;margin: 4em auto 0 auto;border: 1px solid #ccc;border-right-color: #999;border-bottom-color: #999;'}
     %h1{:style=>'font-size: 100%; color: #f00; line-height: 1.5;'} #{message}


### PR DESCRIPTION
Currently unauthorized ajax calls return a 500 error because the application controller does not handle json formatted errors for unauthorized requests (it tries to load the shared/unauthorized partial in json format).  This change is needed in another story (https://www.pivotaltracker.com/story/show/98616438) so that the client side ajax can detect the unauthorized request and present a better error message.  I thought it best to split PR from that story so that it stands alone.