### PR TITLE
Hide right logo in NGSS-Assessment theme

### DIFF
--- a/app/assets/stylesheets/theme-ngss-assessment.scss
+++ b/app/assets/stylesheets/theme-ngss-assessment.scss
@@ -43,3 +43,7 @@ td.nav-menu {
 .bottom-buttons .gen-report {
     display: none;
 }
+
+.site-logo.logo-r {
+  visibility: hidden;
+}


### PR DESCRIPTION
@ddamelin asked for this tiny change. It hides logo in the top-right corner.