### PR TITLE
Add ability to log event_value separately from params

### DIFF
--- a/app/assets/javascripts/logger.js
+++ b/app/assets/javascripts/logger.js
@@ -173,7 +173,7 @@ LoggerUtils.prototype._logInteractiveEvents = function(iframe) {
   phone.addListener('log', function (content) {
     this._logger.log({
       event: content.action,
-      event_value: JSON.stringify(content.data),
+      event_value: content.value,
       parameters: content.data,
       interactive_id: $(iframe).data().id,
       interactive_url: iframe.src


### PR DESCRIPTION
Previously we just stringified the data in the event_value, which was
redundant as it was also being saved in `parameters`. It also led to
errors when the string was > 255 chars.

Now we can log like so:

`phone.post('log', {action: 'actionName', value: 'actionValue', data: {someValue: 1, otherValue: 2})`

Note: We could support backward compatibility by putting `data` in
`eventValue` if `value` doesn't exist (and trimming it to 255 chars).
But if only Lab is logging like this, it would be quick to update Lab.