### PR TITLE
Add logging when a run is sent to the portal

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -190,8 +190,10 @@ class Run < ActiveRecord::Base
     return true if remote_endpoint.nil? || remote_endpoint.blank? # Drop it on the floor
     return true if answers.blank? # Pretend we sent it, nobody will notice
     is_success = PortalSender::Protocol.instance(remote_endpoint).post_answers(answers,remote_endpoint)
+    Rails.logger.info("Run sent to portal, success:#{is_success}, " +
+      "num_answers:#{answers.count}, #{run_info_string}")
     # TODO: better error detection?
-    abort_job_and_requeue(error_string() ) unless is_success
+    abort_job_and_requeue(run_info_string() ) unless is_success
     is_success
   end
 
@@ -350,15 +352,11 @@ class Run < ActiveRecord::Base
     # end
   end
 
-  def error_string()
-    "
-    remote_endpoint:#{remote_endpoint}\
-    run_id: #{id}\
-    run_key: #{key}\
-    dirty: #{dirty?}\
-    activity: #{activity.name} [#{activity_id}]\
-    sequence: #{sequence_id}
-    "
+  def run_info_string()
+    "remote_endpoint:#{remote_endpoint}, run_id:#{id}, " +
+    "run_key:#{key}, dirty:#{dirty?}, " +
+    "activity:#{activity_id}, activity_name:\"#{activity.name}\", " +
+    "sequence:#{sequence_id}"
   end
 
   def lara_to_portal_secret_auth

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -355,7 +355,7 @@ class Run < ActiveRecord::Base
   def run_info_string()
     "remote_endpoint:#{remote_endpoint}, run_id:#{id}, " +
     "run_key:#{key}, dirty:#{dirty?}, " +
-    "activity:#{activity_id}, activity_name:\"#{activity.name}\", " +
+    "activity:#{activity_id}, activity_name:\"#{activity ? activity.name : 'nil'}\", " +
     "sequence:#{sequence_id}"
   end
 


### PR DESCRIPTION
This log info should show up in the worker log when running on production.

While setting up the ngss assessment portal in ECS. I had an issue where learner data was not being sent from LARA to the portal. It turned out to be an issue with an old sequences run that had not been updated to https. I never really reconstructed what exactly happened, and it took a lot of time to track down. Hopefully with this new logging, it will be easier to get a handle on issues like this. 

I'd note that the portal does log its side of this in its request log. However in this case there wasn't anything useful showing up in the portal logs. And the portal log did not contain info about the LARA run id and key that was sending the data.

The formatting change is so the log is just a single line instead of split into multiple lines with bunches of spaces in between.

[#156348385]