### PR TITLE
widen print boxes, open activities in a new window

### DIFF
--- a/app/views/lightweight_activities/print_blank.html.haml
+++ b/app/views/lightweight_activities/print_blank.html.haml
@@ -24,7 +24,7 @@
   .print-warning
     box-sizing: border-box
     margin: 1em auto
-    width: 400px
+    width: 700px
     padding: 10px
     text-align: center
     background-color: hsl(200,0%,95%)

--- a/app/views/sequences/print_blank.html.haml
+++ b/app/views/sequences/print_blank.html.haml
@@ -12,7 +12,7 @@
 
     .submit
       - @sequence.activities.each do |a|
-        %a{href: print_blank_activity_path(a) }
+        %a{href: print_blank_activity_path(a), target: '_blank' }
           %input.button{type: 'submit', value: t('PRINT_BLANK.PRINT', activity: a.name)}
 
 
@@ -20,7 +20,7 @@
   .print-warning
     box-sizing: border-box
     margin: 1em auto
-    width: 400px
+    width: 700px
     padding: 10px
     text-align: left
     background-color: hsl(200,0%,95%)


### PR DESCRIPTION
Long activity titles were being cut off. This widening fix should reduce the chances of that. 
Also when a user clicks on the activity buttons on the sequence print page they should open in new tabs or windows.  

[#130152563]