### PR TITLE
 Extend LARA Interactive API, so interactive can pick the most recent linked state

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If you are going to deploy to a server with load balancing enabled (production),
 ## Docker and docker-compose for developers:
 
 * See [the portal docker documentation](https://github.com/concord-consortium/rigse/blob/master/docs/docker.md) for an overview of how to get your develepment environment configured with docker-compose.
-* There is [LARA specific docker documentation][https://github.com/concord-consortium/lara/blob/master/docs/dockerdev.md] in this repo.
+* There is [LARA specific docker documentation](https://github.com/concord-consortium/lara/blob/master/docs/dockerdev.md) in this repo.
 
 ## History
 

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -6,16 +6,23 @@ getAuthoredState = ($dataDiv) ->
     authoredState = JSON.parse(authoredState)
   authoredState
 
-parseLinkedStateMetadata = (metadataArray) ->
-  metadataArray.map (metadata) ->
-    interactiveId: metadata.interactive_id
-    interactiveStateUrl: metadata.interactive_state_url
-    data: JSON.parse(metadata.data)
-    createdAt: metadata.created_at
-    updatedAt: metadata.updated_at
-    pageNumber: metadata.page_number
-    pageName: metadata.page_name
-    activityName: metadata.activity_name
+interactiveStateProps = (data) ->
+  interactiveState: if data?.raw_data then JSON.parse(data.raw_data) else null
+  hasLinkedInteractive: data?.has_linked_interactive
+  linkedState: if data?.linked_state then JSON.parse(data.linked_state) else undefined
+  allLinkedStates: if data?.all_linked_states then data.all_linked_states.map(interactiveStateProps) else undefined
+  createdAt: data?.created_at
+  updatedAt: data?.updated_at
+  interactiveStateUrl: data?.interactive_state_url
+  interactive:
+    # Keep default values `undefined` (data?.something returns undefined if data is not available),
+    # as they might be obtained the other way. See "init_interactive" function which extends basic data using object
+    # returned from this one. `undefined` ensures that we won't overwrite a valid value.
+    id: data?.interactive_id
+    name: data?.interactive_name
+  pageNumber: data?.page_number
+  pageName: data?.page_name
+  activityName: data?.activity_name
 
 # IFrameSaver : Wrapper around IFramePhone to save & Load IFrame data
 # into interactive_run_state models in LARA.
@@ -191,33 +198,29 @@ class IFrameSaver
   # this is the newer method of initializing an interactive
   # it returns the current state and linked state
   init_interactive: (err = null, response = null) ->
-
-    @iframePhone.post 'initInteractive',
+    init_interactive_msg =
       version: 1
       error: err
       mode: 'runtime'
       authoredState: @authoredState
-      interactiveState: if response?.raw_data then JSON.parse(response.raw_data) else null
-      createdAt: response?.created_at
-      updatedAt: response?.updated_at
       # See: global-iframe-saver.coffee
       globalInteractiveState: if globalIframeSaver? then globalIframeSaver.globalState else null
-      hasLinkedInteractive: response?.has_linked_interactive or false
-      linkedState: if response?.linked_state then JSON.parse(response.linked_state) else null
-      allLinkedStates: if response?.all_linked_states then parseLinkedStateMetadata(response.all_linked_states) else []
       interactiveStateUrl: @interactive_run_state_url
       collaboratorUrls: if @collaborator_urls? then @collaborator_urls.split(';') else null
       classInfoUrl: @class_info_url
       interactive:
         id: @interactive_id
         name: @interactive_name
-      pageNumber: if response?.page_number then response.page_number else null
-      pageName: if response?.page_name then response.page_name else null
-      activityName: if response?.activity_name then response.activity_name else null
       authInfo:
         provider: @auth_provider
         loggedIn: @logged_in
         email: @user_email
+    # Perhaps it would be nicer to keep `interactiveStateProps` in some separate property instead of mixing
+    # it directly into general init message. However, multiple interactives are already using this format
+    # and it doesn't seem to be worth changing at this point.
+    $.extend(true, init_interactive_msg, interactiveStateProps(response))
+
+    @iframePhone.post 'initInteractive', init_interactive_msg
 
   set_autosave_enabled: (v) ->
     return unless @learner_state_saving_enabled()

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -200,7 +200,7 @@ class IFrameSaver
       globalInteractiveState: if globalIframeSaver? then globalIframeSaver.globalState else null
       hasLinkedInteractive: response?.has_linked_interactive or false
       linkedState: if response?.linked_state then JSON.parse(response.linked_state) else null
-      allLinkedStates: parseLinkedStateMetadata(response.all_linked_states)
+      allLinkedStates: if response?.all_linked_states then parseLinkedStateMetadata(response.all_linked_states) else []
       interactiveStateUrl: @interactive_run_state_url
       collaboratorUrls: if @collaborator_urls? then @collaborator_urls.split(';') else null
       classInfoUrl: @class_info_url

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -13,7 +13,7 @@ parseLinkedStateMetadata = (metadataArray) ->
     data: JSON.parse(metadata.data)
     createdAt: metadata.created_at
     updatedAt: metadata.updated_at
-    pageIndex: metadata.page_index
+    pageNumber: metadata.page_number
     pageName: metadata.page_name
     activityName: metadata.activity_name
 
@@ -211,7 +211,7 @@ class IFrameSaver
       interactive:
         id: @interactive_id
         name: @interactive_name
-      pageIndex: if response?.page_index then response.page_index else null
+      pageNumber: if response?.page_number then response.page_number else null
       pageName: if response?.page_name then response.page_name else null
       activityName: if response?.activity_name then response.activity_name else null
       authInfo:

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -9,6 +9,7 @@ getAuthoredState = ($dataDiv) ->
 parseLinkedStateMetadata = (metadataArray) ->
   metadataArray.map (metadata) ->
     interactiveId: metadata.interactive_id
+    interactiveStateUrl: metadata.interactive_state_url
     data: JSON.parse(metadata.data)
     createdAt: metadata.created_at
     updatedAt: metadata.updated_at

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -13,6 +13,9 @@ parseLinkedStateMetadata = (metadataArray) ->
     data: JSON.parse(metadata.data)
     createdAt: metadata.created_at
     updatedAt: metadata.updated_at
+    pageIndex: metadata.page_index
+    pageName: metadata.page_name
+    activityName: metadata.activity_name
 
 # IFrameSaver : Wrapper around IFramePhone to save & Load IFrame data
 # into interactive_run_state models in LARA.
@@ -195,8 +198,8 @@ class IFrameSaver
       mode: 'runtime'
       authoredState: @authoredState
       interactiveState: if response?.raw_data then JSON.parse(response.raw_data) else null
-      interactiveStateCreatedAt: response?.created_at
-      interactiveStateUpdatedAt: response?.updated_at
+      createdAt: response?.created_at
+      updatedAt: response?.updated_at
       # See: global-iframe-saver.coffee
       globalInteractiveState: if globalIframeSaver? then globalIframeSaver.globalState else null
       hasLinkedInteractive: response?.has_linked_interactive or false
@@ -208,6 +211,9 @@ class IFrameSaver
       interactive:
         id: @interactive_id
         name: @interactive_name
+      pageIndex: if response?.page_index then response.page_index else null
+      pageName: if response?.page_name then response.page_name else null
+      activityName: if response?.activity_name then response.activity_name else null
       authInfo:
         provider: @auth_provider
         loggedIn: @logged_in

--- a/app/controllers/api/v1/interactive_run_states_controller.rb
+++ b/app/controllers/api/v1/interactive_run_states_controller.rb
@@ -4,11 +4,15 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
 
   skip_before_filter :verify_authenticity_token, :only => :update
 
+  def host
+    "#{request.protocol}#{request.host_with_port}"
+  end
+
   def show
     begin
       authorize! :show, @run
 
-      render :json => @run.to_runtime_json
+      render :json => @run.to_runtime_json(host)
     rescue CanCan::AccessDenied
       authorization_error("get")
     end
@@ -26,7 +30,7 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
         @run.learner_url = params['learner_url']
       end
       if @run.save
-        render :json => @run.to_runtime_json
+        render :json => @run.to_runtime_json(host)
       else
         render :json => { :success => false }
       end

--- a/app/controllers/api/v1/interactive_run_states_controller.rb
+++ b/app/controllers/api/v1/interactive_run_states_controller.rb
@@ -17,8 +17,10 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
   def update
     begin
       authorize! :update, @run
+      @run.touch # update timestamp even if no data is provided
       if params.has_key?('raw_data')
-        @run.raw_data = params['raw_data']
+        # Handle 'null' value, so interactive can reset / clear its state if necessary.
+        @run.raw_data = params['raw_data'] == 'null' ? nil : params['raw_data']
       end
       if params.has_key?('learner_url')
         @run.learner_url = params['learner_url']

--- a/app/controllers/api/v1/interactive_run_states_controller.rb
+++ b/app/controllers/api/v1/interactive_run_states_controller.rb
@@ -4,15 +4,11 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
 
   skip_before_filter :verify_authenticity_token, :only => :update
 
-  def host
-    "#{request.protocol}#{request.host_with_port}"
-  end
-
   def show
     begin
       authorize! :show, @run
 
-      render :json => @run.to_runtime_json(host)
+      render :json => @run.to_runtime_json(request.protocol, request.host_with_port)
     rescue CanCan::AccessDenied
       authorization_error("get")
     end
@@ -30,7 +26,7 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
         @run.learner_url = params['learner_url']
       end
       if @run.save
-        render :json => @run.to_runtime_json(host)
+        render :json => @run.to_runtime_json(request.protocol, request.host_with_port)
       else
         render :json => { :success => false }
       end

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -195,8 +195,8 @@ class InteractivePage < ActiveRecord::Base
     self.save!(:validate => false) # This is the part we need to override
   end
 
-  def index_in_activity
-    lightweight_activity.visible_pages.index(self) + 1
+  def page_number
+    lightweight_activity.visible_page_ids.index(self.id) + 1
   end
 
   def duplicate(interactives_cache=nil)

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -195,6 +195,10 @@ class InteractivePage < ActiveRecord::Base
     self.save!(:validate => false) # This is the part we need to override
   end
 
+  def index_in_activity
+    lightweight_activity.visible_pages.index(self) + 1
+  end
+
   def duplicate(interactives_cache=nil)
     interactives_cache = InteractivesCache.new if interactives_cache.nil?
     new_page = InteractivePage.new(self.to_hash)

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -130,6 +130,9 @@ class InteractiveRunState < ActiveRecord::Base
         linked_state_info[:data] = state.raw_data
         linked_state_info[:created_at] = state.created_at
         linked_state_info[:updated_at] = state.updated_at
+        linked_state_info[:page_index] = state.interactive.interactive_page.index_in_activity
+        linked_state_info[:page_name] = state.interactive.interactive_page.name
+        linked_state_info[:activity_name] = state.interactive.interactive_page.lightweight_activity.name
         if host
           linked_state_info[:interactive_state_url] = state.interactive_state_url(host)
         end
@@ -171,6 +174,9 @@ class InteractiveRunState < ActiveRecord::Base
     hash[:run_remote_endpoint] = run_remote_endpoint
     hash[:all_linked_states] = all_linked_states(host)
     hash[:interactive_state_url] = interactive_state_url(host)
+    hash[:page_index] = interactive.interactive_page.index_in_activity
+    hash[:page_name] = interactive.interactive_page.name
+    hash[:activity_name] = interactive.interactive_page.lightweight_activity.name
     hash.to_json
   end
 

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -54,6 +54,14 @@ class InteractiveRunState < ActiveRecord::Base
     @question
   end
 
+  def page
+    interactive.interactive_page
+  end
+
+  def activity
+    page && page.lightweight_activity
+  end
+
   def portal_hash
     # There are two options how interactive can be saved in Portal:
     # - When reporting url is provided, it means that the interactive is supposed to be saved as an URL.
@@ -130,9 +138,11 @@ class InteractiveRunState < ActiveRecord::Base
         linked_state_info[:data] = state.raw_data
         linked_state_info[:created_at] = state.created_at
         linked_state_info[:updated_at] = state.updated_at
-        linked_state_info[:page_index] = state.interactive.interactive_page.index_in_activity
-        linked_state_info[:page_name] = state.interactive.interactive_page.name
-        linked_state_info[:activity_name] = state.interactive.interactive_page.lightweight_activity.name
+        linked_page = state.interactive.interactive_page
+        linked_activity = linked_page && linked_page.lightweight_activity
+        linked_state_info[:page_index] = linked_page && linked_page.index_in_activity
+        linked_state_info[:page_name] = linked_page && linked_page.name
+        linked_state_info[:activity_name] = linked_activity && linked_activity.name
         if host
           linked_state_info[:interactive_state_url] = state.interactive_state_url(host)
         end
@@ -174,9 +184,9 @@ class InteractiveRunState < ActiveRecord::Base
     hash[:run_remote_endpoint] = run_remote_endpoint
     hash[:all_linked_states] = all_linked_states(host)
     hash[:interactive_state_url] = interactive_state_url(host)
-    hash[:page_index] = interactive.interactive_page.index_in_activity
-    hash[:page_name] = interactive.interactive_page.name
-    hash[:activity_name] = interactive.interactive_page.lightweight_activity.name
+    hash[:page_index] = page && page.index_in_activity
+    hash[:page_name] = page && page.name
+    hash[:activity_name] = activity && activity.name
     hash.to_json
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       DB_HOST: db
       DB_USER: master
       DB_PASSWORD: master
-      DB_NAME: lara
       SECRET_TOKEN: b30c94c7-81b7-4f20-8df9-686b079a616a
       C_RATER_FAKE:
       LARA_VERSION: Local Docker

--- a/docs/dockerdev.md
+++ b/docs/dockerdev.md
@@ -27,3 +27,10 @@ The best palce to do this would be in a `.env` file at the root of this director
 
 To run all the (non phantom) spec tests:
 `docker-compose run --rm app docker/dev/run-spec.sh`
+
+To run Jasmine tests:
+
+`docker-compose run -p 8888:8888 --rm app bundle exec rake jasmine`
+
+and open [http://localhost:8888](http://localhost:8888)
+

--- a/spec/javascripts/iframe_saver_spec.coffee
+++ b/spec/javascripts/iframe_saver_spec.coffee
@@ -74,7 +74,11 @@ describe 'IFrameSaver', () ->
         request = jasmine.Ajax.requests.mostRecent()
         request.respondWith({
           status: 200,
-          responseText: JSON.stringify({"raw_data": JSON.stringify({"interactiveState": 321})})
+          responseText: JSON.stringify({
+            "raw_data": JSON.stringify({"interactiveState": 321}),
+            "created_at": "2017",
+            "updated_at": "2018"
+          })
         })
 
       afterEach () ->
@@ -87,9 +91,12 @@ describe 'IFrameSaver', () ->
           mode: 'runtime',
           authoredState: {test: 123},
           interactiveState: {interactiveState: 321},
+          interactiveStateCreatedAt: '2017'
+          interactiveStateUpdatedAt: '2018'
           globalInteractiveState: null,
           hasLinkedInteractive: false,
           linkedState: null,
+          allLinkedStates: [],
           interactiveStateUrl: 'foo/42',
           collaboratorUrls: null,
           classInfoUrl: null,
@@ -110,9 +117,12 @@ describe 'IFrameSaver', () ->
           mode: 'runtime',
           authoredState: {test: 123},
           interactiveState: null,
+          interactiveStateCreatedAt: undefined
+          interactiveStateUpdatedAt: undefined
           globalInteractiveState: null,
           hasLinkedInteractive: false,
           linkedState: null,
+          allLinkedStates: [],
           interactiveStateUrl: 'foo/42',
           collaboratorUrls: null,
           classInfoUrl: null,

--- a/spec/javascripts/iframe_saver_spec.coffee
+++ b/spec/javascripts/iframe_saver_spec.coffee
@@ -77,7 +77,10 @@ describe 'IFrameSaver', () ->
           responseText: JSON.stringify({
             "raw_data": JSON.stringify({"interactiveState": 321}),
             "created_at": "2017",
-            "updated_at": "2018"
+            "updated_at": "2018",
+            "activity_name": "test act",
+            "page_name": "test page",
+            "page_number": 2
           })
         })
 
@@ -94,17 +97,14 @@ describe 'IFrameSaver', () ->
           createdAt: '2017'
           updatedAt: '2018'
           globalInteractiveState: null,
-          hasLinkedInteractive: false,
-          linkedState: null,
-          allLinkedStates: [],
           interactiveStateUrl: 'foo/42',
           collaboratorUrls: null,
           classInfoUrl: null,
           interactive: {id: 1, name: "test"},
           authInfo: {provider: "fakeprovider", loggedIn: true, email: "user@example.com"}
-          pageIndex: null
-          pageName: null
-          activityName: null
+          pageNumber: 2
+          pageName: "test page"
+          activityName: "test act"
         })
 
     describe "when state saving is disabled", () ->
@@ -120,18 +120,10 @@ describe 'IFrameSaver', () ->
           mode: 'runtime',
           authoredState: {test: 123},
           interactiveState: null,
-          createdAt: undefined
-          updatedAt: undefined
           globalInteractiveState: null,
-          hasLinkedInteractive: false,
-          linkedState: null,
-          allLinkedStates: [],
           interactiveStateUrl: 'foo/42',
           collaboratorUrls: null,
           classInfoUrl: null,
           interactive: {id: 1, name: "test"},
           authInfo: {provider: "fakeprovider", loggedIn: true, email: "user@example.com"}
-          pageIndex: null
-          pageName: null
-          activityName: null
         })

--- a/spec/javascripts/iframe_saver_spec.coffee
+++ b/spec/javascripts/iframe_saver_spec.coffee
@@ -91,8 +91,8 @@ describe 'IFrameSaver', () ->
           mode: 'runtime',
           authoredState: {test: 123},
           interactiveState: {interactiveState: 321},
-          interactiveStateCreatedAt: '2017'
-          interactiveStateUpdatedAt: '2018'
+          createdAt: '2017'
+          updatedAt: '2018'
           globalInteractiveState: null,
           hasLinkedInteractive: false,
           linkedState: null,

--- a/spec/javascripts/iframe_saver_spec.coffee
+++ b/spec/javascripts/iframe_saver_spec.coffee
@@ -102,6 +102,9 @@ describe 'IFrameSaver', () ->
           classInfoUrl: null,
           interactive: {id: 1, name: "test"},
           authInfo: {provider: "fakeprovider", loggedIn: true, email: "user@example.com"}
+          pageIndex: null
+          pageName: null
+          activityName: null
         })
 
     describe "when state saving is disabled", () ->
@@ -117,8 +120,8 @@ describe 'IFrameSaver', () ->
           mode: 'runtime',
           authoredState: {test: 123},
           interactiveState: null,
-          interactiveStateCreatedAt: undefined
-          interactiveStateUpdatedAt: undefined
+          createdAt: undefined
+          updatedAt: undefined
           globalInteractiveState: null,
           hasLinkedInteractive: false,
           linkedState: null,
@@ -128,4 +131,7 @@ describe 'IFrameSaver', () ->
           classInfoUrl: null,
           interactive: {id: 1, name: "test"},
           authInfo: {provider: "fakeprovider", loggedIn: true, email: "user@example.com"}
+          pageIndex: null
+          pageName: null
+          activityName: null
         })

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -43,9 +43,10 @@ describe InteractiveRunState do
   describe "instance methods" do
     describe "to_runtime_json" do
       let(:run_data) {'{"second": 2}"'}
-      let(:host) { "https://test.authoring.org" }
+      let(:host) { "test.authoring.org" }
+      let(:protocol) { "https" }
       let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
-      let(:result_hash) { JSON.parse(interactive_run_state.to_runtime_json(host)) }
+      let(:result_hash) { JSON.parse(interactive_run_state.to_runtime_json(protocol, host)) }
 
       it "should have a run_remote_endpoint" do
         expect(result_hash).to have_key "run_remote_endpoint"

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -43,8 +43,9 @@ describe InteractiveRunState do
   describe "instance methods" do
     describe "to_runtime_json" do
       let(:run_data) {'{"second": 2}"'}
+      let(:host) { "https://test.authoring.org" }
       let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
-      let(:result_hash) { JSON.parse(interactive_run_state.to_runtime_json) }
+      let(:result_hash) { JSON.parse(interactive_run_state.to_runtime_json(host)) }
 
       it "should have a run_remote_endpoint" do
         expect(result_hash).to have_key "run_remote_endpoint"


### PR DESCRIPTION
This PR extends Interactive API, so interactives are able to pick the most recent data from linked states chain. Changes:
- `allLinkedStates` array in `initInteractive` message
- `interactiveStateUpdatedAt` timestamp in `initInteractive` message
- `interactiveStateCreatedAt` timestamp in `initInteractive` message (not necessary, but just to be consistent)
- support of `touch` argument passed in `interactiveState` message (it only updates timestamp)
- fix / better support of `null` argument passed in `interactiveState` (so interactive can reset its state)

@scytacki, most of these changes are necessary no matter if we use `touch` message in document-server or not. I've decided to add `touch` and provide a bunch of timestamps, as it's relatively straightforward and makes implementation on the interactive side way easier. It works for doc-server `autolaunch` page and it might work well for other interactives that would like to support similar behavior in the future. Especially if interactive stores all data in LARA. doc-server `launch` page will require separate implementation (it would anyway), but I still hope we can depreciate that page.

Related document-server PR: https://github.com/concord-consortium/document-store/pull/26

BTW, this PR is based on https://github.com/concord-consortium/lara/pull/279, so it includes its changes too.
