### PR TITLE
Generic interactive state

### DIFF
--- a/app/assets/javascripts/components/authoring/mw_interactive.js.coffee
+++ b/app/assets/javascripts/components/authoring/mw_interactive.js.coffee
@@ -2,7 +2,7 @@
 
 modulejs.define 'components/authoring/mw_interactive',
 [
-  'components/authoring/interactive_iframe',
+  'components/common/interactive_iframe',
 ],
 (
   InteractiveIframeClass,
@@ -20,7 +20,6 @@ modulejs.define 'components/authoring/mw_interactive',
         saving: false
         message: ''
       }
-
 
     componentDidMount: ->
       window.addEventListener 'beforeunload', @onBeforeUnload
@@ -89,7 +88,12 @@ modulejs.define 'components/authoring/mw_interactive',
         (InteractiveIframe
           ref: 'interactive'
           src: interactive.url
-          initialAuthoredState: authoredState
+          initMsg: {
+            version: 1
+            error: null
+            mode: 'authoring'
+            authoredState: authoredState
+          }
           onAuthoredStateChange: @handleAuthoredStateChange
           onSupportedFeaturesUpdate: @handleSupportedFeatures
         )

--- a/app/assets/javascripts/components/common/interactive_iframe.js.coffee
+++ b/app/assets/javascripts/components/common/interactive_iframe.js.coffee
@@ -1,6 +1,6 @@
 {iframe} = React.DOM
 
-modulejs.define 'components/authoring/interactive_iframe', [], () ->
+modulejs.define 'components/common/interactive_iframe', [], () ->
 
   InteractiveIframe = React.createClass
     getInitialState: ->
@@ -8,6 +8,8 @@ modulejs.define 'components/authoring/interactive_iframe', [], () ->
 
     getDefaultProps: ->
       src: ''
+      width: '100%'
+      height: '100%'
       initialAuthoredState: null
       onAuthoredStateChange: (authoredState) ->
       onSupportedFeaturesUpdate: (info) ->
@@ -41,17 +43,9 @@ modulejs.define 'components/authoring/interactive_iframe', [], () ->
       @iframePhone.disconnect()
 
     phoneAnswered: ->
-      authoredState = if typeof @props.initialAuthoredState == 'string'
-                        JSON.parse(@props.initialAuthoredState)
-                      else
-                        @props.initialAuthoredState
-      @iframePhone.post 'initInteractive',
-        version: 1
-        error: null
-        mode: 'authoring'
-        authoredState: authoredState
+      @iframePhone.post 'initInteractive', @props.initMsg
 
     render: ->
       { iframeId } = @state
-      { src } = @props
-      (iframe {ref: 'iframe', key: iframeId, src: src, width: '100%', height: '100%', frameBorder: 'no', allowFullScreen: 'true'})
+      { src, width, height } = @props
+      (iframe {ref: 'iframe', src, width, height, key: iframeId, frameBorder: 'no', allowFullScreen: 'true'})

--- a/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
@@ -5,7 +5,7 @@ modulejs.define 'components/itsi_authoring/model_editor',
   'components/itsi_authoring/section_element_editor_mixin',
   'components/itsi_authoring/section_editor_form',
   'components/itsi_authoring/section_editor_element',
-  'components/authoring/interactive_iframe',
+  'components/common/interactive_iframe',
   'components/itsi_authoring/cached_ajax'
 ],
 (
@@ -131,7 +131,12 @@ modulejs.define 'components/itsi_authoring/model_editor',
                 (InteractiveIframe
                   ref: 'iframe'
                   src: @state.values['mw_interactive[url]'],
-                  initialAuthoredState: authoredState,
+                  initMsg: {
+                    version: 1
+                    error: null
+                    mode: 'authoring'
+                    authoredState: authoredState
+                  }
                   onAuthoredStateChange: @onAuthoredStateChange
                   onSupportedFeaturesUpdate: @handleSupportedFeaturesUpdate
                 )

--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -12,6 +12,8 @@
 //
 //= require bind-polyfill
 //= require modulejs
+//= require react
+//= require react_ujs
 //= require jquery-ajax-csrf
 //= require fabric
 //= require hammerjs
@@ -52,4 +54,5 @@
 //= require c_rater
 //= require global-iframe-saver
 //= require interactive-manager
+//= require components
 //= require runtime-init

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -69,7 +69,6 @@ class InteractiveRunState < ActiveRecord::Base
     else
       {
         "type" => "interactive",
-        "question_type" => interactive.class.portal_type,
         "question_id" => interactive.id.to_s,
         "answer" => report_state.to_json,
         "is_final" => false

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -35,8 +35,10 @@ class InteractiveRunState < ActiveRecord::Base
   # Make Embeddable::Answer assumptions work
   class QuestionStandin
     attr_accessor :interactive
-    def name; "Interactive"; end
-    def prompt; "Interactive"; end
+    def name
+      interactive.name.present? ? interactive.name : "Interactive"
+    end
+    def prompt; nil; end
     def is_prediction; false; end
     def give_prediction_feedback; false; end
     def prediction_feedback; nil; end
@@ -136,11 +138,9 @@ class InteractiveRunState < ActiveRecord::Base
   end
 
   class AnswerStandin
-    attr_accessor :run
     def initialize(opts={})
       q = question
       q.interactive = opts[:question] if opts[:question]
-      q.run = opts[:run] if opts[:run]
     end
     def question
       @question ||= QuestionStandin.new
@@ -148,10 +148,13 @@ class InteractiveRunState < ActiveRecord::Base
     def prompt
       question.prompt
     end
+    def name
+      question.name
+    end
   end
 
   def self.default_answer(conditions)
-    return AnswerStandin.new
+    return AnswerStandin.new(conditions)
   end
 
   def add_key_if_nil

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -64,8 +64,7 @@ class MwInteractive < ActiveRecord::Base
     iframe_data = to_hash
     iframe_data[:type] = 'iframe_interactive'
     iframe_data[:id] = id
-    # This info can be used by Portal to generate an iframe with album in teacher report.
-    iframe_data[:display_in_iframe] = true
+    iframe_data[:display_in_iframe] = reportable_in_iframe?
     iframe_data
   end
 
@@ -129,5 +128,10 @@ class MwInteractive < ActiveRecord::Base
 
   def reportable?
     enable_learner_state || has_report_url
+  end
+
+  def reportable_in_iframe?
+    # When iframe is reportable because of the learner state, it should be displayed in iframe.
+    enable_learner_state
   end
 end

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -64,6 +64,8 @@ class MwInteractive < ActiveRecord::Base
     iframe_data = to_hash
     iframe_data[:type] = 'iframe_interactive'
     iframe_data[:id] = id
+    # This info can be used by Portal to generate an iframe with album in teacher report.
+    iframe_data[:display_in_iframe] = true
     iframe_data
   end
 

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -126,6 +126,6 @@ class MwInteractive < ActiveRecord::Base
   end
 
   def reportable?
-    return enable_learner_state && has_report_url
+    enable_learner_state || has_report_url
   end
 end

--- a/app/views/interactive_run_states/_summary.html.haml
+++ b/app/views/interactive_run_states/_summary.html.haml
@@ -1,5 +1,21 @@
 .answer
   - if answer.reporting_url.present?
     = link_to 'View work', answer.reporting_url, :target => '_blank'
+  - elsif answer.report_state.present?
+    - interactive_id = "interactive-state-#{answer.id}"
+    .interactive-summary{id: interactive_id}
+
+    - content_for :extra_javascript do
+      :javascript
+        (function() {
+          var props = {
+            src: '#{answer.interactive.url}',
+            width: '#{answer.interactive.native_width}',
+            height: '#{answer.interactive.native_height}',
+            initMsg: #{answer.report_state.to_json}
+          };
+          InteractiveIframe = React.createElement(modulejs.require('components/common/interactive_iframe'), props);
+          React.render(InteractiveIframe, $('##{interactive_id}')[0]);
+        }());
   - else
     %p! &nbsp;

--- a/app/views/lightweight_activities/summary.html.haml
+++ b/app/views/lightweight_activities/summary.html.haml
@@ -11,7 +11,7 @@
     .prompt
       %span.number= "#{index +1}: "
       %span.text
-        = Nokogiri::HTML(answer.prompt).text
+        = Nokogiri::HTML(answer.prompt.present? ? answer.prompt : answer.name).text
     = render :partial => "#{answer.class.name.underscore.pluralize}/summary",
       :locals => {:answer => answer, :index => index}
 

--- a/spec/javascripts/authoring_spec.coffee
+++ b/spec/javascripts/authoring_spec.coffee
@@ -9,14 +9,19 @@ describe "Authoring components", () ->
   describe "interactive_iframe", ->
     it "loads iframe", ->
       props = {}
-      interactive = jasmine.react.renderComponent "authoring/interactive_iframe", props
+      interactive = jasmine.react.renderComponent "common/interactive_iframe", props
       iframe = jasmine.react.findTag interactive, "iframe"
       expect(iframe).not.toBe(null)
 
     it "sends 'initInteractive' message to iframe", () ->
       props =
-        initialAuthoredState: {test: 123}
-      jasmine.react.renderComponent "authoring/interactive_iframe", props
+        initMsg: {
+          version: 1,
+          error: null,
+          mode: 'authoring',
+          authoredState: {test: 123}
+        }
+      jasmine.react.renderComponent "common/interactive_iframe", props
       iframePhone.connect()
       # initInteractive should be called right after connection.
       expect(iframePhone.messages.findType('initInteractive').message.content).toEqual({
@@ -33,7 +38,7 @@ describe "Authoring components", () ->
       spyOn(props, 'onAuthoredStateChange')
       spyOn(props, 'onSupportedFeaturesUpdate')
 
-      interactive = jasmine.react.renderComponent "authoring/interactive_iframe", props
+      interactive = jasmine.react.renderComponent "common/interactive_iframe", props
       iframePhone.connect()
       iframe = jasmine.react.findTag(interactive, "iframe").getDOMNode()
 
@@ -51,7 +56,7 @@ describe "Authoring components", () ->
           url: 'test-model.txt'
           authored_state: null
       mwInteractive = jasmine.react.renderComponent "authoring/mw_interactive", props
-      iframe = jasmine.react.findComponent mwInteractive, "authoring/interactive_iframe"
+      iframe = jasmine.react.findComponent mwInteractive, "common/interactive_iframe"
       expect(iframe).not.toBe(null)
 
     it "saves updated authored state", ->
@@ -61,7 +66,7 @@ describe "Authoring components", () ->
           url: 'test-model.txt'
           authored_state: null
       mwInteractive = jasmine.react.renderComponent "authoring/mw_interactive", props
-      interactive = jasmine.react.findComponent mwInteractive, "authoring/interactive_iframe"
+      interactive = jasmine.react.findComponent mwInteractive, "common/interactive_iframe"
       interactive.props.onAuthoredStateChange({test: 123})
 
       request = jasmine.react.captureRequest ->

--- a/spec/javascripts/itsi_editor_spec.coffee
+++ b/spec/javascripts/itsi_editor_spec.coffee
@@ -291,7 +291,7 @@ describe "ITSI Editor", () ->
       modelEditor = jasmine.react.renderComponent "itsi_authoring/model_editor", props
       jasmine.react.click (jasmine.react.findClass modelEditor, "ia-section-editor-edit")
 
-      iframe = jasmine.react.findComponent modelEditor, "authoring/interactive_iframe"
+      iframe = jasmine.react.findComponent modelEditor, "common/interactive_iframe"
       expect(iframe).not.toBe(null)
 
     it "provides authored state to InteractiveIframe component", ->
@@ -306,8 +306,13 @@ describe "ITSI Editor", () ->
       modelEditor = jasmine.react.renderComponent "itsi_authoring/model_editor", props
       jasmine.react.click (jasmine.react.findClass modelEditor, "ia-section-editor-edit")
 
-      interactive = jasmine.react.findComponent modelEditor, "authoring/interactive_iframe"
-      expect(interactive.props.initialAuthoredState).toEqual(props.data.authored_state)
+      interactive = jasmine.react.findComponent modelEditor, "common/interactive_iframe"
+      expect(interactive.props.initMsg).toEqual({
+        version: 1
+        error: null
+        mode: 'authoring'
+        authoredState: props.data.authored_state
+      })
 
     it "saves new authored state if it has been updated", ->
       props =
@@ -321,7 +326,7 @@ describe "ITSI Editor", () ->
       modelEditor = jasmine.react.renderComponent "itsi_authoring/model_editor", props
       jasmine.react.click (jasmine.react.findClass modelEditor, "ia-section-editor-edit")
 
-      interactive = jasmine.react.findComponent modelEditor, "authoring/interactive_iframe"
+      interactive = jasmine.react.findComponent modelEditor, "common/interactive_iframe"
       interactive.props.onAuthoredStateChange({test: 123})
 
       request = jasmine.react.itsi.captureSave modelEditor
@@ -343,7 +348,7 @@ describe "ITSI Editor", () ->
       jasmine.react.click (jasmine.react.findClass modelEditor, "ia-section-editor-edit")
 
       # Make sure that status bar and reset button are visible.
-      interactive = jasmine.react.findComponent modelEditor, "authoring/interactive_iframe"
+      interactive = jasmine.react.findComponent modelEditor, "common/interactive_iframe"
       interactive.props.onSupportedFeaturesUpdate({features: {authoredState: true}})
 
       jasmine.react.click (jasmine.react.findClass modelEditor, "ia-reset-authored-state")

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -453,10 +453,13 @@ describe InteractivePage do
 
   describe '#reportable_items' do
     let(:non_reportable_interactive) {
-      FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: false)
+      FactoryGirl.create(:mw_interactive, enable_learner_state: false, has_report_url: false)
     }
     let(:reportable_interactive) {
-      FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: true)
+      FactoryGirl.create(:mw_interactive, enable_learner_state: false, has_report_url: true)
+    }
+    let(:reportable_interactive2) {
+      FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: false)
     }
     let(:video_interactive) { FactoryGirl.create(:video_interactive) }
     let(:image_interactive) { FactoryGirl.create(:image_interactive) }
@@ -480,16 +483,16 @@ describe InteractivePage do
     subject { page.reportable_items }
 
     context 'with a basic set of items' do
-      let(:interactives) { [reportable_interactive] }
+      let(:interactives) { [reportable_interactive, reportable_interactive2] }
       let(:embeddables) { [or_question, im_question, mc_question]}
       it { is_expected.to eql(embeddables + interactives) }
     end
 
     context 'with every possible interactive and embeddable type' do
-      let(:interactives) { [reportable_interactive, video_interactive, image_interactive]}
+      let(:interactives) { [reportable_interactive, reportable_interactive2, video_interactive, image_interactive]}
       let(:embeddables) { [or_question, im_question, mc_question, labbook_question, xhtml]}
       it 'returns just those that are reportable' do
-        expect(subject.length).to eql(5)
+        expect(subject.length).to eql(6)
       end
     end
 
@@ -508,7 +511,7 @@ describe InteractivePage do
           has_report_url: true,
           is_hidden: true)
       }
-      let(:interactives) { [non_reportable_interactive] }
+      let(:interactives) { [reportable_interactive] }
       let(:embeddables) { [] }
       it 'does not return it' do
         expect(subject.length).to eql(0)

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -106,14 +106,14 @@ describe InteractiveRunState do
 
     # this hash is depended on by the Portal
     describe "portal_hash" do
-      let(:run_data) {'{"second": 2}"'}
+      # Only when reporting_url is available.
+      let(:run_data) {'{"second": 2, "lara_options": {"reporting_url": "test.com"}}'}
       let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
 
       subject { interactive_run_state.portal_hash }
 
       # the portal uses this type to match the interactive so it can't change without changing the portal
       it { should include("question_type" => "iframe interactive") }
-
     end
 
     # this key is generated automatically when created

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -374,7 +374,7 @@ describe LightweightActivity do
       let(:page4) { FactoryGirl.create(:interactive_page_with_or, name: 'page 4', position: 3) }
 
       let(:non_reportable_interactive) {
-        FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: false)
+        FactoryGirl.create(:mw_interactive, enable_learner_state: false, has_report_url: false)
       }
 
       let(:reportable_interactive) {


### PR DESCRIPTION
This PR adds support of a new answer type - "interactive". Now, every interactive that has learner state enabled will send this state to the Portal. Previously we were sending only reporting URL when it was available. Reporting URL is still supported and when it's available, it'll be send to the Portal instead of the interactive state JSON.

Note that the interactive state JSON that we send to the portal is actually an argument to the `initInteractive` call that will be made later by consumers of this state (e.g. report app). So, it follows LARA Interactive API format. It ensures that Portal and external apps don't need to know anything about this API and format. They'll just pass this state to the interactive later. Only LARA and Interactives care about it.

Also, there's one small, extension to the LARA Interactive API - "report" mode has been added (other modes are "runtime" and "authoring").

This PR is related to https://github.com/concord-consortium/rigse/pull/303.