### PR TITLE
handle the missing template exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # With +respond_to do |format|+, "406 Not Acceptable" is sent on invalid format.
+  # With a regular render (implicit or explicit), ActionView::MissingTemplate
+  # exception is raised instead. If we then raise a RoutingError Rails turns it
+  # into a 404 response.
+  rescue_from(ActionView::MissingTemplate) do |e|
+    request.format = :html
+    raise ActionController::RoutingError.new('Not Found')
+  end
+
   before_filter :log_session_before
   before_filter :portal_login
   before_filter :reject_old_browsers, :except => [:bad_browser]

--- a/spec/controllers/embeddable/multiple_choices_controller_spec.rb
+++ b/spec/controllers/embeddable/multiple_choices_controller_spec.rb
@@ -24,7 +24,7 @@ describe Embeddable::MultipleChoicesController do
         correct
         begin
           get :check, :id => answer.id, :format => 'html', :choices => correct.id.to_s
-        rescue ActionView::MissingTemplate
+        rescue ActionController::RoutingError
         end
       end
     end


### PR DESCRIPTION
We are getting a number of missing template exceptions. In my opinion, it is not important to know if someone requests a format of a route that we don't support.

The most common example is when Edmodo tries to request the `image/*` version of a activity. 

@knowuh since you probably care the most about watching exceptions, do you agree?