### PR TITLE
Fix view work links for CODAP interactives

### DIFF
--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -127,11 +127,16 @@ class MwInteractive < ActiveRecord::Base
   end
 
   def reportable?
-    enable_learner_state || has_report_url
+    enable_learner_state
   end
 
   def reportable_in_iframe?
-    # When iframe is reportable because of the learner state, it should be displayed in iframe.
-    enable_learner_state
+    # An MwInactive should only be reported on in iframe if it doesn't have a report url
+    # This is mainly for backwards compatibility. Previously interactives were only
+    # reportable if they had a report_url, and they always showed as links (not iframes)
+    # in the report. We want these old interactives to continue to work that way.
+    # If we need more flexibility then we'll need to add a new option on MwInteractive
+    # indicated if the interactive should be reported on in an iframe or not
+    !has_report_url
   end
 end

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -456,10 +456,10 @@ describe InteractivePage do
       FactoryGirl.create(:mw_interactive, enable_learner_state: false, has_report_url: false)
     }
     let(:reportable_interactive) {
-      FactoryGirl.create(:mw_interactive, enable_learner_state: false, has_report_url: true)
+      FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: false)
     }
     let(:reportable_interactive2) {
-      FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: false)
+      FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: true)
     }
     let(:video_interactive) { FactoryGirl.create(:video_interactive) }
     let(:image_interactive) { FactoryGirl.create(:image_interactive) }

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -107,12 +107,15 @@ describe InteractiveRunState do
     # this hash is depended on by the Portal
     describe "portal_hash" do
       # Only when reporting_url is available.
+      let(:interactive)     { FactoryGirl.create(:mw_interactive,
+        enable_learner_state: true, has_report_url: true) }
       let(:run_data) {'{"second": 2, "lara_options": {"reporting_url": "test.com"}}'}
       let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
 
       subject { interactive_run_state.portal_hash }
 
-      # the portal uses this type to match the interactive so it can't change without changing the portal
+      # the portal requires this type. So if you change it,
+      # you need to change the portal too
       it { should include("question_type" => "iframe interactive") }
     end
 


### PR DESCRIPTION
I finished this a while ago and then forgot to make a PR for it.

This also fixes the completion state for interactives that don't have a report_url.
[#150113706]
[#150113578]