### PR TITLE
Save the portal publication data.

### DIFF
--- a/app/models/portal_publication.rb
+++ b/app/models/portal_publication.rb
@@ -1,6 +1,7 @@
 class PortalPublication < ActiveRecord::Base
 
-  attr_accessible :portal_url, :response, :success, :publishable, :publication_hash, :publication_time
+  attr_accessible :portal_url, :response, :success, :publishable, :publication_hash,
+    :publication_time, :sent_data
   # Assuming portals aren't a first-class model - representing them by their URLs
 
   # What got published - usually one of these, not both

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -79,6 +79,7 @@ module Publishable
     Rails.logger.info "Response: #{response.inspect}"
     self.portal_publications.create({
       portal_url: auth_portal.publishing_url,
+      sent_data: json,
       response: response.inspect,
       success: ( response.code == 201 ) ? true : false,
       publishable: self,

--- a/db/migrate/20170524180857_add_sent_data_to_portal_publications.rb
+++ b/db/migrate/20170524180857_add_sent_data_to_portal_publications.rb
@@ -1,0 +1,5 @@
+class AddSentDataToPortalPublications < ActiveRecord::Migration
+  def change
+    add_column :portal_publications, :sent_data, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170206145939) do
+ActiveRecord::Schema.define(:version => 20170524180857) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -442,6 +442,7 @@ ActiveRecord::Schema.define(:version => 20170206145939) do
     t.datetime "updated_at",                     :null => false
     t.string   "publication_hash", :limit => 40
     t.integer  "publication_time"
+    t.text     "sent_data"
   end
 
   add_index "portal_publications", ["publishable_id", "publishable_type"], :name => "index_portal_publications_on_publishable_id_and_publishable_type"


### PR DESCRIPTION
I'm running into a problem on authoring.staging with publishing an activity.  I didn't find a good way to track this down.  So I'm adding this recording of the publication data. 

In the future it could be useful to provide an admin with a way to view this publication data as well as the response from the portal after the publication.

Additionally in the future it could be useful for authors to compare the publication data to see what has changed from one publication to another. 

[#146040445]