### PR TITLE
Don’t save objects to DB before authorizing

### DIFF
--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -60,8 +60,9 @@ class InteractivePagesController < ApplicationController
 
   def create
     @activity = LightweightActivity.find(params[:activity_id])
-    @page = InteractivePage.create!(:lightweight_activity => @activity)
+    @page = InteractivePage.new(:lightweight_activity => @activity)
     authorize! :create, @page
+    @page.save!
     update_activity_changed_by
     flash[:notice] = "A new page was added to #{@activity.name}"
     redirect_to edit_activity_page_path(@activity, @page)

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -92,7 +92,7 @@ class LightweightActivitiesController < ApplicationController
   end
 
   def create
-    @activity = LightweightActivity.create(params[:lightweight_activity])
+    @activity = LightweightActivity.new(params[:lightweight_activity])
     authorize! :create, @activity
     @activity.user = current_user
     @activity.changed_by = current_user


### PR DESCRIPTION
This was allowing some ownerless objects into the database.

@knowuh can you take a look?