### PR TITLE
Use version env variable

### DIFF
--- a/config/app_environment_variables.sample.rb
+++ b/config/app_environment_variables.sample.rb
@@ -26,3 +26,6 @@ ENV['LABBOOK_PROVIDER_URL']              ||= 'https://labbook.concord.org'
 # upload LabBook
 ENV['UPLOAD_ONLY_MODEL_URLS']            ||= "https://models-resources.concord.org/itsi/upload_photo/index.html"
 ENV['MODEL_JSON_LIST_URL']               ||= 'https://itsi.portal.concord.org/interactives/export_model_library'
+
+# Set the portal version displayed in the UI footer.
+ENV['LARA_VERSION']                      ||= ''

--- a/config/initializers/load_version.rb
+++ b/config/initializers/load_version.rb
@@ -1,8 +1,0 @@
-begin
-  yaml_file_path = File.join(Rails.root, 'config', 'version.yml')
-  yaml_config = YAML.load_file(yaml_file_path)
-  ENV['LARA_VERSION'] = yaml_config['version']
-rescue Exception => e
-  # no known version
-  ENV['LARA_VERSION'] = 'unknown'
-end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       DB_NAME: lara
       SECRET_TOKEN: b30c94c7-81b7-4f20-8df9-686b079a616a
       C_RATER_FAKE:
+      LARA_VERSION: Local Docker
     # no ports are published, see below for details
     depends_on:
       - db


### PR DESCRIPTION
This follows the pattern the Portal uses

The version is added to the bottom of the footer already using an environment variable.
Before this PR this environment variable was always overridden by load_version.rb
We aren't using the version.yml file any more, so its loader is deleted. 
With this deleted, the LARA_VERSION environment variable can be set by docker environment.

@knowuh can you take a look?