### PR TITLE
Don't add "Copy of" prefix to name of the duplicated interactive

### DIFF
--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -1,6 +1,6 @@
 class MwInteractive < ActiveRecord::Base
   attr_accessible :name, :url, :native_width, :native_height, :save_state, :has_report_url, :click_to_play, :image_url,
-                  :is_hidden, :linked_interactive_id, :full_window
+                  :is_hidden, :linked_interactive_id, :full_window, :model_library_url
 
   default_value_for :native_width, 576
   default_value_for :native_height, 435
@@ -54,7 +54,8 @@ class MwInteractive < ActiveRecord::Base
       click_to_play: click_to_play,
       full_window: full_window,
       image_url: image_url,
-      is_hidden: is_hidden
+      is_hidden: is_hidden,
+      model_library_url: model_library_url
     }
   end
 
@@ -89,7 +90,8 @@ class MwInteractive < ActiveRecord::Base
                               :click_to_play,
                               :full_window,
                               :image_url,
-                              :is_hidden])
+                              :is_hidden,
+                              :model_library_url])
   end
 
   def self.import(import_hash)

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -67,10 +67,7 @@ class MwInteractive < ActiveRecord::Base
 
   def duplicate
     # Generate a new object with those values
-    new_interactive = MwInteractive.new(self.to_hash)
-    # Clarify the name # Not sure why we do this
-    new_interactive.name = "Copy of #{new_interactive.name}"
-    return new_interactive
+    MwInteractive.new(self.to_hash)
     # N.B. the duplicate hasn't been saved yet
   end
 

--- a/app/services/itsi_authoring/editor.rb
+++ b/app/services/itsi_authoring/editor.rb
@@ -97,6 +97,7 @@ class ITSIAuthoring::Editor
       is_hidden: i.is_hidden,
       url: i.url,
       image_url: i.image_url,
+      model_library_url: i.model_library_url,
       update_url: page_mw_interactive_path(page, i)
     }
   end

--- a/db/migrate/20161115194608_add_model_library_url_to_mw_interactives.rb
+++ b/db/migrate/20161115194608_add_model_library_url_to_mw_interactives.rb
@@ -1,0 +1,5 @@
+class AddModelLibraryUrlToMwInteractives < ActiveRecord::Migration
+  def change
+    add_column :mw_interactives, :model_library_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161108100733) do
+ActiveRecord::Schema.define(:version => 20161115194608) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -404,6 +404,7 @@ ActiveRecord::Schema.define(:version => 20161108100733) do
     t.boolean  "is_hidden",             :default => false
     t.integer  "linked_interactive_id"
     t.boolean  "full_window",           :default => false
+    t.string   "model_library_url"
   end
 
   add_index "mw_interactives", ["linked_interactive_id"], :name => "index_mw_interactives_on_linked_interactive_id"

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -41,6 +41,7 @@ describe MwInteractive do
         has_report_url: interactive.has_report_url,
         click_to_play: interactive.click_to_play,
         full_window: interactive.full_window,
+        model_library_url: interactive.model_library_url,
         image_url: interactive.image_url,
         is_hidden: interactive.is_hidden
        }
@@ -58,6 +59,7 @@ describe MwInteractive do
         native_height: interactive.native_height,
         click_to_play: interactive.click_to_play,
         full_window: interactive.full_window,
+        model_library_url: interactive.model_library_url,
         image_url: interactive.image_url,
         is_hidden: interactive.is_hidden
       })

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -52,7 +52,7 @@ describe MwInteractive do
     it 'is a new instance of MwInteractive with values' do
       interactive.is_hidden = true
       expect(interactive.duplicate).to be_a_new(MwInteractive).with({
-        name: "Copy of #{interactive.name}",
+        name: interactive.name,
         url: interactive.url,
         native_width: interactive.native_width,
         native_height: interactive.native_height,


### PR DESCRIPTION
Interactives in ITSI authoring model editor are matched using names. Don't add "Copy of" prefix, so the same of the interactive stays the same. When it's deployed, we can fix old interactives using this script:

```ruby
MwInteractive.all.each do |i|
  new_name = i.name.gsub "Copy of ", ""
  i.update_attributes!(name: new_name)
end
```