### PR TITLE
Docker connect to portal

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,3 +1,5 @@
+# This file will NOT be automatically included if you define COMPOSE_FILE in .env
+# You need to explicity include it in the list COMPOSE_FILE files.
 version: '2'
 services:
   app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,12 @@ services:
       MYSQL_USER: master
       MYSQL_ROOT_PASSWORD: xyzzy
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
+    volumes:
+      # use a named volume here so the database is preserved after a down and up
+      - mysql:/var/lib/mysql
 volumes:
   bundle:
+  mysql:
 
 # In this file the web app port is not published. However, if you run
 # `docker-compose up` (without customizing your environment) the port will be published

--- a/docker/dev/docker-compose-portal-net.yml
+++ b/docker/dev/docker-compose-portal-net.yml
@@ -1,23 +1,39 @@
-# This is an docker-compose overlay that connects the LARA service to a portal network
-# the Concord Portal docker-compose file sets up this network so LARA and other services
-# can access it
+# If you are running with a proxy and dns setup like dinghy proxy you should use
+# docker-compose-portal-proxy.yml instead of this override
 
-# A convient way to overlay it is to add a `.env` file with the contents:
-#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-portal-net.yml
-# You can also do it manually when you run docker-compose each time with
-# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-portal-net.yml
-# if you are making changes to docker-compose.yml or this file it is useful to
-# run `docker-compose config` which shows how the two files get merged together
+# This override can be used to connect the portal with LARA.
+# The key issue is that both your browser and LARA need to be able to connect to lara
+# using the same URL.
 
+# To use this override you need to define a entry in your host machines /etc/hosts
+# So your browser can access the portal at some URL other than localhost.
+# for example lets say you add the the entry:
+#  127.0.0.1 portal.concord
+# You also need to know what the exposed port of the portal is. By default it will be
+# 3000 but that conflicts with the default port of LARA so you might have changed it.
+# For this example lets assume it is 9000
+# So now you need modify your .env file with:
+# COMPOSE_FILE=... # add this file to the list of files
+# PORTAL_HOST=portal.concord
+# GATEWAY_IP= # you need to set the IP of docker gateway for the lara container
+# one way to figure this out is to run this command:
+# docker-compose run --rm app ip route | awk '/^default via /{print $3}'
+
+# To setup the client id and client secret you should run this command in the portal project:
+#   docker-compose run --rm app rake sso:add_client
 version: '2'
 services:
   app:
-    networks:
-      rigse_portal:
-        aliases:
-          - lara
-      default:
-
-networks:
-  rigse_portal:
-    external: true
+    environment:
+      CONCORD_CONFIGURED_PORTALS: LOCALHOST HAS_STAGING
+      CONCORD_LOCALHOST_URL: http://${PORTAL_HOST}:${PORTAL_PORT}/
+      CONCORD_LOCALHOST_CLIENT_ID: localhost
+      CONCORD_LOCALHOST_CLIENT_SECRET: 'unsecure local secret'
+      # the code requires at least 2 portals configured this second one to has Staging
+      # will not actually work
+      CONCORD_HAS_STAGING_URL: http://has.staging.concord.org/
+      CONCORD_HAS_STAGING_CLIENT_ID: localhost
+      CONCORD_HAS_STAGING_CLIENT_SECRET: XXXXXX
+      CONCORD_HAS_STAGING_DISPLAY_NAME: Do not use
+    extra_hosts:
+      - '${PORTAL_HOST}:${GATEWAY_IP}'

--- a/docker/dev/docker-compose-portal-proxy.yml
+++ b/docker/dev/docker-compose-portal-proxy.yml
@@ -1,0 +1,28 @@
+# This is an docker-compose overlay that connects LARA to the portal via a proxy
+# container. It assumes the proxy container name is http-proxy.  This is the name
+# the dinghy proxy will have if you followed its documentation:
+#   https://github.com/codekitchen/dinghy-http-proxy#os-x
+# You will also need to set the PORTAL_HOST environment variable to match the name of
+# the portal host. If you are using the dinghy proxy this will be:
+#   app.[project name of portal].docker
+#   examples: app.portal.docker, app.rigse.docker
+#
+# To setup the client id and client secret you should run this command in the portal project:
+#   docker-compose run --rm app rake sso:add_client
+# and then use the client secret below
+version: '2'
+services:
+  app:
+    environment:
+      CONCORD_CONFIGURED_PORTALS: LOCALHOST HAS_STAGING
+      CONCORD_LOCALHOST_URL: http://${PORTAL_HOST}/
+      CONCORD_LOCALHOST_CLIENT_ID: localhost
+      CONCORD_LOCALHOST_CLIENT_SECRET: 'unsecure local secret'
+      # the code requires at least 2 portals configured this second one to has Staging
+      # will not actually work
+      CONCORD_HAS_STAGING_URL: http://has.staging.concord.org/
+      CONCORD_HAS_STAGING_CLIENT_ID: localhost
+      CONCORD_HAS_STAGING_CLIENT_SECRET: XXXXXX
+      CONCORD_HAS_STAGING_DISPLAY_NAME: Do not use
+    external_links:
+      - http-proxy:${PORTAL_HOST}


### PR DESCRIPTION
These changes should make it possible to connect lara to the portal locally.

There are two options: one when you are using a proxy/dns setup like dinghy and one when you are not. Hopefully the comments in the two overlay files provide enough info to set it up.

This PR also includes a change to help preserve the lara database better.  However to switch to this better approach you will have to lose your current database. This is done by running the command `docker-compose rm db`. A normal `docker-compose up db` does not cause docker to remove the old database volume so it can use the new one. Docker compose does print a warning about this but it is easy to miss.