### PR TITLE
This fixes a bug with the Sound Grapher in the ITSI portal.

### DIFF
--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -83,6 +83,7 @@ module InteractiveRunHelper
       :allowfullscreen => "true",
       :webkitallowfullscreen => "true",
       :mozallowfullscreen => "true",
+      :allow => "geolocation; microphone; camera",
       :src => iframe_src ? url : nil,
       :data => data,
       # Note that iframe is hidden in print mode. It won't have enough time to load anyway.

--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -83,7 +83,7 @@ module InteractiveRunHelper
       :allowfullscreen => "true",
       :webkitallowfullscreen => "true",
       :mozallowfullscreen => "true",
-      :allow => "geolocation; microphone; camera",
+      :allow => "geolocation *; microphone *; camera *",
       :src => iframe_src ? url : nil,
       :data => data,
       # Note that iframe is hidden in print mode. It won't have enough time to load anyway.


### PR DESCRIPTION
[#156171608]
https://www.pivotaltracker.com/story/show/156171608

Chrome has changed the way iFrames need to request access to microphones.

Specifically the iFrame has to declare that it will allow access to the microphone.

See this article:
https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes