### PR TITLE
Speedup bulk prompt change for Labbook items (ITSI)

### DIFF
--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -184,24 +184,18 @@ module Embeddable
       show_in_runtime?
     end
 
-    def update_itsi_prompts
-      return if prompt.blank?
-      def close_enough(str1,str2)
-        str1.downcase.chomp.squish.starts_with? str2.downcase.chomp.squish[0..60]
-      end
+    def self.update_itsi_prompts
 
       old_snapshot_prompt = I18n.t("LABBOOK.OLD_ITSI.SNAPSHOT_PROMPT")
       old_upload_prompt   = I18n.t("LABBOOK.OLD_ITSI.UPLOAD_PROMPT")
       new_snapshot_prompt = I18n.t("LABBOOK.ITSI.SNAPSHOT_PROMPT")
       new_upload_prompt   = I18n.t("LABBOOK.ITSI.UPLOAD_PROMPT")
 
-      if close_enough prompt, old_snapshot_prompt
-        update_attribute(:prompt, new_snapshot_prompt)
-      end
-
-      if close_enough prompt, old_upload_prompt
-        update_attribute(:prompt, new_upload_prompt)
-      end
+      changed_snapshot_count = self.where("prompt like ?", "%#{old_snapshot_prompt[0..80]}%").update_all(prompt: new_snapshot_prompt)
+      changed_upload_count = self.where("prompt like ?", "%#{old_upload_prompt[0..80]}%").update_all(prompt: new_upload_prompt)
+      report_string = "updated #{changed_snapshot_count} snapshot prompts, and #{changed_upload_count} upload labbook prompts"
+      Rails.logger.info report_string
+      puts report_string
     end
 
     private

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -195,7 +195,6 @@ module Embeddable
       changed_upload_count = self.where("prompt like ?", "%#{old_upload_prompt[0..80]}%").update_all(prompt: new_upload_prompt)
       report_string = "updated #{changed_snapshot_count} snapshot prompts, and #{changed_upload_count} upload labbook prompts"
       Rails.logger.info report_string
-      puts report_string
     end
 
     private

--- a/lib/tasks/itsi_tasks.rake
+++ b/lib/tasks/itsi_tasks.rake
@@ -50,9 +50,7 @@ namespace :itsi do
 
   desc "Reword the lab book prompts for itsi. See config/locales/en.yml  and Embeddable::Labbook#update_itsi_prompts"
   task :update_labbook_prompts => :environment do
-    Embeddable::Labbook.find_in_batches do |labbooks|
-      labbooks.each(&:update_itsi_prompts)
-    end
+    Embeddable::Labbook.update_itsi_prompts
   end
 
 end

--- a/spec/models/embeddable/labbook_spec.rb
+++ b/spec/models/embeddable/labbook_spec.rb
@@ -178,7 +178,9 @@ describe Embeddable::Labbook do
       let(:labbook) { Embeddable::Labbook.create(prompt: prompt) }
 
       before(:each) do
-        labbook.update_itsi_prompts
+        labbook
+        Embeddable::Labbook.update_itsi_prompts
+        labbook.reload
       end
 
       describe "when the prompt is nil" do


### PR DESCRIPTION
This commit speeds up the bulk update on Labbook prompts and simplifies the code.

Original Story: https://www.pivotaltracker.com/story/show/112928599
The text included for Lab album instructions in ITSI activities says that "A snapshot must be included for the activity to show as complete."

[#112928599]