### PR TITLE
Changes to support a portal connection

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,5 @@
+version: '2'
+services:
+  app:
+    ports:
+      - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,7 @@ services:
       DB_PASSWORD: master
       DB_NAME: lara
       SECRET_TOKEN: b30c94c7-81b7-4f20-8df9-686b079a616a
-    ports:
-      - "3000:3000"
+    # no ports are published, see below for details
     depends_on:
       - db
     volumes:
@@ -29,3 +28,11 @@ services:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
 volumes:
   bundle:
+
+# In this file the web app port is not published. However, if you run
+# `docker-compose up` (without customizing your environment) the port will be published
+# to 3000.  This is because the docker-compose.override.yml file will be loaded
+# automatically by docker-compose.
+# You will likely want to modify how the port is published, so it doesn't conflict.
+# Take a look at the this overlay for more information:
+#   docker/dev/docker-compose-random-port.yml

--- a/docker/dev/docker-compose-portal-net.yml
+++ b/docker/dev/docker-compose-portal-net.yml
@@ -1,0 +1,23 @@
+# This is an docker-compose overlay that connects the LARA service to a portal network
+# the Concord Portal docker-compose file sets up this network so LARA and other services
+# can access it
+
+# A convient way to overlay it is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-portal-net.yml
+# You can also do it manually when you run docker-compose each time with
+# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-portal-net.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+
+version: '2'
+services:
+  app:
+    networks:
+      rigse_portal:
+        aliases:
+          - lara
+      default:
+
+networks:
+  rigse_portal:
+    external: true

--- a/docker/dev/docker-compose-random-port.yml
+++ b/docker/dev/docker-compose-random-port.yml
@@ -1,0 +1,16 @@
+# This is an docker-compose overlay that publishes the app port to a random
+# host port. This is most useful when using a dynamic proxy and dns system like:
+# https://github.com/codekitchen/dinghy-http-proxy
+
+# A convient way to overlay this file is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-random-ports.yml
+# You can also do it manually when you run docker-compose each time with
+# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-random-ports.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+
+version: '2'
+services:
+  app:
+    ports:
+      - "3000"


### PR DESCRIPTION
These changes make it possible change which port LARA binds too.
Also there is a compose overlay for connecting with the portal network.

More detail can be seen in this PR:
https://github.com/concord-consortium/rigse/pull/290