### PR TITLE
Add print url to sequences

### DIFF
--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -112,6 +112,9 @@ class Sequence < ActiveRecord::Base
 
   def serialize_for_portal(host)
     local_url = "#{host}#{Rails.application.routes.url_helpers.sequence_path(self)}"
+    author_url = "#{local_url}/edit"
+    print_url = "#{local_url}/print_blank"
+
     data = {
       'type' => "Sequence",
       'name' => self.title,
@@ -119,6 +122,8 @@ class Sequence < ActiveRecord::Base
       'abstract' => self.abstract,
       "url" => local_url,
       "create_url" => local_url,
+      "author_url" => author_url,
+      "print_url"  => print_url,
       "external_report_url" => external_report_url,
       "thumbnail_url" => thumbnail_url,
       "author_email" => self.user.email

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -327,8 +327,8 @@ describe LightweightActivity do
     let(:report_url) { "http://reports.concord.org/" }
     let(:simple_portal_hash) do
       url = "http://test.host/activities/#{activity.id}"
-      author_url = "http://test.host/activities/#{activity.id}/edit"
-      print_url = "http://test.host/activities/#{activity.id}/print_blank"
+      author_url = "#{url}/edit"
+      print_url = "#{url}/print_blank"
       {
         "type"          =>"Activity",
         "name"          => activity.name,

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -102,8 +102,8 @@ describe Sequence do
 
     let(:simple_portal_hash) do
       url = "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence)}"
-      author_url = "http://test.host/sequences/#{sequence.id}/edit"
-      print_url = "http://test.host/sequences/#{sequence.id}/print_blank"
+      author_url = "#{url}/edit"
+      print_url = "#{url}/print_blank"
       {"type"=>"Sequence", "name"=> sequence.title, "description"=> sequence.description,
         "abstract" => sequence.abstract,
         "url"=> url,
@@ -119,8 +119,8 @@ describe Sequence do
 
     let(:complex_portal_hash) do
       url = "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence_with_activities)}"
-      author_url = "http://test.host/sequences/#{sequence_with_activities.id}/edit"
-      print_url = "http://test.host/sequences/#{sequence_with_activities.id}/print_blank"
+      author_url = "#{url}/edit"
+      print_url = "#{url}/print_blank"
       {
         "type"=>"Sequence", "name"=> sequence_with_activities.title, "description"=> sequence_with_activities.description,
         "abstract" => sequence_with_activities.abstract,

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -102,10 +102,14 @@ describe Sequence do
 
     let(:simple_portal_hash) do
       url = "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence)}"
+      author_url = "http://test.host/sequences/#{activity.id}/edit"
+      print_url = "http://test.host/sequences/#{activity.id}/print_blank"
       {"type"=>"Sequence", "name"=> sequence.title, "description"=> sequence.description,
         "abstract" => sequence.abstract,
         "url"=> url,
         "create_url"=> url,
+        "author_url"    => author_url,
+        "print_url"     => print_url,
         "thumbnail_url" => nil, # our simple sequence doesn't have one
         "author_email" => sequence.user.email,
         "activities"=>[],

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -102,8 +102,8 @@ describe Sequence do
 
     let(:simple_portal_hash) do
       url = "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence)}"
-      author_url = "http://test.host/sequences/#{activity.id}/edit"
-      print_url = "http://test.host/sequences/#{activity.id}/print_blank"
+      author_url = "http://test.host/sequences/#{sequence.id}/edit"
+      print_url = "http://test.host/sequences/#{sequence.id}/print_blank"
       {"type"=>"Sequence", "name"=> sequence.title, "description"=> sequence.description,
         "abstract" => sequence.abstract,
         "url"=> url,
@@ -119,11 +119,15 @@ describe Sequence do
 
     let(:complex_portal_hash) do
       url = "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence_with_activities)}"
+      author_url = "http://test.host/sequences/#{sequence_with_activities.id}/edit"
+      print_url = "http://test.host/sequences/#{sequence_with_activities.id}/print_blank"
       {
         "type"=>"Sequence", "name"=> sequence_with_activities.title, "description"=> sequence_with_activities.description,
         "abstract" => sequence_with_activities.abstract,
         "url"=> url,
         "create_url"=> url,
+        "author_url"    => author_url,
+        "print_url"     => print_url,
         "thumbnail_url" => thumbnail_url,
         "author_email" => sequence_with_activities.user.email,
         "activities"=> [


### PR DESCRIPTION
This adds in a missing print_url when sequences are published to the portal.

@knowuh or @dougmartin can you take a look?