### PR TITLE
Fix completed banner (handle Labbook answers better)

### DIFF
--- a/app/models/embeddable/answer.rb
+++ b/app/models/embeddable/answer.rb
@@ -69,9 +69,13 @@ module Embeddable::Answer
     end
   end
 
-  # Overwrite this method in class that includes this module.
+  # Overwrite these methods in class that includes this module:
   def copy_answer!(another_answer)
     raise "#copy_answer! unimplemented for a given type of answer"
+  end
+
+  def answered?
+    raise "#answered? unimplemented for a given type of answer"
   end
 
   def to_json
@@ -95,5 +99,4 @@ module Embeddable::Answer
   def show_in_report?
     true
   end
-
 end

--- a/app/models/embeddable/image_question_answer.rb
+++ b/app/models/embeddable/image_question_answer.rb
@@ -53,8 +53,8 @@ module Embeddable
       }
     end
 
-    def blank?
-      self.image_url.blank? && self.annotated_image_url.blank? && self.answer_text.blank?
+    def answered?
+      image_url.present? || annotated_image_url.present? || answer_text.present?
     end
   end
 end

--- a/app/models/embeddable/labbook_answer.rb
+++ b/app/models/embeddable/labbook_answer.rb
@@ -80,11 +80,11 @@ module Embeddable
       }
     end
 
-    def blank?
+    def answered?
       # Labbook is an external service, we don't really know its content. However, there is an assumption that once
       # Labbook is opened, `update_at` timestamp is updated and the album link is sent to Portal. So, if `created_at`
-      # and `updated_at` are equal, it means that Labbook has never been  opened and there can't be any content yet.
-      created_at == updated_at
+      # and `updated_at` are equal, it means that Labbook has never been opened and there can't be any content yet.
+      created_at != updated_at
     end
     # End of Answer interface.
   end

--- a/app/models/embeddable/labbook_answer.rb
+++ b/app/models/embeddable/labbook_answer.rb
@@ -79,6 +79,13 @@ module Embeddable
         is_final: false
       }
     end
+
+    def blank?
+      # Labbook is an external service, we don't really know its content. However, there is an assumption that once
+      # Labbook is opened, `update_at` timestamp is updated and the album link is sent to Portal. So, if `created_at`
+      # and `updated_at` are equal, it means that Labbook has never been  opened and there can't be any content yet.
+      created_at == updated_at
+    end
     # End of Answer interface.
   end
 end

--- a/app/models/embeddable/multiple_choice_answer.rb
+++ b/app/models/embeddable/multiple_choice_answer.rb
@@ -90,8 +90,8 @@ module Embeddable
       return self.update_attributes(params)
     end
 
-    def blank?
-      self.answers.size == 0
+    def answered?
+      answers.size > 0
     end
   end
 

--- a/app/models/embeddable/open_response_answer.rb
+++ b/app/models/embeddable/open_response_answer.rb
@@ -35,8 +35,8 @@ module Embeddable
       }
     end
 
-    def blank?
-      self.answer_text.blank?
+    def answered?
+      self.answer_text.present?
     end
 
     def c_rater_item_settings

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -71,6 +71,10 @@ class InteractiveRunState < ActiveRecord::Base
     interactive.respond_to?('save_state') && interactive.save_state && interactive.respond_to?('has_report_url') && interactive.has_report_url
   end
 
+  def answered?
+    reporting_url.present?
+  end
+
   class AnswerStandin
     attr_accessor :run
     def initialize(opts={})

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -288,7 +288,7 @@ class Run < ActiveRecord::Base
   end
 
   def num_answers
-    q_answers = activity_q_answers = self.question_answers.reject { |a| a.blank? }
+    q_answers = activity_q_answers = self.question_answers.reject { |a| !a.answered? }
     begin # this really shouldn't happen, but there are some bad runs in the DB
       activity_q_answers = q_answers.reject { |a| a.question.activity.id != self.activity_id }
       unless q_answers.size == activity_q_answers.size


### PR DESCRIPTION
LARA sends Labbook album link to Portal when user opens Labbook dialog. That causes Portal report update and only then Portal treats Labbook question as completed.

However, internally LARA was always assuming that Labbook is a completed question. That was causing difference between progress reported in Portal and LARA. 

This PR makes that consistent with Portal reporting - Labbook is completed (non-blank) in LARA after user closes Labbook dialog for the first time. Implementation may seem a bit strange, but I hope that comment explains that. 