### PR TITLE
remove re-login, this has caused problems

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -271,17 +271,13 @@ class ApplicationController < ActionController::Base
 
 
   def after_sign_out_path_for(resource)
-    if params[:re_login] && params[:user_provider]
+    if params[:user_provider]
       provider = params[:user_provider]
       provider_id = provider.clone
-      redirect_url = "#{request.protocol}#{request.host_with_port}"
-      params_hash = {
-        :re_login => true,
-        :redirect_uri => redirect_url,
-        :provider => provider
-      }
+      "#{Concord::AuthPortal.url_for_strategy_name(provider_id)}users/sign_out"
+    else
+      root_path
     end
-    params[:re_login] && params[:user_provider] ? "#{Concord::AuthPortal.url_for_strategy_name(provider_id)}users/sign_out?#{params_hash.to_query}" : root_path
   end
 
   def respond_with_edit_form

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,15 +1,11 @@
 class HomeController < ApplicationController
   def home
-    if(params[:re_login])
-      redirect_to user_omniauth_authorize_path(params[:provider])
-    else
-      @filter  = CollectionFilter.new(current_user, LightweightActivity, params[:filter] || {})
-      # TODO: Add 'oficial' to the criteron?
-      @activities = @filter.collection.includes(:user,:changed_by,:portal_publications).first(10)
-      @filter.klass = Sequence
-      # TODO: Add 'oficial' to the criteron?
-      @sequences  = @filter.collection.includes(:user,:lightweight_activities).first(10)
-    end
+    @filter  = CollectionFilter.new(current_user, LightweightActivity, params[:filter] || {})
+    # TODO: Add 'oficial' to the criteron?
+    @activities = @filter.collection.includes(:user,:changed_by,:portal_publications).first(10)
+    @filter.klass = Sequence
+    # TODO: Add 'oficial' to the criteron?
+    @sequences  = @filter.collection.includes(:user,:lightweight_activities).first(10)
   end
   def bad_browser
     render "/home/bad_browser"

--- a/app/views/sequences/show.html.haml
+++ b/app/views/sequences/show.html.haml
@@ -27,7 +27,7 @@
         %span
           - user_provider = current_user.nil? ? nil : current_user.authentications.first.provider
           Not You?
-          = link_to " Click here", destroy_user_session_path(:re_login => true, :user_provider => user_provider), :method => :delete, :data_trigger_save => false
+          = link_to " Click here", destroy_user_session_path(:user_provider => user_provider), :method => :delete, :data_trigger_save => false
 
   
   .sequence_info

--- a/app/views/shared/_activity_nav.html.haml
+++ b/app/views/shared/_activity_nav.html.haml
@@ -85,7 +85,7 @@
       %span
         - user_provider = current_user.nil? ? nil : current_user.authentications.first.provider
         Not You?
-        = link_to " Click here", destroy_user_session_path(:re_login => true, :user_provider => user_provider), :method => :delete, :'data-trigger-save' => false
+        = link_to " Click here", destroy_user_session_path(:user_provider => user_provider), :method => :delete, :'data-trigger-save' => false
 :javascript
   jQuery(function() {
     var rowWidth = jQuery('.l-nav').outerWidth();

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -41,14 +41,4 @@ describe HomeController do
       end
     end
   end
-
-  describe "relogin" do
-    let(:domain)    { 'http://portal.org/' }
-    let(:auth_path) { Concord::AuthPortal.strategy_name_for_url(domain) }
-    it "re-logins to portal" do
-     get :home, {:re_login => true, :provider => auth_path}
-     expect(response).to redirect_to user_omniauth_authorize_path(auth_path)
-    end
-  end
-  
 end


### PR DESCRIPTION
Currently, if a student clicks the "not me" link:
1. they are logged out of the LARA
2. redirected to a logout route of the portal with the re-login and provider param
3. redirected back to LARA with the re-login and provider param
4. redirected back to the portal and shown the simple portal login screen
5. redirected back to LARA and shown the page that they clicked the "not me" link on.

This last step causes problems because this page is likely somewhere this user is not supposed to go.

This PR changes this to:
1. they are logged out of the LARA
2. redirected to a logout route of the portal with no parameters

They should end up on the portal home page with the login on the top right (either a button or the actual login fields).

It was not strictly necessary to remove the support for 're-login' to make this change, but since no other code was using it it seems best to remove it. One bit of removed code can be partially supported by some slightly different parameters. I'll comment on that inline.

[#131411477]