### PR TITLE
send more data to the portal with answers

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -189,7 +189,7 @@ class Run < ActiveRecord::Base
   def send_to_portal(answers)
     return true if remote_endpoint.nil? || remote_endpoint.blank? # Drop it on the floor
     return true if answers.blank? # Pretend we sent it, nobody will notice
-    is_success = PortalSender::Protocol.instance(remote_endpoint).post_answers(answers,remote_endpoint)
+    is_success = PortalSender::Protocol.instance(remote_endpoint).post_answers(answers,self)
     # TODO: better error detection?
     abort_job_and_requeue(error_string() ) unless is_success
     is_success

--- a/app/services/portal_sender.rb
+++ b/app/services/portal_sender.rb
@@ -41,12 +41,13 @@ module PortalSender
       "#{endpoint}/#{PortalSender::Protocol::VersionRoutePrefix}/#{self.version[:name]}"
     end
 
-    def post_answers(answers, remote_endpoint)
+    def post_answers(answers, run)
+      remote_endpoint = run.remote_endpoint
       assume_latest_version if @last_try < retry_interval.ago
       try_again = true
       while try_again
         @last_try = Time.now
-        serialized_data = self.send serialization_method_name, answers
+        serialized_data = self.send serialization_method_name, run, answers
         response = HTTParty.post(
             versioned_endpoint(remote_endpoint), {
             :body => serialized_data,
@@ -94,22 +95,30 @@ module PortalSender
     ################################################
     # Version 1.0 of the protocol
     ################################################
-    def response_for_portal_1_0(_answer)
+    def response_for_portal_1_0(run, _answer)
       answers  = arrayify_answers(_answer)
+      oldest_answer = answers.min_by(&:updated_at)
+      oldest_answer_id = -1
+      if oldest_answer
+        oldest_answer_id = oldest_answer.id
+      end
+
       lara_start = answers.map(&:updated_at).min
 
       return {
         answers: answers.map { |ans| ans.portal_hash },
         version: "1",
         lara_end: Time.now.utc.to_s,
-        lara_start: lara_start.utc.to_s
+        lara_start: lara_start.utc.to_s,
+        oldest_answer_id: oldest_answer_id,
+        run_id: run.id
       }.to_json
     end
 
     ################################################
     # Version 0.0 of the protocol
     ################################################
-    def response_for_portal(_answer)
+    def response_for_portal(run, _answer)
       answers = arrayify_answers(_answer)
       answers.map { |ans| ans.portal_hash }.to_json
     end


### PR DESCRIPTION
We saw some hard to explain to data coming from LARA. This extra data should help explain issues like what we saw.  This PR adds:

`oldest_answer_id` and `run_id`
