### PR TITLE
LARA activities published to portal include URLs for pages.

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -208,6 +208,7 @@ class LightweightActivity < ActiveRecord::Base
 
     pages = []
     visible_pages_with_embeddables.each do |page|
+      page_url = "#{host}#{Rails.application.routes.url_helpers.page_path(page)}"
       elements = []
       page.reportable_items.each do |embeddable|
         if embeddable.respond_to?(:portal_hash)
@@ -217,6 +218,7 @@ class LightweightActivity < ActiveRecord::Base
       end
       pages.push({
                    "name" => page.name,
+                   "url" => page_url,
                    "elements" => elements
                  })
     end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -361,7 +361,9 @@ describe LightweightActivity do
         pages = activity.serialize_for_portal('http://test.host')['sections'][0]['pages']
         expect(pages.length).to eql(2)
         expect(pages[0]['name']).to eql('page 1')
+        expect(pages[0]['url']).to match /http:\/\/test.host\/pages\/\d+/
         expect(pages[1]['name']).to eql('page 2')
+        expect(pages[1]['url']).to match /http:\/\/test.host\/pages\/\d+/
       end
     end
 


### PR DESCRIPTION
This PR goes hand in hand with [Rigse #278](https://github.com/concord-consortium/rigse/pull/278) 

Show links to LARA pages in teacher reports so teacher can quickly show the question in context of the page it came from.

Originated from this story:
https://www.pivotaltracker.com/story/show/112613409