### PR TITLE
Added user idle check in authoring pages [#136522673]

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,4 +41,6 @@
 //= require tinymce-jquery
 //= require iframe-phone
 //= require iframe-phone-manager
+//= require idle
+//= require check-author-idle
 //= require application-init

--- a/app/assets/javascripts/check-author-idle.coffee
+++ b/app/assets/javascripts/check-author-idle.coffee
@@ -15,7 +15,7 @@ $ ->
       '<div id="', blockerId, '" >',
         '<div style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; background-color: #000; opacity: 0.25"></div>',
         '<div style="position: absolute; top: 25%; left: 25%; right: 25%; background-color: #fff; text-align: center; font-size: 24px; line-height: 2em; padding: 30px;">',
-          'Your login session has timed out.  <a href="/" target="_blank">Click here to login in a different window</a>.  After you login you will be able to continue with this activity in this window.'
+          'Your login session has timed out.  Reload this page to log back in and continue editing.'
         '</div>',
       '</div>'
     ].join('')

--- a/app/assets/javascripts/check-author-idle.coffee
+++ b/app/assets/javascripts/check-author-idle.coffee
@@ -1,0 +1,44 @@
+$ ->
+  # abort if not on authoring page
+  authoringPages = [
+    /\/activities\/new/
+    /\/activities\/(\d+)\/edit/
+    /\/activities\/(\d+)\/pages\/(\d+)\/edit/
+  ]
+  inAuthoringPages = (true for regex in authoringPages when regex.test(window.location.pathname)).length > 0
+
+  if inAuthoringPages
+    blockerId = 'edit-blocker'
+    $body = $ document.body
+
+    blockerHTML = $ [
+      '<div id="', blockerId, '" >',
+        '<div style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; background-color: #000; opacity: 0.25"></div>',
+        '<div style="position: absolute; top: 25%; left: 25%; right: 25%; background-color: #fff; text-align: center; font-size: 24px; line-height: 2em; padding: 30px;">',
+          'Your login session has timed out.  <a href="/" target="_blank">Click here to login in a different window</a>.  After you login you will be able to continue with this activity in this window.'
+        '</div>',
+      '</div>'
+    ].join('')
+
+    blockEdits = (block) ->
+      $blocker = $body.find '#' + blockerId
+      hasBlocker = $blocker.length > 0
+
+      if block and !hasBlocker
+        $body.append blockerHTML
+      else if !block and hasBlocker
+        $blocker.remove()
+
+    userCheck = ->
+      onSuccess = (result) ->
+        haveUser = result?.user?
+        blockEdits !haveUser
+      onFail = ->
+        blockEdits true
+      $.getJSON('/api/v1/user_check', onSuccess).fail(onFail)
+
+    idleCheck = new IdleCheck
+      onAwayBack: -> userCheck()
+      onVisible: -> userCheck()
+      awayTimeout: 10000
+

--- a/app/assets/javascripts/idle.coffee
+++ b/app/assets/javascripts/idle.coffee
@@ -1,0 +1,94 @@
+# adapted from https://github.com/shawnmclean/Idle.js/blob/master/src/idle.coffee
+#
+#  1) Added jQuery
+#  2) Cleaned up some of the CoffeeScript
+#
+
+window.IdleCheck = class IdleCheck
+
+  constructor: (options) ->
+    @isAway = false
+    @awayTimeout = 3000
+    @awayTimestamp = 0
+    @awayTimer = null
+
+    @onAway = null
+    @onAwayBack = null
+    @onVisible = null
+    @onHidden = null
+
+    @listener = null
+
+    if(options)
+      @awayTimeout = parseInt(options.awayTimeout, 10) or @awayTimeout
+      @onAway = options.onAway
+      @onAwayBack = options.onAwayBack
+      @onVisible = options.onVisible
+      @onHidden = options.onHidden
+
+    activeMethod = => @onActive()
+
+    $window = $ window
+    $window.on 'click', activeMethod
+    $window.on 'mousemove', activeMethod
+    $window.on 'mouseenter', activeMethod
+    $window.on 'keydown', activeMethod
+    $window.on 'scroll', activeMethod
+    $window.on 'mousewheel', activeMethod
+    $window.on 'touchmove', activeMethod
+    $window.on 'touchstart', activeMethod
+
+    @listener = => @handleVisibilityChange()
+    $document = $ document
+    $document.on "visibilitychange", @listener
+    $document.on "webkitvisibilitychange", @listener
+    $document.on "msvisibilitychange", @listener
+
+    @start()
+
+  onActive: () ->
+    now = new Date().getTime()
+    @awayTimestamp = now + @awayTimeout
+    if @isAway
+      @onAwayBack?(now - @awayAt)
+      @start()
+    @isAway = false
+    true
+
+  start: () ->
+    clearTimeout @awayTimer
+    @awayTimestamp = new Date().getTime() + @awayTimeout
+    @awayTimer = setTimeout (=> @checkAway()), @awayTimeout + 100
+    @
+
+  stop: () ->
+    clearTimeout @awayTimer
+    if @listener
+      $document = $ document
+      $document.off "visibilitychange", @listener
+      $document.off "webkitvisibilitychange", @listener
+      $document.off "msvisibilitychange", @listener
+      @listener = null
+    @
+
+  setAwayTimeout: (ms) ->
+    @awayTimeout = parseInt ms, 10
+    @
+
+  checkAway: () ->
+    t = new Date().getTime()
+    if t < @awayTimestamp
+      @isAway = false
+      @awayTimer = setTimeout (=> @checkAway()), @awayTimestamp - t + 100
+    else
+      clearTimeout @awayTimer
+      @isAway = true
+      @awayAt = t
+      @onAway?()
+
+  handleVisibilityChange: () ->
+    if document.hidden || document.msHidden || document.webkitHidden
+      @onHidden?()
+    else
+      @onVisible?()
+

--- a/app/controllers/api/v1/user_check_controller.rb
+++ b/app/controllers/api/v1/user_check_controller.rb
@@ -4,6 +4,6 @@ class Api::V1::UserCheckController < ApplicationController
   skip_before_filter :verify_authenticity_token, :only => :index
 
   def index
-    render :json => {user: current_user}
+    render :json => {user: current_user ? current_user.attributes.slice('id', 'email', 'is_admin', 'is_author') : nil}
   end
 end

--- a/app/controllers/api/v1/user_check_controller.rb
+++ b/app/controllers/api/v1/user_check_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::UserCheckController < ApplicationController
+  layout false
+
+  skip_before_filter :verify_authenticity_token, :only => :index
+
+  def index
+    render :json => {user: current_user}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,8 @@ LightweightStandalone::Application.routes.draw do
 
       match "interactive_run_states/:key" => 'interactive_run_states#show', :as => 'show_interactive_run_state', :via => 'get'
       match "interactive_run_states/:key" => 'interactive_run_states#update', :as => 'update_interactive_run_state', :via => 'put'
+
+      match "user_check" => 'user_check#index', defaults: { format: 'json' }
     end
   end
 


### PR DESCRIPTION
This adds a new /api/v1/user_check endpoint that returns either null if the user is not logged in or the user object if they are logged in.  A modified third party library was used to perform the idle checks.  When the user comes back from being idle the user_check endpoint is called and if it fails then a blocking modal message is shown with a _blank targeted link to re-login.  Once the user logs back in and comes back to the edit page the user check is automatically called which should then dismiss the modal if they are logged in.