### PR TITLE
Fix reporting too few submissions in sequence runlists.

### DIFF
--- a/app/services/dashboard_sequence_runlist.rb
+++ b/app/services/dashboard_sequence_runlist.rb
@@ -80,14 +80,18 @@ class DashboardSequenceRunlist
     if num_tries < 1
       return []
     end
-    submission = submissions.last
-    return {
-      page: submission.interactive_page_id,
-      pageIndex: submission.interactive_page.position,
-      tryCount: num_tries,
-      numQuestions: 4,
-      answers: submission_answers(submission)
-    }
+    submissions = submissions.group_by(&:interactive_page_id)
+    submissions.map do |page_id, sumbissions|
+      num_tries = sumbissions.length
+      submission = sumbissions.last
+      {
+        page: page_id,
+        pageIndex: submission.interactive_page.position,
+        tryCount: num_tries,
+        numQuestions: 4,
+        answers: submission_answers(submission)
+      }
+    end
   end
 
   def submission_answers(submission)

--- a/app/services/dashboard_sequence_runlist.rb
+++ b/app/services/dashboard_sequence_runlist.rb
@@ -81,15 +81,15 @@ class DashboardSequenceRunlist
       return []
     end
     submissions = submissions.group_by(&:interactive_page_id)
-    submissions.map do |page_id, sumbissions|
-      num_tries = sumbissions.length
-      submission = sumbissions.last
+    submissions.map do |page_id, page_sumbissions|
+      num_tries = page_sumbissions.length
+      page_sumbission = page_sumbissions.last
       {
         page: page_id,
-        pageIndex: submission.interactive_page.position,
+        pageIndex: page_sumbission.interactive_page.position,
         tryCount: num_tries,
         numQuestions: 4,
-        answers: submission_answers(submission)
+        answers: submission_answers(page_sumbission)
       }
     end
   end

--- a/app/services/dashboard_sequence_runlist.rb
+++ b/app/services/dashboard_sequence_runlist.rb
@@ -81,15 +81,15 @@ class DashboardSequenceRunlist
       return []
     end
     submissions = submissions.group_by(&:interactive_page_id)
-    submissions.map do |page_id, page_sumbissions|
-      num_tries = page_sumbissions.length
-      page_sumbission = page_sumbissions.last
+    submissions.map do |page_id, page_submissions|
+      num_tries = page_submissions.length
+      page_submission = page_submissions.last
       {
         page: page_id,
-        pageIndex: page_sumbission.interactive_page.position,
+        pageIndex: page_submission.interactive_page.position,
         tryCount: num_tries,
         numQuestions: 4,
-        answers: submission_answers(page_sumbission)
+        answers: submission_answers(page_submission)
       }
     end
   end


### PR DESCRIPTION
Previous implementation assumed that there was only one submission per activity.  Activities may have several arg block sections.