### PR TITLE
Interactive sizing

### DIFF
--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -19,6 +19,8 @@ ResizableInteractive.prototype.fixSize = function () {
 
 // Setup
 $(document).ready(function () {
-    resizingInteractive = new ResizableInteractive($('[data-aspect-ratio]'));
-    resizingInteractive.fixSize();
+    $('[data-aspect-ratio]').each(function (index, element){
+      resizingInteractive = new ResizableInteractive($(element));
+      resizingInteractive.fixSize();
+    });
 });

--- a/app/assets/stylesheets/partials/_click_to_play.scss
+++ b/app/assets/stylesheets/partials/_click_to_play.scss
@@ -10,6 +10,8 @@
     .img-container {
       img {
         width : 100%;
+        height: 100%;
+        object-fit: contain;
       }
     }
     .click_to_play {

--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -63,10 +63,8 @@ module InteractiveRunHelper
       :iframe_mouseover => "false"
     }
 
-    width = interactive.native_width ? "#{interactive.native_width}px" : 'inherit'
-    height = interactive.native_height ? "#{interactive.native_height}px" : 'inherit'
-
     opts = {
+      :width => "100%",
       :frameborder => "no",
       :scrolling => "no",
       :allowfullscreen => "true",
@@ -75,8 +73,7 @@ module InteractiveRunHelper
       :src => iframe_src ? url : nil,
       :data => data,
       :class => 'interactive',
-      :id => "interactive_#{interactive.id}",
-      :style => "width: #{width}; height: #{height}"
+      :id => "interactive_#{interactive.id}"
     }
     capture_haml do
       haml_tag 'iframe', opts

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -1,37 +1,38 @@
 .interactive-container{class: interactive.save_state ? 'savable' : ''}
-  - if !interactive.image_url.blank?
-    .img-container{:id => dom_id_for(interactive, :interactive_image),:style => interactive.click_to_play ? "display:block" : "display:none"}
-      =image_tag(interactive.image_url)
-  - else
-    .interactive-print-text
-      %div
-        Interactive Model
-      %p
-        See :-
-        =link_to "#{interactive.url}","#{interactive.url}"
+  - if interactive.native_height > 1
+    - if !interactive.image_url.blank?
+      .img-container{:id => dom_id_for(interactive, :interactive_image),:style => interactive.click_to_play ? "display:block" : "display:none"}
+        =image_tag(interactive.image_url)
+    - else
+      .interactive-print-text
+        %div
+          Interactive Model
+        %p
+          See :-
+          =link_to "#{interactive.url}","#{interactive.url}"
 
-  - if interactive.click_to_play
-    .click_to_play.shown{:id => dom_id_for(interactive, :click_to_play)}
-      .background
-      .text= "Click here to start the interactive."
+    - if interactive.click_to_play
+      .click_to_play.shown{:id => dom_id_for(interactive, :click_to_play)}
+        .background
+        .text= "Click here to start the interactive."
 
-    = interactive_iframe_tag(interactive, @run,false) do
+      = interactive_iframe_tag(interactive, @run,false) do
 
-      Your browser does not support inline frames, or is currently not configured to display inline frames.
-      Content can be viewed at the actual source page:
-      = link_to interactive.url, interactive.url
+        Your browser does not support inline frames, or is currently not configured to display inline frames.
+        Content can be viewed at the actual source page:
+        = link_to interactive.url, interactive.url
 
-  - else
-    = interactive_iframe_tag(interactive, @run) do
+    - else
+      = interactive_iframe_tag(interactive, @run) do
 
-      Your browser does not support inline frames, or is currently not configured to display inline frames.
-      Content can be viewed at the actual source page:
-      = link_to interactive.url, interactive.url
+        Your browser does not support inline frames, or is currently not configured to display inline frames.
+        Content can be viewed at the actual source page:
+        = link_to interactive.url, interactive.url
 
-  - if interactive.save_state
-    .below_interactive
-      = interactive_data_div(interactive, @run)
-      = button_tag 'Undo all my work', {class: 'delete_interactive_data'}
+    - if interactive.save_state
+      .below_interactive
+        = interactive_data_div(interactive, @run)
+        = button_tag 'Undo all my work', {class: 'delete_interactive_data'}
 
 - labbook = show_labbook_under_interactive?(@run, interactive)
 - if labbook


### PR DESCRIPTION
This fixes a bug when multiple interactives are on the same page and have different aspect ratios.
It also fixes another bug when the click to play image for an interactive has a different aspect ratio than the interactive. Previously the image could extend down the page.
Finally it adds a shortcut for some display problems. Only interactives with a height greater than 1 are render. Otherwise they are not rendered at all.  

For ITSI we have some interactives that are fake interactives, which just hold a spot in the template system. Sizing them with a height of 1 or 0, didn't work well because the click to play text and area were not limited to this height.  With this change none of that is rendered so the interactive is complete invisible at runtime.