### PR TITLE
Create "External Scripts" in Lara. Model Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ To support new Embeddables:
 ## Current work: reporting
 LARA's runtime is being rebuilt to support reporting student answers and progress to [Concord's project portals](https://github.com/concord-consortium/rigse).
 
+
+## External Scripting ##
+
+* Admins must create a new `ApprovedScript` record.  The record includes the
+    * URL to the remote script
+    * An internal label for reference.
+* ExternalScripts must conform to this (developing) API:
+    * They must call `ExternalScripts.register("label", NewableClass)` immediately;
+    * `new NewableClass(config, ctx)` must return an instance of an ExternalScript
+        * `config` is an object of your choice.  Author's can edit this as json when adding a script instance.
+        * `ctx` is the runtime context. Includes  `name`,`scriptLabel`, `scriptUrl`, `embeddableId` and `div`.
+    * The API for a `NewableClass` is still being worked out.  Right now it only needs to implement `handleEvent({event: string, time: number, parameters: {}})`. These are logEvents as per `logger.js`.
+    * see `external-scripts.js` and `external_script.rb` for more info.
+
+
+
 ## Single Sign-On
 If you want to use a single sign-on provider, you will need to configure a client in the sign-on authority (e.g. the portal). You should also copy `config/app_environmental_variables.sample.rb` to  `config/app_environmental_variables.rb` and edit as appropriate.
 

--- a/app/assets/javascripts/c_rater.coffee
+++ b/app/assets/javascripts/c_rater.coffee
@@ -101,6 +101,7 @@ class ArgumentationBlockController
           alert(t('ARG_BLOCK.SUBMIT_ERROR'))
         else
           @fbOnFeedback.activate(data.submission_id)
+          LoggerUtils.craterResponseLogging(data)
 
         @submissionCount += 1
         @updateSubmitBtnText()

--- a/app/assets/javascripts/external-scripts.js
+++ b/app/assets/javascripts/external-scripts.js
@@ -1,0 +1,48 @@
+ExternalScripts = { _scripts: [] };
+
+ExternalScripts.register = function(_constructor, env) {
+  try {
+    var config = {};
+    if (typeof env.config == 'string'){
+      config = JSON.parse(env.config);
+      delete env.config;
+    };
+    var script = new _constructor(config, env);
+    this._scripts.push(script);
+    console.group("ExternalScripts: Register");
+      console.dir(env);
+    console.groupEnd();
+  }
+  catch(e) {
+    console.group("External Script Error");
+    console.error(e);
+    console.groupEnd();
+  }
+};
+
+ExternalScripts.nameForScript = function(script) {
+  return(script.name || "(unknown)");
+}
+
+ExternalScripts.try = function(funcName, arguments) {
+  for(var i=0; i < this._scripts.length; i++) {
+    var script = this._scripts[i];
+    var name = this.nameForScript(script);
+    try {
+      if(typeof script[funcName] == 'function') {
+        script[funcName].call(script, arguments);
+      }
+      else {
+        console.error("script " + name + " doesn't respond to  " + funcName);
+      }
+    }
+    catch (exception) {
+      console.error("Error calling " + funcName + " on "+ name);
+      console.error(exception);
+    }
+  }
+}
+
+ExternalScripts.handleLogEvent = function(evt, logger) {
+  this.try('handleEvent', evt, logger);
+};

--- a/app/assets/javascripts/external-scripts.js
+++ b/app/assets/javascripts/external-scripts.js
@@ -1,23 +1,52 @@
-ExternalScripts = { _scripts: [] };
+ExternalScripts = {
+  _constructors: {},
+  _scripts:[],
+  _script_labels:[]
+};
 
-ExternalScripts.register = function(_constructor, env) {
-  try {
-    var config = {};
-    if (typeof env.config == 'string'){
-      config = JSON.parse(env.config);
-      delete env.config;
+ExternalScripts.notRegistered = function(label) {
+  console.error("No external script registered for " + label);
+};
+
+ExternalScripts.externalScriptError = function(e, other) {
+  console.group("External Script Error");
+  console.error(e);
+  console.dir(other);
+  console.groupEnd();
+};
+
+ExternalScripts.init = function(_label, ctx) {
+  var constructor = this._constructors[_label];
+  var config = {};
+  var script = null;
+  if (typeof constructor == 'function') {
+    if (typeof ctx.config == 'string'){
+      config = JSON.parse(ctx.config);
+      delete ctx.config;
     };
-    var script = new _constructor(config, env);
-    this._scripts.push(script);
-    console.group("ExternalScripts: Register");
-      console.dir(env);
-      console.dir(config);
-    console.groupEnd();
+    try {
+      script = new constructor(config, ctx);
+      this._scripts.push(script);
+      this._script_labels.push(_label);
+    }
+    catch(e) {
+      this.externalScriptError(e, ctx);
+    }
   }
-  catch(e) {
-    console.group("External Script Error");
-    console.error(e);
-    console.groupEnd();
+  else {
+    this.notRegistered(_label);
+  }
+}
+
+
+ExternalScripts.register = function(_label, _constructor) {
+  if(typeof _constructor == 'function') {
+    if(this._constructors[_label]) {
+      console.error("Duplicate script constructor for label " + _label);
+    }
+    else {
+      this._constructors[_label] = _constructor;
+    }
   }
 };
 
@@ -34,12 +63,11 @@ ExternalScripts.try = function(funcName, arguments) {
         script[funcName].call(script, arguments);
       }
       else {
-        console.error("script " + name + " doesn't respond to  " + funcName);
+        this.externalScriptError("script " + name + " doesn't respond to  " + funcName);
       }
     }
     catch (exception) {
-      console.error("Error calling " + funcName + " on "+ name);
-      console.error(exception);
+      this.externalScriptError(exception, {name: name, funcName: funcName});
     }
   }
 }

--- a/app/assets/javascripts/external-scripts.js
+++ b/app/assets/javascripts/external-scripts.js
@@ -11,6 +11,7 @@ ExternalScripts.register = function(_constructor, env) {
     this._scripts.push(script);
     console.group("ExternalScripts: Register");
       console.dir(env);
+      console.dir(config);
     console.groupEnd();
   }
   catch(e) {

--- a/app/assets/javascripts/logger.js
+++ b/app/assets/javascripts/logger.js
@@ -30,6 +30,17 @@ LoggerUtils.submitArgblockLogging = function(data) {
 };
 
 
+LoggerUtils.craterResponseLogging = function(data) {
+  var loggerConfig = window.gon && window.gon.loggerConfig;
+  if (!loggerConfig) {
+    return;
+  };
+
+  var logger_utils = LoggerUtils.instance(loggerConfig);
+  logger_utils._craterResponseLogging(data);
+};
+
+
 LoggerUtils.logInteractiveEvents = function(iframe){
   var loggerConfig = window.gon && window.gon.loggerConfig;
   if (!loggerConfig) {
@@ -99,6 +110,13 @@ LoggerUtils.prototype._submittedQuestionLogging = function(data,autoSave) {
 LoggerUtils.prototype._submitArgblockLogging = function(data) {
   this._logger.log({
     event  : "arg-block submit",
+    page_id: data
+  });
+};
+
+LoggerUtils.prototype._craterResponseLogging = function(data) {
+  this._logger.log({
+    event  : "c-rater response",
     page_id: data
   });
 };
@@ -186,11 +204,15 @@ function Logger(options) {
   this._defaultData = options.defaultData;
 }
 
+
 Logger.prototype.log = function(data) {
   if (typeof(data) === 'string') {
     data = {event: data};
   }
   data.time = Date.now(); // millisecons
+  if (( typeof ExternalScripts != "undefined") && ExternalScripts.handleLogEvent) {
+    ExternalScripts.handleLogEvent(data);
+  };
   this._post(data);
 };
 

--- a/app/assets/javascripts/logger.js
+++ b/app/assets/javascripts/logger.js
@@ -211,7 +211,7 @@ Logger.prototype.log = function(data) {
   }
   data.time = Date.now(); // millisecons
   if (( typeof ExternalScripts != "undefined") && ExternalScripts.handleLogEvent) {
-    ExternalScripts.handleLogEvent(data);
+    ExternalScripts.handleLogEvent(data, this);
   };
   this._post(data);
 };

--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -48,6 +48,7 @@
 //= require prediction
 //= require activity-box-click
 //= require wait-message
+//= require external-scripts
 //= require logger
 //= require sidebar
 //= require labbook

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -1065,3 +1065,16 @@ body.iframed {
   }
 }
 
+form {
+  #error_explanation {
+    margin: 2em 0px;
+    border: 2px solid #800000;
+    padding: 1em;
+  }
+
+  .field_with_errors {
+    background-color: #CAA;
+    padding: 0.5em;
+  }
+}
+

--- a/app/controllers/approved_scripts_controller.rb
+++ b/app/controllers/approved_scripts_controller.rb
@@ -1,0 +1,84 @@
+class ApprovedScriptsController < ApplicationController
+  load_and_authorize_resource
+  # GET /approved_scripts
+  # GET /approved_scripts.json
+  def index
+    @approved_scripts = ApprovedScript.all
+
+    respond_to do |format|
+      format.html # index.html.html.haml
+      format.json { render json: @approved_scripts }
+    end
+  end
+
+  # GET /approved_scripts/1
+  # GET /approved_scripts/1.json
+  def show
+    @approved_script = ApprovedScript.find(params[:id])
+
+    respond_to do |format|
+      format.html # show.html.html.haml
+      format.json { render json: @approved_script }
+    end
+  end
+
+  # GET /approved_scripts/new
+  # GET /approved_scripts/new.json
+  def new
+    @approved_script = ApprovedScript.new
+
+    respond_to do |format|
+      format.html # new.html.html.haml
+      format.json { render json: @approved_script }
+    end
+  end
+
+  # GET /approved_scripts/1/edit
+  def edit
+    @approved_script = ApprovedScript.find(params[:id])
+  end
+
+  # POST /approved_scripts
+  # POST /approved_scripts.json
+  def create
+    @approved_script = ApprovedScript.new(params[:approved_script])
+
+    respond_to do |format|
+      if @approved_script.save
+        format.html { redirect_to approved_scripts_url, notice: 'Approved script was successfully created.' }
+        format.json { render json: @approved_script, status: :created, location: @approved_script }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @approved_script.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PUT /approved_scripts/1
+  # PUT /approved_scripts/1.json
+  def update
+    @approved_script = ApprovedScript.find(params[:id])
+
+    respond_to do |format|
+      if @approved_script.update_attributes(params[:approved_script])
+        format.html { redirect_to approved_scripts_url, notice: 'Approved script was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: "edit" }
+        format.json { render json: @approved_script.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /approved_scripts/1
+  # DELETE /approved_scripts/1.json
+  def destroy
+    @approved_script = ApprovedScript.find(params[:id])
+    @approved_script.destroy
+
+    respond_to do |format|
+      format.html { redirect_to approved_scripts_url }
+      format.json { head :no_content }
+    end
+  end
+end

--- a/app/controllers/embeddable/external_scripts_controller.rb
+++ b/app/controllers/embeddable/external_scripts_controller.rb
@@ -1,0 +1,8 @@
+class Embeddable::ExternalScriptsController < Embeddable::EmbeddablesController
+  before_filter :set_embeddable
+
+  private
+  def set_embeddable
+    @embeddable = Embeddable::ExternalScript.find(params[:id])
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,7 @@ class Ability
       can :inspect, Run
       can :manage, QuestionTracker
       can :report, QuestionTracker
+      can :manage, ApprovedScript
     elsif user.author?
       # Authors can create new items and manage those they created
       can :create, Sequence

--- a/app/models/approved_script.rb
+++ b/app/models/approved_script.rb
@@ -1,0 +1,4 @@
+class ApprovedScript < ActiveRecord::Base
+  attr_accessible :name, :url, :description
+  belongs_to :appoved_script
+end

--- a/app/models/approved_script.rb
+++ b/app/models/approved_script.rb
@@ -1,4 +1,13 @@
 class ApprovedScript < ActiveRecord::Base
-  attr_accessible :name, :url, :description
+  attr_accessible :name, :url, :label, :description
+  validates :name, presence: true
+  validates :label, format: {
+    with: /^([A-Za-z0-9]+)$/,
+    message: "only use letters and numbers."
+  }
+  validates :url, format: {
+    with: /^https?:\/\//i,
+    message: "include protocol (https://)"
+  }
   belongs_to :appoved_script
 end

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -5,7 +5,8 @@ module Embeddable
       Embeddable::OpenResponse   => "Open response",
       Embeddable::Xhtml          => "Text box",
       Embeddable::Labbook        => "Labbook",
-      QuestionTracker            => "Tracked Question"
+      QuestionTracker            => "Tracked Question",
+      Embeddable::ExternalScript  => "External Script"
     }
 
   def self.table_name_prefix

--- a/app/models/embeddable/external_script.rb
+++ b/app/models/embeddable/external_script.rb
@@ -8,7 +8,8 @@ module Embeddable
     has_many :page_items, :as => :embeddable, :dependent => :destroy
     has_many :interactive_pages, :through => :page_items
     delegate :name,  to: :approved_script, allow_nil: true
-    delegate :url,  to: :approved_script, allow_nil: true
+    delegate :label, to: :approved_script, allow_nil: true
+    delegate :url,   to: :approved_script, allow_nil: true
 
     def self.name_as_param
       :embeddable_external_script

--- a/app/models/embeddable/external_script.rb
+++ b/app/models/embeddable/external_script.rb
@@ -1,0 +1,64 @@
+module Embeddable
+  class ExternalScript < ActiveRecord::Base
+    include Embeddable
+
+    attr_accessible :description, :configuration, :approved_script_id
+    # PageItem instances are join models, so if the embeddable is gone the join should go too.
+    belongs_to :approved_script
+    has_many :page_items, :as => :embeddable, :dependent => :destroy
+    has_many :interactive_pages, :through => :page_items
+    delegate :name,  to: :approved_script, allow_nil: true
+    delegate :url,  to: :approved_script, allow_nil: true
+
+    def self.name_as_param
+      :embeddable_external_script
+    end
+
+    def self.display_partial
+      :external_script
+    end
+
+    def self.human_description
+      "External Script"
+    end
+
+    def self.import(import_hash)
+      return self.new(import_hash)
+    end
+
+    def to_hash
+      {
+        approved_script_id: approved_script_id,
+        configuration: configuration,
+        description: description
+      }
+    end
+
+    def portal_hash
+      {
+        type: "external_script",
+        id: id,
+        url: url,
+        configuration: configuration,
+        name: name
+      }
+    end
+
+    def duplicate
+      return Embeddable::ExternalScript.new(self.to_hash)
+    end
+
+    def reportable?
+      false
+    end
+
+    def is_hidden
+      false
+    end
+
+    def export
+      return self.as_json(only:[:name, :url, :configuration, :description])
+    end
+
+  end
+end

--- a/app/views/approved_scripts/_form.html.haml
+++ b/app/views/approved_scripts/_form.html.haml
@@ -1,0 +1,25 @@
+= form_for(@approved_script) do |f|
+  - if @approved_script.errors.any?
+    #error_explanation
+      %h2
+        = pluralize(@approved_script.errors.count, "error")
+        prohibited this approved_script from being saved:
+      %ul
+        - @approved_script.errors.full_messages.each do |msg|
+          %li= msg
+
+  .field
+    = f.label :name
+    %br
+    = f.text_field :name
+  .field
+  .field
+    = f.label :url
+    %br
+    = f.text_field :url
+  .field
+    = f.label :description
+    %br
+    = f.text_area :description
+  .actions
+    = f.submit

--- a/app/views/approved_scripts/_form.html.haml
+++ b/app/views/approved_scripts/_form.html.haml
@@ -1,25 +1,29 @@
 = form_for(@approved_script) do |f|
-  - if @approved_script.errors.any?
-    #error_explanation
-      %h2
-        = pluralize(@approved_script.errors.count, "error")
-        prohibited this approved_script from being saved:
-      %ul
-        - @approved_script.errors.full_messages.each do |msg|
-          %li= msg
+  %div{style: "margin: 0em 5em; display: flex; flex-direction: column; width: 300px;"}
+    - if @approved_script.errors.any?
+      #error_explanation
+        %h2
+          = pluralize(@approved_script.errors.count, "error")
+          prohibited this approved_script from being saved:
+        %ul
+          - @approved_script.errors.full_messages.each do |msg|
+            %li= msg
 
-  .field
-    = f.label :name
-    %br
-    = f.text_field :name
-  .field
-  .field
-    = f.label :url
-    %br
-    = f.text_field :url
-  .field
-    = f.label :description
-    %br
-    = f.text_area :description
-  .actions
-    = f.submit
+    .field{style: "margin: 1em 0px;"}
+      = f.label :name
+      %br
+      = f.text_field :name
+    .field{style: "margin: 1em 0px;"}
+      = f.label :label
+      %br
+      = f.text_field :label
+    .field{style: "margin: 1em 0px;"}
+      = f.label :url
+      %br
+      = f.text_field :url
+    .field{style: "margin: 1em 0px;"}
+      = f.label :description
+      %br
+      = f.text_area :description
+    .actions{style: "margin: 1em 0px;"}
+      = f.submit

--- a/app/views/approved_scripts/edit.html.haml
+++ b/app/views/approved_scripts/edit.html.haml
@@ -1,0 +1,17 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :name do
+  = "Edit #{@approved_script.name}"
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li 
+        \/
+        = link_to 'All External Scripts', approved_scripts_path
+      %li= "/ Edit #{@approved_script.name}"
+
+%h1.name= "Edit #{@approved_script.name}"
+
+=render :partial => 'form'

--- a/app/views/approved_scripts/index.html.haml
+++ b/app/views/approved_scripts/index.html.haml
@@ -24,7 +24,7 @@
     %li{ :id => dom_id_for(approved_script, :item), :class => 'item' }
       %div.action_menu
         %div.action_menu_header_left
-          = link_to approved_script.name, edit_approved_script_path(approved_script), :class => 'container_link'
+          = link_to approved_script.label, edit_approved_script_path(approved_script), :class => 'container_link'
         %div.action_menu_header_right.themes
           %ul.menu
             %li.edit= link_to "Edit", edit_approved_script_path(approved_script) if can? :update, approved_script

--- a/app/views/approved_scripts/index.html.haml
+++ b/app/views/approved_scripts/index.html.haml
@@ -1,0 +1,34 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :name do
+  External Scripts
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li= link_to "Approved Scripts", approved_scripts_path
+
+.action_menu#activity-actions
+  .action_menu_header
+    .action_menu_header_left
+    .action_menu_header_right.index
+      %ul#new-menu
+        - if can? :create, ApprovedScript
+          %li#add= link_to 'create new approved_script', new_approved_script_path
+
+#official_listing_heading
+  %h1 ApprovedScripts
+%ul.quiet_list.official_listing
+  - @approved_scripts.each do |approved_script|
+    %li{ :id => dom_id_for(approved_script, :item), :class => 'item' }
+      %div.action_menu
+        %div.action_menu_header_left
+          = link_to approved_script.name, edit_approved_script_path(approved_script), :class => 'container_link'
+        %div.action_menu_header_right.themes
+          %ul.menu
+            %li.edit= link_to "Edit", edit_approved_script_path(approved_script) if can? :update, approved_script
+            %li.delete= link_to 'Delete', approved_script_path(approved_script), method: :delete, data: { confirm: 'Are you sure?' } if can? :update, approved_script
+      %div.tiny
+        links to
+        = link_to approved_script.url, approved_script.url

--- a/app/views/approved_scripts/new.html.haml
+++ b/app/views/approved_scripts/new.html.haml
@@ -1,0 +1,17 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :title do
+  New Approved Script
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li 
+        \/
+        = link_to 'All Approved Scripts', projects_path
+      %li / New Approved Script
+
+%h1.title New Approved Script
+
+=render :partial => 'form'

--- a/app/views/embeddable/external_scripts/_author.html.haml
+++ b/app/views/embeddable/external_scripts/_author.html.haml
@@ -1,0 +1,10 @@
+.embeddable_tools
+  .drag_handle
+  = render :partial => "shared/embedded_editor_links",
+    :locals => { :embeddable => embeddable, :page => page, :type => 'external_script',
+    :allow_hide => allow_hide }
+.embeddable_options
+  .name
+    Name: #{embeddable.name.html_safe unless embeddable.name.blank?}
+  .url{name: "questions[embeddable__#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}]"}
+    URL: #{(embeddable.url or "")}

--- a/app/views/embeddable/external_scripts/_form.html.haml
+++ b/app/views/embeddable/external_scripts/_form.html.haml
@@ -10,9 +10,9 @@
       = f.collection_select(:approved_script_id, ApprovedScript.all, :id, :name)
   %div{style: "margin-top: 0.5em;"}
     = f.label "description"
-    = f.text_area :configuration, :size => "40,10"
+    = f.text_field :description
   %div{style: "margin-top: 0.5em;"}
     = f.label "tree json"
-    = f.text_area :configuration
+    = f.text_area :configuration, {id:'jsonConfigText'}
   = f.submit "Cancel", :class => 'close'
   = f.submit "Save", :class => 'embeddable-save'

--- a/app/views/embeddable/external_scripts/_form.html.haml
+++ b/app/views/embeddable/external_scripts/_form.html.haml
@@ -1,0 +1,18 @@
+%h1{style: "font-size: 1.5em; font-weight: bold; margin-bottom: 1em;"}
+  External Script
+
+= form_for @embeddable do |f|
+  = f.error_messages
+  %div{style: "display: grid; grid-template-columns: 100px auto;"}
+    %div
+      = f.label "Script:"
+    %div
+      = f.collection_select(:approved_script_id, ApprovedScript.all, :id, :name)
+  %div{style: "margin-top: 0.5em;"}
+    = f.label "description"
+    = f.text_area :configuration, :size => "40,10"
+  %div{style: "margin-top: 0.5em;"}
+    = f.label "tree json"
+    = f.text_area :configuration
+  = f.submit "Cancel", :class => 'close'
+  = f.submit "Save", :class => 'embeddable-save'

--- a/app/views/embeddable/external_scripts/_lightweight.html.haml
+++ b/app/views/embeddable/external_scripts/_lightweight.html.haml
@@ -23,8 +23,8 @@
         name: '#{embeddable.name}',
         scriptUrl: '#{embeddable.url}',
         embeddableId: '#{embeddable.id}',
-        config: '#{embeddable.configuration}',
-        div: '#{outputId}'
+        config: '#{embeddable.configuration.gsub(/'/, "").gsub(/\s+/i, " " )}',
+        div: $('#{outputId}')
       }
       ExternalScripts.register(ScriptConstructor, env);
     }

--- a/app/views/embeddable/external_scripts/_lightweight.html.haml
+++ b/app/views/embeddable/external_scripts/_lightweight.html.haml
@@ -1,31 +1,25 @@
-- outputId = "output-#{embeddable.id}"
+- runtimeDiv = "output-#{embeddable.id}"
+= content_for :external_scripts do
+  %script{src:embeddable.url}
 - unless embeddable.name.blank?
   .question-hdr
     %h5.h5= embeddable.name
 .question-bd
   .question-txt
     != embeddable.url
-  .output{id:outputId}
+  .output{id:runtimeDiv}
 
-%script{src:embeddable.url}
+
 :javascript
   // Begin script for #{embeddable.name}
   $(document).ready( function() {
-    var env = {};
-    if(typeof ScriptConstructor == 'undefined') {
-      console.group("External Script Error");
-        console.error("External Scripts must define a temporary 'ScriptConstructor' object");
-        console.error("See README document section ExternalScript");
-      console.groupEnd();
+    env = {
+      name: '#{embeddable.name}',
+      scriptLabel: '#{embeddable.label}',
+      scriptUrl: '#{embeddable.url}',
+      embeddableId: '#{embeddable.id}',
+      config: '#{embeddable.configuration.gsub(/'/, "").gsub(/\s+/i, " " )}',
+      div: $('#{runtimeDiv}')
     }
-    else {
-      env = {
-        name: '#{embeddable.name}',
-        scriptUrl: '#{embeddable.url}',
-        embeddableId: '#{embeddable.id}',
-        config: '#{embeddable.configuration.gsub(/'/, "").gsub(/\s+/i, " " )}',
-        div: $('#{outputId}')
-      }
-      ExternalScripts.register(ScriptConstructor, env);
-    }
+    ExternalScripts.init('#{embeddable.label}', env);
   });

--- a/app/views/embeddable/external_scripts/_lightweight.html.haml
+++ b/app/views/embeddable/external_scripts/_lightweight.html.haml
@@ -1,0 +1,31 @@
+- outputId = "output-#{embeddable.id}"
+- unless embeddable.name.blank?
+  .question-hdr
+    %h5.h5= embeddable.name
+.question-bd
+  .question-txt
+    != embeddable.url
+  .output{id:outputId}
+
+%script{src:embeddable.url}
+:javascript
+  // Begin script for #{embeddable.name}
+  $(document).ready( function() {
+    var env = {};
+    if(typeof ScriptConstructor == 'undefined') {
+      console.group("External Script Error");
+        console.error("External Scripts must define a temporary 'ScriptConstructor' object");
+        console.error("See README document section ExternalScript");
+      console.groupEnd();
+    }
+    else {
+      env = {
+        name: '#{embeddable.name}',
+        scriptUrl: '#{embeddable.url}',
+        embeddableId: '#{embeddable.id}',
+        config: '#{embeddable.configuration}',
+        div: '#{outputId}'
+      }
+      ExternalScripts.register(ScriptConstructor, env);
+    }
+  });

--- a/app/views/embeddable/external_scripts/_lightweight.html.haml
+++ b/app/views/embeddable/external_scripts/_lightweight.html.haml
@@ -1,10 +1,7 @@
 - runtimeDiv = "output-#{embeddable.id}"
 = content_for :external_scripts do
   %script{src:embeddable.url}
-- unless embeddable.name.blank?
-  .question-hdr
-    %h5.h5= embeddable.name
-.question-bd
+.question-bd{style: "display:none;"}
   .question-txt
     != embeddable.url
   .output{id:runtimeDiv}

--- a/app/views/embeddable/external_scripts/edit.html.haml
+++ b/app/views/embeddable/external_scripts/edit.html.haml
@@ -1,0 +1,1 @@
+= render :partial => 'form'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
   <%= include_gon %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
+  <%= yield :external_scripts %>
 </head>
 <%- @body_class = request.original_fullpath.split('/').join(' ') -%>
 <%- if @session_key -%>

--- a/app/views/layouts/runtime.html.erb
+++ b/app/views/layouts/runtime.html.erb
@@ -135,6 +135,6 @@
 <![endif]-->
 
 <%= yield :extra_javascript %>
-
+<%= yield :external_scripts %>
 </body>
 </html>

--- a/app/views/shared/_embedded_editor_links.html.haml
+++ b/app/views/shared/_embedded_editor_links.html.haml
@@ -24,6 +24,8 @@
       edit_embeddable_multiple_choice_path(embeddable)
     when "lb"
       edit_embeddable_labbook_path(embeddable)
+    when "external_script"
+      edit_embeddable_external_script_path(embeddable)
     when "xhtml"
       edit_embeddable_xhtml_path(embeddable)
   end

--- a/app/views/shared/_session.html.haml
+++ b/app/views/shared/_session.html.haml
@@ -14,6 +14,9 @@
   -if can? :manage, QuestionTracker
     |
     = link_to "QuestionTrackers", question_trackers_path
+  -if can? :manage, ApprovedScript
+    |
+    = link_to "Scripts", approved_scripts_path
   -if can? :manage, User
     |
     = link_to "Failed runs", dirty_runs_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 LightweightStandalone::Application.routes.draw do
 
+  resources :approved_scripts
+
+
   resources :projects do
     member do
       get :about
@@ -143,6 +146,7 @@ LightweightStandalone::Application.routes.draw do
       end
     end
     resources :xhtmls
+    resources :external_scripts
     resources :open_responses
     resources :labbooks
     resources :labbook_answers, :only => [:update]

--- a/db/migrate/20180123191239_create_external_script.rb
+++ b/db/migrate/20180123191239_create_external_script.rb
@@ -1,0 +1,16 @@
+class CreateExternalScript < ActiveRecord::Migration
+
+  def up
+    create_table :embeddable_external_scripts do |t|
+      t.belongs_to :approved_script, index: true
+      t.text       :configuration
+      t.text       :description
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :embeddable_external_scripts
+  end
+
+end

--- a/db/migrate/20180202184436_create_approved_scripts.rb
+++ b/db/migrate/20180202184436_create_approved_scripts.rb
@@ -1,0 +1,11 @@
+class CreateApprovedScripts < ActiveRecord::Migration
+  def change
+    create_table :approved_scripts do |t|
+      t.string :name
+      t.string :url
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180206162724_add_label_to_approved_scripts.rb
+++ b/db/migrate/20180206162724_add_label_to_approved_scripts.rb
@@ -1,0 +1,5 @@
+class AddLabelToApprovedScripts < ActiveRecord::Migration
+  def change
+    add_column :approved_scripts, :label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180202184436) do
+ActiveRecord::Schema.define(:version => 20180206162724) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(:version => 20180202184436) do
     t.text     "description"
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
+    t.string   "label"
   end
 
   create_table "authentications", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,21 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170524180857) do
+ActiveRecord::Schema.define(:version => 20180202184436) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
     t.text     "message"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+  end
+
+  create_table "approved_scripts", :force => true do |t|
+    t.string   "name"
+    t.string   "url"
+    t.text     "description"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
   end
 
   create_table "authentications", :force => true do |t|
@@ -109,6 +117,14 @@ ActiveRecord::Schema.define(:version => 20170524180857) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], :name => "delayed_jobs_priority"
+
+  create_table "embeddable_external_scripts", :force => true do |t|
+    t.integer  "approved_script_id"
+    t.text     "configuration"
+    t.text     "description"
+    t.datetime "created_at",         :null => false
+    t.datetime "updated_at",         :null => false
+  end
 
   create_table "embeddable_feedback_items", :force => true do |t|
     t.integer  "answer_id"


### PR DESCRIPTION
This commit adds two models:
 * ApprovedScripts              - Scripts that admins allow authors to add to page.
 * Embeddable::ExternalScript   - A script in the page added by author.

external_script.js library defines a very rough API for intializing
external scripts.  More work needs to be done defining this API in the
README.

Create "Interactivity Feedback" embeddable assessment item.

[#154444435]

https://www.pivotaltracker.com/story/show/154444435