### PR TITLE
Spec tests wont clobber dev DB.  Unison prefers local changes.

### DIFF
--- a/docker/dev/run-ci.sh
+++ b/docker/dev/run-ci.sh
@@ -6,10 +6,17 @@
 #        then type `dci` to start Continuous Integration Testing.
 #   – Or run from shell in docker (`docker-compose run --rm bash` … ./docker/dev/run-ci.sh`)
 
+# We have to explicitly set these, because the docker compose files
+# Assume master/master and mysql image wont let us create more than
+# one DB at startup.  master/master doesn't have create DB permissions.
+export RAILS_ENV=test
+export DB_NAME=lara_test
+export DB_USER=root
+export DB_PASSWORD=xyzzy
+
 #
 # Prepare spec tests
 #
-export RAILS_ENV=test
 bundle exec rake db:create
 bundle exec rake db:schema:load
 bundle exec rake db:test:prepare

--- a/docker/dev/run-spec.sh
+++ b/docker/dev/run-spec.sh
@@ -6,10 +6,17 @@
 #        then type `dspec` to start Continuous Integration Testing.
 #   – Or run from shell in docker (`docker-compose run --rm bash` … ./docker/dev/run-rpsec.sh`)
 
+# We have to explicitly set these, because the docker compose files
+# Assume master/master and mysql image wont let us create more than
+# one DB at startup.  master/master doesn't have create DB permissions.
+export RAILS_ENV=test
+export DB_NAME=lara_test
+export DB_USER=root
+export DB_PASSWORD=xyzzy
+
 #
 # Prepare spec tests
 #
-export RAILS_ENV=test
 bundle exec rake db:create
 bundle exec rake db:schema:load
 bundle exec rake db:test:prepare

--- a/docker/dev/start-unison.sh
+++ b/docker/dev/start-unison.sh
@@ -9,4 +9,4 @@
 
 port=$(docker-compose port unison 5000 | awk -F: '{print $NF}')
 echo Connecting to unison on port: $port
-unison . socket://localhost:$port/ -repeat watch -auto -batch
+unison . socket://localhost:$port/ -repeat watch -auto -batch -prefer .


### PR DESCRIPTION
@jsimpson-cc -- I was still deleting my development environment when running tests.  

I reviewed the docker compose files and finally worked out what was happening.  

I can verify that running tests this way doesn't clobber the dev environment.

I also committed a change to make unison prefer the workstation (dev) copy of a file by default, to avoid synchronization failures.