### PR TITLE
Optimize Dashboard API (reduce N+1 queries, support update timestamps)

### DIFF
--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -90,7 +90,8 @@ class RunsController < ApplicationController
   def dashboard
     page_id = params[:page_id]
     endpoint_urls = params[:endpoint_urls] || []
-    dashboard = DashboardRunlist.new(endpoint_urls, page_id)
+    submissions_created_after = params[:submissions_created_after]
+    dashboard = DashboardRunlist.new(endpoint_urls, page_id, submissions_created_after)
     render json: dashboard.to_json, callback: params[:callback]
   end
 

--- a/app/services/dashboard_runlist.rb
+++ b/app/services/dashboard_runlist.rb
@@ -1,21 +1,32 @@
 class DashboardRunlist
-  def initialize(endpoint_urls, page_id)
-    @runs = Run.includes(:activity).where(remote_endpoint: endpoint_urls).map do |run|
+  DATA_VERSION = 2
+
+  def initialize(endpoint_urls, page_id, submissions_created_after = 0)
+    # DB query can be optimized by filtering out submissions older
+    # than provided timestamp. If it's not provided (or nil), we will simply return all the submissions.
+    submissions_created_after = Time.at(submissions_created_after ? submissions_created_after.to_i : 0)
+    runs_data = Run.includes(:activity).where(remote_endpoint: endpoint_urls).map do |run|
       {
         endpoint_url: run.remote_endpoint,
         group_id: run.collaboration_run_id,
         last_page_id: run.page_id,
-        submissions: submissions(run, page_id),
+        submissions: submissions(run, page_id, submissions_created_after),
         sequence_id: run.sequence_id,
         updated_at: run.updated_at.to_i,
         activity_id: run.activity_id,
         page_ids: run.activity.page_ids
       }
     end
+    @data = {
+      runs: runs_data,
+      # Timestamp can be used by the client to provide submissions_created_after param in the subsequent requests.
+      timestamp: Time.now.to_i,
+      version: DATA_VERSION
+    }
   end
 
   def to_hash
-    @runs
+    @data
   end
 
   def to_json
@@ -24,8 +35,19 @@ class DashboardRunlist
 
   private
 
-  def submissions(run, page_id)
-    CRater::FeedbackSubmission.includes(:c_rater_feedback_items => :answer).where(run_id: run.id, interactive_page_id: page_id).order(:id).map do |submission|
+  def submissions(run, page_id, submissions_created_after)
+    CRater::FeedbackSubmission
+      .includes(
+        c_rater_feedback_items: {answer: [:run, :question]},
+        embeddable_feedback_items: {answer: [:run, :question]}
+      )
+      .where('created_at > ?', submissions_created_after)
+      .where(
+        run_id: run.id,
+        interactive_page_id: page_id
+      )
+      .order(:id)
+      .map do |submission|
       {
         id: submission.id,
         group_id: submission.collaboration_run_id,

--- a/db/migrate/20160620140813_add_index_to_feedback_submissions.rb
+++ b/db/migrate/20160620140813_add_index_to_feedback_submissions.rb
@@ -1,0 +1,11 @@
+class AddIndexToFeedbackSubmissions < ActiveRecord::Migration
+  def up
+    add_index :c_rater_feedback_submissions, [:interactive_page_id, :run_id, :created_at], name: 'c_rater_fed_submission_page_run_created_idx'
+    remove_index :c_rater_feedback_submissions, name: 'c_rater_fed_submission_page_run_idx'
+  end
+
+  def down
+    add_index :c_rater_feedback_submissions, [:interactive_page_id, :run_id], name: 'c_rater_fed_submission_page_run_idx'
+    remove_index :c_rater_feedback_submissions, name: 'c_rater_fed_submission_page_run_created_idx'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160614200402) do
+ActiveRecord::Schema.define(:version => 20160620140813) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -62,15 +62,15 @@ ActiveRecord::Schema.define(:version => 20160614200402) do
   end
 
   add_index "c_rater_feedback_submissions", ["base_submission_id"], :name => "feedback_submissions_base_sub_id_idx"
-  add_index "c_rater_feedback_submissions", ["interactive_page_id", "run_id"], :name => "c_rater_fed_submission_page_run_idx"
+  add_index "c_rater_feedback_submissions", ["interactive_page_id", "run_id", "created_at"], :name => "c_rater_fed_submission_page_run_created_idx"
 
   create_table "c_rater_item_settings", :force => true do |t|
-    t.string   "item_id"
     t.integer  "score_mapping_id"
     t.integer  "provider_id"
     t.string   "provider_type"
     t.datetime "created_at",       :null => false
     t.datetime "updated_at",       :null => false
+    t.string   "item_id"
   end
 
   add_index "c_rater_item_settings", ["provider_id", "provider_type"], :name => "c_rat_set_prov_idx"
@@ -243,8 +243,8 @@ ActiveRecord::Schema.define(:version => 20160614200402) do
     t.boolean  "is_prediction",            :default => false
     t.boolean  "give_prediction_feedback", :default => false
     t.text     "prediction_feedback"
-    t.string   "default_text"
     t.boolean  "is_hidden",                :default => false
+    t.string   "default_text"
   end
 
   create_table "embeddable_xhtmls", :force => true do |t|

--- a/spec/services/dashboard_runlist_spec.rb
+++ b/spec/services/dashboard_runlist_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe DashboardRunlist do
   include_context "activity with arg block submissions"
-  let(:runlist) { DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash }
+  let(:runlist) { DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash[:runs] }
 
   it 'returns all the submissions of provided runs' do
     expect(runlist.length).to eql(1)
@@ -18,6 +18,27 @@ describe DashboardRunlist do
     expect(runlist[0][:submissions][0][:answers][2][:score]).to eql(3)
     expect(runlist[0][:submissions][0][:answers][3][:answer]).to eql('text4')
     expect(runlist[0][:submissions][0][:answers][3][:score]).to eql(4)
+  end
+
+  describe "submissions_created_after argument" do
+    it "returns all submissions if timestamp is not provided or nil" do
+      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id).to_hash[:runs]
+      expect(runlist[0][:submissions].length).to eql(1)
+      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id, nil).to_hash[:runs]
+      expect(runlist[0][:submissions].length).to eql(1)
+    end
+
+    it "returns submissions created after provided timestamp" do
+      timestamp = @submission.created_at - 10
+      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id, timestamp).to_hash[:runs]
+      expect(runlist[0][:submissions].length).to eql(1)
+    end
+
+    it "filters out submissions created before provided timestamp" do
+      timestamp = @submission.created_at + 10
+      runlist = DashboardRunlist.new([@run.remote_endpoint], page.id, timestamp).to_hash[:runs]
+      expect(runlist[0][:submissions].length).to eql(0)
+    end
   end
 
   it 'includes a reference to the sequence' do


### PR DESCRIPTION
I was playing with Dashboard API and I had following observations:
- There were some N+1 queries, easy to fix so I did it. It helped a bit, but still calls to `/runs/dashboard` was expensive.
- The most expensive part was calculating submissions - we need submissions, answers and related questions data. I created a test setup (5 learners, a few submissions) and single request was taking around 500-800ms in total.
- Basic run info (endpoint, last_page_id, etc.) can be returned pretty fast, around 50-100ms.

So, I decided that the best approach would be to remember data timestamp and make sure that we don't calculate old submissions info again and again during each request. Fortunately, it's quite simple here in LARA API and a bit more complicated in the client code (I guess that's our preference anyway). Related HASDashboard PR:
https://github.com/concord-consortium/HASDashboard/pull/17

Also, I' changed data format a bit, so I added version number. The client app is backward compatible, it would work with old and new API (e.g. fake data is equivalent to old API). 

Results:
<img width="585" alt="dashboard" src="https://cloud.githubusercontent.com/assets/767857/16195804/966ca24a-36fb-11e6-8c2c-2cbb20e6cfb6.png">
Initial request that returns all the submissions took around 500-600ms. Then we had a few requests < 100ms that returned no submissions. Then I logged in as a student, created one new submission and it was returned by request which took 350ms. 