### PR TITLE
fix issue with https portals

### DIFF
--- a/app/services/create_collaboration.rb
+++ b/app/services/create_collaboration.rb
@@ -5,7 +5,9 @@ class CreateCollaboration
   def initialize(collaborators_data_url, user, material)
     @collaborators_data_url = collaborators_data_url
     # URI.parse(url).host returns nil when scheme is not provided.
-    @portal_domain = URI(collaborators_data_url).host || URI("http://#{collaborators_data_url}")
+    uri = URI(collaborators_data_url)
+    fail 'Scheme is required for collaborators_data_url' if uri.scheme.nil?
+    @portal_url = "#{uri.scheme}://#{uri.host}"
     @owner = user
     @activity = material.is_a?(LightweightActivity) ? material : nil
     @sequence = material.is_a?(Sequence) ? material : nil
@@ -35,7 +37,7 @@ class CreateCollaboration
     response = HTTParty.get(
       @collaborators_data_url, {
         :headers => {
-          "Authorization" => Concord::AuthPortal.auth_token_for_url(@portal_domain),
+          "Authorization" => Concord::AuthPortal.auth_token_for_url(@portal_url),
           "Content-Type" => 'application/json'
         }
       }


### PR DESCRIPTION
Recently LARA was changed to use both the host and the port when looking up which authentication token should be used. This change broke the run with collaborators support, because that was only passing in the host and assuming the protocol was http with a port of 80. 

This PR fixes that issue, and also requires that the collaborators_data_url include the protocol.  Originally the portal did not send the correct protocol with this url, but that was fixed in early 2015. So every production portal should be sending it by now:
https://github.com/concord-consortium/rigse/commit/fae61205fe6696b5519cb4afde3fbbe7b22635c5