### PR TITLE
Hide question hints by default. Only when (?) clicked.

### DIFF
--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -4,9 +4,6 @@
   display: none;
 }
 
-.screen-only {
- display: block;
-}
 
 @media print {
   .print-only {


### PR DESCRIPTION
Question hints were styled with this selector:  `.help-content.screen-only`

`.screen-only` forced `display` to `block`.  By default all divs are display `block`
so it is not necessary to specify it when not `@media print`

[#131758055]

https://www.pivotaltracker.com/story/show/131758055