### PR TITLE
Add group support to arg block submissions

### DIFF
--- a/app/models/c_rater/feedback_submission.rb
+++ b/app/models/c_rater/feedback_submission.rb
@@ -1,11 +1,15 @@
 class CRater::FeedbackSubmission < ActiveRecord::Base
   # Provided by student.
-  attr_accessible :usefulness_score, :interactive_page, :run
+  attr_accessible :usefulness_score, :interactive_page, :run, :collaboration_run
 
   has_many :c_rater_feedback_items, as: :feedback_submission, class_name: 'CRater::FeedbackItem'
   has_many :embeddable_feedback_items, as: :feedback_submission, class_name: 'Embeddable::FeedbackItem'
   belongs_to :interactive_page
   belongs_to :run
+  belongs_to :collaboration_run
+  belongs_to :base_submission, class_name: 'CRater::FeedbackSubmission'
+
+  delegate :user, to: :run, allow_nil: true
 
   def self.usefulness_score_names
     {
@@ -15,11 +19,63 @@ class CRater::FeedbackSubmission < ActiveRecord::Base
     }
   end
 
+  # For given page and run, generates feedback for all the argumentation block questions,
+  # creates a new submission and returns a hash with basic information about submission.
+  def self.generate_feedback(page, run)
+    finder = Embeddable::AnswerFinder.new(run)
+    arg_block_answers = page.section_embeddables(CRater::ARG_SECTION_NAME).map { |e| finder.find_answer(e) }
+    submission = CRater::FeedbackSubmission.create!(interactive_page: page, run: run, collaboration_run: run.collaboration_run)
+    feedback_items = {}
+    arg_block_answers.each do |a|
+      f = a.save_feedback
+      unless f.nil?
+        f.feedback_submission = submission
+        f.save!
+        feedback_items[a.id] = {score: f.score, text: f.feedback_text}
+      end
+    end
+    submission.propagate_to_collaborators
+    {
+      submission_id: submission.id,
+      feedback_items: feedback_items
+    }
+  end
+
   def usefulness_score_name
     self.class.usefulness_score_names[usefulness_score]
   end
 
   def feedback_items
     c_rater_feedback_items + embeddable_feedback_items
+  end
+
+  def update_usefulness_score(value)
+    update_attributes!(usefulness_score: value)
+    if collaboration_run
+      CRater::FeedbackSubmission.where(base_submission_id: self.id).each do |submission|
+        submission.update_attributes!(usefulness_score: value)
+      end
+    end
+  end
+
+  def activity
+    interactive_page && interactive_page.lightweight_activity
+  end
+
+  def propagate_to_collaborators
+    return unless collaboration_run
+    collaboration_run.collaborators_runs(activity, user).each do |run|
+      submission_copy = self.dup
+      submission_copy.run = run
+      submission_copy.base_submission = self
+      submission_copy.save!
+      finder = Embeddable::AnswerFinder.new(run)
+      feedback_items.each do |fi|
+        fi_copy = fi.dup
+        fi_copy.feedback_submission = submission_copy
+        fi_copy.answer = finder.find_answer(fi.answer.question)
+        fi_copy.save!
+      end
+    end
   end
 end

--- a/db/migrate/20160119025740_add_collaboration_run_to_feedback_submissions.rb
+++ b/db/migrate/20160119025740_add_collaboration_run_to_feedback_submissions.rb
@@ -1,0 +1,5 @@
+class AddCollaborationRunToFeedbackSubmissions < ActiveRecord::Migration
+  def change
+    add_column :c_rater_feedback_submissions, :collaboration_run_id, :integer
+  end
+end

--- a/db/migrate/20160119025810_add_base_submission_to_feedback_submissions.rb
+++ b/db/migrate/20160119025810_add_base_submission_to_feedback_submissions.rb
@@ -1,0 +1,6 @@
+class AddBaseSubmissionToFeedbackSubmissions < ActiveRecord::Migration
+  def change
+    add_column :c_rater_feedback_submissions, :base_submission_id, :integer
+    add_index :c_rater_feedback_submissions, :base_submission_id, name: 'feedback_submissions_base_sub_id_idx'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150818153040) do
+ActiveRecord::Schema.define(:version => 20160119025810) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -53,21 +53,24 @@ ActiveRecord::Schema.define(:version => 20150818153040) do
 
   create_table "c_rater_feedback_submissions", :force => true do |t|
     t.integer  "usefulness_score"
-    t.datetime "created_at",          :null => false
-    t.datetime "updated_at",          :null => false
+    t.datetime "created_at",           :null => false
+    t.datetime "updated_at",           :null => false
     t.integer  "interactive_page_id"
     t.integer  "run_id"
+    t.integer  "collaboration_run_id"
+    t.integer  "base_submission_id"
   end
 
+  add_index "c_rater_feedback_submissions", ["base_submission_id"], :name => "feedback_submissions_base_sub_id_idx"
   add_index "c_rater_feedback_submissions", ["interactive_page_id", "run_id"], :name => "c_rater_fed_submission_page_run_idx"
 
   create_table "c_rater_item_settings", :force => true do |t|
-    t.string   "item_id"
     t.integer  "score_mapping_id"
     t.integer  "provider_id"
     t.string   "provider_type"
     t.datetime "created_at",       :null => false
     t.datetime "updated_at",       :null => false
+    t.string   "item_id"
   end
 
   add_index "c_rater_item_settings", ["provider_id", "provider_type"], :name => "c_rat_set_prov_idx"
@@ -129,7 +132,7 @@ ActiveRecord::Schema.define(:version => 20150818153040) do
     t.integer  "image_question_id"
     t.datetime "created_at",                                                   :null => false
     t.datetime "updated_at",                                                   :null => false
-    t.text     "annotation",          :limit => 2147483647
+    t.text     "annotation",          :limit => 4294967294
     t.string   "annotated_image_url"
     t.boolean  "is_dirty",                                  :default => false
     t.boolean  "is_final",                                  :default => false
@@ -240,8 +243,8 @@ ActiveRecord::Schema.define(:version => 20150818153040) do
     t.boolean  "is_prediction",            :default => false
     t.boolean  "give_prediction_feedback", :default => false
     t.text     "prediction_feedback"
-    t.string   "default_text"
     t.boolean  "is_hidden",                :default => false
+    t.string   "default_text"
   end
 
   create_table "embeddable_xhtmls", :force => true do |t|
@@ -381,16 +384,16 @@ ActiveRecord::Schema.define(:version => 20150818153040) do
 
   create_table "mw_interactives", :force => true do |t|
     t.string   "name"
-    t.text     "url"
-    t.datetime "created_at",                        :null => false
-    t.datetime "updated_at",                        :null => false
+    t.text     "url",            :limit => 2048
+    t.datetime "created_at",                                        :null => false
+    t.datetime "updated_at",                                        :null => false
     t.integer  "native_width"
     t.integer  "native_height"
-    t.boolean  "save_state",     :default => false
-    t.boolean  "has_report_url", :default => false
+    t.boolean  "save_state",                     :default => false
+    t.boolean  "has_report_url",                 :default => false
     t.boolean  "click_to_play"
     t.string   "image_url"
-    t.boolean  "is_hidden",      :default => false
+    t.boolean  "is_hidden",                      :default => false
   end
 
   create_table "page_items", :force => true do |t|

--- a/spec/models/c_rater/feedback_submission_spec.rb
+++ b/spec/models/c_rater/feedback_submission_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe CRater::FeedbackSubmission do
+  before(:each) do
+    @users = FactoryGirl.create_list(:user, 2)
+    @activity = FactoryGirl.create(:activity_with_page)
+    @question = FactoryGirl.create(:multiple_choice)
+    @runs = FactoryGirl.create_list(:run, 2).each_with_index do |run, idx|
+      run.activity = @activity
+      run.user = @users[idx]
+      run.save!
+    end
+    @answers = FactoryGirl.create_list(:multiple_choice_answer, 2).each_with_index do |ans, idx|
+      ans.answers << FactoryGirl.create(:multiple_choice_choice, choice: "answer", prompt: "feedback")
+      ans.question = @question
+      ans.run = @runs[idx]
+      ans.save!
+    end
+    @page = @activity.pages.first
+    @page.add_embeddable(@question, nil, CRater::ARG_SECTION_NAME)
+  end
+
+  def create_collaboration_run
+    @c_run = FactoryGirl.create(:collaboration_run)
+    @c_run.user = @users[0]
+    @c_run.runs.concat(@runs)
+    @c_run.save!
+  end
+
+  describe "CRater::FeedbackSubmission.generate_feedback" do
+    it "generates submission, feedback items and returns basic information about submission" do
+      info = CRater::FeedbackSubmission.generate_feedback(@page, @runs[0])
+      expect(CRater::FeedbackSubmission.count).to eql(1)
+      expect(info[:submission_id]).to eql(CRater::FeedbackSubmission.first.id)
+      expect(info[:feedback_items][@answers[0].id][:text]).to eql('feedback')
+    end
+
+    describe "when user runs activity with collaborators" do
+      before(:each) do
+        create_collaboration_run
+      end
+
+      it "copies submission and feedback items to other runs" do
+        info = CRater::FeedbackSubmission.generate_feedback(@page, @runs[0])
+        expect(CRater::FeedbackSubmission.count).to eql(2)
+        expect(info[:submission_id]).to eql(CRater::FeedbackSubmission.first.id)
+        expect(info[:feedback_items][@answers[0].id][:text]).to eql('feedback')
+        expect(info[:feedback_items][@answers[1].id]).to be_nil # it's other user answer!
+
+        submission = CRater::FeedbackSubmission.first
+        submission_copy = CRater::FeedbackSubmission.last
+        expect(submission_copy.base_submission).to eql(submission)
+
+        expect(submission.run).to eql(@runs[0])
+        expect(submission_copy.run).to eql(@runs[1])
+
+        expect(submission.feedback_items.count).to eql(1)
+        expect(submission.feedback_items.first.feedback_text).to eql('feedback')
+        expect(submission.feedback_items.first.answer).to eql(@answers[0])
+        expect(submission_copy.feedback_items.count).to eql(1)
+        expect(submission_copy.feedback_items.first.feedback_text).to eql('feedback')
+        expect(submission_copy.feedback_items.first.answer).to eql(@answers[1])
+      end
+    end
+  end
+
+  describe "#update_usefulness_score" do
+    let(:submission) do
+      info = CRater::FeedbackSubmission.generate_feedback(@page, @runs[0])
+      CRater::FeedbackSubmission.find(info[:submission_id])
+    end
+
+    it "updates usefulness_score attribute" do
+      submission.update_usefulness_score(99)
+      expect(submission.usefulness_score).to eql(99)
+    end
+
+    describe "when user runs activity with collaborators" do
+      before(:each) do
+        create_collaboration_run
+      end
+
+      it "updates usefulness_score attribute of all related submissions" do
+        submission.update_usefulness_score(99)
+        expect(CRater::FeedbackSubmission.count).to eql(2)
+        CRater::FeedbackSubmission.all.each do |s|
+          expect(s.usefulness_score).to eql(99)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds group support to argumentation block submissions.
If user is running activity with collaborators, each submission is automatically copied to other students.
Each submission copy keeps reference to the base submission, so when "usefulness score" (aka "feedback on feedback") is updated, we can also update submission copies.