### PR TITLE
squash the filtering of interactives and embeddables

### DIFF
--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -92,7 +92,7 @@ class LightweightActivitiesController < ApplicationController
     if !params[:response_key]
       redirect_to summary_with_response_path(@activity, @session_key) and return
     end
-    @answers = @activity.answers(@run).select { |a| a.show_in_report? }
+    @answers = @activity.answers(@run)
   end
 
   # The remaining actions are all authoring actions.

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -47,7 +47,13 @@ module Embeddable
     true
   end
 
+  # This should not take into account the hidden attribute. The caller should combine
+  # is_hidden with reportable? to know what to show in a report
+  def reportable?
+    raise "#reportable? unimplemented for #{self.class}"
+  end
+
   def index_in_activity(activity)
-    activity.questions.index(self) + 1
+    activity.reportable_items.index(self) + 1
   end
 end

--- a/app/models/embeddable/answer.rb
+++ b/app/models/embeddable/answer.rb
@@ -95,8 +95,4 @@ module Embeddable::Answer
     # wont invoke callbacks
     update_column(:is_dirty, false)
   end
-
-  def show_in_report?
-    true
-  end
 end

--- a/app/models/embeddable/answer_finder.rb
+++ b/app/models/embeddable/answer_finder.rb
@@ -1,3 +1,13 @@
+# This class is used for two general purposes:
+#  1. To get answers for reports
+#  2. To get "answers" to generate the page for the student
+#
+# In the case #2 the page is currently generated from the answer objects. It is not generated
+# from questions and then student answers filled in. So any "question" that isn't able to have
+# an answer should return itself.
+#
+# Currently in case #2 the AnswerFinder should only be passed the Page#page_items which means
+# it shouldn't be sent MwInteractives
 module Embeddable
   class AnswerFinder
     attr_accessor :run, :answer_map
@@ -15,6 +25,12 @@ module Embeddable
       when MwInteractive
         return "if_#{question.id}"
       when InteractiveRunState::QuestionStandin
+        # It is not clear but I beleive this bit of hackyness is here for this reason:
+        # When a InteractiveRunState is asked for its
+        # question, it returns an InteractiveRunState::QuestionStandin instead of MwInteractive
+        # (I'm not sure why). And then that question is sometimes used later in the process
+        # to try to find the answer again. So that is why it is OK for the same key to be used
+        # in that case. I haven't found where this happens.
         return question.interactive ? "if_#{question.interactive.id}" : nil
       end
       return nil

--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -73,6 +73,10 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
     bg_source == 'Drawing'
   end
 
+  def reportable?
+    true
+  end
+
   def self.name_as_param
     :embeddable_image_question
   end

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -178,12 +178,8 @@ module Embeddable
       ((action_type == UPLOAD_ACTION) && !has_interactive?) || interactive_is_visible?
     end
 
-    def show_in_report?
+    def reportable?
       show_in_runtime?
-    end
-
-    def hide_from_report?
-      !show_in_report?
     end
 
     def update_itsi_prompts

--- a/app/models/embeddable/labbook_answer.rb
+++ b/app/models/embeddable/labbook_answer.rb
@@ -26,7 +26,6 @@ module Embeddable
     delegate :is_snapshot?,    to: :question
     delegate :action_label,    to: :question
     delegate :interactive,     to: :question
-    delegate :show_in_report?, to: :question
 
     def labbook_user_id
       # Construct an unique ID - model ID + run key. Run key is actually unnecessary, but it provides salting,

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -131,6 +131,9 @@ module Embeddable
       layout == "likert"
     end
 
+    def reportable?
+      true
+    end
 
     def self.import (import_hash)
       choices = import_hash[:choices]

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -34,6 +34,10 @@ module Embeddable
       return Embeddable::OpenResponse.new(self.to_hash)
     end
 
+    def reportable?
+      true
+    end
+
     def self.name_as_param
       :embeddable_open_response
     end

--- a/app/models/embeddable/xhtml.rb
+++ b/app/models/embeddable/xhtml.rb
@@ -28,6 +28,10 @@ module Embeddable
       self.as_json(only:[:name, :content, :is_hidden])
     end
 
+    def reportable?
+      false
+    end
+
     def self.import(import_hash)
       return self.new(import_hash)
     end

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -124,6 +124,11 @@ class InteractivePage < ActiveRecord::Base
     section_visible_embeddables(nil)
   end
 
+  def reportable_items
+    items = visible_embeddables + visible_interactives
+    items.select { |item| item.reportable? }
+  end
+
   def add_interactive(interactive, position = nil, validate = true)
     self[:show_interactive] = true;
     self.save!(validate: validate)

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -34,6 +34,9 @@ class InteractiveRunState < ActiveRecord::Base
     def is_prediction; false; end
     def give_prediction_feedback; false; end
     def prediction_feedback; nil; end
+    def reportable?
+      interactive.reportable?
+    end
   end
 
   def question
@@ -67,10 +70,6 @@ class InteractiveRunState < ActiveRecord::Base
     arg ? original_json(arg) : answer_json
   end
 
-  def show_in_report?
-    interactive.respond_to?('save_state') && interactive.save_state && interactive.respond_to?('has_report_url') && interactive.has_report_url
-  end
-
   def answered?
     reporting_url.present?
   end
@@ -87,9 +86,6 @@ class InteractiveRunState < ActiveRecord::Base
     end
     def prompt
       question.prompt
-    end
-    def show_in_report?
-      false
     end
   end
 

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -110,7 +110,7 @@ class MwInteractive < ActiveRecord::Base
     end
   end
 
-  def is_reportable
+  def reportable?
     return save_state && has_report_url
   end
 end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -278,17 +278,12 @@ class Run < ActiveRecord::Base
     self.activity.increment!(:portal_run_count)
   end
 
-  def num_questions
-    return self.activity.questions.size
-  end
-
-  # HACK for interactive run state saving...
-  def question_answers
-    self.answers.reject {|a| a.question.kind_of? InteractiveRunState::QuestionStandin}
+  def num_reportable_items
+    return self.activity.reportable_items.size
   end
 
   def num_answers
-    q_answers = activity_q_answers = self.question_answers.reject { |a| !a.answered? }
+    q_answers = activity_q_answers = self.answers.reject { |a| !a.answered? }
     begin # this really shouldn't happen, but there are some bad runs in the DB
       activity_q_answers = q_answers.reject { |a| a.question.activity.id != self.activity_id }
       unless q_answers.size == activity_q_answers.size
@@ -300,11 +295,11 @@ class Run < ActiveRecord::Base
   end
 
   def completed?
-    return has_been_run && num_answers == num_questions
+    return has_been_run && num_answers == num_reportable_items
   end
 
   def percent_complete
-    return (num_answers / Float(num_questions) ) * 100.0
+    return (num_answers / Float(num_reportable_items) ) * 100.0
   end
 
   # See PT https://www.pivotaltracker.com/story/show/59365552
@@ -335,7 +330,7 @@ class Run < ActiveRecord::Base
         remote_endpoint: #{remote_endpoint}
        percent_complete: #{percent_complete}
       number of answers: #{num_answers}  (#{answers.size})
-    number of questions: #{num_questions}
+    number of questions: #{num_reportable_items}
                activity: #{activity.name} [#{activity_id}]
                sequence: #{sequence_id}
           collaboration: #{collaboration_run_id}

--- a/app/services/question_tracker/reporter.rb
+++ b/app/services/question_tracker/reporter.rb
@@ -4,7 +4,7 @@ class QuestionTracker::Reporter
 
   # Return a list of tracked questions in an activity to report on.
   def self.question_trackers_for_activity(activity)
-    return activity.questions.select{ |q| q.respond_to?(:question_tracker)}.map {|q| q.question_tracker }.compact.uniq
+    return activity.reportable_items.select{ |q| q.respond_to?(:question_tracker)}.map {|q| q.question_tracker }.compact.uniq
   end
 
   def self.question_trackers_for_sequence(sequence)

--- a/app/views/runs/details.html.haml
+++ b/app/views/runs/details.html.haml
@@ -33,7 +33,7 @@
             %td=run.dirty? ? " ✖ " : " ✔ "
             %td=run.run_count || 0
             %td=run.page ? run.page.position : 0
-            %td #{run.num_answers} / #{run.num_questions}
+            %td #{run.num_answers} / #{run.num_reportable_items}
             
             %td=sprintf("%04.1f%", run.percent_complete)
             %td=run.collaboration_run_id || "none"

--- a/documentation/embeddable-interactive-filtering.md
+++ b/documentation/embeddable-interactive-filtering.md
@@ -8,61 +8,46 @@ Interactives on the page bypass this "answer" approach. They use the interactive
 
 The numbering of items in the activity boils down to:
 
-    activity.questions.index(item) + 1
+    activity.reportable_items.index(item) + 1
 
-This happens when individual 'answer' partials call the Embeddable::Answer#question_index to find the index of the 'question' on the page. The Xhtml partial  doesn't look for an index. Reportable interactives technically have an index, but they do not display it.
+This happens when individual 'answer' partials call the `Embeddable::Answer#question_index` to find the index of the 'question' on the page. The Xhtml partial  doesn't look for an index. Reportable interactives technically have an index because they are part of reportable_items, but they do not display it.
 
 ## Activity Progress
 
 LARA shows activity progress in completion ribbons on the sequence table of contents. The progess is also shown in some admin info reports.
 
-The progress is based on `Run#num_answers` / `Run#num_questions`.
+The progress is based on `Run#num_answers` / `Run#num_reportable_items`.
 
-The num_questions is the count of `Activity#questions`.
+`Activity#reportable_items` is the combination of `Page#reportable_items` on all visible pages.
 
-`Activity#questions` is the combination of
-- visible_embeddables filtered by QUESTION_TYPES, this removes Xhtml items.
-- visible_interactives filtered to only inclue interactives that are reportable.
+`Page#reportable_items` is the combination of visible_embeddables and visible_interactives that are `#reportable?`.
 
-`Run#num_answers` is
-- `open_response_answers + multiple_choice_answers + image_question_answers + labbook_answers + interactive_run_states`
-- interactive_run_states removed (BUG)
-- answers that are not `#answered?` are removed
-- answers with questions that aren't in the activity are removed
+`Run#num_answers` is the count of `Run#answers` that are:
+- `#answered?`.
+- not part of another activity
 
-BUG: The num_answers doesn't include interactive run states that are included in num_questions. It should include interactive run states for reportable interactives.
+`Run#answers` is the simple combination of
+`open_response_answers + multiple_choice_answers + image_question_answers + labbook_answers + interactive_run_states`
 
-I tested this with a activity that had a reportable codap interactive. The inteactive run state was filled with data and the interactive was set to be reportable, but num_answers was still 0.
+NOTE: `Run#answers` differs from `Activity#answers(run)`. `Activity#answers(run)` will create an answer object for every `Activity#reportable_items` if the answer doesn't already exist. `Run#answers` doesn't do this.
+This might be for speed as well as supporting the idea of clearing answers from a run.
 
-Because `Activity#questions` is already filtering interactives that are not reportable, this incorrect filtering can be removed here.
-
-BUG: Labbooks are not handled by the progress correctly. Labbooks that don't have an interactive are included in `Activty#questions`, but they are not seen by the user so they are not `answered?`. This makes them part of `num_questions` but they are not ever part of `num_answers`. The solution is to remove them from `Activity#questions`. This should also allow us to remove the `show_in_report?` method that is used by the summary report.
-
-Addtionally renaming `questions` to `answerable_items` would help. Because the reason this all started was because it seemed wrong to filter things
-from `Activity#questions` and instead `show_in_report?` was added to handle LabBooks. It might also be possible to simplify some of this by using a single
-`show_in_runtime?` for both embeddables and interactives.
+TODO: Improve this confusing use of the answers method on two objects. There shouldn't be a need for both approaches.
 
 ## LARA summary report
 
 The summary report is based off of:
 
-    @answers = @activity.answers(@run).select { |a| a.show_in_report? }
+    @answers = @activity.answers(@run)
+
+`Activity#answers` uses the AnswerFinder to get answers from all of the `Activity#reportable_items`.
 
 The numbering of the items in the report is based off of the index of the answer in the @answers array.
-
-TODO: `show_in_report` should be unnessary here, because `Activity#questions` should correctly filter out any any interactives or labbooks
-that should not be in the report.  Currently there is a bug where LabBooks are not handled correctly by `Activity#questions` (see above).
 
 ## Sending answers to the portal
 
 The code to look at here is `LightweightActivity#serialize_for_portal`. It goes through each page.
 
-It filters the combination of `Page#embddables + Page#interactives` with:
-- `Embeddable#is_hidden?` and `Embeddable#hide_from_report?`
-- `MwInteractive#is_reportable?`
-- A switch statement is used of known types so this is how Xhtml embeddables get filtered.
-
-As it is currently written it cannot use the existing `Activity#questions` filtering because the items need to be grouped by page.
-
-TODO: Move the logic of `Activity#questions` into `Page`. Then this can be used in both places. This has the additional benefit of leaving the intra page
-ordering of embeddables and interactives up to the Page.
+It uses `Page#reportable_items` to get a filtered list of embeddables and interactives
+A switch statement is used of known types with a fallback of looking for a `#portal_hash` method.
+Xhtml isn't in the list of known types, and it doesn't have a `#portal_hash` method.

--- a/spec/features/activity_run_from_portal_spec.rb
+++ b/spec/features/activity_run_from_portal_spec.rb
@@ -5,7 +5,7 @@ feature "Activity is run from the portal", :js => true do
   # need an activity with at least a open response question
   let(:activity)   { FactoryGirl.create(:activity_with_page_and_or) }
   let(:user)       { FactoryGirl.create(:user_with_authentication)  }
-  let(:question)   { activity.questions.find {|q| q.class == Embeddable::OpenResponse} }
+  let(:question)   { activity.reportable_items.find {|q| q.class == Embeddable::OpenResponse} }
   let(:question_id){ question.id }
   let(:url) do
     activity_path(activity, :params => {

--- a/spec/features/hide_show_questions_spec.rb
+++ b/spec/features/hide_show_questions_spec.rb
@@ -6,7 +6,7 @@ feature "Activity page", :js => true do
   let(:activity)     { FactoryGirl.create(:activity_with_page_and_or) }
   let(:user)       { FactoryGirl.create(:admin)  }
   let(:activity_page) { activity.pages.first }
-  let(:question)     { activity.questions.find {|q| q.class == Embeddable::OpenResponse} }
+  let(:question)     { activity.reportable_items.find {|q| q.class == Embeddable::OpenResponse} }
   let(:activity_page_url) { edit_activity_page_path(activity, activity_page) }
   let(:hideshow_url) { page_hideshow_embeddable_path(activity_page, question) }
 

--- a/spec/models/embeddable/labbook_answer_spec.rb
+++ b/spec/models/embeddable/labbook_answer_spec.rb
@@ -42,16 +42,13 @@ describe Embeddable::LabbookAnswer do
     end
   end
 
-  describe '#show_in_runtime? and #show_in_report' do
-    let(:stubs) { { show_in_runtime?: true, show_in_report?: true } }
+  describe '#show_in_runtime?' do
+    let(:stubs) { { show_in_runtime?: true } }
     let(:labbook) { stub_model(Embeddable::Labbook, stubs) }
 
     describe 'with an enabled labbook' do
       it "should return true for show_in_runtime?" do
         expect(labbook_answer.show_in_runtime?).to eql(true)
-      end
-      it "should return true for show_in_report?" do
-        expect(labbook_answer.show_in_report?).to eql(true)
       end
     end
 
@@ -59,9 +56,6 @@ describe Embeddable::LabbookAnswer do
       let(:stubs) { { show_in_runtime?: false, show_in_report?: false } }
       it "should return false for #show_in_runtime?" do
         expect(labbook_answer.show_in_runtime?).to eql(false)
-      end
-      it "should return false for #show_in_report?" do
-        expect(labbook_answer.show_in_report?).to eql(false)
       end
     end
 

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -87,7 +87,7 @@ describe LightweightActivity do
     end
   end
 
-  describe '#questions' do
+  describe '#reportable_items' do
     let(:page1) { FactoryGirl.create(:interactive_page_with_or, position: 1) }
     let(:page2) { FactoryGirl.create(:interactive_page_with_or, position: 2) }
     let(:non_reportable_interactive) {
@@ -106,8 +106,8 @@ describe LightweightActivity do
     end
 
     it 'returns an array of embeddables and reportable interactives' do
-      expect(activity.questions.length).to eql(3)
-      expect(activity.questions).to eql(
+      expect(activity.reportable_items.length).to eql(3)
+      expect(activity.reportable_items).to eql(
         [page1.embeddables[0], page2.embeddables[0], reportable_interactive])
     end
 
@@ -116,9 +116,9 @@ describe LightweightActivity do
 
       it 'doesnt report on items on the hidden page' do
         expect(activity.pages[1].is_hidden).to eq true
-        expect(activity.questions).not_to include reportable_interactive
-        expect(activity.questions.length).to eql(1)
-        expect(activity.questions).to eql(page1.embeddables)
+        expect(activity.reportable_items).not_to include reportable_interactive
+        expect(activity.reportable_items.length).to eql(1)
+        expect(activity.reportable_items).to eql(page1.embeddables)
       end
     end
 
@@ -131,24 +131,20 @@ describe LightweightActivity do
       }
       it 'the list of questions without the hidden reportable interactive' do
         expect(reportable_interactive.is_hidden).to eq true
-        expect(activity.questions).not_to include reportable_interactive
+        expect(activity.reportable_items).not_to include reportable_interactive
       end
     end
 
     context 'when the embeddable open reponse is hidden' do
       let (:page2) { FactoryGirl.create(:interactive_page_with_hidden_or) }
       it 'returns an the questions without the open repose' do
-        expect(activity.questions.length).to eql(2)
-        expect(activity.questions).to include page1.embeddables[0]
-        expect(activity.questions).to include reportable_interactive
+        expect(activity.reportable_items.length).to eql(2)
+        expect(activity.reportable_items).to include page1.embeddables[0]
+        expect(activity.reportable_items).to include reportable_interactive
       end
     end
-  end
 
-  describe '#question_keys' do
-    it 'returns an array of storage_keys from questions' do
-      expect(activity.question_keys).to eq([])
-    end
+    # TODO: Add tests for Labbooks in various states of being hidden or not-hidden
   end
 
   context 'it has embeddables' do
@@ -173,20 +169,14 @@ describe LightweightActivity do
     end
 
 
-    describe '#questions' do
+    describe '#reportable_items' do
       it 'returns an array of Embeddables which are MultipleChoice or OpenResponse' do
-        expect(activity.questions.length).to be(4)
-        activity.questions.each { |q| expect(activity.questions).to include(q) }
-        expect(activity.questions).not_to include(text_emb)
+        expect(activity.reportable_items.length).to be(4)
+        activity.reportable_items.each { |q| expect(activity.reportable_items).to include(q) }
+        expect(activity.reportable_items).not_to include(text_emb)
       end
     end
 
-    describe '#question_keys' do
-      it 'returns an array of storage_keys from questions' do
-        expect(activity.question_keys.length).to be(4)
-        expect(activity.question_keys.first).to be_kind_of String
-      end
-    end
   end
 
   describe "#publish!" do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -559,14 +559,14 @@ describe Run do
     let(:questions) { [1,2,3]  }
     let(:answers) { [or_answer, mc_answer, iq_answer]  }
     before(:each) do
-      allow(activity).to receive(:questions).and_return(questions)
+      allow(activity).to receive(:reportable_items).and_return(questions)
       allow(run).to receive(:answers).and_return(answers)
       allow(run).to receive(:has_been_run).and_return(true)
     end
 
-    describe "#num_questions" do
-      describe '#num_questions' do
-        subject { super().num_questions }
+    describe "#num_reportable_items" do
+      describe '#num_reportable_items' do
+        subject { super().num_reportable_items }
         it { is_expected.to eq 3}
       end
     end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -600,5 +600,74 @@ describe Run do
         it { is_expected.to be_within(0.1).of(66.6) }
       end
     end
+
+    describe "With three answers and one that is not answered" do
+      before(:each) do
+        allow(mc_answer).to receive(:answered?).and_return(false)
+      end
+      describe '#num_answers' do
+        subject { super().num_answers }
+        it { is_expected.to eq 2 }
+      end
+      it { is_expected.not_to be_completed }
+
+      describe '#percent_complete' do
+        subject { super().percent_complete }
+        it { is_expected.to be_within(0.1).of(66.6) }
+      end
+    end
+  end
+  describe "with real DB objects" do
+    let(:page) { FactoryGirl.create(:page, name: 'page 1', position: 0) }
+    before(:each) do
+      # Add answers
+      run.open_response_answers << or_answer
+      run.multiple_choice_answers << mc_answer
+
+      # make sure it has been run
+      run.increment_run_count!
+
+      activity.pages << page
+      activity.reload
+      page.add_embeddable(or_question)
+      page.add_embeddable(mc_question)
+    end
+
+    describe '#num_answers' do
+      subject { run.num_answers }
+      it { is_expected.to eq 2 }
+    end
+
+    describe "page.reportable_items" do
+      subject { page.reportable_items }
+      it { is_expected.to eql [or_question, mc_question] }
+    end
+
+    describe '#complete?' do
+      subject { run }
+      it { is_expected.to be_completed }
+    end
+
+    context 'with a disconnected labbook' do
+
+      before(:each) do
+        page.add_embeddable(FactoryGirl.create(:labbook, interactive: nil ))
+      end
+
+      describe "page.visible_embeddables.count" do
+        subject { page.visible_embeddables.count }
+        it { is_expected.to eql 3 }
+      end
+
+      describe "page.reportable_items.count" do
+        subject { page.reportable_items.count }
+        it { is_expected.to eql 2 }
+      end
+
+      describe '#complete?' do
+        subject { run }
+        it { is_expected.to be_completed }
+      end
+    end
   end
 end

--- a/spec/support/shared_context/collaboration_run.rb
+++ b/spec/support/shared_context/collaboration_run.rb
@@ -5,7 +5,7 @@ shared_context "collaboration run" do
   let(:activity) { FactoryGirl.create(:activity_with_page_and_or) }
   # There is no need to test other types of questions, as answer copying / duplication is handled
   # in their separate unit tests.
-  let(:or_question) { activity.questions[0] }
+  let(:or_question) { activity.reportable_items[0] }
   let(:or_answer1)  { FactoryGirl.create(:or_answer, { answer_text: "the answer", question: or_question }) }
   let(:or_answer2)  { FactoryGirl.create(:or_answer, { answer_text: "the different answer", question: or_question }) }
 


### PR DESCRIPTION
The intention of this PR is to make the code easier to maintain. It also fixes a few bugs in the process.

Here are the basic changes:
removes show_in_report from answers
changes is_reportable to reportable? on interactives
adds reportable? to all embeddables
moves old Activity#questions logic into Pages#reportable_items
removes extra answer filtering from Run

Fixed bugs:
- completion ribbons on Sequence TOC would never show if an activity had a LabBook that was not hidden, but didn't have a valid interactive.  This LabBook would be counted as a question but the student would never see it in order to complete it.
- question numbers would be wrong after a LabBook that was not hidden, but didn't have a valid interactive.
- completion ribbons on Sequence TOC would not show if a interactive was reportable and the student had opened the interactive. All interactives were not counted as answers in the completion equation, but reportable interactives were counted as questions.
