### PR TITLE
destroy answers when an embeddable is destroyed

### DIFF
--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -32,7 +32,8 @@ module Embeddable
     # "Answer" isn't the best word probably, but it fits the rest of names and convention.
     # LabbookAnswer is an instance related to particular activity run and user.
     has_many :answers,
-             :class_name  => 'Embeddable::LabbookAnswer'
+      :class_name  => 'Embeddable::LabbookAnswer',
+      :dependent => :destroy
 
     default_value_for :name, 'Labbook album' # it's used in Portal reports
 

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -9,7 +9,10 @@ module Embeddable
     LAYOUT_LIKERT = "likert"
     
 
-    has_many :choices, :class_name => 'Embeddable::MultipleChoiceChoice', :foreign_key => 'multiple_choice_id'
+    has_many :choices,
+      :class_name => 'Embeddable::MultipleChoiceChoice',
+      :foreign_key => 'multiple_choice_id',
+      :dependent => :destroy
     has_many :page_items, :as => :embeddable, :dependent => :destroy
     # PageItem instances are join models, so if the embeddable is gone
     # the join should go too.
@@ -17,7 +20,8 @@ module Embeddable
 
     has_many :answers,
       :class_name => 'Embeddable::MultipleChoiceAnswer',
-      :foreign_key => 'multiple_choice_id'
+      :foreign_key => 'multiple_choice_id',
+      :dependent => :destroy
 
     attr_accessible :name, :prompt, :hint, :custom, :choices_attributes,
       :enable_check_answer, :multi_answer, :show_as_menu, :is_prediction,

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -10,7 +10,8 @@ module Embeddable
     has_many :interactive_pages, :through => :page_items
     has_many :answers,
       :class_name  => 'Embeddable::OpenResponseAnswer',
-      :foreign_key => 'open_response_id'
+      :foreign_key => 'open_response_id',
+      :dependent => :destroy
 
     has_one :tracked_question, :as => :question, :dependent => :delete
     has_one :question_tracker, :through => :tracked_question

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -12,7 +12,7 @@ class MwInteractive < ActiveRecord::Base
   # InteractiveItem is a join model; if this is deleted, that instance should go too
 
   has_one :interactive_page, :through => :interactive_item
-  has_many :interactive_run_states, :as => :interactive
+  has_many :interactive_run_states, :as => :interactive, :dependent => :destroy
 
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'
   belongs_to :linked_interactive, :class_name => 'MwInteractive'


### PR DESCRIPTION
image_questions already did this.
this commit also destroys multiple_choice choices when the multiple_choice
is destroyed.
[#133189183]