### PR TITLE
without collaborator URLs interactives fail

### DIFF
--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -141,7 +141,7 @@ class IFrameSaver
         hasLinkedInteractive: response?.has_linked_interactive or false
         linkedState: if response?.linked_state then JSON.parse(response.linked_state) else null
         interactiveStateUrl: @interactive_run_state_url
-        collaboratorUrls: @collaborator_urls.split(';')
+        collaboratorUrls: if @collaborator_urls? then @collaborator_urls.split(';') else null
 
     $.ajax
       url: @interactive_run_state_url


### PR DESCRIPTION
If there are no collaborators then this code was breaking. And that then broke any CODAP interactives because they didn't get the initInteractive call.

[#132185691]
