### PR TITLE
Display warning when user tries to leave page and data is not saved

### DIFF
--- a/app/assets/javascripts/image_question_drawing_tool.js.coffee
+++ b/app/assets/javascripts/image_question_drawing_tool.js.coffee
@@ -79,6 +79,7 @@ class ImageQuestionDrawingTool
     })
 
     @save_indicator = SaveIndicator.instance()
+    @page_lock_id = null
 
     # See: https://www.pivotaltracker.com/story/show/77973722
     @drawing_tool.setStrokeColor('#e66665') if @is_snapshot_question()
@@ -234,9 +235,17 @@ class ImageQuestionDrawingTool
     @$content.dialog("open")
     # Always reset history (undo / redo) when user opens a dialog, as it may be confusing otherwise.
     @drawing_tool.resetHistory()
+    # Lock page as soon as the user opens drawing tool.
+    @page_lock_id = lockPageUnload() if @page_lock_id == null
 
   hide_dialog: () ->
     @$content.dialog("close");
+    # Unlock page when dialog is closed.
+    # Note that when user clicks "Save", we hide dialog only when question is successfuly saved.
+    if @page_lock_id != null
+      # See: page-unload-warning.coffee
+      unlockPageUnload(@page_lock_id)
+      @page_lock_id = null
 
   set_dialog_buttons_enabled: (val) ->
     [@$done_button, @$cancel_button].forEach ($btn) =>

--- a/app/assets/javascripts/page-unload-warning.coffee
+++ b/app/assets/javascripts/page-unload-warning.coffee
@@ -1,0 +1,17 @@
+_locks = {}
+_lockId = 0
+
+window.addEventListener('beforeunload', (event) =>
+  if Object.keys(_locks).length > 0
+    message = t('DATA_MAY_BE_LOST')
+    event.returnValue = message # Gecko, Trident, Chrome 34+
+    message                     # Gecko, WebKit, Chrome <34
+)
+
+window.lockPageUnload = () ->
+  id = _lockId++
+  _locks[id] = true
+  return id
+
+window.unlockPageUnload = (id) ->
+  delete _locks[id]

--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -25,6 +25,7 @@
 //= require jquery.jcarousel
 //= require waypoints
 //= require waypoints-sticky
+//= require page-unload-warning
 //= require common
 //= require modals
 //= require modal-dialog

--- a/app/assets/javascripts/save-on-change.coffee
+++ b/app/assets/javascripts/save-on-change.coffee
@@ -219,6 +219,7 @@ class @SaveOnChangePage
       $('.live_submit').each (i,e) =>
         @forms.push(new SaveOnChange($(e),@))
     @dirty_forms = {}
+    @pageUnloadLockID = null
 
   intercept_navigation: ->
     $("a").not('.colorbox').not('[target]').not("#menu-trigger").not("[data-trigger-save=false]").on 'click', (e) =>
@@ -252,12 +253,18 @@ class @SaveOnChangePage
 
   mark_dirty: (form) ->
     @dirty_forms[form] = form
+    # See: page-unload-warning.coffee
+    @pageUnloadLockID = lockPageUnload() if @pageUnloadLockID == null
 
   navigate_away: (callback) ->
     callback and callback()
 
   mark_clean: (form) ->
     delete @dirty_forms[form]
+    # See: page-unload-warning.coffee
+    if @pageUnloadLockID != null && Object.keys(@dirty_forms).length == 0
+      unlockPageUnload(@pageUnloadLockID)
+      @pageUnloadLockID = null
 
   force_save_item: ($form_jq) ->
     for f in @forms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
   OLD_DRAWING_FORMAT: "Old drawing format detected - all annotations or drawings will be cleared if you continue."
   OPEN_ALBUM: "Open album"
   QUESTION: "Question"
+  DATA_MAY_BE_LOST: "Your work hasn't been saved."
 
   LOADING_LABBOOK: "Loading Labbook album..."
   SNAPSHOT_FAILED: "Could not take your snapshot. Please try again later."


### PR DESCRIPTION
The confirmation dialog will be displayed when:
- Image question dialog is open (or still saving). That's easy to test.
- When regular question is changed, but it's not saved to server. To test that, you need to type something and quickly use browser reload button. If you try to use regular page link in the LARA navigation bar, you won't notice anything, as we handle that case and force save (unless you make sure that it fails, e.g. by killing your local rails server).

Note that browsers have predefined text that is displayed. Some display our custom message too (Chrome, Safari), but other ignore it (Firefox). But even when it's ignored, the confirmation dialog still makes sense (as it mentions possible data loss).

