### PR TITLE
Update dashboard API to use endpoint_urls instead of run keys

### DIFF
--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -87,12 +87,6 @@ class RunsController < ApplicationController
   end
 
   # Used by Dashboard app.
-  # This API is open, there is no authorization, but it requires secure
-  # form of endpoint_urls that use long UUID keys instead of numeric IDs.
-  # E.g. this endpoint URL will be accepted:
-  # https://learn.concord.org/dataservice/external_activity_data/key:19679d16-e79e-4f36-8253-5deb1321e6d9
-  # but this will be filtered out:
-  # https://learn.concord.org/dataservice/external_activity_data/123
   def dashboard
     page_id = params[:page_id]
     endpoint_urls = params[:endpoint_urls] || []

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -87,10 +87,16 @@ class RunsController < ApplicationController
   end
 
   # Used by Dashboard app.
+  # This API is open, there is no authorization, but it requires secure
+  # form of endpoint_urls that use long UUID keys instead of numeric IDs.
+  # E.g. this endpoint URL will be accepted:
+  # https://learn.concord.org/dataservice/external_activity_data/key:19679d16-e79e-4f36-8253-5deb1321e6d9
+  # but this will be filtered out:
+  # https://learn.concord.org/dataservice/external_activity_data/123
   def dashboard
-    page_id  = params[:page_id]
-    runs     = params[:runs] || []
-    dashboard = DashboardRunlist.new(runs, page_id)
+    page_id = params[:page_id]
+    endpoint_urls = params[:endpoint_urls] || []
+    dashboard = DashboardRunlist.new(endpoint_urls, page_id)
     render json: dashboard.to_json, callback: params[:callback]
   end
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -4,7 +4,7 @@ class Run < ActiveRecord::Base
   class PortalUpdateIncomplete < StandardError; end
   class InvalidJobState < StandardError; end
 
-  attr_accessible :run_count, :user_id, :key, :activity, :user, :remote_id, :remote_endpoint, :activity_id, :sequence_id
+  attr_accessible :run_count, :user_id, :key, :activity, :user, :page_id, :remote_id, :remote_endpoint, :activity_id, :sequence_id
 
   belongs_to :activity, :class_name => LightweightActivity
 

--- a/app/services/dashboard_runlist.rb
+++ b/app/services/dashboard_runlist.rb
@@ -1,11 +1,35 @@
 class DashboardRunlist
+  # If remote endpoint includes `key:` prefix, it means it's using long UUID key
+  # instead of numeric ID, e.g.:
+  # https://learn.concord.org/dataservice/external_activity_data/key:19679d16-e79e-4f36-8253-5deb1321e6d9
+  SECURE_ENDPOINT_URL_REGEXP = /key:/
 
-  def initialize(run_keys, page_id)
-    @runs = Run.where(key: run_keys).map do |run|
+  def initialize(endpoint_urls, page_id)
+    # Make sure that we accept only endpoints that use UUID to identify learner.
+    # If we accepted numeric ID, it would be easy to modify it and download other students data.
+    endpoint_urls = filter_endpoints(endpoint_urls)
+    @runs = Run.where(remote_endpoint: endpoint_urls).map do |run|
       {
-        key: run.key,
+        endpoint_url: run.remote_endpoint,
+        last_page_id: run.last_page ? run.last_page.id : nil,
         submissions: submissions(run, page_id)
       }
+    end
+  end
+
+  def to_hash
+    @runs
+  end
+
+  def to_json
+    to_hash.to_json
+  end
+
+  private
+
+  def filter_endpoints(endpoints)
+    endpoints.select do |endpoint|
+      endpoint =~ SECURE_ENDPOINT_URL_REGEXP
     end
   end
 
@@ -23,18 +47,11 @@ class DashboardRunlist
       {
         question_index: fi.answer.question_index,
         answer: fi.answer_text,
+        feedback_type: fi.class.name,
         feedback: fi.feedback_text,
         score: fi.score
       }
     end
     answers.sort { |a,b| a[:question_index] <=> b[:question_index] }
-  end
-
-  def to_hash
-    @runs
-  end
-
-  def to_json
-    to_hash.to_json
   end
 end

--- a/app/services/dashboard_runlist.rb
+++ b/app/services/dashboard_runlist.rb
@@ -1,17 +1,10 @@
 class DashboardRunlist
-  # If remote endpoint includes `key:` prefix, it means it's using long UUID key
-  # instead of numeric ID, e.g.:
-  # https://learn.concord.org/dataservice/external_activity_data/key:19679d16-e79e-4f36-8253-5deb1321e6d9
-  SECURE_ENDPOINT_URL_REGEXP = /key:/
-
   def initialize(endpoint_urls, page_id)
-    # Make sure that we accept only endpoints that use UUID to identify learner.
-    # If we accepted numeric ID, it would be easy to modify it and download other students data.
-    endpoint_urls = filter_endpoints(endpoint_urls)
     @runs = Run.where(remote_endpoint: endpoint_urls).map do |run|
       {
         endpoint_url: run.remote_endpoint,
-        last_page_id: run.last_page ? run.last_page.id : nil,
+        group_id: run.collaboration_run_id,
+        last_page_id: run.page_id,
         submissions: submissions(run, page_id)
       }
     end
@@ -27,16 +20,11 @@ class DashboardRunlist
 
   private
 
-  def filter_endpoints(endpoints)
-    endpoints.select do |endpoint|
-      endpoint =~ SECURE_ENDPOINT_URL_REGEXP
-    end
-  end
-
   def submissions(run, page_id)
     CRater::FeedbackSubmission.where(run_id: run.id, interactive_page_id: page_id).order(:id).map do |submission|
       {
         id: submission.id,
+        group_id: submission.collaboration_run_id,
         answers: answers(submission)
       }
     end

--- a/spec/services/dashboard_runlist_spec.rb
+++ b/spec/services/dashboard_runlist_spec.rb
@@ -3,19 +3,37 @@ require 'spec_helper'
 describe DashboardRunlist do
   include_context "activity with arg block submissions"
 
-  it 'returns all the submissions of provided runs' do
-    runlist = DashboardRunlist.new([@run.key], page.id).to_hash
-    expect(runlist.length).to eql(1)
-    expect(runlist[0][:key]).to eql(@run.key)
-    expect(runlist[0][:submissions].length).to eql(1)
-    expect(runlist[0][:submissions][0][:answers].length).to eql(4)
-    expect(runlist[0][:submissions][0][:answers][0][:answer]).to eql('text1')
-    expect(runlist[0][:submissions][0][:answers][0][:score]).to eql(1)
-    expect(runlist[0][:submissions][0][:answers][1][:answer]).to eql('text2')
-    expect(runlist[0][:submissions][0][:answers][1][:score]).to eql(2)
-    expect(runlist[0][:submissions][0][:answers][2][:answer]).to eql('text3')
-    expect(runlist[0][:submissions][0][:answers][2][:score]).to eql(3)
-    expect(runlist[0][:submissions][0][:answers][3][:answer]).to eql('text4')
-    expect(runlist[0][:submissions][0][:answers][3][:score]).to eql(4)
+  describe 'when run endpoint is secure (=> uses UUID key)' do
+    before(:each) do
+      @run.update_attributes(remote_endpoint: 'http://test.portal/dataservice/key:123-aaa-bbb-ccc-ddd-987-xyz')
+    end
+
+    it 'returns all the submissions of provided runs' do
+      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash
+      expect(runlist.length).to eql(1)
+      expect(runlist[0][:endpoint_url]).to eql(@run.remote_endpoint)
+      expect(runlist[0][:last_page_id]).to eql(page.id)
+      expect(runlist[0][:submissions].length).to eql(1)
+      expect(runlist[0][:submissions][0][:answers].length).to eql(4)
+      expect(runlist[0][:submissions][0][:answers][0][:answer]).to eql('text1')
+      expect(runlist[0][:submissions][0][:answers][0][:score]).to eql(1)
+      expect(runlist[0][:submissions][0][:answers][1][:answer]).to eql('text2')
+      expect(runlist[0][:submissions][0][:answers][1][:score]).to eql(2)
+      expect(runlist[0][:submissions][0][:answers][2][:answer]).to eql('text3')
+      expect(runlist[0][:submissions][0][:answers][2][:score]).to eql(3)
+      expect(runlist[0][:submissions][0][:answers][3][:answer]).to eql('text4')
+      expect(runlist[0][:submissions][0][:answers][3][:score]).to eql(4)
+    end
+  end
+
+  describe 'when run endpoint is not secure (=> uses numeric ID)' do
+    before(:each) do
+      @run.update_attributes(remote_endpoint: 'http://test.portal/dataservice/123')
+    end
+
+    it 'does not return run data' do
+      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash
+      expect(runlist.length).to eql(0)
+    end
   end
 end

--- a/spec/services/dashboard_runlist_spec.rb
+++ b/spec/services/dashboard_runlist_spec.rb
@@ -2,38 +2,20 @@ require 'spec_helper'
 
 describe DashboardRunlist do
   include_context "activity with arg block submissions"
-
-  describe 'when run endpoint is secure (=> uses UUID key)' do
-    before(:each) do
-      @run.update_attributes(remote_endpoint: 'http://test.portal/dataservice/key:123-aaa-bbb-ccc-ddd-987-xyz')
-    end
-
-    it 'returns all the submissions of provided runs' do
-      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash
-      expect(runlist.length).to eql(1)
-      expect(runlist[0][:endpoint_url]).to eql(@run.remote_endpoint)
-      expect(runlist[0][:last_page_id]).to eql(page.id)
-      expect(runlist[0][:submissions].length).to eql(1)
-      expect(runlist[0][:submissions][0][:answers].length).to eql(4)
-      expect(runlist[0][:submissions][0][:answers][0][:answer]).to eql('text1')
-      expect(runlist[0][:submissions][0][:answers][0][:score]).to eql(1)
-      expect(runlist[0][:submissions][0][:answers][1][:answer]).to eql('text2')
-      expect(runlist[0][:submissions][0][:answers][1][:score]).to eql(2)
-      expect(runlist[0][:submissions][0][:answers][2][:answer]).to eql('text3')
-      expect(runlist[0][:submissions][0][:answers][2][:score]).to eql(3)
-      expect(runlist[0][:submissions][0][:answers][3][:answer]).to eql('text4')
-      expect(runlist[0][:submissions][0][:answers][3][:score]).to eql(4)
-    end
-  end
-
-  describe 'when run endpoint is not secure (=> uses numeric ID)' do
-    before(:each) do
-      @run.update_attributes(remote_endpoint: 'http://test.portal/dataservice/123')
-    end
-
-    it 'does not return run data' do
-      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash
-      expect(runlist.length).to eql(0)
-    end
+  it 'returns all the submissions of provided runs' do
+    runlist = DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash
+    expect(runlist.length).to eql(1)
+    expect(runlist[0][:endpoint_url]).to eql(@run.remote_endpoint)
+    expect(runlist[0][:last_page_id]).to eql(page.id)
+    expect(runlist[0][:submissions].length).to eql(1)
+    expect(runlist[0][:submissions][0][:answers].length).to eql(4)
+    expect(runlist[0][:submissions][0][:answers][0][:answer]).to eql('text1')
+    expect(runlist[0][:submissions][0][:answers][0][:score]).to eql(1)
+    expect(runlist[0][:submissions][0][:answers][1][:answer]).to eql('text2')
+    expect(runlist[0][:submissions][0][:answers][1][:score]).to eql(2)
+    expect(runlist[0][:submissions][0][:answers][2][:answer]).to eql('text3')
+    expect(runlist[0][:submissions][0][:answers][2][:score]).to eql(3)
+    expect(runlist[0][:submissions][0][:answers][3][:answer]).to eql('text4')
+    expect(runlist[0][:submissions][0][:answers][3][:score]).to eql(4)
   end
 end

--- a/spec/support/shared_context/activity_with_arg_block_submissions.rb
+++ b/spec/support/shared_context/activity_with_arg_block_submissions.rb
@@ -5,7 +5,7 @@ shared_context "activity with arg block submissions" do
 
   before(:each) do
     # Setup run.
-    @run = FactoryGirl.create(:run, activity: act, remote_endpoint: 'http://remote.endpoint')
+    @run = FactoryGirl.create(:run, activity: act, page: page, remote_endpoint: 'http://remote.endpoint')
     # Setup arg block embeddables.
     @q1 = FactoryGirl.create(:mc_embeddable, prompt: 'q1')
     @q2 = FactoryGirl.create(:open_response, prompt: 'q2')


### PR DESCRIPTION
1. Use endpoint URLs instead of run keys in `runs/dashboard` API
2. Filter out endpoint URLs that use numeric IDs, accept only those which use long UUID keys.
3. Return `last_page_id` for each run (will be useful in  Dashboard TOC view).