### PR TITLE
Change labbook prompt wording in so that students know its important.

### DIFF
--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -11,8 +11,8 @@ module Embeddable
       ['Snapshot', SNAPSHOT_ACTION]
     ]
 
-    WONT_DISPLAY_MSG     = I18n.t('LABBOOK_WONT_DISPLAY')
-    NO_INTERACTIVE_LABLE =   I18n.t('LABBOOK_NO_INTERACTIVE')
+    WONT_DISPLAY_MSG     = I18n.t('LABBOOK.WONT_DISPLAY')
+    NO_INTERACTIVE_LABLE =   I18n.t('LABBOOK.NO_INTERACTIVE')
     NO_INTERACTIVE_VALUE = "no-interactive"
     NO_INTERACTIVE_SELECT = [NO_INTERACTIVE_LABLE, NO_INTERACTIVE_VALUE];
     attr_accessible :action_type, :name, :prompt,
@@ -184,6 +184,25 @@ module Embeddable
 
     def hide_from_report?
       !show_in_report?
+    end
+
+    def update_itsi_prompts
+      def close_enough(str1,str2)
+        str1.downcase.chomp.squish.starts_with? str2.downcase.chomp.squish[0..60]
+      end
+
+      old_snapshot_prompt = I18n.t("LABBOOK.OLD_ITSI.SNAPSHOT_PROMPT")
+      old_upload_prompt   = I18n.t("LABBOOK.OLD_ITSI.UPLOAD_PROMPT")
+      new_snapshot_prompt = I18n.t("LABBOOK.ITSI.SNAPSHOT_PROMPT")
+      new_upload_prompt   = I18n.t("LABBOOK.ITSI.UPLOAD_PROMPT")
+
+      if close_enough prompt, old_snapshot_prompt
+        update_attribute(:prompt, new_snapshot_prompt)
+      end
+
+      if close_enough prompt, old_upload_prompt
+        update_attribute(:prompt, new_upload_prompt)
+      end
     end
 
     private

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -97,13 +97,13 @@ class MwInteractive < ActiveRecord::Base
       if upload_only_model_urls.include? url
         labbook.action_type = Embeddable::Labbook::UPLOAD_ACTION
         labbook.custom_action_label = "Take a Snapshot"
-        labbook.prompt = t('LABBOOK.ITSI.UPLOAD_PROMPT')
+        labbook.prompt = I18n.t 'LABBOOK.ITSI.UPLOAD_PROMPT'
         labbook.save!
       else
         if upload_only_model_urls.include? url_was
           labbook.action_type = Embeddable::Labbook::SNAPSHOT_ACTION
           labbook.custom_action_label = nil
-          labbook.prompt = t('LABBOOK.ITSI.SNAPSHOT_PROMPT')
+          labbook.prompt = I18n.t 'LABBOOK.ITSI.SNAPSHOT_PROMPT'
           labbook.save!
         end
       end

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -97,13 +97,13 @@ class MwInteractive < ActiveRecord::Base
       if upload_only_model_urls.include? url
         labbook.action_type = Embeddable::Labbook::UPLOAD_ACTION
         labbook.custom_action_label = "Take a Snapshot"
-        labbook.prompt = '<p>Add your pictures to your album by clicking on the "<em>Take a Snapshot</em>" button and add the pictures to your album by clicking on the Browse button and selecting the picture on your computer. Describe what you see below the picture in the Comments box. Click on the Save button to add the picture to your album.'
+        labbook.prompt = t('LABBOOK.ITSI.UPLOAD_PROMPT')
         labbook.save!
       else
         if upload_only_model_urls.include? url_was
           labbook.action_type = Embeddable::Labbook::SNAPSHOT_ACTION
           labbook.custom_action_label = nil
-          labbook.prompt = '<p>Take a snapshot and upload it to your Snapshot Album by clicking the "<em>Take a Snapshot</em>" button. &nbsp;To browse your Snapshot Album, click the album icon.</p>'
+          labbook.prompt = t('LABBOOK.ITSI.SNAPSHOT_PROMPT')
           labbook.save!
         end
       end

--- a/app/views/embeddable/labbook_answers/_lightweight.html.haml
+++ b/app/views/embeddable/labbook_answers/_lightweight.html.haml
@@ -1,6 +1,6 @@
 - embeddable_dom_id = "#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"
 .question-hdr
-  %h5.h5= "#{t('LABBOOK_ALBUM')} ##{embeddable.question_index}"
+  %h5.h5= "#{t('LABBOOK.ALBUM')} ##{embeddable.question_index}"
 .question-bd.labbook{id: embeddable_dom_id,
                     'data-labbook-url' => embeddable.class.labbook_provider,
                     'data-lara-update-url' => embeddable_labbook_answer_path(embeddable),

--- a/config/app_environment_variables.sample.rb
+++ b/config/app_environment_variables.sample.rb
@@ -22,7 +22,7 @@ ENV['C_RATER_PASSWORD']                  ||= 'XXXXXXX'
 ENV['LABBOOK_PROVIDER_URL']              ||= 'https://labbook.concord.org'
 
 # this specifies a | separated list of urls for interactives
-# these special interactive URLs trigger LARA to conver their associated LabBook to
+# these special interactive URLs trigger LARA to convert their associated LabBook to
 # upload LabBook
-ENV['UPLOAD_ONLY_MODEL_URLS']            ||= ''
+ENV['UPLOAD_ONLY_MODEL_URLS']            ||= "https://models-resources.concord.org/itsi/upload_photo/index.html"
 ENV['MODEL_JSON_LIST_URL']               ||= 'https://itsi.portal.concord.org/interactives/export_model_library'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,9 +92,9 @@ en:
         button and add the pictures to your album by clicking on the Browse button and selecting the
         picture on your computer. Describe what you see below the picture in the Comments box.
         Click on the Save button to add the picture to your album.
-        A picture must be included for the activity to show as complete.</p>
+        A picture must be included for the activity to show as completed.</p>
       SNAPSHOT_PROMPT: |
         <p>Take a snapshot and upload it to your Snapshot Album by clicking the "<em>Take a Snapshot</em>" button.
         &nbsp;To browse your Snapshot Album, click the album icon.
-        A snapshot must be included for the activity to show as complete.</p>
+        A snapshot must be included for the activity to show as completed.</p>
       BUTTON: "Take a Snapshot"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,9 +17,7 @@ en:
   OLD_DRAWING_FORMAT: "Old drawing format detected - all annotations or drawings will be cleared if you continue."
   OPEN_ALBUM: "Open album"
   QUESTION: "Question"
-  LABBOOK_ALBUM: "Labbook album"
-  LABBOOK_NO_INTERACTIVE: "No Interactive"
-  LABBOOK_WONT_DISPLAY: "Labbook will not be shown. No visible interactive is set. 'snapshot' is selected."
+
   LOADING_LABBOOK: "Loading Labbook album..."
   SNAPSHOT_FAILED: "Could not take your snapshot. Please try again later."
   DRAWING_SAVE_ERROR: "Could not save your drawing after 30 seconds. Please try again later."
@@ -74,3 +72,29 @@ en:
     USEFUL_0: "Not at all"
     USEFUL_1: "Somewhat"
     USEFUL_2: "Very"
+  LABBOOK:
+    ALBUM: "Labbook album"
+    NO_INTERACTIVE: "No Interactive"
+    WONT_DISPLAY: "Labbook will not be shown. No visible interactive is set. 'snapshot' is selected."
+    OLD_ITSI:
+      UPLOAD_PROMPT: |
+        <p>Add your pictures to your album by clicking on the "<em>Take a Snapshot</em>"
+        button and add the pictures to your album by clicking on the Browse button and  selecting the
+        picture on your computer. Describe what you see below the picture in the Comments box.
+        Click on the Save button to add the picture to your album.
+      SNAPSHOT_PROMPT: |
+        <p>Take a snapshot and upload it to your Snapshot Album by clicking the "<em>Take a Snapshot</em>" button.
+        &nbsp;To browse your Snapshot Album, click the album icon.</p>'
+      BUTTON: "Take a Snapshot"
+    ITSI:
+      UPLOAD_PROMPT: |
+        <p>Add your pictures to your album by clicking on the "<em>Take a Snapshot</em>"
+        button and add the pictures to your album by clicking on the Browse button and selecting the
+        picture on your computer. Describe what you see below the picture in the Comments box.
+        Click on the Save button to add the picture to your album.
+        A picture must be included for the activity to show as complete.</p>
+      SNAPSHOT_PROMPT: |
+        <p>Take a snapshot and upload it to your Snapshot Album by clicking the "<em>Take a Snapshot</em>" button.
+        &nbsp;To browse your Snapshot Album, click the album icon.
+        A snapshot must be included for the activity to show as complete.</p>
+      BUTTON: "Take a Snapshot"

--- a/lib/concord/auth_portal.rb
+++ b/lib/concord/auth_portal.rb
@@ -39,15 +39,17 @@ module Concord
     def self.portal_for_url(url)
       # URI.parse(url).host returns nil when scheme is not provided.
       host = URI(url).host || URI("http://#{url}").host
+      port = URI(url).port || 80
       return nil unless host
       self.all.each_pair do |name, portal|
         portal_host =''
         begin
           portal_host = URI.parse(portal.url).host.downcase.strip
+          portal_port = URI.parse(portal.url).port || 80
         rescue URI::InvalidURIError
           puts "portal.url is not valud URL : #{portal.url}"
         end
-        return portal if portal_host == host.downcase.strip
+        return portal if portal_host == host.downcase.strip && portal_port == port
         # return portal if url == portal.url || (trimmed_url && trimmed_url == portal.url)
       end
       return nil # we couldn't find one.

--- a/lib/tasks/itsi_tasks.rake
+++ b/lib/tasks/itsi_tasks.rake
@@ -47,4 +47,12 @@ namespace :itsi do
     }
     puts "Total Updated: #{total_count}, Total with Wrong Name: #{total_wrong_name_count}"
   end
+
+  desc "Reword the lab book prompts for itsi. See config/locales/en.yml  and Embeddable::Labbook#update_itsi_prompts"
+  task :update_labbook_prompts do
+    Embeddable::Labbook.find_in_batches do |labbooks|
+      labbooks.each(&:update_itsi_prompts)
+    end
+  end
+
 end

--- a/spec/models/concord/auth_portal_spec.rb
+++ b/spec/models/concord/auth_portal_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Concord::AuthPortal do
   describe "AuthPortal#add" do
     let(:name)       { "name"}
-    let(:url)        { "http://foo.bar/"}
+    let(:url)        { "http://foo.bar:3000/"}
     let(:client_id)  { "foo" }
     let(:secret)     { "secret" }
     let(:auth_token) { 'Bearer %s' % secret }
@@ -61,6 +61,20 @@ describe Concord::AuthPortal do
       describe "finding the auth token by the url" do
         it "should find the right auth token" do
           expect(Concord::AuthPortal.auth_token_for_url(url)).to eq(auth_token)
+        end
+      end
+
+      describe "When there many servers on the same host with different ports" do
+        it "should use the port number to find the correct auth client" do
+          port3333 = Concord::AuthPortal.add("port3333","http://foo.bar:3333/","port3333","3333token")
+          expect(Concord::AuthPortal.portal_for_url(url)).to eq(auth) # the original one on port 3000
+          expect(Concord::AuthPortal.portal_for_url("http://foo.bar:3333/")).to eq(port3333)
+        end
+        it "even https and http should be considered different portals" do
+          http  = Concord::AuthPortal.add("http","http://foo.bar/","http","httpToken")
+          https = Concord::AuthPortal.add("https","https://foo.bar/","https","httpToken")
+          expect(Concord::AuthPortal.portal_for_url("https://foo.bar/")).to eq(https)
+          expect(Concord::AuthPortal.portal_for_url("http://foo.bar/")).to eq(http)
         end
       end
     end


### PR DESCRIPTION
Suggested wording in PT: "A snapshot must be included for the activity to show as complete."

This change also tries to put all that text in I18n files.

Running `rake itsi:update_labbook_prompts`  should make the necessary changes to close [#112928599].  

[#112928599]
https://www.pivotaltracker.com/story/show/112928599