### PR TITLE
Print format fixes

### DIFF
--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -29,7 +29,7 @@
   }
 
   .interactive-container {
-    .img-container, .interactive-print-text {
+    .interactive-print-text {
       display: block !important;
     }
   }
@@ -70,6 +70,14 @@
     text-align: center;
     padding-top: 25%;
     page-break-inside: avoid;
+  }
+
+  .interactive-image-placeholder {
+    width: 100%;
+    height: 250px;
+    page-break-inside: avoid;
+    background-size: contain;
+    background-repeat: no-repeat;
   }
 
   .iframe-url {

--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -75,6 +75,9 @@
   .iframe-url {
     padding-top: 0.5em;
     font-size: 0.75em;
+    a {
+      word-wrap: break-word;
+    }
   }
 
   .image-question {

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -2,10 +2,13 @@
 
 .interactive-container
   - if interactive.native_height > 1
-    .interactive-placeholder.print-only
-      Interactive Model
+    - if interactive.image_url.present?
+      .interactive-image-placeholder.print-only{:style => "background-image: url(#{interactive.image_url});"}
+    - else
+      .interactive-placeholder.print-only
+        Interactive Model
 
-    - if !interactive.image_url.blank?
+    - if interactive.image_url.present?
       .img-container{:id => dom_id_for(interactive, :interactive_image),:style => interactive.click_to_play ? "display:block" : "display:none"}
         =image_tag(interactive.image_url)
 


### PR DESCRIPTION
Small CSS fix for printing activities.

* if there is an preview image for an interactive show that in the printout.  Otherwise show a border box with "Interactive" in the center.

* The interactives URL should not be truncated in the print.

@scytacki  if you can have a look.