### PR TITLE
Fix arg block update (wrong IDs), add #answer_id method to Answer module

### DIFF
--- a/app/assets/javascripts/c_rater.coffee
+++ b/app/assets/javascripts/c_rater.coffee
@@ -3,7 +3,7 @@ class ArgumentationBlockController
   QUESTION_FROMS_SEL = QUESTION_SEL + ' form'
   SUBMIT_BTN_SEL = '.ab-submit'
   FEEDBACK_SEL = '.ab-feedback'
-  FEEDBACK_ID_SEL = '#feedback_on_answer_'
+  FEEDBACK_ID_SEL = '#feedback_on_'
   FEEDBACK_TEXT_SEL = '.ab-robot-feedback-text'
   DIRTY_MSG_SEL = '.ab-dirty'
   ERROR_MSG_SEL = '.ab-error'
@@ -210,8 +210,9 @@ class ArgumentationBlockController
       $feedbackScore.removeClass (idx, oldClasses) ->
         (oldClasses.match(/(^|\s)max-score-\S+/g) || []).join(' ') # matches all max-score-<val> classes
       # Set new score & max-score
-      $feedbackScore.addClass("max-score-#{feedbackItem.max_score || 6}")
-      if feedbackItem.score? && feedbackItem.score >= 0 && feedbackItem.score <= feedbackItem.max_score
+      maxScore = feedbackItem.max_score || 6
+      $feedbackScore.addClass("max-score-#{maxScore}")
+      if feedbackItem.score? && feedbackItem.score >= 0 && feedbackItem.score <= maxScore
         $feedbackScore.addClass("score-#{feedbackItem.score}")
       else
         $feedbackScore.addClass("score--error")

--- a/app/models/c_rater/feedback_submission.rb
+++ b/app/models/c_rater/feedback_submission.rb
@@ -27,13 +27,12 @@ class CRater::FeedbackSubmission < ActiveRecord::Base
     submission = CRater::FeedbackSubmission.create!(interactive_page: page, run: run, collaboration_run: run.collaboration_run)
     feedback_items = {}
     arg_block_answers.each do |a|
-      # E.g. open_response_answer_123, multiple_choice_answer_321, etc.
-      id = "#{a.class.to_s.demodulize.underscore}_#{a.id}"
       f = a.save_feedback
       unless f.nil?
         f.feedback_submission = submission
         f.save!
-        feedback_items[id] = {score: f.score, text: f.feedback_text, max_score: f.max_score, error: f.error?}
+        # a.answer_id is unique among all the answer types, e.g. open_response_answer_123, multiple_choice_answer_321.
+        feedback_items[a.answer_id] = {score: f.score, text: f.feedback_text, max_score: f.max_score, error: f.error?}
       end
     end
     submission.propagate_to_collaborators

--- a/app/models/embeddable/answer.rb
+++ b/app/models/embeddable/answer.rb
@@ -96,4 +96,9 @@ module Embeddable::Answer
     # wont invoke callbacks
     update_column(:is_dirty, false)
   end
+
+  # ID which is unique among all the answer types.
+  def answer_id
+    "#{self.class.to_s.demodulize.underscore}_#{self.id}"
+  end
 end

--- a/app/views/c_rater/argumentation_block/_feedback.html.haml
+++ b/app/views/c_rater/argumentation_block/_feedback.html.haml
@@ -7,7 +7,7 @@
 - fb_score     = (feedback && feedback.score && (feedback.score >= 0 && feedback.score <= fb_max_score)) ? feedback.score : '-error'
 - feedback_classes = "max-score-#{fb_max_score} score-#{fb_score}"
 
-.ab-feedback{:id => "feedback_on_answer_#{emb_id}",
+.ab-feedback{:id => "feedback_on_#{emb_id}",
                    :style => fb_visible ? '' : 'display: none',
                    :class => "ab-score#{fb_score}",
                    'data-dirty' => fb_dirty ? 'true' : 'false',

--- a/app/views/c_rater/argumentation_block/_runtime.html.haml
+++ b/app/views/c_rater/argumentation_block/_runtime.html.haml
@@ -28,8 +28,8 @@
     - embeddables.each_with_index do |m,index|
       .question
         = render :partial => "#{m.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => m}
-        = render :partial => "c_rater/argumentation_block/feedback", :locals => { feedback: m.get_saved_feedback, emb_id: m.id }
-
+        = render :partial => "c_rater/argumentation_block/feedback",
+                              :locals => { feedback: m.get_saved_feedback, emb_id: m.answer_id }
 
     - submission = last_submission(page, @run)
     - show_f_on_f = submission && submission.usefulness_score.nil? && !submission.any_errors?

--- a/app/views/embeddable/labbook_answers/_lightweight.html.haml
+++ b/app/views/embeddable/labbook_answers/_lightweight.html.haml
@@ -1,6 +1,5 @@
-- embeddable_dom_id = "#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"
 = render :partial => 'shared/question_header', :locals => { :embeddable => embeddable }
-.question-bd.labbook{id: embeddable_dom_id,
+.question-bd.labbook{id: embeddable.answer_id,
                     'data-labbook-url' => embeddable.class.labbook_provider,
                     'data-lara-update-url' => embeddable_labbook_answer_path(embeddable),
                     'data-labbook-album-id' => embeddable.album_id,
@@ -26,6 +25,6 @@
       new EmbeddableQuestionsLogging({
         type  :"#{embeddable.class.to_s.demodulize.underscore}",
         id    :"#{embeddable.id}",
-        dom_id:"#{embeddable_dom_id}"
+        dom_id:"#{embeddable.answer_id}"
       });
     });

--- a/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
+++ b/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
@@ -1,7 +1,6 @@
-- embeddable_string = "#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"
-- check_button_string = "check_button_#{embeddable_string}"
+- check_button_string = "check_button_#{embeddable.answer_id}"
 = render :partial => 'shared/question_header', :locals => { :embeddable => embeddable }
-.question-bd{ :id => embeddable_string }
+.question-bd{ :id => embeddable.answer_id }
   .question-txt
     != embeddable.prompt
   = form_for embeddable,
@@ -24,7 +23,7 @@
               :id => check_button_string,
               :value => 'Check answer',
               :disabled => (embeddable.answers.length == 0),
-              :data => { :check => embeddable_string } }
+              :data => { :check => embeddable.answer_id } }
     = prediction_button(embeddable,f)
 - content_for :extra_javascript do
   :javascript
@@ -32,6 +31,6 @@
       new EmbeddableQuestionsLogging({
         type  :"#{embeddable.class.to_s.demodulize.underscore}",
         id    :"#{embeddable.id}",
-        dom_id:"#{embeddable_string}"
+        dom_id:"#{embeddable.answer_id}"
       });
     });

--- a/app/views/embeddable/open_response_answers/_lightweight.html.haml
+++ b/app/views/embeddable/open_response_answers/_lightweight.html.haml
@@ -1,6 +1,5 @@
-- embeddable_string = "#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"
 = render :partial => 'shared/question_header', :locals => { :embeddable => embeddable }
-.question-bd{ :id => embeddable_string }
+.question-bd{ :id => embeddable.answer_id }
   .question-txt
     != embeddable.prompt
   = form_for embeddable,
@@ -15,6 +14,6 @@
       new EmbeddableQuestionsLogging({
         type  :"#{embeddable.class.to_s.demodulize.underscore}",
         id    :"#{embeddable.id}",
-        dom_id:"#{embeddable_string}"
+        dom_id:"#{embeddable.answer_id}"
       });
     });

--- a/spec/models/c_rater/feedback_submission_spec.rb
+++ b/spec/models/c_rater/feedback_submission_spec.rb
@@ -27,16 +27,12 @@ describe CRater::FeedbackSubmission do
     @c_run.save!
   end
 
-  def answer_id_string(answer)
-    "#{answer.class.to_s.demodulize.underscore}_#{answer.id}"
-  end
-
   describe "CRater::FeedbackSubmission.generate_feedback" do
     it "generates submission, feedback items and returns basic information about submission" do
       info = CRater::FeedbackSubmission.generate_feedback(@page, @runs[0])
       expect(CRater::FeedbackSubmission.count).to eql(1)
       expect(info[:submission_id]).to eql(CRater::FeedbackSubmission.first.id)
-      expect(info[:feedback_items][answer_id_string(@answers[0])][:text]).to eql('feedback')
+      expect(info[:feedback_items][@answers[0].answer_id][:text]).to eql('feedback')
     end
 
     describe "when user runs activity with collaborators" do
@@ -48,8 +44,8 @@ describe CRater::FeedbackSubmission do
         info = CRater::FeedbackSubmission.generate_feedback(@page, @runs[0])
         expect(CRater::FeedbackSubmission.count).to eql(2)
         expect(info[:submission_id]).to eql(CRater::FeedbackSubmission.first.id)
-        expect(info[:feedback_items][answer_id_string(@answers[0])][:text]).to eql('feedback')
-        expect(info[:feedback_items][answer_id_string(@answers[1])]).to be_nil # it's other user answer!
+        expect(info[:feedback_items][@answers[0].answer_id][:text]).to eql('feedback')
+        expect(info[:feedback_items][@answers[1].answer_id]).to be_nil # it's other user answer!
 
         submission = CRater::FeedbackSubmission.first
         submission_copy = CRater::FeedbackSubmission.last


### PR DESCRIPTION
Feedback wasn't showing up, as the feedback DOM elements ID were still using numeric-only answer IDs, like "feedack_on_answer_123" instead of "feedback_on_open_response_answer_123".

Also, answer ID calculation was done in quite a few places (#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}"), so I've added `#answer_id` method to `Answer` module / mixin and tried to use it where possible.