### PR TITLE
Improve print styles

### DIFF
--- a/app/assets/stylesheets/partials/_click_to_play.scss
+++ b/app/assets/stylesheets/partials/_click_to_play.scss
@@ -1,6 +1,6 @@
 .interactive-container {
     position: relative;
-    .img-container,.click_to_play,.click_to_play .background,.click_to_play .text,.interactive-print-text {
+    .img-container,.click_to_play,.click_to_play .background,.click_to_play .text{
       position: absolute;
       top: 0;
       right: 0;
@@ -24,14 +24,6 @@
         text-align: center;
         font-size: 2em;
         margin-top: 4em;
-      }
-    }
-    .interactive-print-text {
-      text-align: center;
-      display: none;
-      padding-top:35%;
-      div {
-          font-size: 1.5em;
       }
     }
   }

--- a/app/assets/stylesheets/partials/_single-page.scss
+++ b/app/assets/stylesheets/partials/_single-page.scss
@@ -3,12 +3,7 @@
   display: none;
 }
 
-@import "compass/css3/user-interface";
-
-@media print {
-  textarea {
-    @include input-placeholder {
-      color:#fff;
-    } 
-  }
+.submit{
+  width:80px;
+  margin:0 auto;
 }

--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -1,0 +1,82 @@
+@import "compass/css3/user-interface";
+
+.print-only {
+  display: none;
+}
+
+.screen-only {
+ display: block;
+}
+
+@media print {
+  .print-only {
+    display: block;
+  }
+
+  .screen-only {
+    display: none;
+  }
+
+  .arg-block, .related-mod, footer {
+    page-break-inside: avoid;
+  }
+
+  .question,.interactive-mod {
+    img, video, .img-container {
+      page-break-inside: avoid;
+    }
+  }
+
+  button, #nav-activity-menu, .sidebar-mod, a.sp-submit, #save.error, #save, .profile-dropdown, .nav-menu {
+    display: none;
+  }
+
+  .interactive-container {
+    .img-container, .interactive-print-text {
+      display: block !important;
+    }
+  }
+
+  textarea {
+    @include input-placeholder {
+      color: transparent;
+    }
+  }
+
+  .question-bd {
+    border: none !important;
+
+    textarea {
+      border: none !important;
+      resize: none;
+    }
+  }
+
+  .interactive-mod {
+    float: right;
+    width: 40% !important;
+  }
+
+  .activity-nav-title {
+    color: #333 !important;
+  }
+
+  .activity-nav-title, .intro-mod h4, .question-hdr h5 {
+    color: #333 !important;
+  }
+
+  .interactive-placeholder {
+    width: 100%;
+    height: 250px;
+    border: 1px solid #333;
+    border-radius: 8px;
+    text-align: center;
+    padding-top: 25%;
+    page-break-inside: avoid;
+  }
+
+  .iframe-url {
+    padding-top: 0.5em;
+    font-size: 0.75em;
+  }
+}

--- a/app/assets/stylesheets/runtime-base.scss
+++ b/app/assets/stylesheets/runtime-base.scss
@@ -15,4 +15,5 @@
 @import "partials/runtime-labbook";
 @import "partials/runtime-errors";
 @import "activity-menu";
-@import "multiple-choice-answers"
+@import "multiple-choice-answers";
+@import "print-styles";

--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -72,7 +72,8 @@ module InteractiveRunHelper
       :mozallowfullscreen => "true",
       :src => iframe_src ? url : nil,
       :data => data,
-      :class => 'interactive',
+      # Note that iframe is hidden in print mode. It won't have enough time to load anyway.
+      :class => 'interactive screen-only',
       :id => "interactive_#{interactive.id}"
     }
     capture_haml do

--- a/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
+++ b/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
@@ -10,7 +10,11 @@
     :html => {:'data-type' => 'json', :class=> 'live_submit'} do |f|
     %fieldset.options
       - if embeddable.show_as_menu
-        = f.select :answers, options_from_collection_for_select(embeddable.choices, 'id', 'choice', (embeddable.answers.empty? ? nil : embeddable.answers.last.id) ), { :include_blank => t("PICK_ONE")}, { :data => {:button_id => check_button_string} }
+        = f.select :answers, options_from_collection_for_select(embeddable.choices, 'id', 'choice', (embeddable.answers.empty? ? nil : embeddable.answers.last.id) ),
+                             { :include_blank => t("PICK_ONE")}, {:class => "screen-only", :data => {:button_id => check_button_string} }
+        %ul.print-only
+          - embeddable.choices.each do |choice|
+            %li= choice.choice
       - else
         .choice-container{:class => embeddable.layout}
           - embeddable.choices.each do |choice|

--- a/app/views/lightweight_activities/single_page.html.haml
+++ b/app/views/lightweight_activities/single_page.html.haml
@@ -13,37 +13,6 @@
   %a.sp-submit{ :href => "javascript:void(0);", :class => 'forward_nav', "data-trigger-save" => "false" }
     %input{ :class => 'button forward_nav', :type => 'submit', :value => "Submit"}
 
-:scss
-  .submit{
-    width:80px;
-    margin:0 auto;
-  }
-
-  @media print {
-    .arg-block, .related-mod, footer {
-      page-break-inside: avoid;
-    }
-    .question,.interactive-mod {
-      img, video, .img-container {
-        page-break-inside: avoid;
-      }
-    }
-    #nav-activity-menu,.sidebar-mod,a.sp-submit,#save.error,#save {
-      display: none;
-    }
-    .interactive-container {
-      .click_to_play {
-        display: none;
-      }
-      iframe {
-        visibility: hidden;
-      }
-      .img-container,.interactive-print-text {
-        display: block !important;
-      }
-    }
-  }
-
 :javascript
   $(function(){
     if (window.location.search.indexOf("print=true") > -1) {

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -1,18 +1,14 @@
 .interactive-container{class: interactive.save_state ? 'savable' : ''}
   - if interactive.native_height > 1
+    .interactive-placeholder.print-only
+      Interactive Model
+
     - if !interactive.image_url.blank?
       .img-container{:id => dom_id_for(interactive, :interactive_image),:style => interactive.click_to_play ? "display:block" : "display:none"}
         =image_tag(interactive.image_url)
-    - else
-      .interactive-print-text
-        %div
-          Interactive Model
-        %p
-          See :-
-          =link_to "#{interactive.url}","#{interactive.url}"
 
     - if interactive.click_to_play
-      .click_to_play.shown{:id => dom_id_for(interactive, :click_to_play)}
+      .click_to_play.shown.screen-only{:id => dom_id_for(interactive, :click_to_play)}
         .background
         .text= "Click here to start the interactive."
 
@@ -30,9 +26,12 @@
         = link_to interactive.url, interactive.url
 
     - if interactive.save_state
-      .below_interactive
+      .below_interactive.screen-only
         = interactive_data_div(interactive, @run)
         = button_tag 'Undo all my work', {class: 'delete_interactive_data'}
+
+.print-only.iframe-url
+  = link_to "#{interactive.url}", "#{interactive.url}"
 
 - labbook = show_labbook_under_interactive?(@run, interactive)
 - if labbook


### PR DESCRIPTION
Bunch of CSS changes:
- Remove the light grey text in each textarea that has a prompt to write text here.
- Remove the boxes around open response questions and the text areas for the open response questions.
- For interactives, images, and videos, float the image on the right and have the questions and text boxes in the info/assessment block flow around them.
- Hide interactive iframes (as they usually don't have enough time to load). There's a placeholder box instead + URL below. I've also removed "Click to play" overlay from the image if it's available.
- Hide "menu" and it's icon in the upper left side of the navigation bar.
- Hide "Welcome ...".
- Replace pulldown menu in multiple choice question is with normal list
- Hide buttons (check answer, draw image, etc.)

Also, I've extracted the print-specific styles to `print-styles.scss`.

There're quite a few `!important` rules which are typically considered to be a bad idea, but I think it makes sense in this case. Otherwise, I would need to provide lots of nested selectors, making sure that it's more specific than the original one. I guess it's more error prone long-term, for example if the dom structure changes.