### PR TITLE
require branch on deploy, show branch name to users

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,6 +48,9 @@
         <a href="mailto:authoring-help@concord.org?subject=Authoring%20question">Send us an email</a>
       </p>
     <% end %>
+    <p style="margin-top:10px">
+      Version: <%= ENV['LARA_VERSION'] %>
+    </p>
   </div>
 </div>
 <div id="overlay"></div>

--- a/config/deploy/benchmark.rb
+++ b/config/deploy/benchmark.rb
@@ -1,4 +1,3 @@
-set :branch, "master"
 set :domain, "benchmark-authoring.concord.org"
 
 server domain, :app, :web

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -1,4 +1,3 @@
-set :branch, "master"
 set :domain, "authoring-demo.concord.org"
 
 server domain, :app, :web

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,4 +1,3 @@
-set :branch, "master"
 set :domain, "authoring.dev.concord.org"
 
 server domain, :app, :web

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,3 @@
-set :branch, "production"
 set :domain, "authoring.production.concord.org"
 
 server domain, :app, :web

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,4 +1,3 @@
-set :branch, "staging"
 set :domain, "authoring.staging.concord.org"
 
 server domain, :app, :web

--- a/config/initializers/load_version.rb
+++ b/config/initializers/load_version.rb
@@ -1,0 +1,8 @@
+begin
+  yaml_file_path = File.join(Rails.root, 'config', 'version.yml')
+  yaml_config = YAML.load_file(yaml_file_path)
+  ENV['LARA_VERSION'] = yaml_config['version']
+rescue Exception => e
+  # no known version
+  ENV['LARA_VERSION'] = 'unknown'
+end


### PR DESCRIPTION
This is the same deploy approach that the portal is using now.
This PR also displays the deployed branch to the user.