### PR TITLE
ESAAF dashboard: Include MC choices in TOC

### DIFF
--- a/app/services/dashboard_toc.rb
+++ b/app/services/dashboard_toc.rb
@@ -48,10 +48,15 @@ class DashboardToc
   end
   def questions(page)
     questions = page.section_embeddables(CRater::ARG_SECTION_NAME).map do |q|
+      choices = []
+      if q.respond_to? :choices
+        choices = q.choices.map { |c| c.choice }
+      end
       {
           index: q.index_in_activity(page.lightweight_activity),
           name: q.name,
-          prompt: q.prompt
+          prompt: q.prompt,
+          choices: choices
       }
     end
     questions.sort! { |a,b| a[:index] <=> b[:index] }


### PR DESCRIPTION
We need to know the Question choices for all answers now in the HAS Dashboard report.

This change sends the choices down as part of the activity structure for the dashboard report.

(Also included here are changes from `np-dev-docker-fixes` branch -- pending review in a separate PR. -- you can ignore those)