### PR TITLE
Set Google Analytics content group in various places

### DIFF
--- a/app/views/interactive_pages/show.html.haml
+++ b/app/views/interactive_pages/show.html.haml
@@ -36,3 +36,8 @@
         .next-page
           %a{ :href => runnable_activity_page_path(@page.lightweight_activity, @page.next_visible_page), :class => 'next forward_nav' }
             %input{ :class => 'button next forward_nav', :type => 'submit', :value => t("NEXT")}
+
+-# Set Google Analytics content group based on the project. Note that project might be undefined
+-# for activity, but defined for sequence. Always try to use sequence data first.
+-# If @sequence is defined, it's a sequence run.
+= render partial: "shared/analytics_content_group", locals: {resource: @sequence || @activity}

--- a/app/views/lightweight_activities/show.html.haml
+++ b/app/views/lightweight_activities/show.html.haml
@@ -34,3 +34,8 @@
         %p.warning
           = t("NO_PAGES_IN_ACTIVITY")
           %input.button.disabled{ :type => "submit", :disabled => true, :value => t("BEGIN_ACTIVITY")}
+
+-# Set Google Analytics content group based on the project. Note that project might be undefined
+-# for activity, but defined for sequence. Always try to use sequence data first.
+-# If @sequence is defined, it's a sequence run.
+= render partial: "shared/analytics_content_group", locals: {resource: @sequence || @activity}

--- a/app/views/lightweight_activities/single_page.html.haml
+++ b/app/views/lightweight_activities/single_page.html.haml
@@ -13,6 +13,11 @@
   %a.sp-submit{ :href => "javascript:void(0);", :class => 'forward_nav', "data-trigger-save" => "false" }
     %input{ :class => 'button forward_nav', :type => 'submit', :value => "Submit"}
 
+-# Set Google Analytics content group based on the project. Note that project might be undefined
+-# for activity, but defined for sequence. Always try to use sequence data first.
+-# If @sequence is defined, it's a sequence run.
+= render partial: "shared/analytics_content_group", locals: {resource: @sequence || @activity}
+
 :javascript
   $(function(){
     if (window.location.search.indexOf("print=true") > -1) {

--- a/app/views/lightweight_activities/summary.html.haml
+++ b/app/views/lightweight_activities/summary.html.haml
@@ -16,3 +16,7 @@
       :locals => {:answer => answer, :index => index}
 
 = render :partial => 'shared/share_popup'
+-# Set Google Analytics content group based on the project. Note that project might be undefined
+-# for activity, but defined for sequence. Always try to use sequence data first.
+-# If @sequence is defined, it's a sequence run.
+= render partial: "shared/analytics_content_group", locals: {resource: @sequence || @activity}

--- a/app/views/sequences/show.html.haml
+++ b/app/views/sequences/show.html.haml
@@ -54,4 +54,6 @@
             = link_to image_tag(activity.thumbnail_url), sequence_activity_path(@sequence, activity) unless activity.thumbnail_url.blank?
 
     = link_to 'Edit', edit_sequence_path(@sequence) if can? :update, @sequence
-       
+
+-# Set Google Analytics content group based on the project.
+= render partial: "shared/analytics_content_group", locals: {resource: @sequence}

--- a/app/views/shared/_analytics.html.haml
+++ b/app/views/shared/_analytics.html.haml
@@ -5,4 +5,8 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-6899787-36', 'concord.org');
+
+= yield :google_analytics_setup
+
+:javascript
   ga('send', 'pageview');

--- a/app/views/shared/_analytics_content_group.html.haml
+++ b/app/views/shared/_analytics_content_group.html.haml
@@ -1,0 +1,6 @@
+-# Set Google Analytics content group based on the activity or sequence (resource) project.
+- project = resource && resource.project
+- if project.present?
+  - content_for :google_analytics_setup do
+    :javascript
+      ga("set", "contentGroup1", "#{project.title}");


### PR DESCRIPTION
Set Google Analytics content group on:

- sequence index page
- activity index page
- activity page 
- activity summary / report 

Name is based on the project name.

PT story: https://www.pivotaltracker.com/story/show/124827621
