### PR TITLE
disable the print_url because of rendering issues

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -191,7 +191,9 @@ class LightweightActivity < ActiveRecord::Base
       "url" => local_url,
       "create_url" => local_url,
       "author_url" => author_url,
-      "print_url"  => print_url,
+      # disable the print url because the print_blank rendering has issues:
+      # https://www.pivotaltracker.com/story/show/102391640/comments/143981561
+      # "print_url"  => print_url,
       "thumbnail_url" => thumbnail_url,
       "author_email" => self.user.email,
       "is_locked" => self.is_locked

--- a/spec/controllers/publication_controller_spec.rb
+++ b/spec/controllers/publication_controller_spec.rb
@@ -49,7 +49,8 @@ describe PublicationsController do
        "url"           =>"http://test.host/activities/#{act_one.id}",
        "create_url"    =>"http://test.host/activities/#{act_one.id}",
        "author_url"    =>"http://test.host/activities/#{act_one.id}/edit",
-       "print_url"     =>"http://test.host/activities/#{act_one.id}/print_blank",
+       # print_url has been disabled due to issues with print rendering
+       #  "print_url"     =>"http://test.host/activities/#{act_one.id}/print_blank",
        "thumbnail_url" =>"thumbnail",
        "author_email"  => @user.email,
        "is_locked"     =>false,

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -321,7 +321,8 @@ describe LightweightActivity do
         "url"           => url,
         "create_url"    => url,
         "author_url"    => author_url,
-        "print_url"     => print_url,
+        # print_url has been disabled due to rendering issues
+        # "print_url"     => print_url,
         "thumbnail_url" => thumbnail_url,
         "author_email"  => activity.user.email,
         "is_locked"     => false,


### PR DESCRIPTION
By removing the print_url from the LARA publication, it will prevent the print button from being shown in the portal.  When the print rendering issues are fixed the print_url can be published again.

[#102391640]