### PR TITLE
hide the navigation if the user is unauthorized

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -128,6 +128,7 @@ class ApplicationController < ActionController::Base
   # if the current_user is not authorized to access the run then this method
   # is called
   def user_id_mismatch
+    @hide_navigation = true
     @user = current_user ? current_user.email : 'anonymous'
     @response_key = params[:response_key] || 'no response key'
     @session = session.clone

--- a/app/views/layouts/runtime.html.erb
+++ b/app/views/layouts/runtime.html.erb
@@ -77,11 +77,13 @@
     <div class="activity-mod">
       <!-- Add class of fixed to activity-nav-mod for fixed nav -->
       <!-- TODO: How to control that? -->
-      <div class="activity-nav-mod">
+      <% unless @hide_navigation %>
+        <div class="activity-nav-mod">
 
-        <%= render :partial => 'shared/activity_nav' %>
+          <%= render :partial => 'shared/activity_nav' %>
 
-      </div>
+        </div>
+      <% end %>
       <!-- end activity-nav-mod -->
 
       <div class="site-width">


### PR DESCRIPTION
Previously the unauthorized user would see the navigation and clicking
the home button would take them to the activity page without a run_key
this would could create a disconnected run if there is some other user
logged in. 

Perhaps it would be better to use a custom layout instead, but I was concerned about losing the current activity's theming if I did that.
[#131412141]