### PR TITLE
image and video interactives fix, plus export fix for labbooks without interactives

### DIFF
--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -11,6 +11,10 @@ class ImageInteractive < ActiveRecord::Base
     "image interactive"
   end
 
+  def reportable?
+    false
+  end
+
   def to_hash
     {
       url: url,

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -42,6 +42,10 @@ class VideoInteractive < ActiveRecord::Base
     end
   end
 
+  def reportable?
+    false
+  end
+
   def to_hash
     {
       poster_url: poster_url,

--- a/app/services/lara_serialization_helper.rb
+++ b/app/services/lara_serialization_helper.rb
@@ -31,7 +31,7 @@ class LaraSerializationHelper
     when MwInteractive, ImageInteractive, VideoInteractive
       results[:ref_id] = key(item)
     when Embeddable::Labbook
-      results[:interactive_ref_id] = key(item.interactive)
+      results[:interactive_ref_id] = key(item.interactive) if item.interactive
     end
     results
   end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -108,7 +108,7 @@ describe LightweightActivity do
     end
 
     context 'when some pages are hidden' do
-      let (:page2) { FactoryGirl.create(:interactive_page_with_or, is_hidden: true) }
+      let (:page2) { FactoryGirl.create(:interactive_page_with_or, is_hidden: true, position: 2) }
 
       it 'doesnt report on items on the hidden page' do
         expect(activity.pages[1].is_hidden).to eq true

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -90,14 +90,10 @@ describe LightweightActivity do
   describe '#reportable_items' do
     let(:page1) { FactoryGirl.create(:interactive_page_with_or, position: 1) }
     let(:page2) { FactoryGirl.create(:interactive_page_with_or, position: 2) }
-    let(:non_reportable_interactive) {
-      FactoryGirl.create(:mw_interactive, save_state: true, has_report_url: false)
-    }
     let(:reportable_interactive) {
       FactoryGirl.create(:mw_interactive, save_state: true, has_report_url: true)
     }
     before(:each) do
-      page1.add_interactive non_reportable_interactive
       page2.add_interactive reportable_interactive
       activity.pages << page1
       activity.pages << page2
@@ -121,30 +117,6 @@ describe LightweightActivity do
         expect(activity.reportable_items).to eql(page1.embeddables)
       end
     end
-
-    context 'when the reportable interactive is hidden' do
-      let(:reportable_interactive) {
-        FactoryGirl.create(:mw_interactive,
-          save_state: true,
-          has_report_url: true,
-          is_hidden: true)
-      }
-      it 'the list of questions without the hidden reportable interactive' do
-        expect(reportable_interactive.is_hidden).to eq true
-        expect(activity.reportable_items).not_to include reportable_interactive
-      end
-    end
-
-    context 'when the embeddable open reponse is hidden' do
-      let (:page2) { FactoryGirl.create(:interactive_page_with_hidden_or) }
-      it 'returns an the questions without the open repose' do
-        expect(activity.reportable_items.length).to eql(2)
-        expect(activity.reportable_items).to include page1.embeddables[0]
-        expect(activity.reportable_items).to include reportable_interactive
-      end
-    end
-
-    # TODO: Add tests for Labbooks in various states of being hidden or not-hidden
   end
 
   context 'it has embeddables' do

--- a/spec/services/lara_serialization_helper_spec.rb
+++ b/spec/services/lara_serialization_helper_spec.rb
@@ -49,15 +49,15 @@ describe LaraSerializationHelper do
     describe "for an interactive" do
       it "should call export on our test-subject" do
         expect(interactive).to receive(:export).and_return(export)
-        expect(result).to match a_hash_including(a:1, b:2)
+        expect(result).to include(a:1, b:2)
       end
       it "should append `ref_id` and `type` tags the export data" do
         expect(interactive).to receive(:export).and_return(export)
-        expect(result).to match a_hash_including(ref_id: expected_key, type:'MwInteractive')
+        expect(result).to include(ref_id: expected_key, type:'MwInteractive')
       end
     end
 
-    describe "for an embeddable" do
+    describe "for a Labbook embeddable" do
       let(:em_stubs)      { { interactive: interactive }              }
       let(:embeddable)    { mock_model(Embeddable::Labbook, em_stubs) }
       let(:expected_hash) { {interactive_ref_id: expected_key, type:'Embeddable::Labbook'} }
@@ -65,11 +65,21 @@ describe LaraSerializationHelper do
 
       it "should call export on our test-subject" do
         expect(embeddable).to receive(:export).and_return(export)
-        expect(result).to match a_hash_including(a:1, b:2)
+        expect(result).to include(a:1, b:2)
       end
       it "should append `interactive_ref_id` and `type` tags the export data" do
         expect(embeddable).to receive(:export).and_return(export)
-        expect(result).to match a_hash_including(expected_hash)
+        expect(result).to include(expected_hash)
+      end
+
+      context "when the Labook has no interactive" do
+        let(:embeddable)    { mock_model(Embeddable::Labbook, interactive: nil) }
+        let(:expected_hash) { {interactive_ref_id: expected_key, type:'Embeddable::Labbook'} }
+
+        it "should not append `interactive_ref_id`" do
+          expect(embeddable).to receive(:export).and_return(export)
+          expect(result).not_to include(:interactive_ref_id)
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes an issue with image and video interactives not handling the new `reportable?` method.
It also moves some of the reportable_items tests around and expands them.
Finally it fixes an issue when trying to export activities with Labbooks that don't have a interactive set.

