### PR TITLE
Send processing times to portal. Version Protocol

### DIFF
--- a/app/services/portal_sender.rb
+++ b/app/services/portal_sender.rb
@@ -1,0 +1,118 @@
+module PortalSender
+
+  class Protocol
+    Versions =[
+        { name: "1", serialization_method_name: :response_for_portal_1_0 },
+        { name: "0", serialization_method_name: :response_for_portal     }
+    ]
+
+    PortalProtocolMap = {}
+
+    def self.instance(endpoint)
+      uri = URI.parse(endpoint)
+      portal_key   = "#{uri.host}:#{uri.port}"
+      PortalProtocolMap[portal_key] ||= self.new
+      PortalProtocolMap[portal_key]
+    end
+
+    def initialize()
+      @last_try      = 12.months.ago
+      @version_index = 0
+    end
+
+    def version
+      Versions[@version_index]
+    end
+
+    def retry_interval
+      20.minutes
+    end
+
+    def assume_latest_version
+      @version_index = 0
+    end
+
+    def versioned_endpoint(endpoint)
+      # special case the oldest portals that didn't have an versioned endpoint
+      if @version_index == oldest_version_index
+        return endpoint
+      end
+      "#{endpoint}/protocol_version/#{self.version[:name]}"
+    end
+
+    def post_answers(answers, remote_endpoint)
+      assume_latest_version if @last_try < retry_interval.ago
+      try_again = true
+      while try_again
+        @last_try = Time.now
+        serialized_data = self.send serialization_method_name, answers, version
+        response = HTTParty.post(
+            versioned_endpoint(remote_endpoint), {
+            :body => serialized_data,
+            :headers => {
+                "Authorization" => Concord::AuthPortal.auth_token_for_url(remote_endpoint),
+                "Content-Type" => 'application/json'
+            }
+        })
+        return true if response.success?
+        Rails.logger.error "URL: #{versioned_endpoint(remote_endpoint)} |#{response.code}| #{response.message}"
+        try_again = can_try_earlier_version?
+        next_version!
+      end
+      return false
+    end
+
+
+    def oldest_version_index
+      return Versions.length() -1
+    end
+
+
+    def can_try_earlier_version?
+      @version_index < oldest_version_index
+    end
+
+    def next_version!
+      if can_try_earlier_version?
+        @version_index = @version_index + 1
+      end
+    end
+
+    def serialization_method_name
+      version[:serialization_method_name]
+    end
+
+    def arrayify_answers(answer)
+      if answer.kind_of? Array
+        answer
+      else
+        [answer]
+      end
+    end
+
+    ################################################
+    # Version 1.0 of the protocol
+    ################################################
+    def response_for_portal_1_0(_answer, version)
+      answers  = arrayify_answers(_answer)
+      lara_start = answers.map(&:updated_at).min
+
+      return {
+        answers: answers.map { |ans| ans.portal_hash },
+        version: version[:name],
+        lara_end: Time.now,
+        lara_start: lara_start
+      }.to_json
+    end
+
+    ################################################
+    # Version 0.0 of the protocol
+    ################################################
+    def response_for_portal(_answer, version)
+      answers = arrayify_answers(_answer)
+      answers.map { |ans| ans.portal_hash }.to_json
+    end
+
+  end
+
+end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -395,22 +395,6 @@ describe Run do
       ].to_json
     end
 
-    describe '#response_for_portal' do
-      before(:each) do
-        run.open_response_answers << or_answer
-        run.multiple_choice_answers << mc_answer
-        run.image_question_answers << iq_answer
-      end
-
-      it 'matches the expected JSON for a single specified answer' do
-        expect(JSON.parse(run.response_for_portal(or_answer))).to eq(JSON.parse(one_expected))
-      end
-
-      it "matches the expected JSON for multiple specified answers" do
-        expect(JSON.parse(run.response_for_portal([or_answer, mc_answer,iq_answer]))).to eq(JSON.parse(all_expected))
-      end
-    end
-
     describe '#all_responses_for_portal' do
       it 'matches the expected JSON for all responses' do
         run.open_response_answers << or_answer
@@ -441,7 +425,8 @@ describe Run do
         let(:remote_endpoint) { valid_remote_endpoint }
         describe "with a positive response from the server" do
           it "should be successful" do
-            payload = run.response_for_portal([or_answer,mc_answer])
+            # get the payload from the very first protocol version
+            payload = PortalSender::Protocol.instance(remote_endpoint).response_for_portal([or_answer,mc_answer])
             stub_http_request(:post, remote_endpoint).to_return(
               :body   => "OK", # TODO: What returns?
               :status => 200)
@@ -463,7 +448,7 @@ describe Run do
               :body   => "boo", # TODO: What returns?
               :status => 503)
             # We now expect the error message to include payload information
-            expect {run.send_to_portal([or_answer,mc_answer])}.to raise_error Run::PortalUpdateIncomplete, /payload/
+            expect {run.send_to_portal([or_answer,mc_answer])}.to raise_error Run::PortalUpdateIncomplete
           end
         end
       end

--- a/spec/services/portal_sender_spec.rb
+++ b/spec/services/portal_sender_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe PortalSender::Protocol do
+  let(:endpoint)            { "http://localhost/dataservice/external_activity_data/6" }
+  let(:auth_stubs)          { {} }
+  let(:protocol)            { PortalSender::Protocol.new       }
+  let(:mock_auth_provider)  { double(auth_stubs)               }
+  let(:post_results)        { {}                               }
+  let(:answer_data)         { double({portal_hash: {one: 1}, updated_at: Time.now }) }
+  let(:sad_result)   { double({ success?: false, code: 500, message: 'failure'})}
+  let(:happy_result) { double({ success?: true, code: 200, message: 'yipee'})}
+
+  before(:each) do
+    allow(Run).to receive(:auth_provider).and_return mock_auth_provider
+    allow(HTTParty).to receive(:post).and_return post_results
+    allow(Concord::AuthPortal).to receive(:auth_token_for_url).and_return "xyzzy"
+  end
+
+
+  describe "add-hoc routing maddness" do
+
+  end
+
+  describe "when the portal supports the latest version of the protocol" do
+    let(:post_results) { happy_result }
+    it "should not be using the most rescent protocol version after sending" do
+      protocol.post_answers(answer_data, endpoint)
+      expect(protocol.version).to eq PortalSender::Protocol::Versions.first
+    end
+  end
+
+  describe "when the portal is using an older version of the protocol" do
+    let(:post_results) { sad_result }
+    it "should not be using the most rescent protocol version after sending" do
+      protocol.post_answers(answer_data, endpoint)
+      expect(protocol.version).to eq PortalSender::Protocol::Versions.last
+    end
+  end
+
+  describe "retrying the first version again after some time passes" do
+
+    let(:post_results) { sad_result }
+    it "should not be using the most rescent protocol version after sending" do
+      # Using old version
+      allow(HTTParty).to receive(:post).and_return sad_result
+      protocol.post_answers(answer_data, endpoint)
+      expect(protocol.version).to eq PortalSender::Protocol::Versions.last
+
+      # Checkin again in the future:
+      Timecop.travel(3.hours.from_now)
+      allow(HTTParty).to receive(:post).and_return happy_result
+      protocol.post_answers(answer_data, endpoint)
+      expect(protocol.version).to eq PortalSender::Protocol::Versions.first
+    end
+  end
+
+  describe "#instance and caching protocols for servers" do
+    let(:endpoint_a)  { "http://localhost/dataservice/external_activity_data/6"    }
+    let(:endpoint_b)  { "http://localhost/dataservice/external_activity_data/7"    }
+    let(:endpoint_c)  { "http://localhost:80/dataservice/external_activity_data/8" }
+    let(:endpoint_d)  { "http://127.0.0.1/dataservice/external_activity_data/6"    }
+    let(:endpoint_e)  { "http://google.com/dataservice/external_activity_data/6"    }
+
+    describe "when multiple endpoints use the same serve" do
+      it "should return the same protocol" do
+        expect(PortalSender::Protocol.instance(endpoint_a)).to eq PortalSender::Protocol.instance(endpoint_b)
+        expect(PortalSender::Protocol.instance(endpoint_b)).to eq PortalSender::Protocol.instance(endpoint_c)
+      end
+    end
+
+    describe "when endpoints use different servers" do
+      it "should use a new protocol for each one" do
+        expect(PortalSender::Protocol.instance(endpoint_a)).not_to eq PortalSender::Protocol.instance(endpoint_d)
+        expect(PortalSender::Protocol.instance(endpoint_d)).not_to eq PortalSender::Protocol.instance(endpoint_e)
+      end
+    end
+  end
+
+end

--- a/spec/services/portal_sender_spec.rb
+++ b/spec/services/portal_sender_spec.rb
@@ -23,7 +23,7 @@ describe PortalSender::Protocol do
 
   describe "when the portal supports the latest version of the protocol" do
     let(:post_results) { happy_result }
-    it "should not be using the most rescent protocol version after sending" do
+    it "should use the most rescent protocol version after sending" do
       protocol.post_answers(answer_data, endpoint)
       expect(protocol.version).to eq PortalSender::Protocol::Versions.first
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,6 +102,9 @@ RSpec.configure do |config|
   config.before :suite do
     Warden.test_mode!
   end
+  config.before(:each) do
+    stub_temporary_protocol_routes
+  end
 end
 
 class ActiveRecord::Base
@@ -126,3 +129,9 @@ def wait_for_ajax
   end
 end
 
+def stub_temporary_protocol_routes
+  # These requests are made when attempting to post to a portal.
+  # This code will be removed when versioned learner data is widely deployed to portals.
+  stub_request(:any, /.*\/#{PortalSender::Protocol::VersionRoutePrefix}\/.*/)
+  .to_return(:status => [500, "Internal Server Error"])
+end


### PR DESCRIPTION
NOTE:  There are still some pending tests that I am going to look into before asking for a review.

* PortalSender::Protocol handles  different versions of learner data
* Send additional processing time info to potral.

[#112926927]

https://www.pivotaltracker.com/story/show/112926927