### PR TITLE
Added interactiveStateUrl to iframe-saver initInteractive message

### DIFF
--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -134,12 +134,14 @@ class IFrameSaver
     # this is the newer method of initializing an interactive
     # it returns the current state and linked state
     init_interactive = (err, response) =>
+      loc = window.location
       @iframePhone.post 'initInteractive',
         version: 1,
         error: err
         interactiveState: if response?.raw_data then JSON.parse(response.raw_data) else null
         hasLinkedInteractive: response?.has_linked_interactive or false
         linkedState: if response?.linked_state then JSON.parse(response.linked_state) else null
+        interactiveStateUrl: "#{loc.protocol}//#{loc.hostname}#{if loc.port then ":#{loc.port}" else ""}#{@get_url}"
 
     $.ajax
       url: @get_url

--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -21,12 +21,12 @@ module InteractiveRunHelper
 
   def get_url(interactive,run)
     interactive_run = InteractiveRunState.by_run_and_interactive(run,interactive)
-    show_interactive_run_state_path(:key => interactive_run.key)
+    api_v1_show_interactive_run_state_path(:key => interactive_run.key)
   end
 
   def put_url(interactive,run)
     interactive_run = InteractiveRunState.by_run_and_interactive(run,interactive)
-    update_interactive_run_state_path(:key => interactive_run.key)
+    api_v1_update_interactive_run_state_path(:key => interactive_run.key)
   end
 
   def interactive_data_div(interactive,run)


### PR DESCRIPTION
This is needed so that the v2 launch page can add the url to the codap launch url.

Also fixed the get/put url helpers for interactive run state api endpoints.  When the endpoints were moved until the /api/v1 namespace the url helpers needed to have the namespace prepended to them.