### PR TITLE
fail fast if the activity is not part of sequence

### DIFF
--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -271,8 +271,11 @@ class LightweightActivitiesController < ApplicationController
 
   private
   def set_activity
-    id = params[:id]
-    id = params[:activity_id] if params[:activity_id]
+    if params[:activity_id]
+      id = params[:activity_id]
+    else
+      id = params[:id]
+    end
 
     if params[:sequence_id]
       sequence = Sequence.find(params[:sequence_id])

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -271,10 +271,14 @@ class LightweightActivitiesController < ApplicationController
 
   private
   def set_activity
-    if params[:activity_id]
-      @activity = LightweightActivity.find(params[:activity_id])
+    id = params[:id]
+    id = params[:activity_id] if params[:activity_id]
+
+    if params[:sequence_id]
+      sequence = Sequence.find(params[:sequence_id])
+      @activity = sequence.activities.find(id)
     else
-      @activity = LightweightActivity.find(params[:id])
+      @activity = LightweightActivity.find(id)
     end
   end
 

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -183,6 +183,7 @@ class LightweightActivity < ActiveRecord::Base
     seq.activities.each_with_index do |a,i|
       return i+1 if a.id == self.id
     end
+    raise "Activity #{id} is not part of Sequence #{seq.id}"
   end
 
   def serialize_for_portal(host)

--- a/spec/controllers/interactive_page_controller_spec.rb
+++ b/spec/controllers/interactive_page_controller_spec.rb
@@ -22,7 +22,7 @@ describe InteractivePagesController do
   let (:ar) { FactoryGirl.create(:run, :activity_id => act.id, :user_id => user.id) }
 
   let (:interactive) { FactoryGirl.create(:mw_interactive) }
-  let (:sequence) { FactoryGirl.create(:sequence) }
+  let (:sequence) { FactoryGirl.create(:sequence, :lightweight_activities => [act]) }
 
   describe 'routing' do
     it 'recognizes and generates #show' do


### PR DESCRIPTION
This should prevent or at least clarify some of the exceptions we are seeing recently.
The exceptions I've seen are:
```
An ActionView::Template::Error occurred in interactive_pages#show:
  comparison of Fixnum with Array failed 
    app/views/shared/_nav_page_list.html.haml:4:in `>'
```
That happens because there is code to look up the position of the activity in the sequence but the activity isn't in the sequence. In that case the position code returns all of the activities.  With the new code in this case it would throw an exception. It should still result in exceptions being emailed to us, but it will be more clear. And...

This all happened because someone accessed the activity by mis typing the URL. They put in `http://authoring.concord.org/sequences/47/activities/28` instead of `http://authoring.concord.org/sequences/47/activities/281`. The old code would happily create a Run that referenced both activity 28 and sequence 47. Then later the error above would happen.  The new code should return a 404 if someone puts in the `http://authoring.concord.org/sequences/47/activities/28`

@knowuh or @dougmartin could you take a look?

[#130257637]