### PR TITLE
don't send annotation to portal

### DIFF
--- a/app/models/embeddable/image_question_answer.rb
+++ b/app/models/embeddable/image_question_answer.rb
@@ -48,8 +48,7 @@ module Embeddable
         "question_id" => image_question_id.to_s,
         "answer" => answer_text,
         "is_final" => is_final,
-        "image_url" => annotated_image_url || image_url,
-        "annotation" => annotation
+        "image_url" => annotated_image_url || image_url
       }
     end
 

--- a/spec/models/embeddable/image_question_answer_spec.rb
+++ b/spec/models/embeddable/image_question_answer_spec.rb
@@ -34,8 +34,7 @@ describe Embeddable::ImageQuestionAnswer do
           "question_id" => question.id.to_s,
           "answer"      => answer.answer_text,
           "is_final"    => answer.is_final,
-          "image_url"   => answer.image_url,
-          "annotation"  => nil
+          "image_url"   => answer.image_url
         }
       end
 
@@ -57,8 +56,7 @@ describe Embeddable::ImageQuestionAnswer do
           "question_id" => question.id.to_s,
           "answer"      => answer.answer_text,
           "is_final"    => answer.is_final,
-          "image_url"   => answer.annotated_image_url,
-          "annotation"  => nil
+          "image_url"   => answer.annotated_image_url
         }
       end
 

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -389,8 +389,7 @@ describe Run do
           "question_id" => iq_answer.question.id.to_s,
           "answer" => iq_answer.answer_text,
           "is_final" => iq_answer.is_final,
-          "image_url" => iq_answer.image_url,
-          "annotation" => nil
+          "image_url" => iq_answer.image_url
         },
       ].to_json
     end

--- a/spec/services/portal_sender_spec.rb
+++ b/spec/services/portal_sender_spec.rb
@@ -122,8 +122,7 @@ describe PortalSender::Protocol do
               "question_id" => iq_answer.question.id.to_s,
               "answer" => iq_answer.answer_text,
               "is_final" => iq_answer.is_final,
-              "image_url" => iq_answer.image_url,
-              "annotation" => nil
+              "image_url" => iq_answer.image_url
         }]
       end
 


### PR DESCRIPTION
The portal is not saving this annotation data, so we are wasting resources sending it.

As far as I can tell here is the code in the portal that is ignoring the annotation:
https://github.com/concord-consortium/rigse/blob/master/app/models/dataservice/process_external_activity_data_job.rb#L69