### PR TITLE
Let authors set custom "Click to play" prompt

### DIFF
--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -1,6 +1,8 @@
 class MwInteractive < ActiveRecord::Base
-  attr_accessible :name, :url, :native_width, :native_height, :enable_learner_state, :has_report_url, :click_to_play, :image_url,
-                  :is_hidden, :linked_interactive_id, :full_window, :model_library_url, :authored_state, :no_snapshots
+  DEFAULT_CLICK_TO_PLAY_PROMPT = "Click here to start the interactive."
+  attr_accessible :name, :url, :native_width, :native_height, :enable_learner_state, :has_report_url, :click_to_play,
+                  :click_to_play_prompt, :image_url, :is_hidden, :linked_interactive_id, :full_window, :model_library_url,
+                  :authored_state, :no_snapshots
 
   default_value_for :native_width, 576
   default_value_for :native_height, 435
@@ -52,6 +54,7 @@ class MwInteractive < ActiveRecord::Base
       enable_learner_state: enable_learner_state,
       has_report_url: has_report_url,
       click_to_play: click_to_play,
+      click_to_play_prompt: click_to_play_prompt,
       full_window: full_window,
       image_url: image_url,
       is_hidden: is_hidden,
@@ -90,6 +93,7 @@ class MwInteractive < ActiveRecord::Base
                               :enable_learner_state,
                               :has_report_url,
                               :click_to_play,
+                              :click_to_play_prompt,
                               :full_window,
                               :image_url,
                               :is_hidden,

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -30,7 +30,7 @@
 
       .click_to_play.shown.screen-only{:id => dom_id_for(interactive, :click_to_play), 'data-trigger-full-window' => interactive.full_window}
         .background
-        .text= "Click here to start the interactive."
+        .text= interactive.click_to_play_prompt.present? ? interactive.click_to_play_prompt : MwInteractive::DEFAULT_CLICK_TO_PLAY_PROMPT
 
       = interactive_iframe_tag(interactive, @run, false) do
 

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -20,8 +20,12 @@
   %br
   = f.label :click_to_play, 'Click to play'
   = f.check_box :click_to_play, :id => "click_to_play_#{@interactive.id}"
+  %br
   = f.label :full_window, :id => "full_window_label_#{@interactive.id}", :text => 'Full window mode'
   = f.check_box :full_window, :id => "full_window_#{@interactive.id}"
+  %br
+  = f.label :click_to_play_prompt, :id => "click_to_play_prompt_label_#{@interactive.id}", :text => 'Click to play prompt'
+  = f.text_field :click_to_play_prompt, :id => "click_to_play_prompt_#{@interactive.id}", :placeholder => MwInteractive::DEFAULT_CLICK_TO_PLAY_PROMPT
   %div{:style => "margin-bottom:5px;"}
     %em Warning:
     Please provide an image_url to use click to play.
@@ -61,10 +65,14 @@
         $("#mw_interactive_image_url").attr("required", true);
         $("#full_window_#{@interactive.id}").removeAttr("disabled");
         $('#full_window_label_#{@interactive.id}').css("opacity", 1);
+        $("#click_to_play_prompt_#{@interactive.id}").removeAttr("disabled");
+        $('#click_to_play_prompt_label_#{@interactive.id}').css("opacity", 1);
       } else {
         $("#mw_interactive_image_url").removeAttr("required");
         $("#full_window_#{@interactive.id}").attr("disabled", true);
         $('#full_window_label_#{@interactive.id}').css("opacity", 0.3);
+        $("#click_to_play_prompt_#{@interactive.id}").attr("disabled", true);
+        $('#click_to_play_prompt_label_#{@interactive.id}').css("opacity", 0.3);
       }
   }
 

--- a/db/migrate/20180321211835_add_click_to_play_prompt_to_mw_interactives.rb
+++ b/db/migrate/20180321211835_add_click_to_play_prompt_to_mw_interactives.rb
@@ -1,0 +1,5 @@
+class AddClickToPlayPromptToMwInteractives < ActiveRecord::Migration
+  def change
+    add_column :mw_interactives, :click_to_play_prompt, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180206162724) do
+ActiveRecord::Schema.define(:version => 20180321211835) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -424,6 +424,7 @@ ActiveRecord::Schema.define(:version => 20180206162724) do
     t.text     "authored_state"
     t.string   "model_library_url"
     t.boolean  "no_snapshots",          :default => false
+    t.string   "click_to_play_prompt"
   end
 
   add_index "mw_interactives", ["linked_interactive_id"], :name => "index_mw_interactives_on_linked_interactive_id"

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -40,6 +40,7 @@ describe MwInteractive do
         enable_learner_state: interactive.enable_learner_state,
         has_report_url: interactive.has_report_url,
         click_to_play: interactive.click_to_play,
+        click_to_play_prompt: interactive.click_to_play_prompt,
         full_window: interactive.full_window,
         model_library_url: interactive.model_library_url,
         image_url: interactive.image_url,


### PR DESCRIPTION
A new feature requested by Dan. Authors can now specify custom "Click to play" prompt.
If it's empty or null, we'll still use the default one and display an appropriate placeholder in the edit dialog, so nothing should break.

[#156177652]