### PR TITLE
Fixes bug: Activities with image interactives don't export.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you haven't run tests on this project before, you first need to initialize th
 
 Then, from the application root, run
 
-      RAILS_ENV=test rspec spec
+      RAILS_ENV=test bundle exec rspec spec
 
 To re-initialize the test database, should that be necessary:
 
@@ -79,6 +79,11 @@ To run the jasmine tests in a browser, run the command below and open your brows
 To run the jasmine tests with PhantomJS, run
 
     rake jasmine:ci
+
+## Running tests in docker containers for developers:
+
+To run all the (non phantom) spec tests:
+`docker-compose run --rm app docker/dev/run-spec.sh`
 
 ## Adding Embeddable support
 _This may be obsolete as of April 2013_

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -275,7 +275,9 @@ class InteractivePage < ActiveRecord::Base
 
     self.interactives.each do |inter|
       interactive_hash = helper.wrap_export(inter)
-      interactive_hash[:linked_interactive] = inter.linked_interactive.present? ? helper.wrap_export(inter.linked_interactive) : nil
+      if inter.respond_to? :linked_interactive
+        interactive_hash[:linked_interactive] = inter.linked_interactive.present? ? helper.wrap_export(inter.linked_interactive) : nil
+      end
       page_json[:interactives] << interactive_hash
     end
     self.main_embeddables.each do |embed|

--- a/docker/dev/run-ci.sh
+++ b/docker/dev/run-ci.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# use:  docker-compose run --rm app docker/dev/run-spec.sh
+# Run rspec tests in docker environment.
+#
+
+#
+# Prepare spec tests
+#
+RAILS_ENV=test bundle exec rake db:test:prepare
+
+#
+# Run non-phantom tests:
+#
+RAILS_ENV=test bundle exec guard

--- a/docker/dev/run-spec.sh
+++ b/docker/dev/run-spec.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# use:  docker-compose run --rm app docker/dev/run-spec.sh
+# Run rspec tests in docker environment.
+#
+
+#
+# Prepare spec tests
+#
+RAILS_ENV=test bundle exec rake db:test:prepare
+
+#
+# Run non-phantom tests:
+#
+RAILS_ENV=test bundle exec rspec spec --tag ~slow --tag ~js

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -242,6 +242,23 @@ describe LightweightActivity do
       end
     end
 
+   describe "an activity with an image interactive" do
+      let(:prompt)        { "xyzzy" }
+      let(:page)          { FactoryGirl.create(:interactive_page, name: "page 1", position: 0) }
+      let(:url)           { "http://foo.bar/kitten.jpg" }
+      let(:interactive)   { FactoryGirl.create(:image_interactive, url:url) }
+      before(:each) do
+        page.add_interactive(interactive)
+        page.reload
+        activity.pages << page
+      end
+      it "the duplicate should have a copy of the interactive" do
+        dup = activity.duplicate(owner)
+        dup_int = dup.pages.first.interactives.first
+        expect(dup_int.url).to eq url
+      end
+    end
+
     describe "for itsi activities" do
       let(:edit_mode) { LightweightActivity::ITSI_EDITOR_MODE   }
       let(:layout)    { LightweightActivity::LAYOUT_SINGLE_PAGE }


### PR DESCRIPTION
…or video interactives.

These types of interactives don't have linked-interactives.  The quick fix was to just check for this.  

[#145795559]

https://www.pivotaltracker.com/story/show/145795559

@scytacki  quick PR review?
