### PR TITLE
Fix arg block rendering

### DIFF
--- a/app/assets/stylesheets/partials/_responsive-layout.scss
+++ b/app/assets/stylesheets/partials/_responsive-layout.scss
@@ -47,7 +47,10 @@
     display: block;
     vertical-align: top;
     width: 250px;
-    margin: 0 20px 20px 0;
+  }
+
+  .embeddables {
+    margin-right: 20px;
   }
 
   .interactive-mod {

--- a/app/views/interactive_pages/_show.html.haml
+++ b/app/views/interactive_pages/_show.html.haml
@@ -11,8 +11,8 @@
     - if page.visible_interactives.length > 0 && page.show_interactive
       = render partial: 'interactive_pages/interactive', locals: {page: page, layout: layout}
 
-  - if page.show_info_assessment
-    .questions-mod.ui-block-2{ :class => page.embeddable_display_mode == 'carousel' ? 'jcarousel' : '' }
+  .questions-mod.ui-block-2{ :class => page.embeddable_display_mode == 'carousel' ? 'jcarousel' : '' }
+    - if page.show_info_assessment
       = render partial: 'interactive_pages/list_embeddables', locals: {embeddables: main_section_visible_embeddables(page, @run)}
 
     .buttons


### PR DESCRIPTION
This PR fixes arg block rendering. I introduced the bug while I was working on the responsive layout. Test page:
https://authoring.staging.concord.org/activities/628/pages/2807/

The important change is in the HAML file. Actually, it restores it to what it was before. Scott, I remember you're a bit suspicious about it back then.

I've also tested:
 - responsive layout with questions
 - responsive layout without any questions
 - responsive layout with arg block (unlikely this combination is gonna be used, but just so it's not broken)

[#155515297]