### PR TITLE
Load 1st available interactive state from linked interactives chain if the directly linked one is empty

### DIFF
--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -114,7 +114,7 @@ class InteractiveRunState < ActiveRecord::Base
     (interactive.respond_to? :linked_interactive) && !interactive.linked_interactive.nil?
   end
 
-  def find_linked_interactive_state
+  def linked_state
     # Note that this method will return the first available state of the linked interactives *chain*.
     # Sometimes the interactive that is directly linked might have not be run by student (e.g. when he skipped a page).
     current_interactive = interactive
@@ -122,8 +122,8 @@ class InteractiveRunState < ActiveRecord::Base
       linked_interactive = current_interactive.linked_interactive
       runs = run.sequence_run ? run.sequence_run.runs : [run]
       state = InteractiveRunState.where(run_id: runs.map(&:id), interactive_id: linked_interactive.id).first
-      if state
-        return state
+      if state && state.raw_data
+        return state.raw_data
       else
         # Try next interactive in chain.
         current_interactive = linked_interactive
@@ -131,11 +131,6 @@ class InteractiveRunState < ActiveRecord::Base
     end
     # Return nil if nothing is found.
     nil
-  end
-
-  def linked_state
-    return nil unless linked_state = find_linked_interactive_state
-    linked_state.raw_data
   end
 
   def run_remote_endpoint

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -59,6 +59,7 @@ describe InteractiveRunState do
           expect(result_hash["has_linked_interactive"]).to eql false
         end
       end
+
       describe "when the interactive has a linked interactive but the linked interactive has no state" do
         let(:linked_interactive) { FactoryGirl.create(:mw_interactive)}
         let(:interactive)        { FactoryGirl.create(:mw_interactive, {linked_interactive_id: linked_interactive.id})}
@@ -73,6 +74,7 @@ describe InteractiveRunState do
           expect(result_hash["linked_state"]).to be_nil
         end
       end
+
       describe "when the interactive run state has a linked interactive" do
         let(:linked_run_data)    {'{"first": 1}"'}
         let(:linked_interactive) { FactoryGirl.create(:mw_interactive)}
@@ -104,6 +106,26 @@ describe InteractiveRunState do
           it "should also include linked state" do
             expect(result_hash["linked_state"]).to eql linked_run_data
           end
+        end
+      end
+
+      describe "when the interactive run state has a linked interactives chain and the previous interactive doesn't have a state" do
+        let(:run_data_1)    {'{"first": 1}"'}
+        let(:interactive_1) { FactoryGirl.create(:mw_interactive)}
+        let(:run_state_1)   { InteractiveRunState.create(run: run, interactive: interactive_1, raw_data: run_data_1)}
+        let(:interactive_2) { FactoryGirl.create(:mw_interactive, {linked_interactive_id: interactive_1.id})}
+        let(:interactive) { FactoryGirl.create(:mw_interactive, {linked_interactive_id: interactive_2.id})}
+
+        before(:each) do
+          make run_state_1
+        end
+
+        it "should return the raw_data" do
+          expect(result_hash["raw_data"]).to eql run_data
+        end
+        it "should also include linked state" do
+          expect(result_hash["linked_state"]).to eql run_data_1
+          expect(result_hash["has_linked_interactive"]).to eql true
         end
       end
     end


### PR DESCRIPTION
It improves a case when students are skipping activity pages. E.g.:
- a student does some work on page 1
- then he skips page 2 where the interactive is linked to page 1
- he opens page 3 instead where the interactive is linked to page 2

Without this fix, he'd see an empty interactive. This PR ensures that he'll see his work from page 1.