### PR TITLE
put portal_hash in each embeddable

### DIFF
--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -26,8 +26,7 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
     page && page.visible_interactives.first
   end
 
-  # NOTE: publishing to portal doesn't use this hash. See app/models/lightweight_activity.rb
-  # for the hash used in portal publishing.
+  # NOTE: publishing to portal doesn't use this hash. portal_hash is used instead
   def to_hash
     {
       name: name,
@@ -40,6 +39,16 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
       prediction_feedback: prediction_feedback,
       is_hidden: is_hidden,
       hint: hint
+    }
+  end
+
+  def portal_hash
+    {
+      type: "image_question",
+      id: id,
+      prompt: prompt,
+      drawing_prompt: drawing_prompt,
+      is_required: is_prediction
     }
   end
 

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -101,6 +101,20 @@ module Embeddable
       }
     end
 
+    def portal_hash
+      {
+        type: "multiple_choice",
+        id: id,
+        prompt: prompt,
+        choices: choices.map{|choice| {
+          id: choice.id,
+          content: choice.choice,
+          correct: choice.is_correct
+        } },
+        is_required: is_prediction
+      }
+    end
+
     def duplicate
       mc = Embeddable::MultipleChoice.new(self.to_hash)
       self.choices.each do |choice|

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -32,6 +32,15 @@ module Embeddable
       }
     end
 
+    def portal_hash
+      {
+        type: "open_response",
+        id: id,
+        prompt: prompt,
+        is_required: is_prediction,
+      }
+    end
+
     def duplicate
       return Embeddable::OpenResponse.new(self.to_hash)
     end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -210,53 +210,10 @@ class LightweightActivity < ActiveRecord::Base
     visible_pages_with_embeddables.each do |page|
       elements = []
       page.reportable_items.each do |embeddable|
-        case embeddable
-          # Why aren't we using the to_hash methods for each embeddable here?
-          # Probably because they don't include the "type" attribute
-        when Embeddable::OpenResponse
-          elements.push({
-                          "type" => "open_response",
-                          "id" => embeddable.id,
-                          "prompt" => embeddable.prompt,
-                          "is_required" => embeddable.is_prediction
-                        })
-        when Embeddable::ImageQuestion
-          elements.push({
-                          "type" => "image_question",
-                          "id" => embeddable.id,
-                          "prompt" => embeddable.prompt,
-                          "drawing_prompt" => embeddable.drawing_prompt,
-                          "is_required" => embeddable.is_prediction
-                        })
-        when Embeddable::MultipleChoice
-          choices = []
-          embeddable.choices.each do |choice|
-            choices.push({
-                           "id" => choice.id,
-                           "content" => choice.choice,
-                           "correct" => choice.is_correct
-                         })
-          end
-          mc_data = {
-            "type" => "multiple_choice",
-            "id" => embeddable.id,
-            "prompt" => embeddable.prompt,
-            "choices" => choices,
-            "is_required" => embeddable.is_prediction
-          }
-          elements.push(mc_data)
-        when MwInteractive
-          iframe_data = embeddable.to_hash
-          iframe_data["type"] = 'iframe_interactive'
-          iframe_data["id"] = embeddable.id
-          elements.push(iframe_data)
-        else
-          # Why do we explicitly list all the embeddable types above?
-          if embeddable.respond_to?(:portal_hash)
-            elements.push(embeddable.portal_hash)
-          end
-          # Otherwise we don't support this embeddable type right now.
+        if embeddable.respond_to?(:portal_hash)
+          elements.push(embeddable.portal_hash)
         end
+        # Otherwise we don't support this embeddable type right now.
       end
       pages.push({
                    "name" => page.name,

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -58,6 +58,13 @@ class MwInteractive < ActiveRecord::Base
     }
   end
 
+  def portal_hash
+    iframe_data = to_hash
+    iframe_data[:type] = 'iframe_interactive'
+    iframe_data[:id] = id
+    iframe_data
+  end
+
   def duplicate
     # Generate a new object with those values
     new_interactive = MwInteractive.new(self.to_hash)


### PR DESCRIPTION
This has been bothering me for a while. This still isn't great, but at least it feels better than what was there before.  Now lightweight_activity doesn't explicitly list all of the embeddable types.

There are still 3 'hashes' for each embeddable though:
portal_hash, to_hash, and export.

- portal_hash needs to match the format expected by the portal
- export should be the most complete, however by itself it doesn't include the type or id of the embeddable during an actual export the type is added and for some things an id is added
- to_hash is used for duplicating

[#134366975]