### PR TITLE
Full window interactives

### DIFF
--- a/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
@@ -29,6 +29,7 @@ modulejs.define 'components/itsi_authoring/model_editor',
       'mw_interactive[image_url]': 'image_url'
       'mw_interactive[native_width]': 'native_width'
       'mw_interactive[native_height]': 'native_height'
+      'mw_interactive[full_window]': 'full_window'
 
     getInitialState: ->
       modelsByName: {}
@@ -44,6 +45,9 @@ modulejs.define 'components/itsi_authoring/model_editor',
       @valueChanged 'mw_interactive[image_url]', model.image_url
       @valueChanged 'mw_interactive[native_width]', model.width
       @valueChanged 'mw_interactive[native_height]', model.height
+
+    onFullWindowChange: (event) ->
+      @valueChanged 'mw_interactive[full_window]', event.target.checked
 
     fetchModelList: ->
       cachedAjax
@@ -83,6 +87,11 @@ modulejs.define 'components/itsi_authoring/model_editor',
               (@select {name: 'mw_interactive[name]', options: @state.modelOptions, onChange: @onSelectChange})
             else
               'Loading models...'
+
+            (label {},
+              (@checkbox {name: 'mw_interactive[full_window]'}),
+              'Start in full window mode'
+            )
           )
         else
           (div {className: 'ia-section-text'},

--- a/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
@@ -29,7 +29,6 @@ modulejs.define 'components/itsi_authoring/model_editor',
       'mw_interactive[image_url]': 'image_url'
       'mw_interactive[native_width]': 'native_width'
       'mw_interactive[native_height]': 'native_height'
-      'mw_interactive[full_window]': 'full_window'
 
     getInitialState: ->
       modelsByName: {}
@@ -45,9 +44,6 @@ modulejs.define 'components/itsi_authoring/model_editor',
       @valueChanged 'mw_interactive[image_url]', model.image_url
       @valueChanged 'mw_interactive[native_width]', model.width
       @valueChanged 'mw_interactive[native_height]', model.height
-
-    onFullWindowChange: (event) ->
-      @valueChanged 'mw_interactive[full_window]', event.target.checked
 
     fetchModelList: ->
       cachedAjax
@@ -87,11 +83,6 @@ modulejs.define 'components/itsi_authoring/model_editor',
               (@select {name: 'mw_interactive[name]', options: @state.modelOptions, onChange: @onSelectChange})
             else
               'Loading models...'
-
-            (label {},
-              (@checkbox {name: 'mw_interactive[full_window]'}),
-              'Start in full window mode'
-            )
           )
         else
           (div {className: 'ia-section-text'},

--- a/app/assets/javascripts/components/itsi_authoring/section_element_editor_mixin.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/section_element_editor_mixin.js.coffee
@@ -95,3 +95,8 @@ modulejs.define 'components/itsi_authoring/section_element_editor_mixin',
       for item in options.options
         (option {value: item.value, key: item.name}, item.name)
     )
+
+  checkbox: (options) ->
+    changed = (e) =>
+      @_handleChange options.name, e.target.checked, options.onChange
+    input {type: 'checkbox', name: options.name, checked: @state.values[options.name], onChange: changed}

--- a/app/assets/javascripts/labbook.coffee
+++ b/app/assets/javascripts/labbook.coffee
@@ -24,8 +24,8 @@ class LabbookController
 
     @$dialog.dialog({
       autoOpen: false,
-      width: 750,
-      height: 750,
+      width: Math.min(window.innerWidth - 10, 750),
+      height: Math.min(window.innerHeight - 10, 750),
       title: 'Labbook',
       dialogClass: 'lb-dialog',
       modal: true,

--- a/app/assets/stylesheets/mw-runtime-base.scss
+++ b/app/assets/stylesheets/mw-runtime-base.scss
@@ -497,10 +497,9 @@ div.intra-page-nav {
     position: absolute;
     bottom: 0;
   }
+}
 
 @import 'partials/click_to_play';
-
-}
 
 
 // .sticky-wrapper need to have hard px widths to work correctly in fixed state

--- a/app/assets/stylesheets/partials/_click_to_play.scss
+++ b/app/assets/stylesheets/partials/_click_to_play.scss
@@ -101,4 +101,9 @@
 
 .noscroll {
   overflow-y: hidden;
+  // This class is applied to HTML tag and fixed position fixes iPad issues.
+  // Full window interactive uses fixed layout too and when iPad keyboard is opened,
+  // it might totally break it (iPad bug). Setting position of HTML element helps. See:
+  // http://stackoverflow.com/questions/14492613/ios-ipad-fixed-position-breaks-when-keyboard-is-opened
+  position: fixed;
 }

--- a/app/assets/stylesheets/partials/_click_to_play.scss
+++ b/app/assets/stylesheets/partials/_click_to_play.scss
@@ -1,29 +1,104 @@
 .interactive-container {
-    position: relative;
-    .img-container,.click_to_play,.click_to_play .background,.click_to_play .text{
-      position: absolute;
+  position: relative;
+  .img-container,.click_to_play,.click_to_play .background,.click_to_play .text{
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+  .img-container {
+    img {
+      width : 100%;
+      height: 100%;
+      object-fit: contain;
+    }
+  }
+  .click_to_play {
+    cursor: pointer;
+    .background {
+      background-color: white;
+      opacity: 0.75;
+    }
+    .text {
+      text-align: center;
+      font-size: 2em;
+      margin-top: 4em;
+    }
+  }
+
+  .full-window-menu, .full-window-overlay {
+    display: none;
+  }
+
+  &.full-window {
+    .full-window-overlay {
+      display: block;
+      position: fixed;
       top: 0;
-      right: 0;
-      bottom: 0;
       left: 0;
-    }
-    .img-container {
-      img {
-        width : 100%;
-        height: 100%;
-        object-fit: contain;
-      }
-    }
-    .click_to_play {
-      cursor: pointer;
-      .background {
-        background-color: white;
-        opacity: 0.75;
-      }
-      .text {
+      width: 100%;
+      height: 100%;
+      background: #f8ac1a;
+      z-index: 1;
+
+      .loading-msg {
         text-align: center;
-        font-size: 2em;
-        margin-top: 4em;
+        font-size: 30px;
+        margin-top: 20%;
+      }
+    }
+
+    iframe {
+      display: block;
+      position: fixed;
+      top: 40px;
+      left: 0;
+      width: 100%;
+      height: calc(100% - 40px);
+      z-index: 2;
+    }
+
+    .full-window-menu {
+      display: block;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 40px;
+      z-index: 2;
+
+      .menu-items {
+        float: right;
+        margin-right: 10px;
+        line-height: 40px;
+        div {
+          display: inline-block;
+          vertical-align: middle;
+        }
+      }
+
+      /* Labbook */
+      .screenshot {
+        .question-hdr {
+          display: none;
+        }
+        .question-bd.labbook {
+          margin-top: -14px;
+          transform: scale(0.8);
+          .text_prompt {
+            display: none;
+          }
+        }
+      }
+
+      .exit-full-window {
+        cursor: pointer;
       }
     }
   }
+}
+
+.noscroll {
+  overflow-y: hidden;
+}

--- a/app/assets/stylesheets/partials/_runtime-interactives.scss
+++ b/app/assets/stylesheets/partials/_runtime-interactives.scss
@@ -46,8 +46,8 @@
       text-decoration: underline;
     }
   }
-  @import 'partials/click_to_play';
 }
+@import 'partials/click_to_play';
 
 .questions-mod {
  /* margin-bottom: 52px; */

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -1,6 +1,6 @@
 class MwInteractive < ActiveRecord::Base
   attr_accessible :name, :url, :native_width, :native_height, :save_state, :has_report_url, :click_to_play, :image_url,
-                  :is_hidden, :linked_interactive_id
+                  :is_hidden, :linked_interactive_id, :full_window
 
   default_value_for :native_width, 576
   default_value_for :native_height, 435
@@ -52,6 +52,7 @@ class MwInteractive < ActiveRecord::Base
       save_state: save_state,
       has_report_url: has_report_url,
       click_to_play: click_to_play,
+      full_window: full_window,
       image_url: image_url,
       is_hidden: is_hidden
     }
@@ -82,6 +83,7 @@ class MwInteractive < ActiveRecord::Base
                               :save_state,
                               :has_report_url,
                               :click_to_play,
+                              :full_window,
                               :image_url,
                               :is_hidden])
   end

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -1,3 +1,5 @@
+- labbook = show_labbook_under_interactive?(@run, interactive)
+
 .interactive-container{class: interactive.save_state ? 'savable' : ''}
   - if interactive.native_height > 1
     .interactive-placeholder.print-only
@@ -8,11 +10,24 @@
         =image_tag(interactive.image_url)
 
     - if interactive.click_to_play
-      .click_to_play.shown.screen-only{:id => dom_id_for(interactive, :click_to_play)}
+      - if interactive.full_window
+        .full-window-overlay
+          .loading-msg
+            %i.wait-icon.fa.fa-spinner.fa-spin
+            Loading interactive...
+        .full-window-menu
+          .menu-items
+            - if labbook
+              .screenshot
+                = render partial: 'embeddable/labbook_answers/lightweight', locals: { embeddable: labbook }
+            .exit-full-window{:id => dom_id_for(interactive, :exit_full_window)}
+              Return to Activity
+
+      .click_to_play.shown.screen-only{:id => dom_id_for(interactive, :click_to_play), 'data-trigger-full-window' => interactive.full_window}
         .background
         .text= "Click here to start the interactive."
 
-      = interactive_iframe_tag(interactive, @run,false) do
+      = interactive_iframe_tag(interactive, @run, false) do
 
         Your browser does not support inline frames, or is currently not configured to display inline frames.
         Content can be viewed at the actual source page:
@@ -33,19 +48,38 @@
 .print-only.iframe-url
   = link_to "#{interactive.url}", "#{interactive.url}"
 
-- labbook = show_labbook_under_interactive?(@run, interactive)
-- if labbook
+- if labbook && !interactive.full_window
   .question
-    = render partial: 'embeddable/labbook_answers/lightweight',
-      locals: { embeddable: labbook }
+    = render partial: 'embeddable/labbook_answers/lightweight', locals: { embeddable: labbook }
+- else
+  %br
+  %br
 
 :javascript
   $(document).ready(function() {
     $('##{dom_id_for(interactive, :click_to_play)}').click(function() {
-      $(this).css('display','none');
-      $(this).removeClass('shown')
-      $('##{dom_id_for(interactive, :interactive_image)}').css('display','none');
-      $('#interactive_#{interactive.id}').attr('src','#{interactive.url}');
-      InteractiveManager.register($(this).parent('.interactive-container'))
-    })
+      var $clickToPlay = $(this);
+      var $interactiveContainer = $clickToPlay.parent('.interactive-container');
+      $clickToPlay.css('display', 'none');
+      $clickToPlay.removeClass('shown');
+      $('##{dom_id_for(interactive, :interactive_image)}').css('display', 'none');
+      if (!$interactiveContainer.data('initialized')) {
+        $('#interactive_#{interactive.id}').attr('src','#{interactive.url}');
+        InteractiveManager.register($interactiveContainer);
+        $interactiveContainer.data('initialized', true);
+      }
+      if (#{interactive.full_window}) {
+        $interactiveContainer.addClass('full-window');
+        $('html').addClass('noscroll');
+      }
+    });
+
+    $('##{dom_id_for(interactive, :exit_full_window)}').click(function() {
+      var $clickToPlay = $('##{dom_id_for(interactive, :click_to_play)}');
+      var $interactiveContainer = $clickToPlay.parent('.interactive-container');
+      $clickToPlay.css('display', 'block');
+      $clickToPlay.addClass('shown');
+      $interactiveContainer.removeClass('full-window');
+      $('html').removeClass('noscroll');
+    });
   })

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -57,8 +57,8 @@
 
 :javascript
   $(document).ready(function() {
-    $('##{dom_id_for(interactive, :click_to_play)}').click(function() {
-      var $clickToPlay = $(this);
+    function startInteractive(clickToPlayElem) {
+      var $clickToPlay = $(clickToPlayElem);
       var $interactiveContainer = $clickToPlay.parent('.interactive-container');
       $clickToPlay.css('display', 'none');
       $clickToPlay.removeClass('shown');
@@ -68,18 +68,34 @@
         InteractiveManager.register($interactiveContainer);
         $interactiveContainer.data('initialized', true);
       }
-      if (#{interactive.full_window}) {
-        $interactiveContainer.addClass('full-window');
-        $('html').addClass('noscroll');
-      }
-    });
-
-    $('##{dom_id_for(interactive, :exit_full_window)}').click(function() {
+    }
+    // Full window interactive uses fixed layout too and when iPad keyboard is opened,
+    // it might totally break it. It's an iOS Safari bug, see (different solutions, but the same bug):
+    // http://stackoverflow.com/questions/14492613/ios-ipad-fixed-position-breaks-when-keyboard-is-opened
+    // Setting fixed position of HTML element helps (that's done by noscroll class). However, it also resets
+    // current scroll position, so we need to save it and restore when user leaves full window mode.
+    var currentScrollTop;
+    function enterFullWindow(clickToPlayElem) {
+      var $interactiveContainer = $(clickToPlayElem).parent('.interactive-container');
+      $interactiveContainer.addClass('full-window');
+      currentScrollTop = $('body').scrollTop();
+      $('html').addClass('noscroll');
+    }
+    function exitFullWindow() {
+      $('html').removeClass('noscroll');
+      $('body').scrollTop(currentScrollTop);
       var $clickToPlay = $('##{dom_id_for(interactive, :click_to_play)}');
       var $interactiveContainer = $clickToPlay.parent('.interactive-container');
       $clickToPlay.css('display', 'block');
       $clickToPlay.addClass('shown');
       $interactiveContainer.removeClass('full-window');
-      $('html').removeClass('noscroll');
+    }
+
+    $('##{dom_id_for(interactive, :click_to_play)}').click(function() {
+      startInteractive(this);
+      if (#{interactive.full_window}) {
+        enterFullWindow(this);
+      }
     });
+    $('##{dom_id_for(interactive, :exit_full_window)}').click(exitFullWindow);
   })

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -20,6 +20,8 @@
   %br
   = f.label :click_to_play, 'Click to play'
   = f.check_box :click_to_play, :id => "click_to_play_#{@interactive.id}"
+  = f.label :full_window, 'Full window mode'
+  = f.check_box :full_window, :id => "full_window_#{@interactive.id}"
   %div{:style => "margin-bottom:5px;"}
     %em Warning: 
     Please provide an image_url to use click to play.

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -20,7 +20,7 @@
   %br
   = f.label :click_to_play, 'Click to play'
   = f.check_box :click_to_play, :id => "click_to_play_#{@interactive.id}"
-  = f.label :full_window, 'Full window mode'
+  = f.label :full_window, :id => "full_window_label_#{@interactive.id}", :text => 'Full window mode'
   = f.check_box :full_window, :id => "full_window_#{@interactive.id}"
   %div{:style => "margin-bottom:5px;"}
     %em Warning: 
@@ -56,10 +56,11 @@
     if ($("#click_to_play_#{@interactive.id}").prop('checked')) {
         $("#mw_interactive_image_url").attr("required", true);
         $("#full_window_#{@interactive.id}").removeAttr("disabled");
-
+        $('#full_window_label_#{@interactive.id}').css("opacity", 1);
       } else {
         $("#mw_interactive_image_url").removeAttr("required");
         $("#full_window_#{@interactive.id}").attr("disabled", true);
+        $('#full_window_label_#{@interactive.id}').css("opacity", 0.3);
       }
   }
 

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -55,8 +55,11 @@
   function click_to_play(){
     if ($("#click_to_play_#{@interactive.id}").prop('checked')) {
         $("#mw_interactive_image_url").attr("required", true);
+        $("#full_window_#{@interactive.id}").removeAttr("disabled");
+
       } else {
         $("#mw_interactive_image_url").removeAttr("required");
+        $("#full_window_#{@interactive.id}").attr("disabled", true);
       }
   }
 

--- a/db/migrate/20161108100733_add_full_window_to_mw_interactives.rb
+++ b/db/migrate/20161108100733_add_full_window_to_mw_interactives.rb
@@ -1,0 +1,5 @@
+class AddFullWindowToMwInteractives < ActiveRecord::Migration
+  def change
+    add_column :mw_interactives, :full_window, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160824191003) do
+ActiveRecord::Schema.define(:version => 20161108100733) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -403,6 +403,7 @@ ActiveRecord::Schema.define(:version => 20160824191003) do
     t.string   "image_url"
     t.boolean  "is_hidden",             :default => false
     t.integer  "linked_interactive_id"
+    t.boolean  "full_window",           :default => false
   end
 
   add_index "mw_interactives", ["linked_interactive_id"], :name => "index_mw_interactives_on_linked_interactive_id"

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -40,6 +40,7 @@ describe MwInteractive do
         save_state: interactive.save_state,
         has_report_url: interactive.has_report_url,
         click_to_play: interactive.click_to_play,
+        full_window: interactive.full_window,
         image_url: interactive.image_url,
         is_hidden: interactive.is_hidden
        }
@@ -56,6 +57,7 @@ describe MwInteractive do
         native_width: interactive.native_width,
         native_height: interactive.native_height,
         click_to_play: interactive.click_to_play,
+        full_window: interactive.full_window,
         image_url: interactive.image_url,
         is_hidden: interactive.is_hidden
       })


### PR DESCRIPTION
Interactive can be configured to use "Full Window Mode". "Click to Play" option has to be tuned on first. "Full window mode" can be set using either normal or ITSI authoring and it also works in both runtimes (normal and ITSI).

Once it's enabled, when user clicks on the interactive image, it automatically opens full window mode. In ITSI mode Labbook buttons are not displayed under the interactive, but they're added to the top bar instead:
<img width="1435" alt="screen shot 2016-11-09 at 15 52 10" src="https://cloud.githubusercontent.com/assets/767857/20142325/834e0f4c-a694-11e6-945e-784f6355c77b.png">

User can exit full window mode and get back to the interactive without losing any progress. 

I tested it in:
- Chrome
- Safari
- Firefox
- iOS Safari (which was problematic due to some bugs related to virtual keyboard and fixed positions of HTML elements, workarounds are visible in the code)
