### PR TITLE
capitalization error was causing inconsistent authoredState

### DIFF
--- a/app/assets/javascripts/components/authoring/mw_interactive.js.coffee
+++ b/app/assets/javascripts/components/authoring/mw_interactive.js.coffee
@@ -15,7 +15,7 @@ modulejs.define 'components/authoring/mw_interactive',
       authoredState = @props.interactive.authored_state
       {
         authoringSupported: false
-        authoredState: if typeof authoredState == 'String' then JSON.parse(authoredState) else authoredState
+        authoredState: if typeof authoredState == 'string' then JSON.parse(authoredState) else authoredState
         modified: false
         saving: false
         message: ''

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -2,7 +2,7 @@ getAuthoredState = ($dataDiv) ->
   authoredState = $dataDiv.data('authored-state')
   if !authoredState? || authoredState == ''
     authoredState = null
-  if typeof authoredState == 'String'
+  if typeof authoredState == 'string'
     authoredState = JSON.parse(authoredState)
   authoredState
 


### PR DESCRIPTION
All of the interactive that I could find were already handling both strings and object
forms of the authoredState. So this fix should not break anything.

During runtime the authoredState was being sent to the interactive as a object
even with this bug. This is because the jquery data method is returning an
object not a string at least in Chrome. I'm not sure if this is a feature of jquery or of
Chrome. The server is sending down `data-authored-state` attribute, but in the
DOM this attribute is not present. Instead there is a dataset property on the element.

[#155754828]

This might break some tests. Lets see...