### PR TITLE
Need to show the sequence title even with no logo

### DIFF
--- a/app/helpers/logo_helper.rb
+++ b/app/helpers/logo_helper.rb
@@ -18,7 +18,7 @@ module LogoHelper
 
   def sequence_logo_tag
     sequence = @sequence
-    return nil unless sequence && sequence.logo.present?
+    return nil unless sequence
     logo = sequence.logo
 
     if @sequence_run
@@ -26,7 +26,10 @@ module LogoHelper
     else
       url = sequence_path(:id => sequence.id, :show_index => true)
     end
-    buffer = logo_tag(logo, sequence.display_title, url)
+    buffer = ''.html_safe
+    if logo.present?
+      buffer << logo_tag(logo, sequence.display_title, url)
+    end
     title  = @sequence.display_title.blank? ? @sequence.title : @sequence.display_title
     unless title.blank?
       link = content_tag(:a, title, :class => "sequence_title", :href=> url)


### PR DESCRIPTION
The sequence title is the only way to get to the sequence TOC.

The code here is not very obvious unfortunately. The method is sequence_logo_tag but really it is the sequence_header.  And the sequence_logo_tag method is called even if an activity is being rendered because the activity might be running inside of a sequence.

I'll see if I can make this a bit cleaner...

[#72204218]