### PR TITLE
Add class hash and extend initInteractive [#138853633]

### DIFF
--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -24,6 +24,9 @@ class IFrameSaver
     @user_email = $data_div.data('user-email')
     @logged_in = $data_div.data('loggedin') # true/false - is the current session associated with a user
     @authoredState = getAuthoredState($data_div) # state / configuration provided during authoring
+    @class_info_url = $data_div.data('class-info-url')
+    @interactive_id = $data_div.data('interactive-id')
+    @interactive_name = $data_div.data('interactive-name')
 
     @$delete_button.click () =>
       @delete_data()
@@ -170,6 +173,7 @@ class IFrameSaver
   # this is the newer method of initializing an interactive
   # it returns the current state and linked state
   init_interactive: (err = null, response = null) ->
+
     @iframePhone.post 'initInteractive',
       version: 1
       error: err
@@ -182,6 +186,14 @@ class IFrameSaver
       linkedState: if response?.linked_state then JSON.parse(response.linked_state) else null
       interactiveStateUrl: @interactive_run_state_url
       collaboratorUrls: if @collaborator_urls? then @collaborator_urls.split(';') else null
+      classInfoUrl: @class_info_url
+      interactive:
+        id: @interactive_id
+        name: @interactive_name
+      authInfo:
+        provider: @auth_provider
+        loggedIn: @logged_in
+        email: @user_email
 
   set_autosave_enabled: (v) ->
     return unless @learner_state_saving_enabled()

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -22,6 +22,11 @@ class LightweightActivitiesController < ApplicationController
   # These are the runtime (student-facing) actions, show and summary
 
   def show # show index
+    if params[:class_info_url]
+      @run.class_info_url = params[:class_info_url]
+      @run.save!
+    end
+
     authorize! :read, @activity
     if params[:print]
       redirect_to activity_single_page_with_response_path(@activity, @run.key, request.query_parameters) and return

--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -38,9 +38,12 @@ module InteractiveRunHelper
       data['loggedin'] = (!!run.user).to_s
       data['authprovider'] = (Concord::AuthPortal.url_for_strategy_name(run.user.most_recent_authentication.provider) rescue nil) if data['loggedin'] == "true"
       data['user-email'] = run.user.email if data['loggedin'] == "true"
+      data['class-info-url'] = run.class_info_url
     end
     data['enable-learner-state'] = interactive.enable_learner_state.to_s
     data['authored-state'] = interactive.authored_state
+    data['interactive-id'] = interactive.id
+    data['interactive-name'] = interactive.name
 
     opts = {
       :src => interactive.url,

--- a/db/migrate/20170206145939_add_class_hash_to_run.rb
+++ b/db/migrate/20170206145939_add_class_hash_to_run.rb
@@ -1,0 +1,5 @@
+class AddClassHashToRun < ActiveRecord::Migration
+  def change
+    add_column :runs, :class_info_url, :text
+  end
+end

--- a/spec/javascripts/fixtures/iframe-saver.html
+++ b/spec/javascripts/fixtures/iframe-saver.html
@@ -6,6 +6,12 @@
        data-enable-learner-state="true"
        data-interactive-run-state-url="foo/42"
        data-authored-state='{"test": 123}'
+       data-class-info-url=null
+       data-interactive-id=1
+       data-interactive-name="test"
+       data-authprovider="fakeprovider"
+       data-user-email="user@example.com"
+       data-loggedin="true"
   >
   </div>
   <button class='delete_interactive_data'>Undo all my work</button>

--- a/spec/javascripts/iframe_saver_spec.coffee
+++ b/spec/javascripts/iframe_saver_spec.coffee
@@ -91,7 +91,10 @@ describe 'IFrameSaver', () ->
           hasLinkedInteractive: false,
           linkedState: null,
           interactiveStateUrl: 'foo/42',
-          collaboratorUrls: null
+          collaboratorUrls: null,
+          classInfoUrl: null,
+          interactive: {id: 1, name: "test"},
+          authInfo: {provider: "fakeprovider", loggedIn: true, email: "user@example.com"}
         })
 
     describe "when state saving is disabled", () ->
@@ -111,5 +114,8 @@ describe 'IFrameSaver', () ->
           hasLinkedInteractive: false,
           linkedState: null,
           interactiveStateUrl: 'foo/42',
-          collaboratorUrls: null
+          collaboratorUrls: null,
+          classInfoUrl: null,
+          interactive: {id: 1, name: "test"},
+          authInfo: {provider: "fakeprovider", loggedIn: true, email: "user@example.com"}
         })


### PR DESCRIPTION
Adds the public class hash and class info url to the run state, passed by the portal.

Also extends the InitInteractive call to pass
  * Class info url
  * Interactive Id
  * Interactive Name
  * Auth Info (same as returned in getAuthInfo)