### PR TITLE
Fix image answer #answered? logic

### DIFF
--- a/app/models/embeddable/image_question_answer.rb
+++ b/app/models/embeddable/image_question_answer.rb
@@ -48,12 +48,12 @@ module Embeddable
         "question_id" => image_question_id.to_s,
         "answer" => answer_text,
         "is_final" => is_final,
-        "image_url" => annotated_image_url || image_url
+        "image_url" => annotated_image_url
       }
     end
 
     def answered?
-      image_url.present? || annotated_image_url.present? || answer_text.present?
+      annotated_image_url.present?
     end
   end
 end

--- a/spec/factories/embeddable_image_question_answers.rb
+++ b/spec/factories/embeddable_image_question_answers.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
     run nil
     answer_text "This is my image answer"
     image_url "http://localhost/foo.png"
+    annotated_image_url "http://localhost/annotated-foo.png"
   end
 end

--- a/spec/models/embeddable/image_question_answer_spec.rb
+++ b/spec/models/embeddable/image_question_answer_spec.rb
@@ -34,7 +34,7 @@ describe Embeddable::ImageQuestionAnswer do
           "question_id" => question.id.to_s,
           "answer"      => answer.answer_text,
           "is_final"    => answer.is_final,
-          "image_url"   => answer.image_url
+          "image_url"   => answer.annotated_image_url
         }
       end
 

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -389,7 +389,7 @@ describe Run do
           "question_id" => iq_answer.question.id.to_s,
           "answer" => iq_answer.answer_text,
           "is_final" => iq_answer.is_final,
-          "image_url" => iq_answer.image_url
+          "image_url" => iq_answer.annotated_image_url
         },
       ].to_json
     end

--- a/spec/services/portal_sender_spec.rb
+++ b/spec/services/portal_sender_spec.rb
@@ -86,7 +86,7 @@ describe PortalSender::Protocol do
       let(:iq_answer)  { FactoryGirl.create(:image_question_answer,
                                             { :answer_text => "the image question answer",
                                               :question => image_quest,
-                                              :image_url => "http://foo.com/bar.jpg" }) }
+                                              :annotated_image_url => "http://foo.com/bar.jpg" }) }
       let(:a1)         { FactoryGirl.create(:multiple_choice_choice, :choice => "answer_one") }
       let(:a2)         { FactoryGirl.create(:multiple_choice_choice, :choice => "answer_two") }
       let(:mc_question){ FactoryGirl.create(:multiple_choice, :choices => [a1, a2]) }
@@ -122,7 +122,7 @@ describe PortalSender::Protocol do
               "question_id" => iq_answer.question.id.to_s,
               "answer" => iq_answer.answer_text,
               "is_final" => iq_answer.is_final,
-              "image_url" => iq_answer.image_url
+              "image_url" => iq_answer.annotated_image_url
         }]
       end
 


### PR DESCRIPTION
It's another issue which is affecting completed banner in LARA. I think it's quite likely that it was causing problems in Dan's activities (as he wasn't using Labbooks).
`image_url` is a background URL and it can be preset by the author. In such case, LARA would assume that given question is always answered and it might cause that banner shows up while it shouldn't.

I've also removed `answer_text` from the `#answered?` conditions, as there is no way to provide answer text without saving an annotated image. It always happens when you click "Save" button, so we can make code a bit simpler.