### PR TITLE
Add questions to tracker API

### DIFF
--- a/app/controllers/api/v1/question_trackers_controller.rb
+++ b/app/controllers/api/v1/question_trackers_controller.rb
@@ -19,10 +19,7 @@ class Api::V1::QuestionTrackersController < ApplicationController
   def report
     tracker = QuestionTracker.find(params[:question_tracker_id])
     reporter = QuestionTracker::Reporter.new(tracker, params[:endpoints])
-    render :json => {
-        "question_tracker" => reporter.report_info,
-        "answers" => reporter.answers
-    }
+    render :json => reporter.report
   end
 
   private

--- a/app/services/question_tracker/reporter.rb
+++ b/app/services/question_tracker/reporter.rb
@@ -28,6 +28,14 @@ class QuestionTracker::Reporter
     self.answers.map! { |ans| answer_hash(ans) }
   end
 
+  def report
+    {
+      question_tracker: report_info,
+      questions: question_tracker.questions.map(&:portal_hash),
+      answers: answers
+    }
+  end
+
   def report_info
     {
         name: question_tracker.name,

--- a/spec/services/question_tracker/reporter_spec.rb
+++ b/spec/services/question_tracker/reporter_spec.rb
@@ -121,6 +121,11 @@ describe QuestionTracker::Reporter do
           expect(user_answers["endpoint"]).to eql run.remote_endpoint
         end
 
+        it "questions should have one serialized question" do
+          questions = reporter.report[:questions]
+          expect(questions.length).to eql 1
+        end
+
         describe "when there is another run by the same student in activty2 with a different endpoint" do
           let(:run2)           { Run.create(user: user1, activity: activity2, remote_endpoint: student1_endpoint2_url) }
           let(:answer_text2) { "I answered it again" }
@@ -152,6 +157,12 @@ describe QuestionTracker::Reporter do
               expect(user_answers["activity_id"]).to eql activity2.id
               expect(user_answers["endpoint"]).to eql run2.remote_endpoint
             end
+
+            it "questions should have two serialized questions" do
+              questions = reporter.report[:questions]
+              expect(questions.length).to eql 2
+            end
+
           end
         end
 


### PR DESCRIPTION
This adds a question list to the tracker report API.

This path to this API is:
/api/v1/question_trackers/:id/report

It is using the `portal_hash` method which isn't the best because that means this portal_hash is no longer just for the portal.  However this tracker report was already using the portal_hash method on the answers, so at least it is consistent.   One reason it uses the portal_hash is because that includes the id of the question which is needed so it can be correlated with the answer.  The other export mechanisms don't have ids.