### PR TITLE
Completion page sometimes clips next-activity icon.

### DIFF
--- a/app/views/interactive_pages/_show_completion.html.haml
+++ b/app/views/interactive_pages/_show_completion.html.haml
@@ -216,7 +216,6 @@
         color: hsl(184, 67%, 40%)
       .image-preview
         margin: 0 10px 0 0
-        overflow: hidden
         img
           width: 200px
           height: auto


### PR DESCRIPTION
Small CSS fix.

[#131758617]
https://www.pivotaltracker.com/story/show/131758617