### PR TITLE
Fix  LARA numbering when interactives save state, but don't report.

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -254,7 +254,7 @@ class LightweightActivity < ActiveRecord::Base
           }
           elements.push(mc_data)
         when MwInteractive
-          if embeddable.save_state && embeddable.has_report_url
+          if embeddable.is_reportable
             iframe_data = embeddable.to_hash
             iframe_data["type"] = 'iframe_interactive'
             iframe_data["id"] = embeddable.id

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -59,8 +59,8 @@ class LightweightActivity < ActiveRecord::Base
           q << e
         end
       end
-      p.interactives.each do |i|
-        q << i if i.respond_to?('save_state') && i.save_state
+      p.visible_interactives.each do |i|
+        q << i if i.respond_to?(:is_reportable) && i.is_reportable
       end
     end
     return q

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -110,4 +110,7 @@ class MwInteractive < ActiveRecord::Base
     end
   end
 
+  def is_reportable
+    return save_state && has_report_url
+  end
 end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -354,20 +354,39 @@ describe LightweightActivity do
       end
     end
 
-    describe 'pages section with hidden embeddables' do
+    describe 'pages section with hidden embeddables & reportable interactives' do
+      let(:page1) { FactoryGirl.create(:interactive_page_with_or, name: 'page 1', position: 0) }
+      let(:page2) { FactoryGirl.create(:interactive_page_with_hidden_or, name: 'page 2', position: 1) }
+      let(:page3) { FactoryGirl.create(:interactive_page_with_or, name: 'page 3', position: 2) }
+      let(:page4) { FactoryGirl.create(:interactive_page_with_or, name: 'page 4', position: 3) }
+
+      let(:non_reportable_interactive) {
+        FactoryGirl.create(:mw_interactive, save_state: true, has_report_url: false)
+      }
+
+      let(:reportable_interactive) {
+        FactoryGirl.create(:mw_interactive, save_state: true, has_report_url: true)
+      }
+
       before(:each) do
-        activity.pages << FactoryGirl.create(:interactive_page_with_or, name: 'page 1', position: 0)
-        activity.pages << FactoryGirl.create(:interactive_page_with_hidden_or, name: 'page 2', position: 1)
+        page3.add_interactive reportable_interactive
+        page4.add_interactive non_reportable_interactive
+        activity.pages << page1
+        activity.pages << page2
+        activity.pages << page3
+        activity.pages << page4
         activity.reload
       end
 
       it 'returns only visible embeddables' do
         pages = activity.serialize_for_portal('http://test.host')['sections'][0]['pages']
-        expect(pages.length).to eql(2)
+        expect(pages.length).to eql(4)
         expect(pages[0]['name']).to eql('page 1')
         expect(pages[0]['elements'].length).to eql(1)
         expect(pages[1]['name']).to eql('page 2')
         expect(pages[1]['elements'].length).to eql(0)
+        expect(pages[2]['elements'].length).to eql(2)
+        expect(pages[3]['elements'].length).to eql(1)
       end
     end
   end


### PR DESCRIPTION
Fix bug where question numbers in the report and the LARA runtime get out of sync following the page that contains the state saving interactive.

This commit is small, it just changes how 'questions' are calculated by activities.  The rest of the commit is just testing that method.

## Before:##
![image](https://cloud.githubusercontent.com/assets/22908/10460871/8685df9e-71a4-11e5-8989-7b67b6b9c875.png)

## After: ##
![image](https://cloud.githubusercontent.com/assets/22908/10460880/8e03c312-71a4-11e5-8065-691896e56312.png)


https://www.pivotaltracker.com/story/show/83009202