### PR TITLE
Add interactive name to click to play fullscreen header

### DIFF
--- a/app/assets/stylesheets/partials/_click_to_play.scss
+++ b/app/assets/stylesheets/partials/_click_to_play.scss
@@ -68,9 +68,15 @@
       height: 40px;
       z-index: 2;
 
+      .full-window-title {
+        float: left;
+        margin: 10px 10px 10px 20px;
+        font-weight: bold;
+      }
+
       .menu-items {
         float: right;
-        margin-right: 10px;
+        margin-right: 20px;
         line-height: 40px;
         div {
           display: inline-block;

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -19,6 +19,8 @@
             %i.wait-icon.fa.fa-spinner.fa-spin
             Loading interactive...
         .full-window-menu
+          .full-window-title
+            = interactive.name
           .menu-items
             - if labbook
               .screenshot


### PR DESCRIPTION
The name looks like this (with an interactive with the name of "Sharinator"):

![image](https://user-images.githubusercontent.com/112938/28281909-9c3cc904-6af6-11e7-92a7-2fbf84021002.png)

this also adds 10px to the right margin of the "Return to Activity" link, which now looks like this:

![image](https://user-images.githubusercontent.com/112938/28281959-c315ed3a-6af6-11e7-9fee-0157b38698ff.png)
