### PR TITLE
increase upload size for nginx

### DIFF
--- a/docker/prod/nginx-sites.conf
+++ b/docker/prod/nginx-sites.conf
@@ -12,6 +12,7 @@ server {
 
   root /lara/public;
   try_files $uri @unicorn_server;
+  client_max_body_size 10M;
 
   location @unicorn_server {
     proxy_set_header X-Forwarded-Port $overriden_forwarded_port;


### PR DESCRIPTION
This fixes a bug found in the draw tool. If drawings are bigger than 1MB then they get rejected by nginx.  I tested a drawing that was bigger than 1MB and it works with this change.
There might be other limits in our stack through.

[#132108989]