### PR TITLE
run the web server after migrating

### DIFF
--- a/docker/prod/run.sh
+++ b/docker/prod/run.sh
@@ -12,6 +12,6 @@ bundle exec rake db:create
 
 if [ "$1" == "migrate" ]; then
   bundle exec rake db:migrate
-else
-  foreman start -d /lara -f /$APP_NAME/docker/prod/Procfile
 fi
+
+foreman start -d /lara -f /$APP_NAME/docker/prod/Procfile


### PR DESCRIPTION
We have not used the ability to only migrate. And we need the ability
to migrate first in order to make it easier to setup demo servers.