### PR TITLE
Fix run lookup in arg block controller and make sure that answer IDs are unique

### DIFF
--- a/app/assets/javascripts/c_rater.coffee
+++ b/app/assets/javascripts/c_rater.coffee
@@ -23,7 +23,7 @@ class ArgumentationBlockController
       $feedbackEl = $(q).closest(QUESTION_SEL).find(FEEDBACK_SEL)
       isFeedbackDirty = $feedbackEl.data('dirty')
       error = $feedbackEl.data('error')
-      @question[@domIDtoNumericID(q.id)] = {
+      @question[@formIDtoAnswerID(q.id)] = {
         # It will be updated by answer_for or no_answer_for event handler.
         answered: false,
         dirty: isFeedbackDirty,
@@ -53,7 +53,7 @@ class ArgumentationBlockController
       @submitButtonClicked(e)
 
   updateQuestion: (id, answered) ->
-    q = @question[@domIDtoNumericID(id)]
+    q = @question[@formIDtoAnswerID(id)]
     # Undefined means that this question isn't part of the argumentation block.
     return unless q
     q.answered = answered
@@ -248,8 +248,9 @@ class ArgumentationBlockController
   feedbackOnFeedbackIsReady: ->
     @fbOnFeedback.isReady()
 
-  domIDtoNumericID: (htmlId) ->
-    htmlId.match(/\d+/)[0]
+  formIDtoAnswerID: (htmlId) ->
+    # E.g. change "edit_embeddable_open_response_answer_240" to "open_response_answer_240"
+    htmlId.replace('edit_embeddable_', '')
 
 class FeedbackOnFeedbackController
   FEEDBACK_ON_FEEDBACK_SEL = '.ab-feedback-on-feedback'

--- a/app/controllers/c_rater/argumentation_blocks_controller.rb
+++ b/app/controllers/c_rater/argumentation_blocks_controller.rb
@@ -50,11 +50,9 @@ class CRater::ArgumentationBlocksController < ApplicationController
   end
 
   def save_feedback
-    # set_run_key expects @page and @activity to be set...
-    @page = InteractivePage.find(params[:page_id])
-    @activity = @page.lightweight_activity
-    set_run_key # sets @run
-    feedback_info = CRater::FeedbackSubmission.generate_feedback(@page, @run)
+    page = InteractivePage.find(params[:page_id])
+    run = Run.find_by_key(params[:response_key])
+    feedback_info = CRater::FeedbackSubmission.generate_feedback(page, run)
     if request.xhr?
       render json: feedback_info
     else

--- a/app/models/c_rater/feedback_submission.rb
+++ b/app/models/c_rater/feedback_submission.rb
@@ -27,11 +27,13 @@ class CRater::FeedbackSubmission < ActiveRecord::Base
     submission = CRater::FeedbackSubmission.create!(interactive_page: page, run: run, collaboration_run: run.collaboration_run)
     feedback_items = {}
     arg_block_answers.each do |a|
+      # E.g. open_response_answer_123, multiple_choice_answer_321, etc.
+      id = "#{a.class.to_s.demodulize.underscore}_#{a.id}"
       f = a.save_feedback
       unless f.nil?
         f.feedback_submission = submission
         f.save!
-        feedback_items[a.id] = {score: f.score, text: f.feedback_text, max_score: f.max_score, error: f.error?}
+        feedback_items[id] = {score: f.score, text: f.feedback_text, max_score: f.max_score, error: f.error?}
       end
     end
     submission.propagate_to_collaborators

--- a/app/views/c_rater/argumentation_block/_runtime.html.haml
+++ b/app/views/c_rater/argumentation_block/_runtime.html.haml
@@ -60,7 +60,7 @@
 
     %input{:class => 'ab-submit button', :type => 'submit',
            :value => submission_count > 0 ? t('ARG_BLOCK.RESUBMIT') : t('ARG_BLOCK.SUBMIT'),
-           'data-href' => c_rater_arg_block_save_feedback_path(page),
+           'data-href' => c_rater_arg_block_save_feedback_path(page, @run.key),
            'data-page_id' => page.id}
     %div.ab-submit-prompt       
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ LightweightStandalone::Application.routes.draw do
     resources :item_settings, :only => [:edit, :update]
     post "/argumentation_blocks/:page_id/create_embeddables" => 'argumentation_blocks#create_embeddables', :as => 'arg_block_create_embeddables'
     post "/argumentation_blocks/:page_id/remove_embeddables" => 'argumentation_blocks#remove_embeddables', :as => 'arg_block_remove_embeddables'
-    post "/argumentation_blocks/:page_id/save_feedback" => 'argumentation_blocks#save_feedback', :as => 'arg_block_save_feedback'
+    post "/argumentation_blocks/:page_id/save_feedback/:response_key" => 'argumentation_blocks#save_feedback', :as => 'arg_block_save_feedback', :constraints => { :response_key => /[-\w]{36}/ }
     post "/argumentation_blocks/feedback_on_feedback" => 'argumentation_blocks#feedback_on_feedback', :as => 'arg_block_feedback_on_feedback'
     resources :score_mappings
     post "/argumentation_blocks/report" => 'argumentation_blocks#report'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160722195644) do
+ActiveRecord::Schema.define(:version => 20160824191003) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -332,8 +332,10 @@ ActiveRecord::Schema.define(:version => 20160722195644) do
     t.datetime "updated_at",                          :null => false
     t.text     "learner_url"
     t.boolean  "is_dirty",         :default => false
+    t.string   "key"
   end
 
+  add_index "interactive_run_states", ["key"], :name => "interactive_run_states_key_idx"
   add_index "interactive_run_states", ["run_id"], :name => "interactive_run_states_run_id_idx"
 
   create_table "lightweight_activities", :force => true do |t|

--- a/spec/models/c_rater/feedback_submission_spec.rb
+++ b/spec/models/c_rater/feedback_submission_spec.rb
@@ -27,12 +27,16 @@ describe CRater::FeedbackSubmission do
     @c_run.save!
   end
 
+  def answer_id_string(answer)
+    "#{answer.class.to_s.demodulize.underscore}_#{answer.id}"
+  end
+
   describe "CRater::FeedbackSubmission.generate_feedback" do
     it "generates submission, feedback items and returns basic information about submission" do
       info = CRater::FeedbackSubmission.generate_feedback(@page, @runs[0])
       expect(CRater::FeedbackSubmission.count).to eql(1)
       expect(info[:submission_id]).to eql(CRater::FeedbackSubmission.first.id)
-      expect(info[:feedback_items][@answers[0].id][:text]).to eql('feedback')
+      expect(info[:feedback_items][answer_id_string(@answers[0])][:text]).to eql('feedback')
     end
 
     describe "when user runs activity with collaborators" do
@@ -44,8 +48,8 @@ describe CRater::FeedbackSubmission do
         info = CRater::FeedbackSubmission.generate_feedback(@page, @runs[0])
         expect(CRater::FeedbackSubmission.count).to eql(2)
         expect(info[:submission_id]).to eql(CRater::FeedbackSubmission.first.id)
-        expect(info[:feedback_items][@answers[0].id][:text]).to eql('feedback')
-        expect(info[:feedback_items][@answers[1].id]).to be_nil # it's other user answer!
+        expect(info[:feedback_items][answer_id_string(@answers[0])][:text]).to eql('feedback')
+        expect(info[:feedback_items][answer_id_string(@answers[1])]).to be_nil # it's other user answer!
 
         submission = CRater::FeedbackSubmission.first
         submission_copy = CRater::FeedbackSubmission.last


### PR DESCRIPTION
Fixes: https://www.pivotaltracker.com/story/show/130399081

I've been able to reproduce this bug locally and this fix helps. The problem was that run lookup was incorrect and sometimes we're asking for feedback for the wrong run (it could happen if user has run given activity a few times, using different sequences).

Now run key is provided explicitly in URL.

Also, previous code was using only numbers as answer ID. Theoretically there could be conflicts between them. I've changed that to use class name + ID.