### PR TITLE
Change URLS  for Has Dashboard C-Rater reports to /api/*

### DIFF
--- a/app/controllers/api/v1/dashboard_controller.rb
+++ b/app/controllers/api/v1/dashboard_controller.rb
@@ -1,0 +1,39 @@
+class Api::V1::DashboardController < ApplicationController
+
+  # Controller for HAS Dashboard (aka HASBot C-Rater) report.
+
+
+  # `#runs` returns the json representing report data for students.
+  # Params:
+  #   page_id: The page to report on.
+  #   endpoint_urls: The runs (students) to report on.
+  #   submissions_created_after: Only report on runs updated after this timestamp. (optional)
+  #   callback: Client side javascript method to invoke. Sent by jquery `jsonP` request. TODO: stop using jsonP.
+  def runs
+    page_id = params[:page_id]
+    endpoint_urls = params[:endpoint_urls] || []
+    submissions_created_after = params[:submissions_created_after]
+    dashboard = DashboardRunlist.new(endpoint_urls, page_id, submissions_created_after)
+    render json: dashboard.to_json, callback: params[:callback]
+  end
+
+  # `#toc` returns the json structure of the offering used in the table of contents in the report.
+  # Params:
+  #   runnable_type: one of either 'sequences' or 'activities'. Clients extract this from the portal run urls.
+  #   runnable_id: the id of the sequence or activity to display TOC data for.
+  #   callback: Client side javascript method to invoke. Sent by jquery `jsonP` request. TODO: stop using jsonP.
+  def toc
+    callback      = params[:callback]
+    runnable_type = params[:runnable_type]
+    runnable_id   = params[:runnable_id]
+    runnable = nil
+    case runnable_type
+      when 'activities'
+        runnable = LightweightActivity.find(runnable_id)
+      when 'sequences'
+        runnable = Sequence.find(runnable_id)
+    end
+    toc = DashboardToc.new(runnable)
+    render json: toc.to_hash, callback: callback
+  end
+end

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -263,16 +263,6 @@ class LightweightActivitiesController < ApplicationController
     redirect_to :back
   end
 
-  def dashboard_toc
-    respond_to do |format|
-      format.js do
-        callback = params[:callback]
-        toc = DashboardToc.new(@activity)
-        render json: toc.to_hash, callback: callback
-      end
-    end
-  end
-
   private
   def set_activity
     if params[:activity_id]

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -38,12 +38,6 @@ class SequencesController < ApplicationController
     end
   end
 
-  def dashboard_toc
-    authorize! :read, @sequence
-    callback = params[:callback]
-    toc = DashboardToc.new(@sequence)
-    render json: toc.to_hash, callback: callback
-  end
 
   # GET /sequences/new
   # GET /sequences/new.json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,8 @@ LightweightStandalone::Application.routes.draw do
       get :duplicate
       get :export
       get :show_status
-      get :dashboard_toc
+      # TODO: dpeprecate this Dashboard route
+      get :dashboard_toc, to: redirect { |params, request| "/api/v1/dashboard_toc/sequences/#{params[:id]}?#{request.params.to_query}" }
     end
     resources :activities, :controller => 'lightweight_activities', :constraints => { :id => /\d+/, :sequence_id => /\d+/ }, :only => [:show, :summary]
   end
@@ -73,7 +74,8 @@ LightweightStandalone::Application.routes.draw do
       get 'preview'
       get 'export'
       get 'show_status'
-      get 'dashboard_toc'
+      # TODO: dpeprecate this Dashboard route
+      get :dashboard_toc, to: redirect { |params, request| "/api/v1/dashboard_toc/activities/#{params[:id]}?#{request.params.to_query}" }
     end
     resources :pages, :controller => 'interactive_pages', :constraints => { :id => /\d+/ } do
       member do
@@ -146,11 +148,16 @@ LightweightStandalone::Application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      # For UW style tracked question reports (longitudinal reports)
       resources :question_trackers, only: [:index] do
         match 'report' =>  "question_trackers#report", via: ['get','post', 'put'], defaults: { format: 'json' }
       end
       match 'question_trackers/find_by_activity/:activity_id' =>  "question_trackers#find_by_activity", via: ['get'], defaults: { format: 'json' }
       match 'question_trackers/find_by_sequence/:sequence_id' =>  "question_trackers#find_by_sequence", via: ['get'], defaults: { format: 'json' }
+
+      # For HASBOT C-Rater reports aka HAS Dashboard
+      match 'dashboard_runs' => "dashboard#runs", defaults: { format: 'json' }
+      match 'dashboard_toc/:runnable_type/:runnable_id' => "dashboard#toc",  defaults: { format: 'json' }
     end
   end
 
@@ -176,7 +183,8 @@ LightweightStandalone::Application.routes.draw do
   get "/activities/:activity_id/single_page/:response_key" => 'lightweight_activities#single_page', :as => 'activity_single_page_with_response', :constraints => { :activity_id => /\d+/, :response_key => /[-\w]{36}/ }
   get "/runs/dirty" => 'runs#dirty', :as => 'dirty_runs'
   get "/runs/details" => 'runs#details', :as => 'run_details'
-  get "/runs/dashboard" => 'runs#dashboard', :as => 'run_dashboard'
+  # TODO: Depricate this older dashboard route
+  get "/runs/dashboard" => 'api/v1/dashboard#runs'
   match "/runs/fix_broken_portal_runs/:run_id" => 'runs#fix_broken_portal_runs', :as => 'fix_broken_portal_runs'
   match "/runs/run_info/:run_id" => 'runs#run_info', :as => 'run_info'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ LightweightStandalone::Application.routes.draw do
       get :export
       get :show_status
       # TODO: dpeprecate this Dashboard route
-      get :dashboard_toc, to: redirect { |params, request| "/api/v1/dashboard_toc/sequences/#{params[:id]}?#{request.params.to_query}" }
+      get :dashboard_toc, to: redirect(path: "/api/v1/dashboard_toc/sequences/%{id}")
     end
     resources :activities, :controller => 'lightweight_activities', :constraints => { :id => /\d+/, :sequence_id => /\d+/ }, :only => [:show, :summary]
   end
@@ -75,7 +75,7 @@ LightweightStandalone::Application.routes.draw do
       get 'export'
       get 'show_status'
       # TODO: dpeprecate this Dashboard route
-      get :dashboard_toc, to: redirect { |params, request| "/api/v1/dashboard_toc/activities/#{params[:id]}?#{request.params.to_query}" }
+      get :dashboard_toc, to: redirect(path: "/api/v1/dashboard_toc/activities/%{id}")
     end
     resources :pages, :controller => 'interactive_pages', :constraints => { :id => /\d+/ } do
       member do

--- a/spec/controllers/api/v1/dashboard_controller_spec.rb
+++ b/spec/controllers/api/v1/dashboard_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Api::V1::DashboardController do
+  let(:sequence) { FactoryGirl.create(:sequence) }
+  let(:activity) { FactoryGirl.create(:activity, name: "my activity") }
+  
+
+  describe 'toc' do
+    describe 'called with a sequence' do
+      before(:each) do
+        get :toc, :runnable_id => sequence.id, :runnable_type => "sequences"
+      end
+      let(:expected_json) { "{\"name\":\"MyString\",\"url\":\"/sequences/#{sequence.id}\",\"activities\":[]}"}
+
+      it 'returns a json hash of the sequence' do
+        expect(response).not_to be_nil
+        expect(response.body).to eql expected_json
+      end
+    end
+    describe 'called with an activity' do
+      before(:each) do
+        get :toc, :runnable_id => activity.id, :runnable_type => "activities"
+      end
+      let(:expected_json) { "{\"name\":\"MyString\",\"url\":\"/sequences/#{sequence.id}\",\"activities\":[]}"}
+
+      it 'returns a json hash of the sequence including our activity' do
+        expect(response).not_to be_nil
+        expect(JSON.parse(response.body)).to include("url","name","activities")
+        expect(JSON.parse(response.body)['activities'][0]).to include("name" => activity.name, "id" => activity.id)
+      end
+    end
+  end
+
+end

--- a/spec/controllers/sequences_controller_spec.rb
+++ b/spec/controllers/sequences_controller_spec.rb
@@ -42,20 +42,6 @@ describe SequencesController do
     end
   end
 
-  describe "GET dashboard_toc" do
-    before(:each) do
-      get :dashboard_toc, :id => sequence.to_param
-    end
-    let(:expected_json) { "{\"name\":\"MyString\",\"url\":\"/sequences/#{sequence.id}\",\"activities\":[]}"}
-    it "assigns the requested sequence as @sequence" do
-      expect(assigns(:sequence)).to eq(sequence)
-    end
-
-    it 'returns a json hash' do
-      expect(response).not_to be_nil
-      expect(response.body).to eql expected_json
-    end
-  end
 
   describe "GET new" do
     it "redirects to edit" do


### PR DESCRIPTION
Put all the Dashboard report endpoints in /api/v1/ 

This is the LARA side of https://github.com/concord-consortium/HASDashboard/pull/23/

https://www.pivotaltracker.com/story/show/121491615