### PR TITLE
Fix interactive printing

### DIFF
--- a/app/assets/stylesheets/mw-runtime-base.scss
+++ b/app/assets/stylesheets/mw-runtime-base.scss
@@ -425,7 +425,10 @@ div.intra-page-nav {
   .question {
     margin: 20px;
     display: inline-block;
-    width: 45%;
+    // the questions sit in two columns in the full width layout.
+    // The 438px width is computed to maximize their size:
+    // 960/2 = 480, 480 - margins = 440, then there is 2 px of padding somewhere
+    width: 438px;
     vertical-align: top;
  }
 

--- a/app/assets/stylesheets/print-styles.scss
+++ b/app/assets/stylesheets/print-styles.scss
@@ -18,8 +18,8 @@
     page-break-inside: avoid;
   }
 
-  .question,.interactive-mod {
-    img, video, .img-container {
+  .question {
+    img, video {
       page-break-inside: avoid;
     }
   }
@@ -51,7 +51,16 @@
 
   .interactive-mod {
     float: right;
-    width: 40% !important;
+    // same width and margin as the full width questions
+    width: 438px !important;
+    margin: 20px;
+    page-break-inside: avoid;
+    .img-container {
+      // switch to static position so the img container takes up space inside its parent
+      // div. In screen-only the interactive iframe is visible and it determines the size
+      // of the parent div. Without that iframe the img-container needs to do this.
+      position: static !important;
+    }
   }
 
   .activity-nav-title {
@@ -70,14 +79,6 @@
     text-align: center;
     padding-top: 25%;
     page-break-inside: avoid;
-  }
-
-  .interactive-image-placeholder {
-    width: 100%;
-    height: 250px;
-    page-break-inside: avoid;
-    background-size: contain;
-    background-repeat: no-repeat;
   }
 
   .iframe-url {

--- a/app/assets/stylesheets/theme-itsi.scss
+++ b/app/assets/stylesheets/theme-itsi.scss
@@ -66,6 +66,15 @@ div.activity-mod > div.site-width {
   margin-bottom: 15px;
 }
 
+// override the default print floating style because we want the interactives to always be
+// after the intro and before the embeddables
+@media print {
+  .interactive-mod {
+    float: none;
+    margin: 0 auto;
+  }
+}
+
 // Full-width question.
 .question {
   margin: 10px 0 !important;
@@ -210,7 +219,7 @@ header {
 .help-popup {
   .close {
     color: #416942;
-  }  
+  }
   h3.title {
     color: #416942;
     background: #f8ac1a;

--- a/app/views/interactive_pages/_show.html.haml
+++ b/app/views/interactive_pages/_show.html.haml
@@ -5,7 +5,7 @@
   - if page.show_introduction && !page.text.blank?
     .intro-txt!= page.text
 
--# Control layout here. Add one of the following classes: l-full-width, l-6040, l-7030, r-6040, r-7030
+-# Control layout here. Add one of the following classes: l-full-width, l-6040, l-7030, r-4060, r-3070
 .content-mod{ :class => layout }
   .ui-block-1
     - if page.visible_interactives.length > 0 && page.show_interactive

--- a/app/views/interactive_pages/_show_completion.html.haml
+++ b/app/views/interactive_pages/_show_completion.html.haml
@@ -91,7 +91,7 @@
   - if completed_activity
     %h4.h4= t("COMPLETION_PAGE.HEADER", {activity: @activity.name})
 
--# Control layout here. Add one of the following classes: l-full-width, l-6040, l-7030, r-6040, r-7030
+-# Control layout here. Add one of the following classes: l-full-width, l-6040, l-7030, r-4060, r-3070
 .content-mod{ :class => 'l-full-width' }
   .ui-block-1
     .congratulations-block

--- a/app/views/lightweight_activities/print_blank.html.haml
+++ b/app/views/lightweight_activities/print_blank.html.haml
@@ -18,6 +18,9 @@
     = render partial: "interactive_pages/show", locals: {page: p, layout: 'l-full-width'}
 
 :javascript
+  // FIXME: bold text doesn't show up the first time the document is printed
+  // it doesn't mater if a long timeout is added before calling window.print()
+  // My guess is that the content has to be rendered once before it works
   $(function(){ window.print(); });
 
 :sass

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -3,14 +3,14 @@
 .interactive-container
   - if interactive.native_height > 1
     - if interactive.image_url.present?
-      .interactive-image-placeholder.print-only{:style => "background-image: url(#{interactive.image_url});"}
+      -# if interactive has click to play, always show the img
+      -# otherwise only show the image in the printout
+      .img-container{:id => dom_id_for(interactive, :interactive_image),
+                     :class => interactive.click_to_play ? "" : "print-only"}
+        =image_tag(interactive.image_url)
     - else
       .interactive-placeholder.print-only
         Interactive Model
-
-    - if interactive.image_url.present?
-      .img-container{:id => dom_id_for(interactive, :interactive_image),:style => interactive.click_to_play ? "display:block" : "display:none"}
-        =image_tag(interactive.image_url)
 
     - if interactive.click_to_play
       - if interactive.full_window

--- a/script/generate-print-test-activty.js
+++ b/script/generate-print-test-activty.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var activity = {
+  "description": "An activity to test printing interactives in various ways.",
+  "editor_mode": 0,
+  "external_report_url": null,
+  "layout": 0,
+  "name": "Interactive Print Test",
+  "notes": "",
+  "project_id": 4,
+  "related": "",
+  "thumbnail_url": "",
+  "time_to_complete": null,
+  "theme_name": "Interactions",
+  "type": "LightweightActivity",
+  "export_site": "Lightweight Activities Runtime and Authoring",
+  "pages": []
+};
+
+var pageTemplate = {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "is_completion": false,
+      "is_hidden": false,
+      "layout": "l-6040",
+      "name": null,
+      "position": 1,
+      "show_info_assessment": true,
+      "show_interactive": true,
+      "show_introduction": true,
+      "show_sidebar": false,
+      "sidebar": null,
+      "sidebar_title": "Did you know?",
+      "text": "Introduction: Interactive with no image defined.",
+      "interactives": [
+        {
+          "authored_state": null,
+          "click_to_play": false,
+          "enable_learner_state": false,
+          "full_window": false,
+          "has_report_url": false,
+          "image_url": "",
+          "is_hidden": false,
+          "model_library_url": null,
+          "name": "No Image Interactive",
+          "native_height": 435,
+          "native_width": 576,
+          "url": "https://concord.org/ngss/",
+          "type": "MwInteractive",
+          "ref_id": "207301-MwInteractive",
+          "linked_interactive": null
+        }
+      ],
+      "embeddables": [
+        {
+          "content": "<b>Text box 1</b>. Some text in a box. On non full width layouts " +
+            "this should be beside the interactive.",
+          "is_hidden": false,
+          "name": "",
+          "type": "Embeddable::Xhtml"
+        },
+        {
+          "content": "<b>Text box 2</b>. More text, in a full width layout this should be " +
+            "in the second column below the interative. In print view the layout is not " +
+            "respected. So in print view this should be to the left of the interactive." +
+            "Later boxes will start wrapping around the interactive in print view.",
+          "is_hidden": false,
+          "name": "",
+          "type": "Embeddable::Xhtml"
+        },
+        {
+          "default_text": "",
+          "give_prediction_feedback": false,
+          "hint": "",
+          "is_hidden": false,
+          "is_prediction": false,
+          "name": "",
+          "prediction_feedback": "",
+          "prompt": "Open response question. How well does this print out?",
+          "type": "Embeddable::OpenResponse"
+        },
+        {
+          "content": "<b>Text box 3</b>. More Text that is below the open response. " +
+            "In print view this should wrap below the interactive.",
+          "is_hidden": false,
+          "name": "",
+          "type": "Embeddable::Xhtml"
+        },
+        {
+          "content": "<b>Text box 4</b>. Another text box. surely this one will wrap.",
+          "is_hidden": false,
+          "name": "",
+          "type": "Embeddable::Xhtml"
+        }
+      ],
+      "sections": [
+        {
+          "name": "arg_block",
+          "section_embeddables": []
+        }
+      ]
+    };
+
+
+
+var interactiveConfigs = [
+  {description: "no image",
+   click_to_play: false,
+   image_size: null,
+  },
+  {description: "image",
+   click_to_play: false,
+   // this is the default size of interactives in LARA
+   image_size: [576, 435],
+  },
+  {description: "image and click to play",
+   click_to_play: true,
+   image_size: [576, 435],
+  },
+  {description: "taller image than interactive",
+   click_to_play: true,
+   image_size: [576, 600],
+  },
+  {description: "shorter image than interactive",
+   click_to_play: true,
+   image_size: [576, 300],
+  },
+];
+
+var layouts = [ "l-6040", "l-7030", "r-4060", "r-3070", "l-full-width"];
+
+// size is a array of [width, height]
+function generateImage(size) {
+  if(size === null || size === ""){
+    return "";
+  }
+  return "http://www.generateit.net/rounded-corner/rounded.php?" +
+         "sh=r&r=0&bw=20&bc=7A70FF&bg=FF0000&fg=999999&" +
+         "w=" + size[0] + "&h=" + size[1] + "&f=png&aa=1&bgt=0&bt=0&fgt=0&tc=FFFFFF";
+}
+
+layouts.forEach(function(layout) {
+  interactiveConfigs.forEach(function (config){
+    var page = JSON.parse(JSON.stringify(pageTemplate));
+    page.name = layout + " " + config.description;
+    page.text = "Intro: Layout: " + layout + ". Interactive with " + config.description;
+    page.layout = layout;
+    page.position = activity.pages.length + 1;
+    var interactive = page.interactives[0];
+    interactive.click_to_play = config.click_to_play;
+    interactive.image_url = generateImage(config.image_size);
+    interactive.ref_id = "Interactive-" + activity.pages.length;
+    activity.pages.push(page);
+  });
+});
+
+console.log(JSON.stringify(activity, null, 2));


### PR DESCRIPTION
Remove the extra div with a image in the background, this doesn’t work when printing.
Fix the img-container layout so it is visible when the iframe is not.
Add margins so the printed interactives line up better with the questions.
Fix ITSI printing so the interactives don’t shift around in relation to questions, and they are centered.
Fix some typos in comments about page layout labels.
Make note of issue with bold text when using the print_blank path.
Add a Node script to generate 24 page activity to check various layouts and interactive settings
Slightly widening the questions in full width mode.
[#142314353]