### PR TITLE
Render more than one interactive on a single page (in mult-page layout)

### DIFF
--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -88,15 +88,6 @@ class InteractivePage < ActiveRecord::Base
     interactives.select { |i| !i.is_hidden }
   end
 
-  # can this page display multiple interactives?
-  # depending on the activity layout, possibly.
-  # For now, only with single-page louts.
-  def show_multiple_interactives?
-    lightweight_activity &&
-      lightweight_activity.layout == LightweightActivity::LAYOUT_SINGLE_PAGE
-  end
-
-
   # This is a sort of polymorphic has_many :through.
   def embeddables
     self.page_items.collect{ |qi| qi.embeddable }

--- a/app/views/interactive_pages/_interactive.html.haml
+++ b/app/views/interactive_pages/_interactive.html.haml
@@ -1,7 +1,5 @@
-.interactive-mod{class: (layout == 'l-full-width') ? nil : 'pinned'}
-  - if page.show_multiple_interactives?
-    - page.visible_interactives.each do |interactive|
-      = render_interactive(interactive)
-
-  - elsif page.visible_interactives.first
-    = render_interactive(page.visible_interactives.first)
+-# Do not pin multiple interactives, as it means that the user might not be able to see the bottom ones
+-# if his screen is shorter that the height of all the interactives
+.interactive-mod{class: (page.visible_interactives.count > 1 || layout == 'l-full-width') ? nil : 'pinned'}
+  - page.visible_interactives.each do |interactive|
+    = render_interactive(interactive)

--- a/app/views/mw_interactives/_author.html.haml
+++ b/app/views/mw_interactives/_author.html.haml
@@ -13,7 +13,7 @@
         $("a[id^=edit-int-#{interactive.id}]").click()
 
   .interactive-content{:style => interactive.is_hidden ? 'display: none;' : ''}
-    #authorable-interactive
+    %div{:id => "authorable-interactive-#{interactive.id}"}
 
 :javascript
   (function() {
@@ -22,5 +22,5 @@
       updateUrl: "#{page_mw_interactive_path(page, interactive)}"
     };
     InteractiveAuthoring = React.createElement(modulejs.require('components/authoring/mw_interactive'), props);
-    React.render(InteractiveAuthoring, $('#authorable-interactive')[0]);
+    React.render(InteractiveAuthoring, $("#authorable-interactive-#{interactive.id}")[0]);
   }());

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -429,28 +429,6 @@ describe InteractivePage do
     end
   end
 
-  describe "#show_multiple_interactives?" do
-    let(:single_page){ LightweightActivity::LAYOUT_SINGLE_PAGE }
-    let(:multi_page) { LightweightActivity::LAYOUT_MULTI_PAGE }
-    let(:layout)     { nil }
-    let(:activity)   { mock_model(LightweightActivity, { layout: layout })     }
-    let(:page)       { InteractivePage.new( { lightweight_activity: activity })}
-
-    describe "When the activity is using single page layout" do
-      let(:layout) { single_page }
-      it "should show multiple interactives on one page" do
-        expect(page.show_multiple_interactives?).to eq true
-      end
-    end
-
-    describe "When the activity is using multi-page layout" do
-      let(:layout) { multi_page }
-      it "should NOT show multiple interactives on one page" do
-        expect(page.show_multiple_interactives?).to eq false
-      end
-    end
-  end
-
   describe '#reportable_items' do
     let(:non_reportable_interactive) {
       FactoryGirl.create(:mw_interactive, enable_learner_state: false, has_report_url: false)


### PR DESCRIPTION
The first, easier solution of multiple interactives being displayed on a single page. 
This PR removes `show_multiple_interactives?` as it doesn't seem to be any reason to keep it. Also, it fixes authoring mode where multiple interactives were not displayed correctly. Interactives are not pinned, as it could make it impossible to see the bottom one when the screen height is smaller than the sum of interactives height.

I've tested generic theme and HAS water. It seems to work fine in 40-60 and full-width mode. 30-70 also works, but this layout has some issues in itself (I've checked that in the production branch).