### PR TITLE
Multiple interactives on one page, interleaving with questions

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -20,14 +20,14 @@ $(document).ready(function () {
     // Set up sortable lists:
     // TODO: Refactor this into an object
     // Embeddables in page edit
-    $('#sort_embeddables').sortable({ handle: '.drag_handle',
+    $('.sortable_embeddables').sortable({ handle: '.drag_handle',
         opacity: 0.8,
         tolerance: 'pointer',
-        update: function () {
+        update: function (event, ui) {
             $.ajax({
                 type: "GET",
                 url: "reorder_embeddables",
-                data: $("#sort_embeddables").sortable("serialize")
+                data: ui.item.closest(".sortable_embeddables").sortable("serialize")
             });
         }
     });

--- a/app/assets/javascripts/embeddable-carousel.js
+++ b/app/assets/javascripts/embeddable-carousel.js
@@ -31,13 +31,16 @@ var EmbeddableCarousel = function (element) {
 };
 
 EmbeddableCarousel.prototype.setCarouselSize = function () {
-    // Set 'bestHeight' and 'bestWidth' values
-    this.calculateSize();
-    // Set the carousel to those values and reload it
-    this.setHeight(this.bestHeight);
-    this.setWidth(this.bestWidth);
-	// recalculate scroll values for new dimensions
-    this.container.jcarousel('reload');
+  // Set 'bestHeight' and 'bestWidth' values
+  this.calculateWidth()
+  this.setWidth(this.bestWidth)
+  // Make sure that interactives have correct height.
+  $('[data-aspect-ratio]').trigger('sizeUpdate')
+  // Set the carousel to those values and reload it
+  this.calculateHeight()
+  this.setHeight(this.bestHeight)
+  // recalculate scroll values for new dimensions
+  this.container.jcarousel('reload')
 };
 
 // Set the height of the container
@@ -144,7 +147,7 @@ EmbeddableCarousel.prototype.calculateHeight = function() {
 /** Calculates the proper width for the carousel container. */
 EmbeddableCarousel.prototype.calculateWidth = function() {
     if (this.isFullWidth()) {
-        this.bestWidth = 960;
+        this.bestWidth = 936;
         return;
     }
     if (this.isResponsive()) {
@@ -152,20 +155,14 @@ EmbeddableCarousel.prototype.calculateWidth = function() {
         return;
     }
     if ($('.content-mod').hasClass('l-6040')) {
-        this.bestWidth = 374;
+        this.bestWidth = 365;
         return;
     }
     if ($('.content-mod').hasClass('r-4060')) {
-        this.bestWidth =  374;
+        this.bestWidth =  365;
         return;
     }
-    this.bestWidth = 278;
-};
-
-/** Calculates the proper width & height the carousel container. */
-EmbeddableCarousel.prototype.calculateSize = function () {
-    this.calculateWidth();
-    this.calculateHeight();
+    this.bestWidth = 271;
 };
 
 // unlike document.ready window.load() is called

--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -17,3 +17,4 @@ function interactiveSizing () {
 }
 
 $(document).ready(interactiveSizing);
+

--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -4,7 +4,7 @@ function interactiveSizing () {
   function setSize () {
     var $iframe = $(this);
     var aspectRatio = $iframe.data('aspect-ratio');
-    var currWidth = $('.interactive-mod').width();
+    var currWidth = $iframe.width()
     $iframe.attr('width', '100%');
     $iframe.attr('height', currWidth / aspectRatio);
   }

--- a/app/assets/javascripts/runtime-init.js
+++ b/app/assets/javascripts/runtime-init.js
@@ -28,4 +28,5 @@ $(document).ready(function () {
 
   // Set up colorbox for ImageInteractives - see jquery.colorbox.js
   $('.interactive-mod .colorbox').colorbox({maxWidth: "100%", maxHeight: "100%", minWidth: "960px", photo: true});
+  $('.questions-mod .colorbox').colorbox({maxWidth: "100%", maxHeight: "100%", minWidth: "960px", photo: true});
 });

--- a/app/assets/stylesheets/mw-runtime-base.scss
+++ b/app/assets/stylesheets/mw-runtime-base.scss
@@ -590,6 +590,12 @@ div.intra-page-nav {
   }
 }
 
+.embedded-interactive {
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+
 .challenge {
   .question-hdr, .question-hdr-collapse {
     background: darken($black-15, 3%);

--- a/app/assets/stylesheets/mw-runtime-base.scss
+++ b/app/assets/stylesheets/mw-runtime-base.scss
@@ -542,43 +542,43 @@ div.intra-page-nav {
   img {
     max-width: 100%;
   }
-
-  .under-image {
-    .fullscreen {
-      float: right;
-      a {
-        outline: none;
-        user-select: none;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        -o-user-select: none;
-      }
-      img {
-        height: 35px;
-        width: 35px;
-      }
-    }
-    .caption {
-      display: block;
-      font-size: 14px;
-      margin: 0px;
-    }
-    .credit {
-      display: block;
-      font-size: 10px;
-      font-style: italic;
-      margin: 0px;
-      a {
-        text-decoration: underline;
-      }
-    }
-  }
 }
 
 .questions-mod {
   margin-bottom: 52px;
   position: relative;
+}
+
+.under-image {
+  .fullscreen {
+    float: right;
+    a {
+      outline: none;
+      user-select: none;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      -o-user-select: none;
+    }
+    img {
+      height: 35px;
+      width: 35px;
+    }
+  }
+  .caption {
+    display: block;
+    font-size: 14px;
+    margin: 0px;
+  }
+  .credit {
+    display: block;
+    font-size: 10px;
+    font-style: italic;
+    margin: 0px;
+    a {
+      text-decoration: underline;
+    }
+  }
 }
 
 .question {

--- a/app/assets/stylesheets/partials/_runtime-interactives.scss
+++ b/app/assets/stylesheets/partials/_runtime-interactives.scss
@@ -14,39 +14,40 @@
   img {
     max-width: 100%;
   }
+}
 
-  .under-image {
-    .fullscreen {
-      float: right;
-      a {
-        outline: none;
-        user-select: none;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        -o-user-select: none;
-      }
-      img {
-        height: 35px;
-        width: 35px;
-      }
-    }
-  }
-  .caption {
-    display: block;
-    font-size: 14px;
-    margin: 0px;
-  }
-  .credit {
-    display: block;
-    font-size: 10px;
-    font-style: italic;
-    margin: 0px;
+.under-image {
+  .fullscreen {
+    float: right;
     a {
-      text-decoration: underline;
+      outline: none;
+      user-select: none;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      -o-user-select: none;
+    }
+    img {
+      height: 35px;
+      width: 35px;
     }
   }
 }
+.caption {
+  display: block;
+  font-size: 14px;
+  margin: 0px;
+}
+.credit {
+  display: block;
+  font-size: 10px;
+  font-style: italic;
+  margin: 0px;
+  a {
+    text-decoration: underline;
+  }
+}
+
 @import 'partials/click_to_play';
 
 .questions-mod {

--- a/app/assets/stylesheets/partials/_runtime-layouts.scss
+++ b/app/assets/stylesheets/partials/_runtime-layouts.scss
@@ -63,6 +63,16 @@
     vertical-align: top;
   }
 
+  .question.embedded-interactive {
+    margin: 0 20px;
+    display: block;
+    width: auto;
+  }
+
+  .jcarousel .question {
+    margin: 0;
+  }
+
   h5:after {
     background-color: none;
     display:none;

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -224,7 +224,6 @@ button.disabled, .btn-primary.disabled, span.edit_trigger.disabled {
 .text {
   float: left;
   height: auto;
-  padding: 1% 1% 1% 0;
   width: 38%;
 }
 .stacked-right .text {
@@ -818,6 +817,11 @@ fieldset {
     form.interactives-form {
       margin-top: 8px;
     }
+  }
+  div.sidebar {
+    background: 0;
+    border-radius: 0;
+    color: #000;
   }
   h2.question {
     margin-bottom: 1em;

--- a/app/controllers/interactive_controller.rb
+++ b/app/controllers/interactive_controller.rb
@@ -53,7 +53,7 @@ class InteractiveController < ApplicationController
   end
 
   def destroy
-    @interactive.interactive_item.delete
+    @interactive.page_item.delete
     typestring = @interactive.class.to_s.match(/(.+)Interactive/)[1]
     if @interactive.delete
       @activity = @page.lightweight_activity

--- a/app/controllers/interactive_controller.rb
+++ b/app/controllers/interactive_controller.rb
@@ -1,25 +1,7 @@
 # Common code for the controllers for the different kinds of Interactive models
 class InteractiveController < ApplicationController
-
-  def new
-    create
-  end
-
   def edit
     respond_with_edit_form
-  end
-
-  def create
-    set_page
-    create_interactive
-    flash[:notice] = "Your new #{@interactive.class.string_name} has been created."
-    if (@page)
-      InteractiveItem.create!(:interactive_page => @page, :interactive => @interactive)
-      update_activity_changed_by
-      redirect_to edit_activity_page_path(@activity, @page, @params)
-    else
-      redirect_to :back # edit_polymorphic_path(@interactive)
-    end
   end
 
   def update
@@ -41,7 +23,6 @@ class InteractiveController < ApplicationController
     end
   end
 
-
   def toggle_visibility
     new_val = !@interactive.is_hidden
     @interactive.update_attributes!(is_hidden: new_val)
@@ -49,18 +30,6 @@ class InteractiveController < ApplicationController
       render json: {is_hidden: new_val}
     else
       redirect_to :back
-    end
-  end
-
-  def destroy
-    @interactive.page_item.delete
-    typestring = @interactive.class.to_s.match(/(.+)Interactive/)[1]
-    if @interactive.delete
-      @activity = @page.lightweight_activity
-      update_activity_changed_by
-      redirect_to edit_activity_page_path(@activity, @page), :flash => { :notice => "Your #{typestring} interactive was deleted." }
-    else
-      redirect_to edit_activity_page_path(@page.lightweight_activity, @page), :flash => { :warning => "There was a problem deleting the #{typestring} interactive." }
     end
   end
 

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -103,23 +103,6 @@ class InteractivePagesController < ApplicationController
     end
   end
 
-  def add_interactive
-    authorize! :update, @page
-    update_activity_changed_by
-    if %w(ImageInteractive MwInteractive VideoInteractive).include?(params[:interactive_type])
-      i = params[:interactive_type].constantize.create!
-    else
-      raise ArgumentError, 'Not a valid Interactive type'
-    end
-    @page.add_interactive(i)
-    param = case i.class.name
-    when "ImageInteractive"   then { :edit_img_int => i.id }
-    when "MwInteractive"      then { :edit_mw_int => i.id }
-    when "VideoInteractive"   then { :edit_vid_int => i.id }
-    end
-    redirect_to edit_activity_page_path(@activity, @page, param)
-  end
-
   def add_tracked
     authorize! :update, @page
     update_activity_changed_by

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -125,6 +125,7 @@ class InteractivePagesController < ApplicationController
     update_activity_changed_by
     qt = QuestionTracker.find(params[:question_tracker])
     question = qt.new_question
+    @page.add_embeddable(question)
     edit_embeddable_redirect(question)
   end
 
@@ -132,6 +133,8 @@ class InteractivePagesController < ApplicationController
     authorize! :update, @page
     update_activity_changed_by
     e = Embeddable.create_for_string(params[:embeddable_type])
+    @page.add_embeddable(e, nil, params[:section])
+    # The call below supposed to open edit dialog, but it doesn't seem to work anymore.
     edit_embeddable_redirect(e)
   end
 
@@ -175,7 +178,6 @@ class InteractivePagesController < ApplicationController
   private
 
   def edit_embeddable_redirect(embeddable)
-    @page.add_embeddable(embeddable)
     case embeddable
       when Embeddable::MultipleChoice
         unless embeddable.choices.length > 0
@@ -190,6 +192,8 @@ class InteractivePagesController < ApplicationController
         param = { :edit_embed_lb => embeddable.id }
       when Embeddable::Xhtml
         param = { :edit_embed_xhtml => embeddable.id }
+      when MwInteractive
+        param = { :edit_mw_int => embeddable.id }
     end
     # Add parameter to open new embeddable modal
     redirect_to edit_activity_page_path(@activity, @page, param)

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -177,6 +177,10 @@ class InteractivePagesController < ApplicationController
         param = { :edit_embed_xhtml => embeddable.id }
       when MwInteractive
         param = { :edit_mw_int => embeddable.id }
+      when ImageInteractive
+        param = { :edit_img_int => embeddable.id }
+      when VideoInteractive
+        param = { :edit_vid_int => embeddable.id }
     end
     # Add parameter to open new embeddable modal
     redirect_to edit_activity_page_path(@activity, @page, param)

--- a/app/helpers/embeddable_helper.rb
+++ b/app/helpers/embeddable_helper.rb
@@ -4,4 +4,8 @@ module EmbeddableHelper
     select_tag :embeddable_type, options_for_select(Embeddable::Types.map { |k,v| [v, k.to_s] })
   end
 
+  def embeddable_interactives_selector
+    select_tag :embeddable_type, options_for_select(Embeddable::InteractiveTypes.map { |k,v| [v, k.to_s] })
+  end
+
 end

--- a/app/helpers/interactive_page_helper.rb
+++ b/app/helpers/interactive_page_helper.rb
@@ -18,16 +18,11 @@ module InteractivePageHelper
     return link_to name, runnable_activity_page_path(activity,page), opts
   end
 
-  def main_section_embeddables(page, run)
-    finder = Embeddable::AnswerFinder.new(run)
-    # Limit embeddables to ones that do not belong to any section.
-    page.main_embeddables.map { |e| finder.find_answer(e) }
-  end
-
   def main_section_visible_embeddables(page, run)
     finder = Embeddable::AnswerFinder.new(run)
     # Limit visible embeddables to ones that do not belong to any section.
-    page.main_visible_embeddables.map { |e| finder.find_answer(e) }
+    # Don't return answer objects for interactives.
+    page.main_visible_embeddables.map { |e| Embeddable::is_interactive?(e) ? e : finder.find_answer(e) }
   end
 
   def labbook_is_under_interactive?

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -1,13 +1,28 @@
 module Embeddable
-  Types = {
-      Embeddable::ImageQuestion  => "Image question",
-      Embeddable::MultipleChoice => "Multiple choice",
-      Embeddable::OpenResponse   => "Open response",
-      Embeddable::Xhtml          => "Text box",
-      Embeddable::Labbook        => "Labbook",
-      QuestionTracker            => "Tracked Question",
-      Embeddable::ExternalScript  => "External Script"
-    }
+  QuestionTypes = {
+    Embeddable::ImageQuestion  => "Image question",
+    Embeddable::MultipleChoice => "Multiple choice",
+    Embeddable::OpenResponse   => "Open response",
+    Embeddable::Xhtml          => "Text box",
+    Embeddable::Labbook        => "Labbook",
+    QuestionTracker            => "Tracked Question",
+    Embeddable::ExternalScript  => "External Script"
+  }
+
+  InteractiveTypes = {
+    MwInteractive => "Iframe Interactive"
+  }
+
+  # Types is just sum of question and interactives.
+  Types = QuestionTypes.merge(InteractiveTypes)
+
+  def self.is_question?(e)
+    QuestionTypes.keys.include?(e.class)
+  end
+
+  def self.is_interactive?(e)
+    InteractiveTypes.keys.include?(e.class)
+  end
 
   def self.table_name_prefix
     'embeddable_'

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -10,7 +10,9 @@ module Embeddable
   }
 
   InteractiveTypes = {
-    MwInteractive => "Iframe Interactive"
+    MwInteractive    => "Iframe Interactive",
+    ImageInteractive => "Image",
+    VideoInteractive => "Video"
   }
 
   # Types is just sum of question and interactives.

--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -92,6 +92,11 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
     true
   end
 
+  def page_section
+    # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+    page_items.count > 0 && page_items.first.section
+  end
+
   def self.name_as_param
     :embeddable_image_question
   end

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -111,11 +111,15 @@ module Embeddable
       action_type == SNAPSHOT_ACTION
     end
 
-
     def page
       # Return first page (note that in practice it's impossible that this model has more
       # than one page, even though it's many-to-many association).
       interactive_pages.first
+    end
+
+    def page_section
+      # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+      page_items.count > 0 && page_items.first.section
     end
 
     def possible_interactives

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -155,6 +155,11 @@ module Embeddable
       true
     end
 
+    def page_section
+      # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+      page_items.count > 0 && page_items.first.section
+    end
+
     def self.import (import_hash)
       choices = import_hash[:choices]
       import_mc = self.new(import_hash.except(:choices))

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -49,6 +49,11 @@ module Embeddable
       true
     end
 
+    def page_section
+      # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+      page_items.count > 0 && page_items.first.section
+    end
+
     def self.name_as_param
       :embeddable_open_response
     end

--- a/app/models/embeddable/xhtml.rb
+++ b/app/models/embeddable/xhtml.rb
@@ -32,6 +32,11 @@ module Embeddable
       false
     end
 
+    def page_section
+      # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+      page_items.count > 0 && page_items.first.section
+    end
+
     def self.import(import_hash)
       return self.new(import_hash)
     end

--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -2,8 +2,7 @@ class ImageInteractive < ActiveRecord::Base
   attr_accessible :url, :caption, :credit, :show_lightbox, :credit_url, :is_hidden
 
   has_one :page_item, :as => :embeddable, :dependent => :destroy
-  # InteractiveItem is a join model; if this is deleted, that instance should go too
-
+  # PageItem is a join model; if this is deleted, that instance should go too
   has_one :interactive_page, :through => :page_item
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'
 

--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -1,10 +1,10 @@
 class ImageInteractive < ActiveRecord::Base
   attr_accessible :url, :caption, :credit, :show_lightbox, :credit_url, :is_hidden
 
-  has_one :interactive_item, :as => :interactive, :dependent => :destroy
+  has_one :page_item, :as => :embeddable, :dependent => :destroy
   # InteractiveItem is a join model; if this is deleted, that instance should go too
 
-  has_one :interactive_page, :through => :interactive_item
+  has_one :interactive_page, :through => :page_item
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'
 
   def self.string_name
@@ -17,6 +17,10 @@ class ImageInteractive < ActiveRecord::Base
 
   def reportable?
     false
+  end
+
+  def page_section
+    page_item && page_item.section
   end
 
   def no_snapshots

--- a/app/models/interactive_item.rb
+++ b/app/models/interactive_item.rb
@@ -1,6 +1,0 @@
-class InteractiveItem < ActiveRecord::Base
-  attr_accessible :interactive, :interactive_page, :position
-
-  belongs_to :interactive_page
-  belongs_to :interactive, :polymorphic => true
-end

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -28,11 +28,7 @@ class InteractivePage < ActiveRecord::Base
   # See https://www.pivotaltracker.com/story/show/60459320
   validates :text, :sidebar, :html => true
 
-  # InteractiveItem is a join model; if this is deleted, it should go too
-  has_many :interactive_items, :order => :position, :dependent => :destroy, :include => [:interactive]
-
-  # Like InteractiveItems, PageItems are join models, so they should not
-  # survive the deletion of associated instances of InteractivePage.
+  # PageItem is a join model; if this is deleted, it should go too
   has_many :page_items, :order => [:section, :position], :dependent => :destroy, :include => [:embeddable]
 
   # Interactive page can register additional page sections:

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -18,9 +18,7 @@ class InteractivePage < ActiveRecord::Base
 
   EMBEDDABLE_DISPLAY_OPTIONS = ['stacked','carousel']
 
-  INTERACTIVE_TYPES = [{ :name => 'Image',  :class_name => 'ImageInteractive' },
-                       { :name => 'Iframe', :class_name => 'MwInteractive' },
-                       { :name => 'Video',  :class_name => 'VideoInteractive' }]
+  INTERACTIVE_BOX = 'interactive_box'
 
   validates :sidebar_title, presence: true
   validates :layout, :inclusion => { :in => LAYOUT_OPTIONS.map { |l| l[:class_val] } }
@@ -81,21 +79,16 @@ class InteractivePage < ActiveRecord::Base
                                                label: CRater::ARG_SECTION_LABEL})
 
   # This is a sort of polymorphic has_many :through.
-  def interactives
-    self.interactive_items.collect{|ii| ii.interactive}
-  end
-
-  def visible_interactives
-    interactives.select { |i| !i.is_hidden }
-  end
-
-  # This is a sort of polymorphic has_many :through.
   def embeddables
-    self.page_items.collect{ |qi| qi.embeddable }
+    page_items.collect{ |qi| qi.embeddable }
+  end
+
+  def interactives
+    embeddables.select{ |e| Embeddable::is_interactive?(e) }
   end
 
   def section_embeddables(section)
-    self.page_items.where(section: section).collect{ |qi| qi.embeddable }
+    page_items.where(section: section).collect{ |qi| qi.embeddable }
   end
 
   def main_embeddables
@@ -103,12 +96,20 @@ class InteractivePage < ActiveRecord::Base
     section_embeddables(nil)
   end
 
+  def main_questions
+    section_embeddables(nil).select{ |e| Embeddable::is_question?(e) }
+  end
+
   def visible_embeddables
-    self.page_items.collect{ |qi| qi.embeddable }.select{ |e| !e.is_hidden }
+    embeddables.select{ |e| !e.is_hidden }
+  end
+
+  def visible_interactives
+    interactives.select{ |e| !e.is_hidden }
   end
 
   def section_visible_embeddables(section)
-    self.page_items.where(section: section).collect{ |qi| qi.embeddable }.select{ |e| !e.is_hidden }
+    section_embeddables(section).select{ |e| !e.is_hidden }
   end
 
   def main_visible_embeddables
@@ -116,26 +117,16 @@ class InteractivePage < ActiveRecord::Base
     section_visible_embeddables(nil)
   end
 
+  def interactive_box_embeddables
+    section_embeddables(INTERACTIVE_BOX)
+  end
+
+  def interactive_box_visible_embeddables
+    section_visible_embeddables(INTERACTIVE_BOX)
+  end
+
   def reportable_items
-    items = visible_embeddables + visible_interactives
-    items.select { |item| item.reportable? }
-  end
-
-  def add_interactive(interactive, position = nil, validate = true)
-    self[:show_interactive] = true;
-    self.save!(validate: validate)
-    InteractiveItem.create!(:interactive_page => self, :interactive => interactive, :position => (position || self.interactive_items.size))
-  end
-
-  def remove_interactives
-    self[:show_interactive] = false;
-    self.save!
-    self.interactives.each do |i|
-      i.destroy
-    end
-    self.interactive_items.each do |ii|
-      ii.destroy
-    end
+    visible_embeddables.select { |item| item.reportable? }
   end
 
   def add_embeddable(embeddable, position = nil, section = nil)
@@ -144,6 +135,12 @@ class InteractivePage < ActiveRecord::Base
     unless position
       join.move_to_bottom
     end
+  end
+
+  def add_interactive(interactive, position = nil, validate = true)
+    self[:show_interactive] = true
+    self.save!(validate: validate)
+    add_embeddable(interactive, position, INTERACTIVE_BOX)
   end
 
   def next_visible_page
@@ -219,11 +216,13 @@ class InteractivePage < ActiveRecord::Base
             interactives_cache.set(linked_key, copy.linked_interactive)
           end
         end
-        new_page.add_interactive(copy, nil, false)
+        position = inter.page_item.position
+        section = inter.page_item.section
+        new_page.add_embeddable(copy, position, section)
         helper.cache_item_copy(inter,copy)
       end
 
-      self.main_embeddables.each do |embed|
+      self.main_questions.each do |embed|
         copy = embed.duplicate
         if embed.respond_to? :interactive=
           unless embed.interactive.nil?
@@ -234,7 +233,8 @@ class InteractivePage < ActiveRecord::Base
         if embed.respond_to? :question_tracker and embed.question_tracker
           embed.question_tracker.add_question(copy)
         end
-        new_page.add_embeddable(copy)
+        position = embed.page_items.first.position
+        new_page.add_embeddable(copy, position)
       end
 
       self.class.registered_additional_sections.each do |s|
@@ -245,7 +245,7 @@ class InteractivePage < ActiveRecord::Base
         end
       end
     end
-    return new_page.reload
+    new_page.reload
   end
 
   def export

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -205,6 +205,7 @@ class InteractivePage < ActiveRecord::Base
     InteractivePage.transaction do
       new_page.save!(validate: false)
 
+      # Preprocess interactives. We need to do that before we start processing any question.
       self.interactives.each do |inter|
         copy = inter.duplicate
         interactives_cache.set(helper.key(inter), copy)
@@ -216,32 +217,28 @@ class InteractivePage < ActiveRecord::Base
             interactives_cache.set(linked_key, copy.linked_interactive)
           end
         end
-        position = inter.page_item.position
-        section = inter.page_item.section
-        new_page.add_embeddable(copy, position, section)
-        helper.cache_item_copy(inter,copy)
+        helper.cache_item_copy(inter, copy)
       end
 
-      self.main_questions.each do |embed|
+      self.embeddables.each do |embed|
         copy = embed.duplicate
-        if embed.respond_to? :interactive=
-          unless embed.interactive.nil?
-            copy.interactive = helper.lookup_new_item(embed.interactive)
+        # Interactives
+        if Embeddable::is_interactive?(embed)
+          inter_copy = helper.lookup_new_item(embed)
+          new_page.add_embeddable(inter_copy, nil, embed.page_section)
+        end
+        # Questions
+        if Embeddable::is_question?(embed)
+          if embed.respond_to? :interactive=
+            unless embed.interactive.nil?
+              copy.interactive = helper.lookup_new_item(embed.interactive)
+            end
           end
-        end
-        copy.save!(validate: false)
-        if embed.respond_to? :question_tracker and embed.question_tracker
-          embed.question_tracker.add_question(copy)
-        end
-        position = embed.page_items.first.position
-        new_page.add_embeddable(copy, position)
-      end
-
-      self.class.registered_additional_sections.each do |s|
-        self.section_embeddables(s[:name]).each do |embed|
-          copy = embed.duplicate
           copy.save!(validate: false)
-          new_page.add_embeddable(copy,nil,s[:name])
+          if embed.respond_to? :question_tracker and embed.question_tracker
+            embed.question_tracker.add_question(copy)
+          end
+          new_page.add_embeddable(copy, nil, embed.page_section)
         end
       end
     end
@@ -264,32 +261,17 @@ class InteractivePage < ActiveRecord::Base
                                     :embeddable_display_mode,
                                     :additional_sections,
                                     :is_completion])
-
-    page_json[:interactives] = []
     page_json[:embeddables] = []
-    page_json[:sections] = []
 
-    self.interactives.each do |inter|
-      interactive_hash = helper.wrap_export(inter)
-      if inter.respond_to? :linked_interactive
-        interactive_hash[:linked_interactive] = inter.linked_interactive.present? ? helper.wrap_export(inter.linked_interactive) : nil
-      end
-      page_json[:interactives] << interactive_hash
-    end
-    self.main_embeddables.each do |embed|
+    self.embeddables.each do |embed|
       embeddable_hash = helper.wrap_export(embed)
-      page_json[:embeddables] << embeddable_hash
-    end
-    self.class.registered_additional_sections.each do |s|
-      additional_section = {name:s[:name],section_embeddables:[]}
-      self.section_embeddables(s[:name]).each do |embed|
-        section_embeddable_hash = helper.wrap_export(embed)
-        additional_section[:section_embeddables] << section_embeddable_hash
+      if embed.respond_to? :linked_interactive
+        embeddable_hash[:linked_interactive] = embed.linked_interactive.present? ? helper.wrap_export(embed.linked_interactive) : nil
       end
-      page_json[:sections] << additional_section
+      page_json[:embeddables] << { embeddable: embeddable_hash, section: embed.page_section }
     end
 
-    return page_json
+    page_json
   end
 
   def self.extact_from_hash(page_json_object)
@@ -314,9 +296,6 @@ class InteractivePage < ActiveRecord::Base
       attributes[key] = page_json_object[key] if page_json_object.has_key?(key)
     end
 
-    if page_json_object[:additional_sections]
-      attributes[:additional_sections] = page_json_object[:additional_sections].as_json
-    end
     attributes
   end
 
@@ -326,35 +305,28 @@ class InteractivePage < ActiveRecord::Base
     import_page = InteractivePage.new(self.extact_from_hash(page_json_object))
     InteractivePage.transaction do
       import_page.save!(validate: false)
-      page_json_object[:interactives].each do |inter|
-        # don't create a new linked interactive automatically as part of the interactive and instead use the cache below to avoid duplicates
-        linked_inter = inter[:linked_interactive]
-        inter.delete(:linked_interactive)
-        import_interactive = helper.wrap_import(inter)
-        interactives_cache.set(inter[:ref_id], import_interactive)
+      page_json_object[:embeddables].each do |embed_hash|
+        embed = embed_hash[:embeddable]
+        section = embed_hash[:section]
+        linked_inter = embed[:linked_interactive]
+        embed.delete(:linked_interactive)
+
+        import_embeddable = helper.wrap_import(embed)
+
+        if Embeddable::is_interactive?(import_embeddable)
+          interactives_cache.set(embed[:ref_id], import_embeddable)
+        end
 
         if linked_inter
-          import_interactive.linked_interactive = interactives_cache.get(linked_inter[:ref_id])
-          if !import_interactive.linked_interactive
-            import_interactive.linked_interactive = helper.wrap_import(linked_inter)
-            interactives_cache.set(linked_inter[:ref_id], import_interactive.linked_interactive)
+          import_embeddable.linked_interactive = interactives_cache.get(linked_inter[:ref_id])
+          if !import_embeddable.linked_interactive
+            import_embeddable.linked_interactive = helper.wrap_import(linked_inter)
+            interactives_cache.set(linked_inter[:ref_id], import_embeddable.linked_interactive)
           end
-          import_interactive.save!(validate: false)
+          import_embeddable.save!(validate: false)
         end
 
-        import_page.add_interactive(import_interactive, nil, false)
-      end
-      page_json_object[:embeddables].each do |embed|
-        import_embeddable = helper.wrap_import(embed)
-        import_page.add_embeddable(import_embeddable)
-      end
-      if page_json_object[:sections]
-        page_json_object[:sections].each do |sec|
-          sec[:section_embeddables].each do |embed|
-            import_embeddable = helper.wrap_import(embed)
-            import_page.add_embeddable(import_embeddable,nil,sec[:name])
-          end
-        end
+        import_page.add_embeddable(import_embeddable, nil, section)
       end
     end
     return import_page

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -45,7 +45,7 @@ class LightweightActivity < ActiveRecord::Base
   # Just a way of getting self.visible_pages with the embeddables eager-loaded
   def visible_pages_with_embeddables
     InteractivePage
-      .includes(:interactive_items, :page_items => :embeddable)
+      .includes(:page_items => :embeddable)
       .where(:lightweight_activity_id => self.id, :is_hidden => false)
       .order(:position)
   end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -127,6 +127,7 @@ class LightweightActivity < ActiveRecord::Base
                                         :editor_mode,
                                         :external_report_url
     ])
+    activity_json[:version] = 1
     activity_json[:theme_name] = self.theme ? self.theme.name : nil
     activity_json[:pages] = []
     self.pages.each do |p|

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -10,10 +10,10 @@ class MwInteractive < ActiveRecord::Base
   validates_numericality_of :native_width
   validates_numericality_of :native_height
 
-  has_one :interactive_item, :as => :interactive, :dependent => :destroy
+  has_one :page_item, :as => :embeddable, :dependent => :destroy
   # InteractiveItem is a join model; if this is deleted, that instance should go too
 
-  has_one :interactive_page, :through => :interactive_item
+  has_one :interactive_page, :through => :page_item
   has_many :interactive_run_states, :as => :interactive, :dependent => :destroy
 
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -11,7 +11,7 @@ class MwInteractive < ActiveRecord::Base
   validates_numericality_of :native_height
 
   has_one :page_item, :as => :embeddable, :dependent => :destroy
-  # InteractiveItem is a join model; if this is deleted, that instance should go too
+  # PageItem is a join model; if this is deleted, that instance should go too
 
   has_one :interactive_page, :through => :page_item
   has_many :interactive_run_states, :as => :interactive, :dependent => :destroy

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -145,4 +145,8 @@ class MwInteractive < ActiveRecord::Base
     # indicated if the interactive should be reported on in an iframe or not
     !has_report_url
   end
+
+  def page_section
+    page_item && page_item.section
+  end
 end

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -1,7 +1,7 @@
 class VideoInteractive < ActiveRecord::Base
-  has_one :interactive_item, :as => :interactive, :dependent => :destroy
+  has_one :page_item, :as => :embeddable, :dependent => :destroy
   # InteractiveItem is a join model; if this is deleted, that instance should go too
-  has_one :interactive_page, :through => :interactive_item
+  has_one :interactive_page, :through => :page_item
   has_many :sources, :class_name => 'VideoSource',
            :foreign_key => 'video_interactive_id',
            :dependent => :destroy # If we delete this video we should dump its sources
@@ -52,6 +52,10 @@ class VideoInteractive < ActiveRecord::Base
 
   def no_snapshots
     false
+  end
+
+  def page_section
+    page_item && page_item.section
   end
 
   def to_hash

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -1,6 +1,6 @@
 class VideoInteractive < ActiveRecord::Base
   has_one :page_item, :as => :embeddable, :dependent => :destroy
-  # InteractiveItem is a join model; if this is deleted, that instance should go too
+  # PageItem is a join model; if this is deleted, that instance should go too
   has_one :interactive_page, :through => :page_item
   has_many :sources, :class_name => 'VideoSource',
            :foreign_key => 'video_interactive_id',

--- a/app/services/itsi_authoring/editor.rb
+++ b/app/services/itsi_authoring/editor.rb
@@ -9,7 +9,7 @@ class ITSIAuthoring::Editor
     {
       metadata: metadata_json,
       sections: @activity.pages
-        .includes(:interactive_items, :page_items)
+        .includes(:page_items)
         .map { |p| section_json(p) },
       active_runs: @activity.active_runs,
       publication_details: {

--- a/app/views/image_interactives/_author.html.haml
+++ b/app/views/image_interactives/_author.html.haml
@@ -1,13 +1,6 @@
-.model-edit
-  .toolbar
-    = render partial: 'shared/hide_interactive_link', locals: {interactive: interactive, toggle_vis_path: toggle_visibility_page_image_interactive_path(@page, interactive)}
-    |
-    = link_to "Edit", edit_page_image_interactive_path(@page, interactive), :remote => true, :id => "edit-int-#{interactive.id}"
-    |
-    = link_to "Delete", page_image_interactive_path(@page, interactive), :method => :delete
-    - if params[:edit_img_int].to_i == interactive.id
-      :javascript
-        $("a[id^=edit-int-#{interactive.id}]").click()
-
-  .interactive-content{:style => interactive.is_hidden ? 'display: none;' : ''}
-    = render :partial => 'image_interactives/show', :locals => { :interactive => interactive }
+.embeddable_tools
+  .drag_handle
+  = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'image', :allow_hide => allow_hide }
+.embeddable_options
+  .interactive-content
+    = render :partial => 'image_interactives/show', :locals => { :interactive => embeddable }

--- a/app/views/image_interactives/_show.html.haml
+++ b/app/views/image_interactives/_show.html.haml
@@ -12,3 +12,5 @@
   - unless interactive.credit.blank?
     .credit
       = interactive.credit_with_link
+%br
+%br

--- a/app/views/interactive_pages/_interactive.html.haml
+++ b/app/views/interactive_pages/_interactive.html.haml
@@ -1,3 +1,3 @@
 .interactive-mod{class: layout == 'l-full-width' ? nil : 'pinned'}
-  - page.visible_interactives.each do |interactive|
+  - page.interactive_box_visible_embeddables.each do |interactive|
     = render_interactive(interactive)

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -1,12 +1,17 @@
 .embeddables
   - unless embeddables.blank?
     - embeddables.each do |e|
-      -# If a labbooks is included within the interactives section,
-      -# dont also display that item here.
-      - unless show_labbook_in_assessment_block?(e)
-        - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
-        - css_class = e.is_a?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : ""
-        - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
-        - if e.show_in_runtime?
-          .question{ class: css_class }
-            = render(partial: partial_name, locals: { embeddable: e })
+      - if Embeddable::is_interactive?(e)
+        .embedded-interactive
+          = render_interactive(e)
+      - else
+        -# Embeddable is a question.
+        -# If a labbooks is included within the interactives section,
+        -# dont also display that item here.
+        - unless show_labbook_in_assessment_block?(e)
+          - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
+          - css_class = e.is_a?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : ""
+          - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
+          - if e.show_in_runtime?
+            .question{ class: css_class }
+              = render(partial: partial_name, locals: { embeddable: e })

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -2,7 +2,7 @@
   - unless embeddables.blank?
     - embeddables.each do |e|
       - if Embeddable::is_interactive?(e)
-        .embedded-interactive
+        .question.embedded-interactive
           = render_interactive(e)
       - else
         -# Embeddable is a question.

--- a/app/views/interactive_pages/_show.html.haml
+++ b/app/views/interactive_pages/_show.html.haml
@@ -8,7 +8,7 @@
 -# Control layout here. Add one of the following classes: l-full-width, l-6040, l-7030, r-4060, r-3070
 .content-mod{ :class => layout }
   .ui-block-1
-    - if page.visible_interactives.length > 0 && page.show_interactive
+    - if page.show_interactive && page.interactive_box_visible_embeddables.length > 0
       = render partial: 'interactive_pages/interactive', locals: {page: page, layout: layout}
 
   .questions-mod.ui-block-2{ :class => page.embeddable_display_mode == 'carousel' ? 'jcarousel' : '' }

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -89,7 +89,7 @@
           = form_tag add_embeddable_activity_page_path(@activity, @page), :class => 'embeddables-form' do
             = embeddable_selector
             = submit_tag 'Add Embeddable', {id: 'add_embeddable_button'}
-          #sort_embeddables.embeddables_list
+          .embeddables_list.sortable_embeddables
             - @page.section_embeddables(nil).each do |e|
               - tracked = e.respond_to?(:tracked_question) && e.tracked_question
               - tracked_class = tracked ? 'tracked' : ''
@@ -100,11 +100,16 @@
         = render :partial => "#{s[:dir]}/author", :locals => { :page => @page, :section_name => s[:name], :section_label => s[:label], :allow_hide => false }
     - if @page.show_interactive
       %div{:class => (@page.show_info_assessment ? 'other' : 'other full-width')}
-        = form_tag add_interactive_activity_page_path(@activity, @page), :class => 'interactives-form' do
-          = select_tag :interactive_type, options_for_select(InteractivePage::INTERACTIVE_TYPES.map { |t| [t[:name], t[:class_name]] })
-          = submit_tag 'Add Interactive'
-        - @page.interactives.each do |interactive|
-          = render :partial => "#{interactive.class.name.underscore.pluralize}/author", :locals => {:interactive => interactive, :page => @page, :allow_hide => false}
+        .questions
+          %h2 Interactive Box
+          = form_tag add_embeddable_activity_page_path(@activity, @page), :class => 'embeddables-form' do
+            = embeddable_interactives_selector
+            = hidden_field_tag :section, InteractivePage::INTERACTIVE_BOX
+            = submit_tag 'Add Interactive'
+          .embeddables_list.sortable_embeddables
+            - @page.interactive_box_visible_embeddables.each do |interactive|
+              .authorable{:id => "embeddable_#{interactive.id}.#{interactive.class.to_s}"}
+                = render :partial => "#{interactive.class.name.underscore.pluralize}/author", :locals => {:embeddable => interactive, :page => @page, :allow_hide => false}
     - if @page.show_sidebar
       %div{style: 'clear: both;'}
         = text_editor @page, :sidebar, { editable_header: true, header_prop: :sidebar_title }

--- a/app/views/mw_interactives/_author.html.haml
+++ b/app/views/mw_interactives/_author.html.haml
@@ -1,26 +1,20 @@
-.model-edit
-  .toolbar
-    .interactice-id{style:"float: left; display:inline-block;"}
-      Interactive ID: #{interactive.id}
-    = render partial: 'shared/hide_interactive_link', locals: {interactive: interactive, toggle_vis_path: toggle_visibility_page_mw_interactive_path(@page, interactive)}
-    |
-    = link_to "Edit", edit_page_mw_interactive_path(@page, interactive), :remote => true, :id => "edit-int-#{interactive.id}"
-    |
-    - confirm_message = "Are you sure you want to delete this element? You will lose data from #{pluralize(@activity.active_runs, "learner")} that #{"has".pluralize(@activity.active_runs)} answered this question."
-    = link_to "Delete", page_mw_interactive_path(@page, interactive), :method => :delete, :data => ({:confirm => (@activity.active_runs > 0) ? confirm_message : 'Are you sure?'} if interactive.enable_learner_state)
-    - if params[:edit_mw_int].to_i == interactive.id
-      :javascript
-        $("a[id^=edit-int-#{interactive.id}]").click()
-
-  .interactive-content{:style => interactive.is_hidden ? 'display: none;' : ''}
-    %div{:id => "authorable-interactive-#{interactive.id}"}
+.embeddable_tools
+  .drag_handle
+  = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'mw_int', :allow_hide => allow_hide }
+.embeddable_options
+  Iframe interactive
+  .model-edit
+    .interactive-content
+      %div{:id => "authorable-interactive-#{embeddable.id}"}
 
 :javascript
   (function() {
     var props = {
-      interactive: #{interactive.to_json},
-      updateUrl: "#{page_mw_interactive_path(page, interactive)}"
+      interactive: #{embeddable.to_json},
+      updateUrl: "#{page_mw_interactive_path(page, embeddable)}"
     };
-    InteractiveAuthoring = React.createElement(modulejs.require('components/authoring/mw_interactive'), props);
-    React.render(InteractiveAuthoring, $("#authorable-interactive-#{interactive.id}")[0]);
+    if (props.interactive.url) {
+      InteractiveAuthoring = React.createElement(modulejs.require('components/authoring/mw_interactive'), props);
+      React.render(InteractiveAuthoring, $("#authorable-interactive-#{embeddable.id}")[0]);
+    }
   }());

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -58,7 +58,6 @@
     = render partial: 'embeddable/labbook_answers/lightweight', locals: { embeddable: labbook }
 - else
   %br
-  %br
 
 :javascript
   $(document).ready(function() {

--- a/app/views/shared/_embedded_editor_links.html.haml
+++ b/app/views/shared/_embedded_editor_links.html.haml
@@ -28,6 +28,8 @@
       edit_embeddable_external_script_path(embeddable)
     when "xhtml"
       edit_embeddable_xhtml_path(embeddable)
+    when "mw_int"
+      edit_page_mw_interactive_path(page, embeddable)
   end
 
 - if tracked

--- a/app/views/shared/_embedded_editor_links.html.haml
+++ b/app/views/shared/_embedded_editor_links.html.haml
@@ -30,6 +30,10 @@
       edit_embeddable_xhtml_path(embeddable)
     when "mw_int"
       edit_page_mw_interactive_path(page, embeddable)
+    when "image"
+      edit_page_image_interactive_path(page, embeddable)
+    when "video"
+      edit_page_video_interactive_path(page, embeddable)
   end
 
 - if tracked

--- a/app/views/video_interactives/_author.html.haml
+++ b/app/views/video_interactives/_author.html.haml
@@ -1,13 +1,6 @@
-.model-edit
-  .toolbar
-    = render partial: 'shared/hide_interactive_link', locals: {interactive: interactive, toggle_vis_path: toggle_visibility_page_video_interactive_path(@page, interactive)}
-    |
-    = link_to "Edit", edit_page_video_interactive_path(@page, interactive), :remote => true, :id => "edit-int-#{interactive.id}"
-    |
-    = link_to "Delete", page_video_interactive_path(@page, interactive), :method => :delete
-    - if params[:edit_vid_int].to_i == interactive.id
-      :javascript
-        $("a[id^=edit-int-#{interactive.id}]").click()
-
-  .interactive-content{:style => interactive.is_hidden ? 'display: none;' : ''}
-    = render :partial => 'video_interactives/show', :locals => { :interactive => interactive }
+.embeddable_tools
+  .drag_handle
+  = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'video', :allow_hide => allow_hide }
+.embeddable_options
+  .interactive-content
+    = render :partial => 'video_interactives/show', :locals => { :interactive => embeddable }

--- a/app/views/video_interactives/_show.html.haml
+++ b/app/views/video_interactives/_show.html.haml
@@ -1,4 +1,4 @@
-%video{ id: "video-interactive-#{interactive.id}", class: "video-js vjs-default-skin", controls: '', preload: "auto", width: interactive.width, height: interactive.height, poster: interactive.poster_url, data: { setup: '{"example_option":true}', aspect_ratio: interactive.aspect_ratio } }
+%video{ id: "video-interactive-#{interactive.id}", class: "video-js vjs-default-skin", controls: '', preload: "auto", width: "100%", height: interactive.height, poster: interactive.poster_url, data: { setup: '{"example_option":true}', aspect_ratio: interactive.aspect_ratio } }
   - interactive.sources.each do |source|
     %source{ :src => source.url, :type => source.format }
 .under-image
@@ -6,3 +6,5 @@
     = interactive.caption
   .credit
     = interactive.credit
+%br
+%br

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,6 @@ LightweightStandalone::Application.routes.draw do
     end
   end
 
-  # This is so we can build the InteractiveItem at the same time as the Interactive
   resources :pages, :controller => 'interactive_pages', :constraints => { :id => /\d+/ }, :except => :create do
     resources :mw_interactives, :controller => 'mw_interactives', :constraints => { :id => /\d+/ }, :except => :show do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,6 @@ LightweightStandalone::Application.routes.draw do
         get 'reorder_embeddables'
         post 'add_embeddable'
         get  'add_tracked'
-        post 'add_interactive'
         get 'move_up', :controller => 'lightweight_activities'
         get 'move_down', :controller => 'lightweight_activities'
         get 'preview'

--- a/db/migrate/20180530151905_convert_interactive_items_to_page_items.rb
+++ b/db/migrate/20180530151905_convert_interactive_items_to_page_items.rb
@@ -1,0 +1,9 @@
+class ConvertInteractiveItemsToPageItems < ActiveRecord::Migration
+  def up
+    execute "INSERT INTO page_items (interactive_page_id, embeddable_id, embeddable_type, position, created_at, updated_at, section) SELECT interactive_page_id, interactive_id, interactive_type, position, created_at, updated_at, 'interactive_box' FROM interactive_items"
+  end
+
+  def down
+    execute "DELETE FROM page_items WHERE section='interactive_box'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180329231011) do
+ActiveRecord::Schema.define(:version => 20180530151905) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"

--- a/spec/controllers/image_interactives_controller_spec.rb
+++ b/spec/controllers/image_interactives_controller_spec.rb
@@ -18,46 +18,6 @@ describe ImageInteractivesController do
 
   context 'when the logged-in user is an author' do
     # Authorization is tested in spec/models/user_spec.rb
-    context 'and an InteractivePage ID is provided' do
-      describe 'new' do
-        it 'automatically creates a new interactive' do
-          activity
-          starting_count = ImageInteractive.count()
-          join_count = InteractiveItem.count()
-          get :new, :page_id => page.id
-
-          expect(ImageInteractive.count()).to equal starting_count + 1
-          expect(InteractiveItem.count()).to equal join_count + 1
-        end
-
-        it 'redirects the submitter back to the page edit page' do
-          activity
-          get :new, :page_id => page.id
-          new_id = ImageInteractive.last().id
-          expect(response).to redirect_to(edit_activity_page_path(activity, page, :edit_img_int => new_id))
-        end
-      end
-
-      describe 'create' do
-        it 'creates an empty MW Interactive' do
-          activity
-          starting_count = ImageInteractive.count()
-          join_count = InteractiveItem.count()
-          post :create, :page_id => page.id
-
-          expect(ImageInteractive.count()).to equal starting_count + 1
-          expect(InteractiveItem.count()).to equal join_count + 1
-        end
-
-        it 'redirects the submitter to the page edit page' do
-          activity
-          post :create, :page_id => page.id
-          new_id = ImageInteractive.last().id
-          expect(response).to redirect_to(edit_activity_page_path(activity, page, :edit_img_int => new_id))
-        end
-      end
-    end
-
     context 'when editing an existing Image Interactive' do
       describe 'edit' do
         it 'shows a form with values of the Image Interactive filled in' do
@@ -106,25 +66,6 @@ describe ImageInteractivesController do
         #   response.should redirect_to(edit_image_interactive_path(int))
         #   flash[:warning].should == 'There was a problem updating your Image Interactive'
         # end
-      end
-
-      describe 'destroy' do
-        it 'removes the requested Image Interactive from the database and page and redirects to the page edit page' do
-          activity
-          int
-          PageItem.create!(:interactive_page => page, :embeddable => int)
-          interactive_count = ImageInteractive.count()
-          page.reload
-          page_count = page.interactives.length
-
-          post :destroy, :id => int.id, :page_id => page.id
-
-          expect(response).to redirect_to(edit_activity_page_path(activity, page))
-          expect(ImageInteractive.count()).to eq(interactive_count - 1)
-          page.reload
-          expect(page.interactives.length).to eq(page_count - 1)
-          expect(flash[:notice]).to eq('Your Image interactive was deleted.')
-        end
       end
     end
   end

--- a/spec/controllers/image_interactives_controller_spec.rb
+++ b/spec/controllers/image_interactives_controller_spec.rb
@@ -112,7 +112,7 @@ describe ImageInteractivesController do
         it 'removes the requested Image Interactive from the database and page and redirects to the page edit page' do
           activity
           int
-          InteractiveItem.create!(:interactive_page => page, :interactive => int)
+          PageItem.create!(:interactive_page => page, :embeddable => int)
           interactive_count = ImageInteractive.count()
           page.reload
           page_count = page.interactives.length

--- a/spec/controllers/interactive_page_controller_spec.rb
+++ b/spec/controllers/interactive_page_controller_spec.rb
@@ -355,33 +355,6 @@ describe InteractivePagesController do
       end
     end
 
-    describe 'add_interactive' do
-      it 'creates an arbitrary interactive and adds it to the page' do
-        images_count = ImageInteractive.count()
-        interactives_count = page1.interactives.length
-        post :add_interactive, :activity_id => act.id, :id => page1.id, :interactive_type => 'ImageInteractive'
-        page1.reload
-        expect(page1.interactives.count).to eq(interactives_count + 1)
-        expect(ImageInteractive.count()).to eq(interactives_count + 1)
-      end
-
-      it 'redirects to the edit page' do
-        post :add_interactive, :activity_id => act.id, :id => page1.id, :interactive_type => 'ImageInteractive'
-        interactive_id = page1.interactives.last.id
-        act.reload
-        expect(act.changed_by).to eq(@user)
-        expect(response).to redirect_to(edit_activity_page_path(act.id, page1.id, { :edit_img_int => interactive_id }))
-      end
-
-      it 'raises an error on invalid interactive_type' do
-        begin
-          post :add_interactive, :activity_id => act.id, :id => page1.id, :interactive_type => 'BogusInteractive'
-          raise 'Should not have been able to post a bogus interactive_type'
-        rescue ArgumentError
-        end
-      end
-    end
-
     describe 'add_embeddable' do
       it 'creates an arbitrary embeddable and adds it to the page' do
         xhtml_count = Embeddable::Xhtml.count()
@@ -410,6 +383,25 @@ describe InteractivePagesController do
           raise 'Should not have been able to post a bogus embeddable_type'
         rescue ArgumentError
         end
+      end
+    end
+
+    describe 'add_embeddable used with Interactive' do
+      it 'creates an arbitrary interactive and adds it to the page' do
+        images_count = ImageInteractive.count()
+        interactives_count = page1.interactives.length
+        post :add_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_type => 'ImageInteractive'
+        page1.reload
+        expect(page1.interactives.count).to eq(interactives_count + 1)
+        expect(ImageInteractive.count()).to eq(images_count + 1)
+      end
+
+      it 'redirects to the edit page' do
+        post :add_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_type => 'ImageInteractive'
+        interactive_id = page1.interactives.last.id
+        act.reload
+        expect(act.changed_by).to eq(@user)
+        expect(response).to redirect_to(edit_activity_page_path(act.id, page1.id, { :edit_img_int => interactive_id }))
       end
     end
 

--- a/spec/controllers/mw_interactives_controller_spec.rb
+++ b/spec/controllers/mw_interactives_controller_spec.rb
@@ -24,46 +24,6 @@ describe MwInteractivesController do
 
   context 'when the logged-in user is an author' do
     # Authorization is tested in spec/models/user_spec.rb
-    context 'and an InteractivePage ID is provided' do
-      describe 'new' do
-        it 'automatically creates a new interactive' do
-          activity
-          starting_count = MwInteractive.count()
-          join_count = InteractiveItem.count()
-          get :new, :page_id => page.id
-
-          expect(MwInteractive.count()).to equal starting_count + 1
-          expect(InteractiveItem.count()).to equal join_count + 1
-        end
-
-        it 'redirects the submitter back to the page edit page' do
-          activity
-          get :new, :page_id => page.id
-          new_id = MwInteractive.last().id
-          expect(response).to redirect_to(edit_activity_page_path(activity, page, :edit_mw_int => new_id))
-        end
-      end
-
-      describe 'create' do
-        it 'creates an empty MW Interactive' do
-          activity
-          starting_count = MwInteractive.count()
-          join_count = InteractiveItem.count()
-          post :create, :page_id => page.id
-
-          expect(MwInteractive.count()).to equal starting_count + 1
-          expect(InteractiveItem.count()).to equal join_count + 1
-        end
-
-        it 'redirects the submitter to the page edit page' do
-          activity
-          post :create, :page_id => page.id
-          new_id = MwInteractive.last().id
-          expect(response).to redirect_to(edit_activity_page_path(activity, page, :edit_mw_int => new_id))
-        end
-      end
-    end
-
     context 'when editing an existing MW Interactive' do
       describe 'edit' do
         it 'shows a form with values of the MW Interactive filled in' do
@@ -110,25 +70,6 @@ describe MwInteractivesController do
           post :update, :id => int.id, :page_id => page.id, :mw_interactive => new_values_hash
           expect(response).to redirect_to(edit_activity_page_path(activity, page))
           expect(flash[:warning]).to eq('There was a problem updating your iframe interactive.')
-        end
-      end
-
-      describe 'destroy' do
-        it 'removes the requested MW Interactive from the database and page and redirects to the page edit page' do
-          activity
-          int
-          PageItem.create!(:interactive_page => page, :embeddable => int)
-          interactive_count = MwInteractive.count()
-          page.reload
-          page_count = page.interactives.length
-
-          post :destroy, :id => int.id, :page_id => page.id
-
-          expect(response).to redirect_to(edit_activity_page_path(activity, page))
-          expect(MwInteractive.count()).to eq(interactive_count - 1)
-          page.reload
-          expect(page.interactives.length).to eq(page_count - 1)
-          expect(flash[:notice]).to eq('Your Mw interactive was deleted.')
         end
       end
     end

--- a/spec/controllers/mw_interactives_controller_spec.rb
+++ b/spec/controllers/mw_interactives_controller_spec.rb
@@ -117,7 +117,7 @@ describe MwInteractivesController do
         it 'removes the requested MW Interactive from the database and page and redirects to the page edit page' do
           activity
           int
-          InteractiveItem.create!(:interactive_page => page, :interactive => int)
+          PageItem.create!(:interactive_page => page, :embeddable => int)
           interactive_count = MwInteractive.count()
           page.reload
           page_count = page.interactives.length

--- a/spec/controllers/video_interactives_controller_spec.rb
+++ b/spec/controllers/video_interactives_controller_spec.rb
@@ -111,7 +111,7 @@ describe VideoInteractivesController do
         it 'removes the requested Video Interactive from the database and page and redirects to the page edit page' do
           activity
           int
-          InteractiveItem.create!(:interactive_page => page, :interactive => int)
+          PageItem.create!(:interactive_page => page, :embeddable => int)
           interactive_count = VideoInteractive.count()
           page.reload
           page_count = page.interactives.length

--- a/spec/controllers/video_interactives_controller_spec.rb
+++ b/spec/controllers/video_interactives_controller_spec.rb
@@ -18,46 +18,6 @@ describe VideoInteractivesController do
 
   context 'when the logged-in user is an author' do
     # Authorization is tested in spec/models/user_spec.rb
-    context 'and an InteractivePage ID is provided' do
-      describe 'new' do
-        it 'automatically creates a new interactive' do
-          activity
-          starting_count = VideoInteractive.count()
-          join_count = InteractiveItem.count()
-          get :new, :page_id => page.id
-
-          expect(VideoInteractive.count()).to equal starting_count + 1
-          expect(InteractiveItem.count()).to equal join_count + 1
-        end
-
-        it 'redirects the submitter back to the page edit page' do
-          activity
-          get :new, :page_id => page.id
-          new_id = VideoInteractive.last().id
-          expect(response).to redirect_to(edit_activity_page_path(activity, page, :edit_vid_int => new_id))
-        end
-      end
-
-      describe 'create' do
-        it 'creates an empty MW Interactive' do
-          activity
-          starting_count = VideoInteractive.count()
-          join_count = InteractiveItem.count()
-          post :create, :page_id => page.id
-
-          expect(VideoInteractive.count()).to equal starting_count + 1
-          expect(InteractiveItem.count()).to equal join_count + 1
-        end
-
-        it 'redirects the submitter to the page edit page' do
-          activity
-          post :create, :page_id => page.id
-          new_id = VideoInteractive.last().id
-          expect(response).to redirect_to(edit_activity_page_path(activity, page, :edit_vid_int => new_id))
-        end
-      end
-    end
-
     context 'when editing an existing Video Interactive' do
       describe 'edit' do
         it 'shows a form with values of the Video Interactive filled in' do
@@ -105,25 +65,6 @@ describe VideoInteractivesController do
         #   response.should redirect_to(edit_video_interactive_path(int))
         #   flash[:warning].should == 'There was a problem updating your Video Interactive'
         # end
-      end
-
-      describe 'destroy' do
-        it 'removes the requested Video Interactive from the database and page and redirects to the page edit page' do
-          activity
-          int
-          PageItem.create!(:interactive_page => page, :embeddable => int)
-          interactive_count = VideoInteractive.count()
-          page.reload
-          page_count = page.interactives.length
-
-          post :destroy, :id => int.id, :page_id => page.id
-
-          expect(response).to redirect_to(edit_activity_page_path(activity, page))
-          expect(VideoInteractive.count()).to eq(interactive_count - 1)
-          page.reload
-          expect(page.interactives.length).to eq(page_count - 1)
-          expect(flash[:notice]).to eq('Your Video interactive was deleted.')
-        end
       end
     end
   end

--- a/spec/import_examples/valid_lightweight_activity_import.json
+++ b/spec/import_examples/valid_lightweight_activity_import.json
@@ -20,73 +20,97 @@
     "sidebar_title": "Did you know?",
     "text": null,
     "is_hidden": false,
-    "interactives": [{
-      "caption": "lightbox",
-      "credit": "lightbox",
-      "credit_url": "",
-      "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
-      "type": "ImageInteractive"
-    }, {
-      "name": "air pollution",
-      "native_height": 435,
-      "native_width": 576,
-      "url": "http://concord-consortium.github.io/agentscript-models/air-pollution/air-pollution-1.html",
-      "type": "MwInteractive"
-    }, {
-      "caption": "caption text",
-      "credit": "credit text",
-      "height": 240,
-      "poster_url": "",
-      "width": 556,
-      "sources": [{
-        "format": "video/mp4",
-        "url": "http://media.w3.org/2010/05/sintel/trailer.mp4"
-      }],
-      "type": "VideoInteractive"
-    }],
     "embeddables": [{
-      "bg_source": "Shutterbug",
-      "bg_url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
-      "drawing_prompt": "\u003Cspan style=\"color: rgb(63, 63, 63); font-family: Lato, arial, helvetica, sans-serif; font-size: 13px; background-color: rgb(255, 255, 255);\"\u003EDrawing Prompt text\u003C/span\u003E",
-      "name": "Image Question",
-      "prompt": "why does ...",
-      "type": "Embeddable::ImageQuestion"
+      "embeddable": {
+        "caption": "lightbox",
+        "credit": "lightbox",
+        "credit_url": "",
+        "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
+        "type": "ImageInteractive"
+      },
+      "section": "interactive_box"
     }, {
-      "custom": false,
-      "enable_check_answer": true,
-      "multi_answer": false,
-      "name": "Multiple Choice Question element",
-      "prompt": "why does ...",
-      "show_as_menu": false,
-      "choices": [{
-        "choice": "a",
-        "is_correct": true,
-        "prompt": ""
-      }, {
-        "choice": "b",
-        "is_correct": false,
-        "prompt": ""
-      }, {
-        "choice": "c",
-        "is_correct": false,
-        "prompt": ""
-      }],
-      "type": "Embeddable::MultipleChoice"
+      "embeddable": {
+        "name": "air pollution",
+        "native_height": 435,
+        "native_width": 576,
+        "url": "http://concord-consortium.github.io/agentscript-models/air-pollution/air-pollution-1.html",
+        "type": "MwInteractive"
+      },
+      "section": "interactive_box"
     }, {
-           "action_type":1,
-           "custom_action_label": "",
-           "name": "Labbook album",
-           "prompt": "This is Labbook!",
-           "type":"Embeddable::Labbook"
+      "embeddable": {
+        "caption": "caption text",
+        "credit": "credit text",
+        "height": 240,
+        "poster_url": "",
+        "width": 556,
+        "sources": [{
+          "format": "video/mp4",
+          "url": "http://media.w3.org/2010/05/sintel/trailer.mp4"
+        }],
+        "type": "VideoInteractive"
+      },
+      "section": "interactive_box"
+    }, {
+      "embeddable": {
+        "bg_source": "Shutterbug",
+        "bg_url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
+        "drawing_prompt": "\u003Cspan style=\"color: rgb(63, 63, 63); font-family: Lato, arial, helvetica, sans-serif; font-size: 13px; background-color: rgb(255, 255, 255);\"\u003EDrawing Prompt text\u003C/span\u003E",
+        "name": "Image Question",
+        "prompt": "why does ...",
+        "type": "Embeddable::ImageQuestion"
+      },
+      "section": null
+    }, {
+      "embeddable": {
+        "custom": false,
+        "enable_check_answer": true,
+        "multi_answer": false,
+        "name": "Multiple Choice Question element",
+        "prompt": "why does ...",
+        "show_as_menu": false,
+        "choices": [{
+          "choice": "a",
+          "is_correct": true,
+          "prompt": ""
         }, {
-      "name": "open responce",
-      "prompt": "why does ...",
-      "type": "Embeddable::OpenResponse"
+          "choice": "b",
+          "is_correct": false,
+          "prompt": ""
+        }, {
+          "choice": "c",
+          "is_correct": false,
+          "prompt": ""
+        }],
+        "type": "Embeddable::MultipleChoice"
+      },
+      "section": null
     }, {
-      "content": "\u003Cb style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003EBlack Sabbath\u003C/b\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;are an English\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Rock_music\" title=\"Rock music\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003Erock\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;band, formed in\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Birmingham\" title=\"Birmingham\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EBirmingham\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;in 1968, by guitarist and main songwriter\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Tony_Iommi\" title=\"Tony Iommi\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003ETony Iommi\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E, bassist and main lyricist\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Geezer_Butler\" title=\"Geezer Butler\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EGeezer Butler\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E, singer\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Ozzy_Osbourne\" title=\"Ozzy Osbourne\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EOzzy Osbourne\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E, and drummer\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Bill_Ward_(musician)\" title=\"Bill Ward (musician)\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EBill Ward\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E. The band have since experienced multiple line-up changes, with guitarist Iommi being the only constant presence in the band through the years. Originally formed in 1968 as a\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Blues_rock\" title=\"Blues rock\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003Eblues rock\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;band, the group soon adopted the Black Sabbath moniker and began incorporating\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Occultism\" title=\"Occultism\" class=\"mw-redirect\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003Eoccult\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;themes with horror-inspired lyrics and tuned-down guitars. Despite an association with these two themes, Black Sabbath also composed songs dealing with social instability, political corruption, the dangers of drug abuse and apocalyptic prophecies of the horrors of war.\u003C/span\u003E",
-      "name": "Black Sabbath",
-      "type": "Embeddable::Xhtml"
-    }]
+        "embeddable": {
+          "action_type":1,
+          "custom_action_label": "",
+          "name": "Labbook album",
+          "prompt": "This is Labbook!",
+          "type":"Embeddable::Labbook"
+        },
+        "section": null
+      }, {
+      "embeddable": {
+        "name": "open responce",
+        "prompt": "why does ...",
+        "type": "Embeddable::OpenResponse"
+      },
+      "section": null
+    }, {
+      "embeddable": {
+        "content": "\u003Cb style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003EBlack Sabbath\u003C/b\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;are an English\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Rock_music\" title=\"Rock music\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003Erock\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;band, formed in\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Birmingham\" title=\"Birmingham\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EBirmingham\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;in 1968, by guitarist and main songwriter\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Tony_Iommi\" title=\"Tony Iommi\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003ETony Iommi\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E, bassist and main lyricist\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Geezer_Butler\" title=\"Geezer Butler\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EGeezer Butler\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E, singer\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Ozzy_Osbourne\" title=\"Ozzy Osbourne\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EOzzy Osbourne\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E, and drummer\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Bill_Ward_(musician)\" title=\"Bill Ward (musician)\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003EBill Ward\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E. The band have since experienced multiple line-up changes, with guitarist Iommi being the only constant presence in the band through the years. Originally formed in 1968 as a\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Blues_rock\" title=\"Blues rock\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003Eblues rock\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;band, the group soon adopted the Black Sabbath moniker and began incorporating\u0026nbsp;\u003C/span\u003E\u003Ca href=\"http://en.wikipedia.org/wiki/Occultism\" title=\"Occultism\" class=\"mw-redirect\" style=\"text-decoration: none; color: rgb(11, 0, 128); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background: none rgb(255, 255, 255);\"\u003Eoccult\u003C/a\u003E\u003Cspan style=\"color: rgb(37, 37, 37); font-family: sans-serif; font-size: 14px; line-height: 22.3999996185303px; background-color: rgb(255, 255, 255);\"\u003E\u0026nbsp;themes with horror-inspired lyrics and tuned-down guitars. Despite an association with these two themes, Black Sabbath also composed songs dealing with social instability, political corruption, the dangers of drug abuse and apocalyptic prophecies of the horrors of war.\u003C/span\u003E",
+        "name": "Black Sabbath",
+        "type": "Embeddable::Xhtml"
+      },
+      "section": null
+    }
+    ]
   }, {
     "layout": "l-6040",
     "name": null,
@@ -99,31 +123,39 @@
     "sidebar_title": "Did you know?",
     "text": null,
     "is_hidden": false,
-    "interactives": [{
-      "caption": "page 2",
-      "credit": "page 2",
-      "credit_url": "",
-      "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
-      "type": "ImageInteractive"
+    "embeddables": [{
+      "embeddable": {
+        "caption": "page 2",
+        "credit": "page 2",
+        "credit_url": "",
+        "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
+        "type": "ImageInteractive"
+      },
+      "section": "interactive_box"
     }, {
-      "name": "simple gas",
-      "native_height": 435,
-      "native_width": 576,
-      "url": "https://lab.concord.org/embeddable.html#interactives/samples/2-simple-gas.json",
-      "type": "MwInteractive"
+      "embeddable":  {
+        "name": "simple gas",
+        "native_height": 435,
+        "native_width": 576,
+        "url": "https://lab.concord.org/embeddable.html#interactives/samples/2-simple-gas.json",
+        "type": "MwInteractive"
+      },
+      "section": "interactive_box"
     }, {
-      "caption": "asd",
-      "credit": "asd",
-      "height": 240,
-      "poster_url": "",
-      "width": 556,
-      "sources": [{
-        "format": "video/mp4",
-        "url": "http://media.w3.org/2010/05/sintel/trailer.mp4"
-      }],
-      "type": "VideoInteractive"
-    }],
-    "embeddables": []
+      "embeddable": {
+        "caption": "asd",
+        "credit": "asd",
+        "height": 240,
+        "poster_url": "",
+        "width": 556,
+        "sources": [{
+          "format": "video/mp4",
+          "url": "http://media.w3.org/2010/05/sintel/trailer.mp4"
+        }],
+        "type": "VideoInteractive"
+      },
+      "section": "interactive_box"
+    }]
   }, {
     "layout": "l-6040",
     "name": null,
@@ -136,46 +168,59 @@
     "sidebar_title": "Did you know?",
     "text": null,
     "is_hidden": false,
-    "interactives": [{
-      "caption": "page 3",
-      "credit": "page3",
-      "credit_url": "",
-      "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
-      "type": "ImageInteractive",
-      "ref_id":"1164-ImageInteractive"
+    "embeddables": [{
+      "embeddable": {
+        "caption": "page 3",
+        "credit": "page3",
+        "credit_url": "",
+        "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
+        "type": "ImageInteractive",
+        "ref_id":"1164-ImageInteractive"
+      },
+      "section": "interactive_box"
+      }, {
+        "embeddable": {
+          "name": null,
+          "native_height": 435,
+          "native_width": 576,
+          "url": null,
+          "type": "MwInteractive"
+        },
+        "section": "interactive_box"
+      }, {
+        "embeddable": {
+          "name": "simple gas 2",
+          "native_height": 435,
+          "native_width": 576,
+          "url": "http://concord-consortium.github.io/agentscript-models/air-pollution/air-pollution-1.html",
+          "type": "MwInteractive"
+        },
+        "section": "interactive_box"
+      }, {
+      "embeddable": {
+        "caption": "page 3",
+        "credit": "page 3",
+        "height": 240,
+        "poster_url": "",
+        "width": 556,
+        "sources": [{
+          "format": "video/mp4",
+          "url": "http://media.w3.org/2010/05/sintel/trailer.mp4"
+        }],
+        "type": "VideoInteractive"
+      },
+      "section": "interactive_box"
     }, {
-      "name": null,
-      "native_height": 435,
-      "native_width": 576,
-      "url": null,
-      "type": "MwInteractive"
-    }, {
-      "name": "simple gas 2",
-      "native_height": 435,
-      "native_width": 576,
-      "url": "http://concord-consortium.github.io/agentscript-models/air-pollution/air-pollution-1.html",
-      "type": "MwInteractive"
-    }, {
-      "caption": "page 3",
-      "credit": "page 3",
-      "height": 240,
-      "poster_url": "",
-      "width": 556,
-      "sources": [{
-        "format": "video/mp4",
-        "url": "http://media.w3.org/2010/05/sintel/trailer.mp4"
-      }],
-      "type": "VideoInteractive"
-    }],
-    "embeddables": [
-      {
-         "action_type":1,
-         "custom_action_label":"LB1",
-         "name":"Lab Book 1",
-         "prompt":"Take a picture of the model",
-         "type":"Embeddable::Labbook",
-         "interactive_ref_id":"1164-ImageInteractive"
-      }
+      "embeddable": {
+        "action_type":1,
+        "custom_action_label":"LB1",
+        "name":"Lab Book 1",
+        "prompt":"Take a picture of the model",
+        "type":"Embeddable::Labbook",
+        "interactive_ref_id":"1164-ImageInteractive"
+      },
+      "section": null
+    }
     ]
   }],
   "type":"LightweightActivity"

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -192,7 +192,6 @@ describe InteractivePage do
   describe '#export' do
     it 'returns json of an interactive page' do
       page_json = page.export.as_json
-      expect(page_json['interactives'].length).to eq(page.interactives.count)
       expect(page_json['embeddables'].length).to eq(page.embeddables.count)
       expect(page_json['is_hidden']).to eq(page.is_hidden)
       expect(page_json['is_completion']).to eq(page.is_completion)
@@ -213,8 +212,9 @@ describe InteractivePage do
         expect(interactive).not_to be_nil
         expect(labbook.interactive).not_to be_nil
         export_data = page.export.as_json
-        interactive_id = export_data['interactives'].first['ref_id']
-        expect(export_data['embeddables'].last).to match a_hash_including('interactive_ref_id' => interactive_id)
+        interactive_id = export_data['embeddables'].select { |e| e['section'] == 'interactive_box' }.first['embeddable']['ref_id']
+        labbook = export_data['embeddables'].select { |e| e['section'] == nil }.last['embeddable']
+        expect(labbook).to match a_hash_including('interactive_ref_id' => interactive_id)
       end
     end
   end
@@ -308,6 +308,7 @@ describe InteractivePage do
     describe "copying a labbook with a reference to an interactive" do
       before(:each) do
         page.add_embeddable labbook
+        page.reload
       end
 
       let(:args)              { {interactive: page_interactive}  }

--- a/spec/views/interactive_pages/edit.html.haml_spec.rb
+++ b/spec/views/interactive_pages/edit.html.haml_spec.rb
@@ -63,12 +63,6 @@ describe "interactive_pages/edit" do
     expect(rendered).to match /<select[^>]+name="embeddable_type"[^>]*>/
   end
 
-  it 'has links for adding Interactives to the page' do
-    render
-    expect(rendered).to match /<form[^>]+action="\/activities\/#{activity.id}\/pages\/#{page.id}\/add_interactive"[^<]*>/
-    expect(rendered).to match /<select[^>]+name="interactive_type"[^>]*>/
-  end
-
   it 'shows navigation links' do
     page1
     page2


### PR DESCRIPTION
@scytacki, @knowuh, I'm opening this PR with the latest changes, but it's not ready to merge. The current status is:

1. All the interactive types should be supported (MW/Iframe, Image, Video).
2. Basic authoring should work (and authoring UI is tweaked so things look reasonable).
3. Basic runtime should work. 
4. Copy, import, and export should work.
5. I've managed to have all the RSpec tests passing (started with ~50 failures).
6. I've tried Labbook and image questions + interactives in a few scenarios (especially page copying), but I didn't have much time to test it.

~~TODO~~ (DONE)
1. Fix Jasmine tests.
2. Test various cases, untypical scenarios, ITSI layout (that might be broken), and other edge cases. I guess it'll produce a bunch of new points in TODO list.
3. Remove `InteractiveItem` class (it might break more tests, but it would be useful to do for sure).
4. Write migration that replaces all the existing `InteractiveItems` with `PageItems` (and `section="interactive_box"`).
