### PR TITLE
External report urls in LARA.

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -145,6 +145,7 @@ class LightweightActivity < ActiveRecord::Base
       related: activity_json_object[:related],
       theme_id: activity_json_object[:theme_id],
       thumbnail_url: activity_json_object[:thumbnail_url],
+      external_report_url: activity_json_object[:external_report_url],
       time_to_complete: activity_json_object[:time_to_complete],
       layout: activity_json_object[:layout],
       editor_mode: activity_json_object[:editor_mode]

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -17,7 +17,8 @@ class LightweightActivity < ActiveRecord::Base
 
   attr_accessible :name, :user_id, :pages, :related, :description,
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :theme_id, :project_id,
-                  :portal_run_count, :layout, :editor_mode, :publication_hash, :copied_from_id
+                  :portal_run_count, :layout, :editor_mode, :publication_hash, :copied_from_id,
+                  :external_report_url
 
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
@@ -89,7 +90,8 @@ class LightweightActivity < ActiveRecord::Base
       thumbnail_url: thumbnail_url,
       notes: notes,
       layout: layout,
-      editor_mode: editor_mode
+      editor_mode: editor_mode,
+      external_report_url: external_report_url
     }
   end
 
@@ -121,7 +123,9 @@ class LightweightActivity < ActiveRecord::Base
                                         :thumbnail_url,
                                         :notes,
                                         :layout,
-                                        :editor_mode])
+                                        :editor_mode,
+                                        :external_report_url
+    ])
     activity_json[:theme_name] = self.theme.name
     activity_json[:pages] = []
     self.pages.each do |p|
@@ -192,6 +196,7 @@ class LightweightActivity < ActiveRecord::Base
       "create_url" => local_url,
       "author_url" => author_url,
       "print_url"  => print_url,
+      "external_report_url"  => external_report_url,
       "thumbnail_url" => thumbnail_url,
       "author_email" => self.user.email,
       "is_locked" => self.is_locked

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,6 +1,7 @@
 class Sequence < ActiveRecord::Base
   attr_accessible :description, :title, :theme_id, :project_id,
-    :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash
+    :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash,
+    :external_report_url
   include Publishable # defines methods to publish to portals
   include PublicationStatus # defines publication status scopes and helpers
   has_many :lightweight_activities_sequences, :order => :position, :dependent => :destroy
@@ -51,7 +52,8 @@ class Sequence < ActiveRecord::Base
       project_id: project_id,
       logo: logo,
       display_title: display_title,
-      thumbnail_url: thumbnail_url
+      thumbnail_url: thumbnail_url,
+      external_report_url: external_report_url
     }
   end
 
@@ -94,7 +96,9 @@ class Sequence < ActiveRecord::Base
                                         :project_id,
                                         :logo,
                                         :display_title,
-                                        :thumbnail_url])
+                                        :thumbnail_url,
+                                        :external_report_url
+    ])
     sequence_json[:activities] = []
     self.lightweight_activities.each_with_index do |a,i|
       activity_hash = a.export
@@ -115,6 +119,7 @@ class Sequence < ActiveRecord::Base
       'abstract' => self.abstract,
       "url" => local_url,
       "create_url" => local_url,
+      "external_report_url" => external_report_url,
       "thumbnail_url" => thumbnail_url,
       "author_email" => self.user.email
     }
@@ -131,7 +136,8 @@ class Sequence < ActiveRecord::Base
       project_id: sequence_json_object[:project_id],
       theme_id: sequence_json_object[:theme_id],
       thumbnail_url: sequence_json_object[:thumbnail_url],
-      title: sequence_json_object[:title]
+      title: sequence_json_object[:title],
+      external_report_url: sequence_json_object[:external_report_url]
     }
 
   end

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -60,6 +60,11 @@
           .activity_thumbnail#thumbnail_preview
             %img
       .field
+        = f.label :external_report_url, t("EXTERNAL_REPORT_URL")
+        = f.text_field :external_report_url
+        %br
+          .hint=t("EXTERNAL_REPORT_WARNING")
+      .field
         = f.label :layout, "Activity layout"
         = f.select :layout, options_for_select(LightweightActivity::LAYOUT_OPTIONS, @activity.layout)
       - if current_user.is_admin

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -30,6 +30,11 @@
         .activity_thumbnail#thumbnail_preview
           %img
     .field
+      = f.label :external_report_url, t("EXTERNAL_REPORT_URL")
+      = f.text_field :external_report_url
+      %br
+        .hint=t("EXTERNAL_REPORT_WARNING")
+    .field
       = f.label :theme_id, "Theme"
       = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @sequence.theme_id), { :include_blank => "None (inherit from project, or site default)" }
     .field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@ en:
   PICK_ONE: "Pick one"
   GENERATE_A_REPORT: "Generate a report"
   EDIT: "Edit"
+  EXTERNAL_REPORT_URL: "Custom Reporting URL"
+  EXTERNAL_REPORT_WARNING: "Leave blank, unless you know what you are doing."
   DATA_WILL_NOT_BE_SAVED:  "Data will not be saved"
   TIME_TO_COMPLETE: "Estimated Time to Complete This Module:"
   MINUTES: "minutes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
   GENERATE_A_REPORT: "Generate a report"
   EDIT: "Edit"
   EXTERNAL_REPORT_URL: "Custom Reporting URL"
-  EXTERNAL_REPORT_WARNING: "Leave blank, unless you know what you are doing."
+  EXTERNAL_REPORT_WARNING: "(Don't change, unless you know what you are doing!)"
   DATA_WILL_NOT_BE_SAVED:  "Data will not be saved"
   TIME_TO_COMPLETE: "Estimated Time to Complete This Module:"
   MINUTES: "minutes"

--- a/db/migrate/20160722195644_add_external_report_url_to_lightweight_activity.rb
+++ b/db/migrate/20160722195644_add_external_report_url_to_lightweight_activity.rb
@@ -1,0 +1,6 @@
+class AddExternalReportUrlToLightweightActivity < ActiveRecord::Migration
+  def change
+    add_column :lightweight_activities, :external_report_url, :text
+    add_column :sequences, :external_report_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160718123400) do
+ActiveRecord::Schema.define(:version => 20160722195644) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -359,6 +359,7 @@ ActiveRecord::Schema.define(:version => 20160718123400) do
     t.string   "publication_hash",      :limit => 40
     t.string   "imported_activity_url"
     t.integer  "copied_from_id"
+    t.text     "external_report_url"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -515,6 +516,7 @@ ActiveRecord::Schema.define(:version => 20160718123400) do
     t.text     "abstract"
     t.string   "publication_hash",      :limit => 40
     t.string   "imported_activity_url"
+    t.text     "external_report_url"
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"

--- a/spec/controllers/publication_controller_spec.rb
+++ b/spec/controllers/publication_controller_spec.rb
@@ -50,6 +50,7 @@ describe PublicationsController do
        "create_url"    =>"http://test.host/activities/#{act_one.id}",
        "author_url"    =>"http://test.host/activities/#{act_one.id}/edit",
        "print_url"     =>"http://test.host/activities/#{act_one.id}/print_blank",
+       "external_report_url"  => act_one.external_report_url,
        "thumbnail_url" =>"thumbnail",
        "author_email"  => @user.email,
        "is_locked"     =>false,

--- a/spec/import_examples/valid_lightweight_activity_import.json
+++ b/spec/import_examples/valid_lightweight_activity_import.json
@@ -6,6 +6,7 @@
   "related": "Contains all interactivities and embeddables.",
   "theme_id": null,
   "thumbnail_url": "",
+  "external_report_url": "https://reports.concord.org/",
   "time_to_complete": null,
   "pages": [{
     "layout": "l-6040",

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 describe LightweightActivity do
   let(:thumbnail_url) { "http://fake.url.com/image" }
   let(:author)        { FactoryGirl.create(:author) }
+  let(:report_url)    { nil }
+  let(:act_opts)      { {thumbnail_url: thumbnail_url, external_report_url: report_url } }
   let(:activity)      {
-    activity = FactoryGirl.create(:activity, :thumbnail_url => thumbnail_url)
+    activity = FactoryGirl.create(:activity, act_opts)
     activity.user = author
     activity.save
     activity.theme = FactoryGirl.create(:theme)
@@ -168,14 +170,21 @@ describe LightweightActivity do
 
   describe '#to_hash' do
     it 'returns a hash with relevant values for activity duplication' do
-      expected = { name: activity.name, related: activity.related, description: activity.description, time_to_complete: activity.time_to_complete, project_id: activity.project_id, theme_id: activity.theme_id, thumbnail_url: activity.thumbnail_url, notes: activity.notes, layout: activity.layout, editor_mode: activity.editor_mode }
+      expected = { name: activity.name, related: activity.related, :external_report_url => nil, description: activity.description, time_to_complete: activity.time_to_complete, project_id: activity.project_id, theme_id: activity.theme_id, thumbnail_url: activity.thumbnail_url, notes: activity.notes, layout: activity.layout, editor_mode: activity.editor_mode }
       expect(activity.to_hash).to eq(expected)
     end
   end
 
   describe '#export' do
-      it 'returns json of an activity' do
-        expect(activity.export[:pages].length).to eq(activity.pages.count)
+    let(:report_url) { "https://reports.concord.org/" }
+    before(:each) do
+      activity.external_report_url = report_url
+    end
+    it 'returns json of an activity' do
+      expect(activity.export[:pages].length).to eq(activity.pages.count)
+    end
+    it 'includes the report url' do
+      expect(activity.export['external_report_url']).to eq(report_url)
     end
   end
 
@@ -183,10 +192,12 @@ describe LightweightActivity do
     let(:owner)     { FactoryGirl.create(:user) }
     let(:edit_mode) { LightweightActivity::STANDARD_EDITOR_MODE }
     let(:layout)    { LightweightActivity::LAYOUT_MULTI_PAGE    }
+    let(:report_url) { "https://reports.concord.org/" }
 
     before :each do
       activity.layout = layout
       activity.editor_mode = edit_mode
+      activity.external_report_url = report_url
     end
 
     it 'creates a new LightweightActivity with attributes from the original' do
@@ -199,8 +210,9 @@ describe LightweightActivity do
       expect(dup.layout).to eq(activity.layout)
       expect(dup.editor_mode).to eq(activity.editor_mode)
       expect(dup.name).to match /^Copy of #{activity.name[0..30]}/
-      expect(dup.copied_from_activity).to eq(activity)
+      expect(dup.external_report_url).to eq(report_url)
     end
+
     describe "an activity with an open response" do
       let(:prompt)        { "xyzzy" }
       let(:page)          { FactoryGirl.create(:interactive_page, name: "page 1", position: 0) }
@@ -310,6 +322,7 @@ describe LightweightActivity do
   end
 
   describe '#serialize_for_portal' do
+    let(:report_url) { "http://reports.concord.org/" }
     let(:simple_portal_hash) do
       url = "http://test.host/activities/#{activity.id}"
       author_url = "http://test.host/activities/#{activity.id}/edit"
@@ -322,10 +335,11 @@ describe LightweightActivity do
         "create_url"    => url,
         "author_url"    => author_url,
         "print_url"     => print_url,
-        "thumbnail_url" => thumbnail_url,
-        "author_email"  => activity.user.email,
-        "is_locked"     => false,
-        "sections"      =>[{"name"=>"#{activity.name} Section", "pages"=>[]}]
+        "thumbnail_url"       => thumbnail_url,
+        "author_email"        => activity.user.email,
+        "external_report_url" => activity.external_report_url,
+        "is_locked"           => false,
+        "sections"            =>[{"name"=>"#{activity.name} Section", "pages"=>[]}]
       }
     end
 

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -313,10 +313,12 @@ describe LightweightActivity do
     it 'should return an activity' do
       json = JSON.parse(File.read(Rails.root + 'spec/import_examples/valid_lightweight_activity_import.json'), :symbolize_names => true)
       imported_activity_url = "http://foo.com/"
+      external_report_url = "https://reports.concord.org/"
       act = LightweightActivity.import(json,new_owner,imported_activity_url)
       expect(act.user).to be new_owner
       expect(act.related).to eq(json[:related])
       expect(act.imported_activity_url).to eq(imported_activity_url)
+      expect(act.external_report_url).to eq(external_report_url)
       expect(act.pages.count).to eq(json[:pages].length)
     end
   end

--- a/spec/views/lightweight_activities/edit.html.haml_spec.rb
+++ b/spec/views/lightweight_activities/edit.html.haml_spec.rb
@@ -8,7 +8,8 @@ end
 
 describe "lightweight_activities/edit" do
 
-  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name') }
+  let(:external_report_url) { "http://reporting.concord.org/" }
+  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name', :external_report_url => external_report_url) }
   let(:user)      { stub_model(User, :is_admin => false)      }
 
   before(:each) do
@@ -46,6 +47,12 @@ describe "lightweight_activities/edit" do
       render
       expect(rendered).to match /<span[^>]+class="editable"[^>]+data-name="lightweight_activity\[description\]"[^<]*>/
     end
+
+    it 'should show the custom reporting URL' do
+      render
+      expect(rendered).to have_css("input#lightweight_activity_external_report_url[value=\"#{external_report_url}\"]")
+    end
+
 
     it 'should show related text' do
       render

--- a/spec/views/sequences/edit.html.haml_spec.rb
+++ b/spec/views/sequences/edit.html.haml_spec.rb
@@ -1,13 +1,15 @@
 require 'spec_helper'
 
 describe "sequences/edit" do
+  let(:report_url) { "https://reporting.concord.org/" }
   before(:each) do
     @user ||= FactoryGirl.create(:admin)
     sign_in @user
 
     @sequence = assign(:sequence, stub_model(Sequence,
       :title => "MyString",
-      :description => "MyText"
+      :description => "MyText",
+      :external_report_url => report_url
     ))
   end
 
@@ -21,6 +23,7 @@ describe "sequences/edit" do
       assert_select "select#sequence_theme_id", :name => "sequence[theme_id]" do
         assert_select 'option'
       end
+      assert_select "input#sequence_external_report_url", :value => report_url
     end
   end
 end


### PR DESCRIPTION
A LARA author can add an external report URL to a LARA activity or sequence.

Handles copying / export / import / duplication for Seq and Act.

See this [pt story](https://www.pivotaltracker.com/story/show/126808389).
