### PR TITLE
Add test for custom labbook labels

### DIFF
--- a/spec/models/embeddable/labbook_spec.rb
+++ b/spec/models/embeddable/labbook_spec.rb
@@ -41,6 +41,12 @@ describe Embeddable::Labbook do
       it 'returns "Upload image"' do
         expect(labbook.action_label).to eql(I18n.t('UPLOAD_IMAGE'))
       end
+      context 'if we manually override custom_action_label' do
+        it 'returns "Take snapshot"' do
+          labbook.custom_action_label = I18n.t('TAKE_SNAPSHOT')
+          expect(labbook.action_label).to eql(I18n.t('TAKE_SNAPSHOT'))
+        end
+      end
     end
     context 'labbook action type is set to snapshot' do
       let(:labbook) { Embeddable::Labbook.new(action_type: Embeddable::Labbook::SNAPSHOT_ACTION) }


### PR DESCRIPTION
In some cases (ITSI)  we want the lab book buttons to read "Take Snapshot" even when the user is uploading images.

This add a test for the `action_label` method, ensuring that it honors the `custom_action_label` DB property of the model.

[#112928599]

https://www.pivotaltracker.com/story/show/112928599