### PR TITLE
Print activities

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -492,14 +492,20 @@ ul.quiet_list {
     padding: 10px 5px;
     margin: 0;
     border-bottom: dashed 1px #ddd;
+
+    .action_menu {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      width: 100%;
+    }
     .action_menu_header_left {
-      float: left;
       font-size: 1.2em;
       font-weight: bold;
-      width: 61%;
+      width: 50%;
     }
     .action_menu_header_right {
-      width: 40%;
+      width: 50%;
     }
     .action_menu_header_right.themes {
       width: 20%;
@@ -514,9 +520,10 @@ ul.quiet_list {
     }
     .active-runs {
       color: red;
-      float: right;
+      width: 150px;
       border: 1px solid red;
       padding: 2px;
+      margin-left: 0px;
     }
   }
   li.item:hover {
@@ -642,6 +649,11 @@ li.edit a {
   color: #333;
   height: 14px;
   padding-left: 18px;
+  text-decoration: none;
+}
+li.print a {
+  color: #333;
+  height: 14px;
   text-decoration: none;
 }
 li.run a {

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -85,6 +85,12 @@ class LightweightActivitiesController < ApplicationController
     @labbook_is_under_interactive = true
   end
 
+  def print_blank
+    authorize! :read, @activity
+    @run = Run.new() #Temporary run for the answer finder. Don't persist.
+    setup_show
+  end
+
   def summary
     authorize! :read, @activity
     current_theme
@@ -278,6 +284,8 @@ class LightweightActivitiesController < ApplicationController
       return 'runtime'
     when 'preview'
       return 'runtime'
+    when 'print_blank'
+      return 'print_blank'
     when 'single_page'
       return 'runtime'
     when 'summary'

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -87,7 +87,7 @@ class LightweightActivitiesController < ApplicationController
 
   def print_blank
     authorize! :read, @activity
-    @run = Run.new() #Temporary run for the answer finder. Don't persist.
+    @run = Run.new()
     setup_show
   end
 

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -1,6 +1,7 @@
 
 class SequencesController < ApplicationController
   layout 'sequence_run', :only => [:show]
+  layout 'print_blank',  :only => [:print_blank]
   before_filter :set_sequence, :except => [:index, :new, :create]
   before_filter :find_or_create_sequence_run, :only => [:show]
 
@@ -16,6 +17,11 @@ class SequencesController < ApplicationController
       format.html # index.html.erb
       format.json { render json: @sequences }
     end
+  end
+
+  # GET /sequences/1/print_blank
+  def print_blank
+    authorize! :read, @sequence
   end
 
   # GET /sequences/1

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -182,12 +182,16 @@ class LightweightActivity < ActiveRecord::Base
 
   def serialize_for_portal(host)
     local_url = "#{host}#{Rails.application.routes.url_helpers.activity_path(self)}"
+    author_url = "#{local_url}/edit"
+    print_url = "#{local_url}/print_blank"
     data = {
       'type' => "Activity",
       "name" => self.name,
       "description" => self.description,
       "url" => local_url,
       "create_url" => local_url,
+      "author_url" => author_url,
+      "print_url"  => print_url,
       "thumbnail_url" => thumbnail_url,
       "author_email" => self.user.email,
       "is_locked" => self.is_locked

--- a/app/views/layouts/print_blank.html.erb
+++ b/app/views/layouts/print_blank.html.erb
@@ -1,0 +1,125 @@
+<!doctype html>
+<!--[if lt IE 7]>
+<html class="no-js ie6 lt-ie9 lt-ie8 lt-ie7" lang="en"> <![endif]-->
+<!--[if IE 7]>
+<html class="no-js ie7 lt-ie9 lt-ie8" lang="en"> <![endif]-->
+<!--[if IE 8]>
+<html class="no-js ie8 lt-ie9" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" lang="en"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+  <title><%= yield :title %></title>
+  <%= csrf_meta_tags %>
+  <!-- TODO: Populate meta tags -->
+  <meta name="description" content="">
+  <meta name="author" content="">
+  <%- if false # @project and @project.og_logo         -%>
+      <meta property="og:image" content="<%= "#{request.protocol}#{request.host_with_port}" %><%= image_path @project.og_logo %>"/>
+  <%- else -%>
+      <meta property="og:image" content="<%= "#{request.protocol}#{request.host_with_port}" %><%= image_path 'mw-logo-og.jpg' %>"/>
+  <%- end -%>
+
+  <!-- Icons -->
+  <%= favicon_link_tag %>
+
+  <!-- Stylesheets -->
+  <%= stylesheet_link_tag '//ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/themes/base/jquery-ui.css' %>
+  <%- if @theme && @theme.css_file %>
+      <%= stylesheet_link_tag @theme.css_file, :media => 'all' %>
+  <%- else -%>
+      <%= stylesheet_link_tag Theme::DEFAULT_CSS_FILE, :media => 'all' %>
+  <%- end -%>
+
+  <!-- Scripts -->
+  <%= render partial: 'shared/rollbar' %>
+  <%= include_gon %>
+  <!--[if IE 8 ]>
+  <%= javascript_include_tag 'respond' %>
+	<![endif]-->
+  <%= javascript_include_tag 'modernizr.min' %>
+  <!-- TODO: CDN or include? Lab is using 2.0.x but self-hosting. -->
+  <%= javascript_include_tag '//ajax.googleapis.com/ajax/libs/jquery/2.0.1/jquery.min.js' %>
+  <%= javascript_include_tag '//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js' %>
+</head>
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+<!-- Page Begins				-->
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+<body class=<%= yield :body_class %>>
+
+<div id="container">
+
+  <header>
+    <div class="site-logo-mod site-width">
+      <div class="site-logo logo-l">
+        <%= left_logo_tag %>
+      </div>
+      <!-- end site-logo logo-l -->
+
+      <div class="site-logo logo-r">
+        <%= right_logo_tag %>
+      </div>
+      <!-- end site-logo logo-r -->
+    </div>
+    <!-- end site-logo-mod site-width -->
+  </header>
+
+  <div id="save" class="error" style="opacity: 1.0">
+    <%= t("DATA_WILL_NOT_BE_SAVED") %>
+  </div>
+
+  <div id="main" role="main">
+
+    <div class="activity-mod">
+      <div class="site-width">
+
+        <%= yield %>
+
+      </div>
+      <!-- end site-width -->
+
+    </div>
+    <!-- end activity-mod -->
+
+    <div class="activity-footer-mod site-width">
+    </div>
+    <!-- end activity-footer-mod -->
+
+  </div>
+  <!-- end #main -->
+
+  <footer>
+    <div class="site-width">
+      <%= raw project_footer %>
+    </div>
+    <!-- end site-width -->
+  </footer>
+
+</div>
+<!-- eo #container -->
+<%= render :partial => "shared/i18njs" %>
+<%= render :partial => 'shared/analytics' if Rails.env == 'production' && !request.host.match(/staging/) %>
+
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+<!-- Scripts					-->
+<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+
+<script>// window.jQuery || document.write('<script src="/assets/jquery-2.0.1.min.js"><\/script>')</script>
+
+<!-- Project-Specific stuff, start with up-base and go into script.js for your code -->
+
+<!-- end scripts-->
+
+<!-- Prompt IE 6 users to install Chrome Frame. Remove this if you want to support IE 6.
+   chromium.org/developers/how-tos/chrome-frame-getting-started -->
+<!--[if lt IE 7 ]>
+  <%= javascript_include_tag '//ajax.googleapis.com/ajax/libs/chrome-frame/1.0.3/CFInstall.min.js' %>
+  <script>window.attachEvent('onload',function(){CFInstall.check({mode:'overlay'})})</script>
+<![endif]-->
+
+</body>
+</html>

--- a/app/views/lightweight_activities/_index_item.html.haml
+++ b/app/views/lightweight_activities/_index_item.html.haml
@@ -13,9 +13,16 @@
         - confirm_message = "Are you sure you want to delete this activity? You will lose data from #{pluralize(activity.active_runs, "learner")} that #{"has".pluralize(activity.active_runs)} attempted this activity."
         %li.delete= link_to 'Delete', activity_path(activity), method: :delete, data: { confirm: (activity.active_runs > 0) ? confirm_message : 'Are you sure?' } if can? :destroy, activity
         %li.publish= link_to('Publish', publication_show_status_path(activity.class,activity.id), :remote => true) if can? :publish, activity
-        %li.run= link_to "Run", activity_path(activity), :target => 'new' if can? :read, activity
+        - if can? :read, activity
+          %li.print
+            %i.fa.fa-print
+            = link_to "print", print_blank_activity_path(activity), :target => 'new'
+          %li.run= link_to "Run", activity_path(activity), :target => 'new'
 
   %div{:id => dom_id_for(activity, :details), :class => 'tiny'}
+    - if (activity.active_runs > 0) && (can? :edit, activity)
+      %p.active-runs
+        = "Has been used by #{pluralize(activity.active_runs, "learner")}."
     - if activity.user && activity.user.email.present?
       %p.author
         = "by #{activity.user.email}"
@@ -26,7 +33,4 @@
     - if activity.portal_publications.length > 0
       %p.published
         = "last published at #{activity.portal_publications.last.updated_at.to_formatted_s(:long)} to #{activity.portal_publications.last.portal_domain}"
-    - if (activity.active_runs > 0) && (can? :edit, activity)
-      %p.active-runs
-        = "Has been used by #{pluralize(activity.active_runs, "learner")}."
     != activity.description

--- a/app/views/lightweight_activities/print_blank.html.haml
+++ b/app/views/lightweight_activities/print_blank.html.haml
@@ -1,0 +1,43 @@
+= content_for :title do
+  = "Print #{@activity.name}"
+
+= content_for :body_class do
+  = 'l-single-page'
+.screen-only
+  .print-warning
+    - if @activity.thumbnail_url.present?
+      %img{src:@activity.thumbnail_url}
+    %div=t("PRINT_BLANK.PRINT_WARNING", activity: @activity.name)
+    .submit
+      %a{href: "javascript:void(0);", onclick: "window.print();"}
+        %input.button{type: 'submit', value: t('PRINT_BLANK.PRINT', activity: @activity.name)}
+
+.print-only
+  - @activity.visible_pages.each do |p|
+    -# Enforce full-width layout for each page rendering.
+    = render partial: "interactive_pages/show", locals: {page: p, layout: 'l-full-width'}
+
+:javascript
+  $(function(){ window.print(); });
+
+:sass
+  .print-warning
+    box-sizing: border-box
+    margin: 1em auto
+    width: 400px
+    padding: 10px
+    text-align: center
+    background-color: hsl(200,0%,95%)
+    border-radius: 6px
+    font-size: 12pt
+    overflow: hidden
+    .submit
+      width: auto
+    img
+      max-width: 380px
+      margin-bottom: 1em
+
+  div.activity-mod
+    div.site-width
+      background: none
+

--- a/app/views/sequences/_index_item.html.haml
+++ b/app/views/sequences/_index_item.html.haml
@@ -10,7 +10,11 @@
         %li.edit= link_to "Edit", edit_sequence_path(sequence) if can? :update, sequence
         %li.delete= link_to 'Delete', sequence_path(sequence), method: :delete, data: { confirm: 'Are you sure?' } if can? :update, sequence
         %li.publish= link_to('Publish', publication_show_status_path(sequence.class,sequence.id), :remote => true) if can? :publish, sequence
-        %li.run= link_to "Run", sequence_path(sequence) if can? :read, sequence
+        - if can? :read, sequence
+          %li.print
+            %i.fa.fa-print
+            = link_to "print", print_blank_sequence_path(sequence), :target => 'new'
+          %li.run= link_to "Run", sequence_path(sequence)
 
   %div{:id => dom_id_for(sequence, :details), :class => 'tiny'}
     = pluralize(sequence.activities.length, 'activity')

--- a/app/views/sequences/print_blank.html.haml
+++ b/app/views/sequences/print_blank.html.haml
@@ -1,0 +1,40 @@
+= content_for :title do
+  = "Print #{@sequence.name}"
+
+= content_for :body_class do
+  = 'l-single-page'
+
+.screen-only
+  .print-warning
+    - if @sequence.thumbnail_url.present?
+      %img{src:@sequence.thumbnail_url}
+    %div=t("PRINT_BLANK.PRINT_WARNING", activity: @sequence.name)
+
+    .submit
+      - @sequence.activities.each do |a|
+        %a{href: print_blank_activity_path(a) }
+          %input.button{type: 'submit', value: t('PRINT_BLANK.PRINT', activity: a.name)}
+
+
+:sass
+  .print-warning
+    box-sizing: border-box
+    margin: 1em auto
+    width: 400px
+    padding: 10px
+    text-align: left
+    background-color: hsl(200,0%,95%)
+    border-radius: 6px
+    font-size: 12pt
+    overflow: hidden
+    .submit
+      width: auto
+      input[type="submit"], button[type="submit"]
+        margin: 1em 0px
+    img
+      max-width: 380px
+      margin-bottom: 1em
+
+  div.activity-mod
+    div.site-width
+      background: none

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,3 +128,7 @@ en:
     CONFIRM_CLOSE: "Exit %{activity}?"
     EXIT_LABEL: "Exit"
     NEXT_UP: "Next Up…"
+  PRINT_BLANK:
+    PRINT: "Print \"%{activity}\""
+    PRINT_WARNING: "Close this window when you are done printing \"%{activity}\"."
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ LightweightStandalone::Application.routes.draw do
     member do
       get 'reorder_pages'
       get 'single_page'
+      get 'print_blank'
       get 'summary'
       get 'resubmit_answers'
       get 'publish'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ LightweightStandalone::Application.routes.draw do
       post :add_activity
       post :remove_activity
       get :reorder_activities
+      get :print_blank
       get :publish
       get :duplicate
       get :export

--- a/spec/controllers/lightweight_activity_controller_spec.rb
+++ b/spec/controllers/lightweight_activity_controller_spec.rb
@@ -167,6 +167,14 @@ describe LightweightActivitiesController do
     end
   end
 
+  describe '#print_blank' do
+    it 'renders print_blank' do
+      page
+      get :print_blank, :id => act.id
+      expect(response).to render_template('lightweight_activities/print_blank')
+    end
+  end
+
   describe '#summary' do
 
     it 'renders 404 when the activity does not exist' do

--- a/spec/controllers/publication_controller_spec.rb
+++ b/spec/controllers/publication_controller_spec.rb
@@ -42,13 +42,30 @@ describe PublicationsController do
   end
 
   describe "#add_portal" do
-    let(:good_body) { "{\"type\":\"Activity\",\"name\":\"Activity One\",\"description\":\"Activity One Description\",\"url\":\"http://test.host/activities/#{act_one.id}\",\"create_url\":\"http://test.host/activities/#{act_one.id}\",\"thumbnail_url\":\"thumbnail\",\"sections\":[{\"name\":\"Activity One Section\",\"pages\":[]}]}" }
+    let(:activity_hash) {
+      {"type"          =>"Activity",
+       "name"          =>"Activity One",
+       "description"   =>"Activity One Description",
+       "url"           =>"http://test.host/activities/#{act_one.id}",
+       "create_url"    =>"http://test.host/activities/#{act_one.id}",
+       "author_url"    =>"http://test.host/activities/#{act_one.id}/edit",
+       "print_url"     =>"http://test.host/activities/#{act_one.id}/print_blank",
+       "thumbnail_url" =>"thumbnail",
+       "author_email"  => @user.email,
+       "is_locked"     =>false,
+       "sections"      => [
+           {"name"  => "Activity One Section",
+            "pages" => []
+           }
+       ]}
+    }
+    let(:good_body) { activity_hash.to_json }
     let(:publishing_url) { "http://foo.bar/publish/v2/blarg"}
     let(:url) { "http://foo.bar/"}
     let(:strategy_name) { "foo_bar"}
     let(:mock_portal) { double(:publishing_url => publishing_url, :url => url, :strategy_name => strategy_name) }
     let(:good_request) {{
-      :body => "{\"type\":\"Activity\",\"name\":\"Activity One\",\"description\":\"Activity One Description\",\"url\":\"http://test.host/activities/#{act_one.id}\",\"create_url\":\"http://test.host/activities/#{act_one.id}\",\"thumbnail_url\":\"thumbnail\",\"author_email\":\"#{@user.email}\",\"is_locked\":false,\"sections\":[{\"name\":\"Activity One Section\",\"pages\":[]}]}",
+      :body => good_body,
       :headers => {'Authorization'=>'Bearer', 'Content-Type'=>'application/json'}
     }}
     let(:good_response)   { {:status => 201, :body => "", :headers => {} }}

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -312,16 +312,20 @@ describe LightweightActivity do
   describe '#serialize_for_portal' do
     let(:simple_portal_hash) do
       url = "http://test.host/activities/#{activity.id}"
+      author_url = "http://test.host/activities/#{activity.id}/edit"
+      print_url = "http://test.host/activities/#{activity.id}/print_blank"
       {
         "type"          =>"Activity",
         "name"          => activity.name,
         "description"   => activity.description,
         "url"           => url,
         "create_url"    => url,
+        "author_url"    => author_url,
+        "print_url"     => print_url,
         "thumbnail_url" => thumbnail_url,
         "author_email"  => activity.user.email,
         "is_locked"     => false,
-        "sections"=>[{"name"=>"#{activity.name} Section", "pages"=>[]}]
+        "sections"      =>[{"name"=>"#{activity.name} Section", "pages"=>[]}]
       }
     end
 

--- a/spec/views/lightweight_activities/print_blank.html.haml_spec.rb
+++ b/spec/views/lightweight_activities/print_blank.html.haml_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'lightweight_activities/print_blank' do
+  # Stub what we need to render the page
+  let (:page1) { stub_model(InteractivePage, :id => 1, :name => Faker::Lorem.sentence(1)[0..20]) }
+  let (:page2) { stub_model(InteractivePage, :id => 2, :name => Faker::Lorem.sentence(1)[0..20]) }
+  let (:activity) { stub_model(LightweightActivity, :id => 1, :name => Faker::Lorem.sentence(2)[0..49], :description => Faker::Lorem.sentences(3).join(" "), :visible_pages => [page1, page2]) }
+
+  # Assigns
+  before(:each) do
+    assign(:activity, activity)
+    assign(:pages, [page1, page2])
+  end
+
+  it 'shows the activity name' do
+    render
+    expect(rendered).to match /#{activity.name}/
+  end
+
+  it 'shows the activity thumbnail' do
+    render
+    expect(rendered).to match /#{activity.thumbnail_url}/
+  end
+
+  it 'has numbered list of pages with titles' do
+    render
+    expect(rendered).to match /#{page1.name}/
+    expect(rendered).to match /#{page2.name}/
+  end
+
+  it 'has a print button' do
+    render
+    expect(rendered).to have_css 'input.button[type=submit]'
+    expect(rendered).to match I18n.t("PRINT_BLANK.PRINT", activity: activity.name)
+  end
+end


### PR DESCRIPTION
* Add `print_url` attributes to portal published activities and sequences.
* Add new `print_blank` routes for activities and sequences.
* Update sequence and activity listings to include print links.

(+ associated tests / style changes)

[PT Story](https://www.pivotaltracker.com/story/show/102391640)
