### PR TITLE
Replace an old jeditable rich text editor with TinyMCE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ gem "jquery-rails", "~> 3.0"
 gem "jquery-ui-rails", "~> 4.1"
 gem "haml", "~> 4.0"
 gem "dynamic_form", "~> 1.1"
-gem "jeditable_wysiwyg_rails", "~> 0.3", {:git=>"git://github.com/concord-consortium/jeditable-wysiwyg-rails.git"}
 gem "acts_as_list", "~> 0.3"
 gem "nested_form", "~> 0.3"
 gem "gon", "~> 5.2"

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem "cancancan", "~> 1.10"
 gem "omniauth", "~> 1.1"
 gem "omniauth-oauth2", "~> 1.1", {:git=>"https://github.com/intridea/omniauth-oauth2.git"}
 gem "default_value_for", "~> 2.0"
-gem "tinymce-rails", "~> 4.2"
+gem "tinymce-rails", "~> 4.7"
 gem "yaml_db", "~> 0.2", {:git=>"git://github.com/lostapathy/yaml_db.git"}
 gem "aws-ses", "~> 0.5", {:require=>"aws/ses"}
 gem "uuidtools", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,6 @@ GIT
       capistrano (< 3)
 
 GIT
-  remote: git://github.com/concord-consortium/jeditable-wysiwyg-rails.git
-  revision: 801fd737847f98b481dadfc2780f9c61cda27a01
-  specs:
-    jeditable_wysiwyg_rails (0.3.12)
-      jquery-rails
-      rails (~> 3.2.0)
-
-GIT
   remote: git://github.com/concord-consortium/ribbons-rails.git
   revision: 8e5f5701f53ad2026c3cafb0d2bc49b2d172a69d
   specs:
@@ -514,7 +506,6 @@ DEPENDENCIES
   httparty (~> 0.12)
   jasmine (~> 2.2)
   jasmine-jquery-rails (~> 2.0)
-  jeditable_wysiwyg_rails (~> 0.3)!
   jquery-rails (~> 3.0)
   jquery-ui-rails (~> 4.1)
   launchy (~> 2.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,7 +439,7 @@ GEM
     thor (0.19.1)
     tilt (1.4.1)
     timecop (0.6.3)
-    tinymce-rails (4.2.5)
+    tinymce-rails (4.7.9)
       railties (>= 3.1.1)
     treetop (1.4.15)
       polyglot
@@ -550,7 +550,7 @@ DEPENDENCIES
   test-unit (~> 3.0)
   therubyracer (~> 0.12)
   timecop (~> 0.6)
-  tinymce-rails (~> 4.2)
+  tinymce-rails (~> 4.7)
   turbo-sprockets-rails3 (~> 0.3)
   uglifier (~> 2.3)
   unicorn

--- a/app/assets/javascripts/application-init.js
+++ b/app/assets/javascripts/application-init.js
@@ -2,4 +2,6 @@
 $(document).ready(function() {
   // Setup Chosen jQuery plugin (convenient select boxes).
   $('.chosen-select').chosen();
+  // Init TinyMCE text editors.
+  initTinyMCE('.wysiwyg', window.TinyMCEConfig);
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,12 +20,6 @@
 //= require jquery_ujs
 //= require jquery.ui.all
 //= require jquery_nested_form
-//= require jquery.jeditable
-//= require jquery.wysiwyg
-//= require wysiwyg.image
-//= require wysiwyg.link
-//= require wysiwyg.table
-//= require jquery.jeditable.wysiwyg
 //= require jquery.jcarousel
 //= require modals
 //= require modal-dialog

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,6 +38,7 @@
 //= require c_rater/score_mapping
 //= require components
 //= require iframed_site_manager
+//= require tinymce-config
 //= require tinymce-jquery
 //= require iframe-phone
 //= require iframe-phone-manager

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -55,6 +55,4 @@ $(document).ready(function () {
             });
         }
     });
-    // Init TinyMCE text editors.
-    initTinyMCE('.wysiwyg', window.TinyMCEConfig);
 });

--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -55,24 +55,6 @@ $(document).ready(function () {
             });
         }
     });
-
-    // WYSIWYG editing, if that's needed
-    if ($('.wysiwyg-text').length > 0) {
-        $('.wysiwyg-text').wysiwyg({
-            "controls": {
-                "html": {
-                    "visible": true
-                },
-                "h1": {
-                    "visible": false
-                },
-                "h2": {
-                    "visible": false
-                },
-                "h3": {
-                    "visible": false
-                }
-            }
-        });
-    }
+    // Init TinyMCE text editors.
+    initTinyMCE('.wysiwyg', window.TinyMCEConfig);
 });

--- a/app/assets/javascripts/components/authoring/editable_field.js.coffee
+++ b/app/assets/javascripts/components/authoring/editable_field.js.coffee
@@ -1,6 +1,6 @@
 {div, span, h2} = React.DOM
 
-modulejs.define 'components/authoring/text_field',
+modulejs.define 'components/authoring/editable_field',
 [
   'components/common/ajax_form_mixin'
 ],
@@ -8,7 +8,7 @@ modulejs.define 'components/authoring/text_field',
   AjaxFormMixin
 ) ->
 
-  TextField = React.createClass
+  EditableField = React.createClass
     mixins:
       [AjaxFormMixin]
 

--- a/app/assets/javascripts/components/authoring/text_editor.js.coffee
+++ b/app/assets/javascripts/components/authoring/text_editor.js.coffee
@@ -1,0 +1,48 @@
+{div, span, h2} = React.DOM
+
+modulejs.define 'components/authoring/text_editor',
+[
+  'components/common/rich_text_editor',
+  'components/common/ajax_form_mixin'
+],
+(
+  RichTextEditorClass,
+  AjaxFormMixin
+) ->
+
+  RichTextEditor = React.createFactory RichTextEditorClass
+
+  TextEditor = React.createClass
+    mixins:
+      [AjaxFormMixin]
+
+    currentText: ->
+      @state.values[@props.textPropName]
+
+    currentHeader: ->
+      @state.values[@props.headerPropName]
+
+    render: ->
+      (div {className: "authoring-text-editor #{if @state.edit then 'edit' else ''}"},
+        (h2 {},
+          if @state.edit && @props.editableHeader
+            (span {className: 'header-edit'}, (@text {name: @props.headerPropName}))
+          else
+            @currentHeader()
+          (div {className: 'authoring-text-links'},
+            if @state.edit
+              (span {},
+                (span {onClick: @save}, 'Save')
+                ' | '
+                (span {onClick: @cancel}, 'Cancel')
+              )
+            else
+              (span {onClick: @edit}, 'Edit')
+          )
+        )
+        if @state.edit
+          (div {className: "authoring-tinymce"},
+            (@richText {name: @props.textPropName})
+          )
+        (div {className: 'authoring-text-content', dangerouslySetInnerHTML: {__html: @currentText()}})
+      )

--- a/app/assets/javascripts/components/authoring/text_field.js.coffee
+++ b/app/assets/javascripts/components/authoring/text_field.js.coffee
@@ -1,0 +1,34 @@
+{div, span, h2} = React.DOM
+
+modulejs.define 'components/authoring/text_field',
+[
+  'components/common/ajax_form_mixin'
+],
+(
+  AjaxFormMixin
+) ->
+
+  TextField = React.createClass
+    mixins:
+      [AjaxFormMixin]
+
+    currentText: ->
+      @state.values[@props.propName] || @props.placeholder
+
+    render: ->
+      (div {className: "authoring-text-field #{if @state.edit then 'edit' else ''}"},
+        if @state.edit
+          (@text {name: @props.propName})
+        else
+          (span {}, @currentText())
+        (span {className: 'text-field-links'},
+          if @state.edit
+            (span {},
+              (span {onClick: @save}, 'Save')
+              '|'
+              (span {onClick: @cancel}, 'Cancel')
+            )
+          else
+            (span {onClick: @edit}, 'Edit')
+        )
+      )

--- a/app/assets/javascripts/components/common/ajax_form_mixin.js.coffee
+++ b/app/assets/javascripts/components/common/ajax_form_mixin.js.coffee
@@ -81,7 +81,7 @@ modulejs.define 'components/common/ajax_form_mixin',
   richText: (options) ->
     changed = (newText) =>
       @_handleChange options.name, newText, options.onChange
-    RichTextEditor {name: options.name, text: @state.values[options.name], onChange: changed}
+    RichTextEditor {name: options.name, text: @state.values[options.name], TinyMCEConfig: options.TinyMCEConfig, onChange: changed}
 
   text: (options) ->
     changed = (e) =>

--- a/app/assets/javascripts/components/common/ajax_form_mixin.js.coffee
+++ b/app/assets/javascripts/components/common/ajax_form_mixin.js.coffee
@@ -1,9 +1,10 @@
 {textarea, input, select, option} = React.DOM
 
+# Mixin that provides helper methods to build dynamic form which can be udpated and saved without page reload.
 # Component that includes this mixin needs to define @updateUrl property.
-modulejs.define 'components/itsi_authoring/section_element_editor_mixin',
+modulejs.define 'components/common/ajax_form_mixin',
 [
-  'components/itsi_authoring/rich_text_editor'
+  'components/common/rich_text_editor'
 ],
 (
   RichTextEditorClass
@@ -18,6 +19,10 @@ modulejs.define 'components/itsi_authoring/section_element_editor_mixin',
       for key, value of @dataMap
         values[key] = @props.data[value]
         defaultValues[key] = @props.data[value]
+    else
+      for key, value of @props.data
+        values[key] = value
+        defaultValues[key] = value
 
     initialState =
       edit: @initialEditState?()
@@ -49,20 +54,20 @@ modulejs.define 'components/itsi_authoring/section_element_editor_mixin',
 
     # Don't issue request if nothing has been updated.
     if $.isEmptyObject @state.changedValues
-      @props.alert 'warn', 'No changes to save'
+      @props.alert? 'warn', 'No changes to save'
       return
 
     # Rails-specific approach to PUT requests.
     @state.changedValues._method = 'PUT'
     $.ajax
-      url: "#{@props.data.update_url}.json"
+      url: "#{@props.updateUrl || @props.data.update_url}.json" # two formats available
       data: @state.changedValues
       type: 'POST',
       success: =>
-        @props.alert 'info', 'Saved'
+        @props.alert? 'info', 'Saved'
         @setState changedValues: {}
       error: (xhr, textStatus, errorThrown) =>
-        @props.alert 'error', 'Save Failed!'
+        @props.alert? 'error', 'Save Failed!'
 
   valueChanged: (key, value, setStateCallback = null) ->
     @state.values[key] = value

--- a/app/assets/javascripts/components/common/rich_text_editor.js.coffee
+++ b/app/assets/javascripts/components/common/rich_text_editor.js.coffee
@@ -1,6 +1,6 @@
 {textarea} = React.DOM
 
-modulejs.define 'components/itsi_authoring/rich_text_editor',
+modulejs.define 'components/common/rich_text_editor',
 [],
 ->
 
@@ -9,18 +9,20 @@ modulejs.define 'components/itsi_authoring/rich_text_editor',
       false
 
     onChange: (editor) ->
-      @props.onChange editor.getContent()
+      if @props.onChange
+        @props.onChange editor.getContent()
 
     componentDidMount: ->
-      @node = $(React.findDOMNode(@refs.textarea))
-      options = $.extend({}, window.ITSIEditorTinyMCEConfig)
+      $node = $(React.findDOMNode(@refs.textarea))
+      options = $.extend({}, @props.TinyMCEConfig || window.TinyMCEConfig)
       options.setup = (editor) =>
           # both events are needed as the 'change' event is only sent when the input loses focus (which handles menu choices like formatting)
           editor.on 'keyup', (e) =>
             @onChange editor
           editor.on 'change', (e) =>
             @onChange editor
-      @node.tinymce options
+
+      $node.tinymce(options)
 
     render: ->
       (textarea {ref: 'textarea', name: @props.name, cols: 100, rows: 5, defaultValue: @props.text})

--- a/app/assets/javascripts/components/itsi_authoring/drawing_response_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/drawing_response_editor.js.coffee
@@ -2,12 +2,12 @@
 
 modulejs.define 'components/itsi_authoring/drawing_response_editor',
 [
-  'components/itsi_authoring/section_element_editor_mixin',
+  'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form',
   'components/itsi_authoring/section_editor_element'
 ],
 (
-  SectionElementEditorMixin,
+  AjaxFormMixin,
   SectionEditorFormClass,
   SectionEditorElementClass
 ) ->
@@ -18,7 +18,7 @@ modulejs.define 'components/itsi_authoring/drawing_response_editor',
   React.createClass
 
     mixins:
-      [SectionElementEditorMixin]
+      [AjaxFormMixin]
 
     # maps form names to @props.data keys
     dataMap:

--- a/app/assets/javascripts/components/itsi_authoring/metadata_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/metadata_editor.js.coffee
@@ -2,18 +2,18 @@
 
 modulejs.define 'components/itsi_authoring/metadata_editor',
 [
-  'components/itsi_authoring/section_element_editor_mixin',
+  'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form'
 ],
 (
-  SectionElementEditorMixin,
+  AjaxFormMixin,
   SectionEditorFormClass
 ) ->
 
   SectionEditorForm = React.createFactory SectionEditorFormClass
 
   React.createClass
-    mixins: [SectionElementEditorMixin]
+    mixins: [AjaxFormMixin]
 
     updateUrl: ->
       @props.data.update_url

--- a/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/model_editor.js.coffee
@@ -2,14 +2,14 @@
 
 modulejs.define 'components/itsi_authoring/model_editor',
 [
-  'components/itsi_authoring/section_element_editor_mixin',
+  'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form',
   'components/itsi_authoring/section_editor_element',
   'components/common/interactive_iframe',
   'components/itsi_authoring/cached_ajax'
 ],
 (
-  SectionElementEditorMixin,
+  AjaxFormMixin,
   SectionEditorFormClass,
   SectionEditorElementClass,
   InteractiveIframeClass,
@@ -23,7 +23,7 @@ modulejs.define 'components/itsi_authoring/model_editor',
   ModelEditor = React.createClass
 
     mixins:
-      [SectionElementEditorMixin]
+      [AjaxFormMixin]
 
     # maps form names to @props.data keys
     dataMap:

--- a/app/assets/javascripts/components/itsi_authoring/open_response_question_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/open_response_question_editor.js.coffee
@@ -2,12 +2,12 @@
 
 modulejs.define 'components/itsi_authoring/open_response_question_editor',
 [
-  'components/itsi_authoring/section_element_editor_mixin',
+  'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form',
   'components/itsi_authoring/section_editor_element'
 ],
 (
-  SectionElementEditorMixin,
+  AjaxFormMixin,
   SectionEditorFormClass,
   SectionEditorElementClass
 ) ->
@@ -18,7 +18,7 @@ modulejs.define 'components/itsi_authoring/open_response_question_editor',
   React.createClass
 
     mixins:
-      [SectionElementEditorMixin]
+      [AjaxFormMixin]
 
     # maps form names to @props.data keys
     dataMap:

--- a/app/assets/javascripts/components/itsi_authoring/open_response_question_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/open_response_question_editor.js.coffee
@@ -4,12 +4,14 @@ modulejs.define 'components/itsi_authoring/open_response_question_editor',
 [
   'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form',
-  'components/itsi_authoring/section_editor_element'
+  'components/itsi_authoring/section_editor_element',
+  'components/itsi_authoring/tiny_mce_config'
 ],
 (
   AjaxFormMixin,
   SectionEditorFormClass,
-  SectionEditorElementClass
+  SectionEditorElementClass,
+  ITSITinyMCEConfig
 ) ->
 
   SectionEditorForm = React.createFactory SectionEditorFormClass
@@ -33,7 +35,7 @@ modulejs.define 'components/itsi_authoring/open_response_question_editor',
         if @state.edit
           (SectionEditorForm {onSave: @save, onCancel: @cancel},
             (label {}, 'Question prompt')
-            (@richText {name: 'embeddable_open_response[prompt]'})
+            (@richText {name: 'embeddable_open_response[prompt]', TinyMCEConfig: ITSITinyMCEConfig})
 
             (label {}, 'Default text in answer area')
             (@text {name: 'embeddable_open_response[default_text]'})

--- a/app/assets/javascripts/components/itsi_authoring/prediction_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/prediction_editor.js.coffee
@@ -2,13 +2,13 @@
 
 modulejs.define 'components/itsi_authoring/prediction_editor',
 [
-  'components/itsi_authoring/section_element_editor_mixin',
+  'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form',
   'components/itsi_authoring/section_editor_element',
   'components/itsi_authoring/cached_ajax'
 ],
 (
-  SectionElementEditorMixin,
+  AjaxFormMixin,
   SectionEditorFormClass,
   SectionEditorElementClass,
   cachedAjax
@@ -20,7 +20,7 @@ modulejs.define 'components/itsi_authoring/prediction_editor',
   React.createClass
 
     mixins:
-      [SectionElementEditorMixin]
+      [AjaxFormMixin]
 
     # maps form names to @props.data keys
     dataMap:

--- a/app/assets/javascripts/components/itsi_authoring/sensor_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/sensor_editor.js.coffee
@@ -2,12 +2,12 @@
 
 modulejs.define 'components/itsi_authoring/sensor_editor',
 [
-  'components/itsi_authoring/section_element_editor_mixin',
+  'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form',
   'components/itsi_authoring/section_editor_element'
 ],
 (
-  SectionElementEditorMixin,
+  AjaxFormMixin,
   SectionEditorFormClass,
   SectionEditorElementClass
 ) ->
@@ -18,7 +18,7 @@ modulejs.define 'components/itsi_authoring/sensor_editor',
   React.createClass
 
     mixins:
-      [SectionElementEditorMixin]
+      [AjaxFormMixin]
 
     render: ->
       (SectionEditorElement {data: @props.data, title: 'Sensor', toHide: 'mw_interactive[is_hidden]', onEdit: @edit, alert: @props.alert, confirmHide: @props.confirmHide},

--- a/app/assets/javascripts/components/itsi_authoring/text_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/text_editor.js.coffee
@@ -2,12 +2,14 @@
 
 modulejs.define 'components/itsi_authoring/text_editor',
 [
-  'components/common/ajax_form_mixin'
+  'components/common/ajax_form_mixin',
   'components/itsi_authoring/section_editor_form',
+  'components/itsi_authoring/tiny_mce_config'
 ],
 (
   AjaxFormMixin,
   SectionEditorFormClass,
+  ITSITinyMCEConfig
 ) ->
 
   SectionEditorForm = React.createFactory SectionEditorFormClass
@@ -29,7 +31,7 @@ modulejs.define 'components/itsi_authoring/text_editor',
       (div {className: 'ia-section-editor-element'},
         if @state.edit
           (SectionEditorForm {onSave: @save, onCancel: @cancel},
-            (@richText {name: 'interactive_page[text]'})
+            (@richText {name: 'interactive_page[text]', TinyMCEConfig: ITSITinyMCEConfig})
           )
         else
           (div {className: 'ia-section-text'},

--- a/app/assets/javascripts/components/itsi_authoring/text_editor.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/text_editor.js.coffee
@@ -2,23 +2,20 @@
 
 modulejs.define 'components/itsi_authoring/text_editor',
 [
-  'components/itsi_authoring/section_element_editor_mixin'
+  'components/common/ajax_form_mixin'
   'components/itsi_authoring/section_editor_form',
-  'components/itsi_authoring/rich_text_editor',
 ],
 (
-  SectionElementEditorMixin,
+  AjaxFormMixin,
   SectionEditorFormClass,
-  RichTextEditorClass,
 ) ->
 
   SectionEditorForm = React.createFactory SectionEditorFormClass
-  RichTextEditor = React.createFactory RichTextEditorClass
 
   React.createClass
 
     mixins:
-      [SectionElementEditorMixin]
+      [AjaxFormMixin]
 
     # maps form names to @props.data keys
     dataMap:

--- a/app/assets/javascripts/components/itsi_authoring/tiny_mce_config.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/tiny_mce_config.js.coffee
@@ -1,0 +1,11 @@
+modulejs.define 'components/itsi_authoring/tiny_mce_config',
+->
+  menubar: false,
+  statusbar: false,
+  toolbar_items_size: 'small',
+  toolbar: "undo redo | bold italic strikethrough underline | " +
+    "aligncenter alignjustify alignleft alignright indent outdent | " +
+    "subscript superscript | numlist bullist | link unlink | hr image",
+  plugins: 'paste link hr image autoresize',
+  paste_as_text: true,
+  autoresize_bottom_margin: 5

--- a/app/assets/javascripts/components/question_tracker/image_question.js.coffee
+++ b/app/assets/javascripts/components/question_tracker/image_question.js.coffee
@@ -1,7 +1,7 @@
 {div, label, input, textarea, img, option, select} = React.DOM
 
 modulejs.define 'components/question_tracker/image_question',
-  ['components/question_tracker/throttle_mixin', 'components/itsi_authoring/rich_text_editor'],
+  ['components/question_tracker/throttle_mixin', 'components/common/rich_text_editor'],
   ( ThrottleMixin, RichTextEditorClass) ->
 
     RichTextEditor = React.createFactory RichTextEditorClass

--- a/app/assets/javascripts/components/question_tracker/multiple_choice.js.coffee
+++ b/app/assets/javascripts/components/question_tracker/multiple_choice.js.coffee
@@ -3,7 +3,7 @@
 modulejs.define 'components/question_tracker/multiple_choice',
   [
     'components/question_tracker/throttle_mixin',
-    'components/itsi_authoring/rich_text_editor',
+    'components/common/rich_text_editor',
     'components/question_tracker/choice'
   ],
   (

--- a/app/assets/javascripts/components/question_tracker/open_response.js.coffee
+++ b/app/assets/javascripts/components/question_tracker/open_response.js.coffee
@@ -3,7 +3,7 @@
 modulejs.define 'components/question_tracker/open_response',
   [
     'components/question_tracker/throttle_mixin',
-    'components/itsi_authoring/rich_text_editor'
+    'components/common/rich_text_editor'
   ],
   (
     ThrottleMixin,

--- a/app/assets/javascripts/tinymce-config.js
+++ b/app/assets/javascripts/tinymce-config.js
@@ -1,0 +1,22 @@
+window.TinyMCEConfig = {
+  menubar: false,
+  statusbar: false,
+  toolbar_items_size: 'small',
+  toolbar: "undo redo | bold italic strikethrough underline | " +
+           "aligncenter alignjustify alignleft alignright indent outdent | " +
+           "subscript superscript | numlist bullist | link unlink | hr image | code",
+  plugins: 'paste link hr image autoresize code',
+  paste_as_text: true,
+  autoresize_bottom_margin: 5
+};
+
+window.TinyMCEConfigMinimal = Object.assign({}, window.TinyMCEConfig, {
+  toolbar: "bold italic strikethrough underline indent outdent " +
+           "subscript superscript numlist bullist link unlink hr image"
+});
+
+window.initTinyMCE = function (selector, config) {
+  // Cleanup previous instances first. If TinyMCE is added twice to the same element, it doesn't work.
+  tinymce.remove(selector);
+  $(selector).tinymce(config)
+};

--- a/app/assets/javascripts/tinymce-config.js
+++ b/app/assets/javascripts/tinymce-config.js
@@ -10,7 +10,7 @@ window.TinyMCEConfig = {
   autoresize_bottom_margin: 5
 };
 
-window.TinyMCEConfigMinimal = Object.assign({}, window.TinyMCEConfig, {
+window.TinyMCEConfigMinimal = $.extend({}, window.TinyMCEConfig, {
   toolbar: "bold italic strikethrough underline indent outdent " +
            "subscript superscript numlist bullist link unlink hr image"
 });

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,7 +11,6 @@
  * This is the stylesheet for the AUTHORING section of the site
  *
  *= require_self
- *= require jquery.wysiwyg
  *= require jquery.ui.all
  *= require style
  *= require modal

--- a/app/assets/stylesheets/components/authoring.scss
+++ b/app/assets/stylesheets/components/authoring.scss
@@ -21,3 +21,38 @@
     }
   }
 }
+
+.authoring-text-editor {
+  border: 1px solid #6fc5d8;
+  padding: 5px;
+
+  h2 {
+    width: 100%;
+    background-color: hsl(192, 64%, 82%);
+    color: #126eac;
+    text-align: left;
+    font-size: 1.3em;
+    margin: -5px -5px 5px;
+    padding: 5px;
+  }
+
+  .header-edit input {
+    width: 70%;
+    font-size: 16px;
+  }
+
+  &.edit {
+    .authoring-text-content {
+      display: none;
+    }
+  }
+  .authoring-text-links {
+    float: right;
+    font-size: 13px;
+    line-height: 20px;
+    margin-right: 10px;
+    span {
+      cursor: pointer;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/authoring.scss
+++ b/app/assets/stylesheets/components/authoring.scss
@@ -56,3 +56,24 @@
     }
   }
 }
+
+.authoring-text-field {
+  display: inline-block;
+
+  input {
+    width: 200px;
+    font-size: 1.1em;
+  }
+
+  .text-field-links {
+    margin-left: 10px;
+    color: #6fc5d8;
+    text-decoration: underline;
+    font-weight: normal;
+    font-size: 0.66em;
+    span {
+      cursor: pointer;
+      margin: 0 3px;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/question_tracker.scss
+++ b/app/assets/stylesheets/components/question_tracker.scss
@@ -78,7 +78,7 @@
     background-color: hsl(0, 2%, 99%);
   }
   button {
-    margin: 1em;
+    // margin: 1em;
     margin-left: 0;
   }
   .ia-section-editor-buttons {
@@ -125,5 +125,7 @@
       color: hsl(0, 70%, 50%);
     }
   }
-
+  .mce-tinymce {
+    width: 80% !important;
+  }
 }

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -14,7 +14,7 @@
 .modal {
   display: none;
   position: absolute;
-  width: 350px;
+  width: 400px;
   left: 50%;
   margin-left: (-350px - 40px) / 2;
   padding: 20px;
@@ -33,9 +33,6 @@
 
   input.close {
     float: right;
-    margin: 1em 1em 5px 0;
-    line-height: 1;
-    height: 1.6em;
   }
 
   input.embeddable-save {

--- a/app/assets/stylesheets/partials/authoring/modal_edit.scss
+++ b/app/assets/stylesheets/partials/authoring/modal_edit.scss
@@ -24,7 +24,7 @@
   fieldset legend {
     font-weight: bold;
   }
-  button, .btn {
+  .btn {
     float: right;
     margin: 1em;
   }

--- a/app/assets/stylesheets/sequence-editing.scss
+++ b/app/assets/stylesheets/sequence-editing.scss
@@ -62,9 +62,9 @@
 #leftcol {
     clear: left;
     float: left;
-    width: 50%;
+    width: 65%;
 }
 #rightcol {
 	float: right;
-	width: 45%;
+	width: 32%;
 }

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -56,7 +56,7 @@ body {
   color: #3f3f3f;
   font: 80% 'Lato', arial, helvetica, sans-serif;
 }
-button, .btn-primary, span.edit_trigger, #modal .embeddable-save {
+button, .btn-primary, span.edit_trigger, #modal .embeddable-save, #modal .close {
   background: #6fc5d8;
   border: none;
   color: #fff;
@@ -69,6 +69,7 @@ button, .btn-primary, span.edit_trigger, #modal .embeddable-save {
   text-decoration: none;
   display: inline-block;
 }
+
 button.disabled, .btn-primary.disabled, span.edit_trigger.disabled {
   background: #ccc !important;
 }
@@ -368,32 +369,7 @@ button.disabled, .btn-primary.disabled, span.edit_trigger.disabled {
     width: 174px;
   }
 }
-.sidebar {
-  background: #6fc5d8;
-  clear: both;
-  color: #fff;
-  height: auto;
-  margin-top: 20px;
-  min-height: 224px;
-  padding: 1%;
-  border-radius: 13px;
-  h2 {
-    font: 500 2em 'Lato', georgia, 'times new roman', serif;
-    margin: 0 0 20px;
-  }
-  img {
-    float: left;
-    margin: 0 10px 0 0;
-  }
-  p {
-    font-size: 1em;
-    line-height: 1.5;
-    margin-bottom: 1em;
-  }
-  small {
-    font-size: .9em;
-  }
-}
+
 .related {
   background: #6fc5d8;
   clear: both;
@@ -775,43 +751,6 @@ fieldset {
   div.edit_interactive_page{
     padding-bottom: 20px;
   }
-  /* Page intro */
-  div.instructions, div.sidebar {
-    border: 1px solid #6fc5d8;
-    position: relative;
-    padding: 5px;
-    .edit_trigger {
-      position: absolute;
-      top: 3px;
-      right: 5px;
-      margin: 0;
-      background: 0;
-      color: #126eac;
-    }
-    h2 {
-      width: 100%;
-      background-color: hsl(192, 64%, 82%);
-      color: #126eac !important;
-      text-align: left;
-      font-size: 1.3em;
-      margin: -5px -5px 5px; /* Undoes padding from div on top, left, & right for background */
-      padding: 5px; /* Gives the head itself some padding */
-    }
-    .editable button {
-      position: absolute;
-      top: 3px;
-      right: 5px;
-      margin: 0;
-      background: 0;
-      color: #126eac;
-    }
-    .editable button.jeditable-submit {
-      right: 55px;
-    }
-    .editable button.jeditable-submit:after {
-      content: " |";
-    }
-  }
   /* Info/assessment block */
   div.questions {
     border: 1px solid #6fc5d8;
@@ -879,11 +818,6 @@ fieldset {
     form.interactives-form {
       margin-top: 8px;
     }
-  }
-  div.sidebar {
-    background: 0;
-    border-radius: 0;
-    color: #000;
   }
   h2.question {
     margin-bottom: 1em;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -120,6 +120,7 @@ module ApplicationHelper
     return default_footer if @project.footer.blank?
     return @project.footer
   end
+
   def time_to_complete(min)
     results = <<-EOF
       <span class='time_to_complete'>
@@ -131,6 +132,37 @@ module ApplicationHelper
       </span>
     EOF
     results.html_safe
+  end
+
+  # Inserts TinyMCE text editor that edits given property (text property).
+  # If :editable_header and :header_prop options are provided, the header will be editable too.
+  # Otherwise, :header option can be used to use constant header / title
+  def text_editor (object, property, options={})
+    update_url = options.delete(:update_url) || url_for(object)
+    id = "text-editor-#{property}-#{object.class.to_s.underscore}-#{object.id}"
+    text_prop_name = "#{object.class.to_s.underscore}[#{property}]"
+    text_value = object.send(property)
+    header_prop_name = options[:header_prop] ? "#{object.class.to_s.underscore}[#{options[:header_prop]}]" : "non-editable-header"
+    header_value =  options[:header_prop] ? object.send(options[:header_prop]) : nil
+    %{
+      <div class="text-editor" id="#{id}"></div>
+      <script type="text/javascript">
+        (function() {
+          var props = {
+            data: {
+              "#{text_prop_name}": #{text_value.to_json},
+              "#{header_prop_name}": #{(header_value ? header_value : options[:header]).to_json},
+            },
+            updateUrl: "#{update_url}",
+            textPropName: "#{text_prop_name}",
+            headerPropName: "#{header_prop_name}",
+            editableHeader: #{options[:editable_header] || false}
+          };
+          TextEditor = React.createElement(modulejs.require('components/authoring/text_editor'), props);
+          React.render(TextEditor, $("##{id}")[0]);
+        }());
+      </script>
+    }.html_safe
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -166,7 +166,7 @@ module ApplicationHelper
   end
 
   # Inserts a simple text field that let users edit given property (text property).
-  def text_field (object, property, options={})
+  def editable_field (object, property, options={})
     update_url = options.delete(:update_url) || url_for(object)
     id = "text-editor-#{property}-#{object.class.to_s.underscore}-#{object.id}"
     prop_name = "#{object.class.to_s.underscore}[#{property}]"
@@ -183,8 +183,8 @@ module ApplicationHelper
             propName: "#{prop_name}",
             placeholder: "#{options[:placeholder]}"
           };
-          TextField = React.createElement(modulejs.require('components/authoring/text_field'), props);
-          React.render(TextField, $("##{id}")[0]);
+          EditableField = React.createElement(modulejs.require('components/authoring/editable_field'), props);
+          React.render(EditableField, $("##{id}")[0]);
         }());
       </script>
     }.html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -145,7 +145,7 @@ module ApplicationHelper
     header_prop_name = options[:header_prop] ? "#{object.class.to_s.underscore}[#{options[:header_prop]}]" : "non-editable-header"
     header_value =  options[:header_prop] ? object.send(options[:header_prop]) : nil
     %{
-      <div class="text-editor" id="#{id}"></div>
+      <div id="#{id}"></div>
       <script type="text/javascript">
         (function() {
           var props = {
@@ -160,6 +160,31 @@ module ApplicationHelper
           };
           TextEditor = React.createElement(modulejs.require('components/authoring/text_editor'), props);
           React.render(TextEditor, $("##{id}")[0]);
+        }());
+      </script>
+    }.html_safe
+  end
+
+  # Inserts a simple text field that let users edit given property (text property).
+  def text_field (object, property, options={})
+    update_url = options.delete(:update_url) || url_for(object)
+    id = "text-editor-#{property}-#{object.class.to_s.underscore}-#{object.id}"
+    prop_name = "#{object.class.to_s.underscore}[#{property}]"
+    value = object.send(property)
+    %{
+      <span id="#{id}"></span>
+      <script type="text/javascript">
+        (function() {
+          var props = {
+            data: {
+              "#{prop_name}": #{value.to_json}
+            },
+            updateUrl: "#{update_url}",
+            propName: "#{prop_name}",
+            placeholder: "#{options[:placeholder]}"
+          };
+          TextField = React.createElement(modulejs.require('components/authoring/text_field'), props);
+          React.render(TextField, $("##{id}")[0]);
         }());
       </script>
     }.html_safe

--- a/app/views/c_rater/score_mappings/_form.html.haml
+++ b/app/views/c_rater/score_mappings/_form.html.haml
@@ -49,8 +49,6 @@
 = f.submit "Cancel", :class => 'close'
 = f.submit "Save", :class => 'embeddable-save'
 :javascript
-$(function() {
-    $('.wysiwyg').each(function(){
-        $( this ).wysiwyg({height: "60px","controls": { "html": { "visible": true }, "h1": { "visible": false }, "h2": { "visible": false }, "h3": { "visible": false } } });
-    });
-});
+  $(function() {
+    initTinyMCE('.wysiwyg', window.TinyMCEConfig);
+  });

--- a/app/views/embeddable/image_questions/_form.html.haml
+++ b/app/views/embeddable/image_questions/_form.html.haml
@@ -10,11 +10,7 @@
   = field_set_tag 'Question Prompt' do
     .help
       This appears next to the text response area. If this is blank, the user will not be shown a text response area.
-      = f.text_area :prompt, :rows => 5
-      :javascript
-        $(function() {
-            $('#embeddable_image_question_prompt').wysiwyg({"controls": { "html": { "visible": true }, "h1": { "visible": false }, "h2": { "visible": false }, "h3": { "visible": false } } });
-        });
+      = f.text_area :prompt, :rows => 5, :class => 'wysiwyg'
   = field_set_tag 'Hint' do
     .help
       If this is provided, the user will be able to see expandable hint next to the question title.
@@ -38,7 +34,7 @@
       = render :partial => 'shared/edit_prediction', :locals => { :f => f }
   :javascript
     $(function() {
-        $('.wysiwyg').wysiwyg({"controls": { "html": { "visible": true }, "h1": { "visible": false }, "h2": { "visible": false }, "h3": { "visible": false } } });
+      initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
     });
 
   = f.submit "Cancel", :class => 'close'

--- a/app/views/embeddable/image_questions/_form.html.haml
+++ b/app/views/embeddable/image_questions/_form.html.haml
@@ -6,15 +6,15 @@
   = field_set_tag 'Drawing Prompt' do
     .help
       This appears above the drawing area.
-      = f.text_area :drawing_prompt, :rows => 5, :class => 'wysiwyg'
+      = f.text_area :drawing_prompt, :rows => 5, :class => 'wysiwyg-minimal'
   = field_set_tag 'Question Prompt' do
     .help
       This appears next to the text response area. If this is blank, the user will not be shown a text response area.
-      = f.text_area :prompt, :rows => 5, :class => 'wysiwyg'
+      = f.text_area :prompt, :rows => 5, :class => 'wysiwyg-minimal'
   = field_set_tag 'Hint' do
     .help
       If this is provided, the user will be able to see expandable hint next to the question title.
-      = f.text_area :hint, :rows => 5, :class => 'wysiwyg'
+      = f.text_area :hint, :rows => 5, :class => 'wysiwyg-minimal'
   = field_set_tag "Options" do
     %ul
       %li
@@ -34,7 +34,7 @@
       = render :partial => 'shared/edit_prediction', :locals => { :f => f }
   :javascript
     $(function() {
-      initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
+      initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);
     });
 
   = f.submit "Cancel", :class => 'close'

--- a/app/views/embeddable/labbooks/edit.html.haml
+++ b/app/views/embeddable/labbooks/edit.html.haml
@@ -24,12 +24,5 @@
 
 :javascript
   $(function() {
-    $('.wysiwyg').wysiwyg({
-      'controls': {
-        'html': {'visible': true},
-        'h1': {'visible': false},
-        'h2': {'visible': false},
-        'h3': {'visible': false}
-       }
-    });
+    initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
   });

--- a/app/views/embeddable/labbooks/edit.html.haml
+++ b/app/views/embeddable/labbooks/edit.html.haml
@@ -3,7 +3,7 @@
   = f.label 'Name (visible in reports)'
   = f.text_field :name
   = field_set_tag 'Prompt' do
-    = f.text_area :prompt, :rows => 5, class: 'wysiwyg'
+    = f.text_area :prompt, :rows => 5, class: 'wysiwyg-minimal'
   = field_set_tag 'Options' do
     %ul
       %li
@@ -18,11 +18,11 @@
   = field_set_tag 'Hint' do
     .help
       If this is provided, the user will be able to see expandable hint next to the question title.
-      = f.text_area :hint, :rows => 5, :class => 'wysiwyg'
+      = f.text_area :hint, :rows => 5, :class => 'wysiwyg-minimal'
   = f.submit 'Cancel', class: 'close'
   = f.submit 'Save', class: 'embeddable-save'
 
 :javascript
   $(function() {
-    initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
+    initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);
   });

--- a/app/views/embeddable/multiple_choices/_form.html.haml
+++ b/app/views/embeddable/multiple_choices/_form.html.haml
@@ -4,11 +4,11 @@
   = f.label 'Heading'
   = f.text_field :name
   = field_set_tag 'Prompt' do
-    = f.text_area :prompt, :rows => 5, :class => 'wysiwyg'
+    = f.text_area :prompt, :rows => 5, :class => 'wysiwyg-minimal'
   = field_set_tag 'Hint' do
     .help
       If this is provided, the user will be able to see expandable hint next to the question title.
-      = f.text_area :hint, :rows => 5, :class => 'wysiwyg'
+      = f.text_area :hint, :rows => 5, :class => 'wysiwyg-minimal'
   = field_set_tag 'Layout',:id => "embeddable_layout_options" do
     .options
       %ul
@@ -57,7 +57,7 @@
     = f.link_to_add "Add choice", :choices
     :javascript
       $(function() {
-          initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
+          initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);
 
           var $radios = $('#embeddable_layout_options input'),
               $showAsMenu = $('##{show_as_menu_id}');

--- a/app/views/embeddable/multiple_choices/_form.html.haml
+++ b/app/views/embeddable/multiple_choices/_form.html.haml
@@ -57,7 +57,7 @@
     = f.link_to_add "Add choice", :choices
     :javascript
       $(function() {
-          $('.wysiwyg').wysiwyg({"controls": { "html": { "visible": true }, "h1": { "visible": false }, "h2": { "visible": false }, "h3": { "visible": false } } });
+          initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
 
           var $radios = $('#embeddable_layout_options input'),
               $showAsMenu = $('##{show_as_menu_id}');

--- a/app/views/embeddable/open_responses/_form.html.haml
+++ b/app/views/embeddable/open_responses/_form.html.haml
@@ -15,9 +15,10 @@
       .ul
         = render :partial => 'shared/edit_prediction', :locals => { :f => f }
 
-    :javascript
-      $(function() {
-          $('.wysiwyg').wysiwyg({"controls": { "html": { "visible": true }, "h1": { "visible": false }, "h2": { "visible": false }, "h3": { "visible": false } } });
-      });
   = f.submit "Cancel", :class => 'close'
   = f.submit "Save", :class => 'embeddable-save'
+
+  :javascript
+    $(function() {
+      initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
+    });

--- a/app/views/embeddable/open_responses/_form.html.haml
+++ b/app/views/embeddable/open_responses/_form.html.haml
@@ -3,13 +3,13 @@
   = f.label "Heading"
   = f.text_field :name
   = field_set_tag 'Prompt' do
-    = f.text_area :prompt, :rows => 5, :class => "wysiwyg"
+    = f.text_area :prompt, :rows => 5, :class => "wysiwyg-minimal"
   = field_set_tag 'Default Text' do
-    = f.text_area :default_text, :rows => 5, :class => "wysiwyg"
+    = f.text_area :default_text, :rows => 5, :class => "wysiwyg-minimal"
   = field_set_tag 'Hint' do
     .help
       If this is provided, the user will be able to see expandable hint next to the question title.
-      = f.text_area :hint, :rows => 5, :class => 'wysiwyg'
+      = f.text_area :hint, :rows => 5, :class => 'wysiwyg-minimal'
   .options
     = field_set_tag "options" do
       .ul
@@ -20,5 +20,5 @@
 
   :javascript
     $(function() {
-      initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
+      initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);
     });

--- a/app/views/embeddable/xhtmls/edit.html.haml
+++ b/app/views/embeddable/xhtmls/edit.html.haml
@@ -3,10 +3,10 @@
   = field_set_tag 'Heading' do
     = f.text_field :name
   = field_set_tag 'Content' do
-    = f.text_area :content, :rows => 5, :class => 'wysiwyg'
+    = f.text_area :content, :rows => 5, :class => 'wysiwyg-minimal'
     :javascript
       $(function() {
-        initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
+        initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);
       });
   = f.submit "Cancel", :class => 'close'
   = f.submit "Save", :class => 'embeddable-save'

--- a/app/views/embeddable/xhtmls/edit.html.haml
+++ b/app/views/embeddable/xhtmls/edit.html.haml
@@ -3,10 +3,10 @@
   = field_set_tag 'Heading' do
     = f.text_field :name
   = field_set_tag 'Content' do
-    = f.text_area :content, :rows => 5
+    = f.text_area :content, :rows => 5, :class => 'wysiwyg'
     :javascript
       $(function() {
-          $('#embeddable_xhtml_content').wysiwyg({"controls": { "html": { "visible": true }, "h1": { "visible": false }, "h2": { "visible": false }, "h3": { "visible": false } } });
+        initTinyMCE('.wysiwyg', window.TinyMCEConfigMinimal);
       });
   = f.submit "Cancel", :class => 'close'
   = f.submit "Save", :class => 'embeddable-save'

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -43,7 +43,7 @@
   = render :partial => "publications/publication_failures", :locals =>{ :publication => @activity}
 
   %h2.question
-    = text_field @page, :name, { :placeholder => 'page title' }
+    = editable_field @page, :name, { :placeholder => 'page title' }
     %span.preview
       = link_to "Preview", preview_activity_page_path(@activity, @page), :target => 'new'
   %div.edit_interactive_page

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -43,7 +43,7 @@
   = render :partial => "publications/publication_failures", :locals =>{ :publication => @activity}
 
   %h2.question
-    = editable_field @page, :name, {:use_trigger => true, :edit_string => 'Edit', :submit => 'Save', :cancel => 'Cancel', :onblur => 'ignore', :placeholder => 'page title'}
+    = text_field @page, :name, { :placeholder => 'page title' }
     %span.preview
       = link_to "Preview", preview_activity_page_path(@activity, @page), :target => 'new'
   %div.edit_interactive_page

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -81,9 +81,7 @@
     =render :partial => "edit_completion"
   - else
     - if @page.show_introduction
-      .instructions{:class => @page.text.blank? ? 'block-empty' : '' }
-        %h2 Introduction
-        = editable_field @page, :text, { :use_trigger => true, :open_if_empty => true, :edit_string => 'Edit', :type => 'wysiwyg', :rows => 5, :cols => 130, :width => '99%', :submit => '<button type="submit" class="jeditable-submit">Save</button>', :cancel => '<button type="cancel" class="jeditable-cancel">Cancel</button>', :onblur => 'ignore', :placeholder => '', :wysiwyg => { :controls => { :html => { :visible => true }, :h1 => { :visible => false }, :h2 => { :visible => false }, :h3 => { :visible => false } } } }
+      = text_editor @page, :text, { header: 'Introduction' }
     .text
       - if @page.show_info_assessment
         .questions
@@ -108,10 +106,8 @@
         - @page.interactives.each do |interactive|
           = render :partial => "#{interactive.class.name.underscore.pluralize}/author", :locals => {:interactive => interactive, :page => @page, :allow_hide => false}
     - if @page.show_sidebar
-      .sidebar
-        %h2
-          = editable_field @page, :sidebar_title, {:type => 'text' }
-        = editable_field @page, :sidebar, { :use_trigger => true, :open_if_empty => true, :edit_string => 'Edit', :type => 'wysiwyg', :rows => 5, :cols => 130, :width => '99%', :submit => '<button type="submit" class="jeditable-submit">Save</button>', :cancel => '<button type="cancel" class="jeditable-cancel">Cancel</button>', :onblur => 'ignore', :placeholder => '', :wysiwyg => { :controls => { :html => { :visible => true }, :h1 => { :visible => false }, :h2 => { :visible => false }, :h3 => { :visible => false } } } }
+      %div{style: 'clear: both;'}
+        = text_editor @page, :sidebar, { editable_header: true, header_prop: :sidebar_title }
     = render :partial => "trackedQuestionSelector", locals: {page: @page, activity: @activity}
 
 :javascript

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -42,10 +42,10 @@
         = f.select :publication_status, options_for_select(LightweightActivity::PUB_STATUSES_OPTIONS, @activity.publication_status)
       .field
         = f.label :description, 'Activity Description'
-        = editable_field @activity, :description, { :use_trigger => true, :edit_string => 'Edit', :update_url => activity_path(@activity), :type => 'wysiwyg', :rows => 5, :cols => 55, :submit => '<button type="submit" class="jeditable-submit">Save</button>', :cancel => '<button type="cancel" class="jeditable-cancel">Cancel</button>', :onblur => 'ignore', :wysiwyg => { :controls => { :html => { :visible => true }, :h1 => { :visible => false }, :h2 => { :visible => false }, :h3 => { :visible => false } }, :rmUnwantedBr => true } }
+        = f.text_area :description, :class => 'wysiwyg'
       .field
         = f.label :related, 'Related Content'
-        = editable_field @activity, :related, { :use_trigger => true, :edit_string => 'Edit', :update_url => activity_path(@activity), :type => 'wysiwyg', :rows => 5, :cols => 55, :submit => '<button type="submit" class="jeditable-submit">Save</button>', :cancel => '<button type="cancel" class="jeditable-cancel">Cancel</button>', :onblur => 'ignore', :wysiwyg => { :controls => { :html => { :visible => true }, :h1 => { :visible => false }, :h2 => { :visible => false }, :h3 => { :visible => false } }, :rmUnwantedBr => true } }
+        = f.text_area :related, :class => 'wysiwyg'
       .field
         = f.label :time_to_complete,  'Estimated time to complete, in minutes'
         = f.text_field :time_to_complete

--- a/app/views/lightweight_activities/itsi_edit.html.haml
+++ b/app/views/lightweight_activities/itsi_edit.html.haml
@@ -7,19 +7,6 @@
 
 = render :partial => "edit_header", locals: {show_publication_details: false}
 
-:javascript
-  window.ITSIEditorTinyMCEConfig = {
-      menubar: false,
-      statusbar: false,
-      toolbar_items_size: 'small',
-      toolbar: "undo redo | bold italic strikethrough underline | " +
-        "aligncenter alignjustify alignleft alignright indent outdent | " +
-        "subscript superscript | numlist bullist | link unlink | hr image",
-      plugins: 'paste link hr image autoresize',
-      paste_as_text: true,
-      content_css: "#{asset_path('tinymce.css')}"
-    }
-
 #itsi-editor
 
 :javascript

--- a/app/views/lightweight_activities/new.html.haml
+++ b/app/views/lightweight_activities/new.html.haml
@@ -35,17 +35,9 @@
   = field_set_tag 'Publication status' do
     = f.select :publication_status, options_for_select(LightweightActivity::PUB_STATUSES_OPTIONS, @activity.publication_status)
   = field_set_tag 'Activity Description' do
-    = f.text_area :description, :cols => 80, :rows => 5
-    :javascript
-      $(function() {
-          $('#lightweight_activity_description').wysiwyg({'controls': { 'html': { 'visible': true } } });
-      });
+    = f.text_area :description, :cols => 80, :rows => 5, :class => 'wysiwyg'
   = field_set_tag 'Related Content' do
-    = f.text_area :related, :cols => 80, :rows => 5
-    :javascript
-      $(function() {
-          $('#lightweight_activity_related').wysiwyg({'controls': { 'html': { 'visible': true } } });
-      });
+    = f.text_area :related, :cols => 80, :rows => 5, :class => 'wysiwyg'
   = field_set_tag 'Estimated time to complete, in minutes' do
     = f.text_field :time_to_complete
   = field_set_tag 'Thumbnail URL' do
@@ -58,4 +50,3 @@
   = field_set_tag 'Notes' do
     The notes area is for storing information for other authors, e.g. source material or usage restrictions, and is not intended to be displayed in the runtime.
     = f.text_area :notes
-=# javascript_tag("focus_first_field();");

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -23,15 +23,15 @@
   .field
     = f.label :footer
     %br
-    = f.text_area :footer, { :class => 'wysiwyg-text', :cols => 80, :rows => 10 }
+    = f.text_area :footer, { :class => 'wysiwyg', :cols => 80, :rows => 10 }
   .field
     = f.label :about
     %br
-    = f.text_area :about, { :class => 'wysiwyg-text', :cols => 80, :rows => 10 }
+    = f.text_area :about, { :class => 'wysiwyg', :cols => 80, :rows => 10 }
   .field
     = f.label :help
     %br
-    = f.text_area :help, { :class => 'wysiwyg-text', :cols => 80, :rows => 10 }
+    = f.text_area :help, { :class => 'wysiwyg', :cols => 80, :rows => 10 }
   .field
     = f.label :theme, "Default theme"
     %br

--- a/app/views/question_trackers/edit.html.haml
+++ b/app/views/question_trackers/edit.html.haml
@@ -4,21 +4,6 @@
 = content_for :title do
   = "Edit #{@question_tracker.name}"
 
-:javascript
-  // QuestionTrackers share ITSI's Rich Text Editing react component.
-  // so we configure it using the same global variable.
-  window.ITSIEditorTinyMCEConfig = {
-      menubar: false,
-      statusbar: false,
-      toolbar_items_size: 'small',
-      toolbar: "undo redo | bold italic strikethrough underline | " +
-        "aligncenter alignjustify alignleft alignright indent outdent | " +
-        "subscript superscript | numlist bullist | link unlink | hr image",
-      plugins: 'paste link hr image autoresize',
-      paste_as_text: true,
-      content_css: "#{asset_path('tinymce.css')}"
-    }
-
 #question-tracker-editor
 
 :javascript

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -50,10 +50,10 @@
     .field
       = f.label :description
       %br
-      = f.text_area :description, { :class => 'wysiwyg-text', :cols => 60, :rows => 10 }
+      = f.text_area :description, { :class => 'wysiwyg', :cols => 60, :rows => 10 }
     .field
       = f.label :abstract
       %br
-      = f.text_area :abstract, { :class => 'wysiwyg-text', :cols => 60, :rows => 10 }
+      = f.text_area :abstract, { :class => 'wysiwyg', :cols => 60, :rows => 10 }
     .actions
       = f.submit

--- a/app/views/shared/_edit_prediction.html.haml
+++ b/app/views/shared/_edit_prediction.html.haml
@@ -6,4 +6,4 @@
   = t(:GIVE_PREDICTION_FEEDBACK)
 .li
   = f.label t(:PREDICTION_FEEDBACK)
-  = f.text_area :prediction_feedback, :rows =>5, :class=>"wysiwyg"
+  = f.text_area :prediction_feedback, :rows =>5, :class=>"wysiwyg-minimal"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180321211835) do
+ActiveRecord::Schema.define(:version => 20180329231011) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -410,21 +410,22 @@ ActiveRecord::Schema.define(:version => 20180321211835) do
   create_table "mw_interactives", :force => true do |t|
     t.string   "name"
     t.text     "url"
-    t.datetime "created_at",                               :null => false
-    t.datetime "updated_at",                               :null => false
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
     t.integer  "native_width"
     t.integer  "native_height"
-    t.boolean  "enable_learner_state",  :default => false
-    t.boolean  "has_report_url",        :default => false
+    t.boolean  "enable_learner_state",    :default => false
+    t.boolean  "has_report_url",          :default => false
     t.boolean  "click_to_play"
     t.string   "image_url"
-    t.boolean  "is_hidden",             :default => false
+    t.boolean  "is_hidden",               :default => false
     t.integer  "linked_interactive_id"
-    t.boolean  "full_window",           :default => false
+    t.boolean  "full_window",             :default => false
     t.text     "authored_state"
     t.string   "model_library_url"
-    t.boolean  "no_snapshots",          :default => false
+    t.boolean  "no_snapshots",            :default => false
     t.string   "click_to_play_prompt"
+    t.boolean  "show_delete_data_button", :default => true
   end
 
   add_index "mw_interactives", ["linked_interactive_id"], :name => "index_mw_interactives_on_linked_interactive_id"

--- a/spec/views/interactive_pages/edit.html.haml_spec.rb
+++ b/spec/views/interactive_pages/edit.html.haml_spec.rb
@@ -22,12 +22,6 @@ describe "interactive_pages/edit" do
     assign(:all_pages, [page])
   end
 
-  it 'displays page fields with edit-in-place capacity' do
-    render
-    expect(rendered).to match /<span[^>]+class="editable"[^>]+data-name="interactive_page\[name\]"[^>]*>#{page.name}<\/span>/
-    expect(rendered).to match /<span[^>]+class="editable"[^>]+data-name="interactive_page\[text\]"[^>]*>#{page.text}<\/span>/
-  end
-
   # it 'saves first edits made in the WYSIWYG editor', :js => true, :slow => true do
   #   pending 'This is an issue with the editor, not this application'
   #   page.show_introduction = 1

--- a/spec/views/lightweight_activities/edit.html.haml_spec.rb
+++ b/spec/views/lightweight_activities/edit.html.haml_spec.rb
@@ -45,7 +45,7 @@ describe "lightweight_activities/edit" do
 
     it 'should show the current activity description' do
       render
-      expect(rendered).to match /<span[^>]+class="editable"[^>]+data-name="lightweight_activity\[description\]"[^<]*>/
+      expect(rendered).to match /<textarea[^>]+name="lightweight_activity\[description\]"[^<]*>/
     end
 
     it 'should show the custom reporting URL' do
@@ -56,7 +56,7 @@ describe "lightweight_activities/edit" do
 
     it 'should show related text' do
       render
-      expect(rendered).to match /<span[^>]+class="editable"[^>]+data-name="lightweight_activity\[related\]"[^<]*>/
+      expect(rendered).to match /<textarea[^>]+name="lightweight_activity\[related\]"[^<]*>/
     end
 
     # TODO: This is breadcrumbs and doesn't get tested in this view


### PR DESCRIPTION
The general idea was to remove an ancient jeditable wysiwyg editor and replace with TinyMCE that was already used by ITSI. That involved:

1. Upgrade of TinyMCE version (slightly different look).
2. New React components used in authoring mode (text editor).
3. Refactoring of ITSI components and mixins, so the code can be shared between ITSI and regular authoring components.
4. Cleanup of various TinyMCE configs. E.g. ITSI, Tracked Questions, and so on. They seemed unnecessary. I've tried to reduce it to only two: regular and minimal. Minimal is used in places where the width is limited (questions edit dialogs). The basic one is pretty much an old ITSI config (and ofc still used by ITSI).
5. Jeditable lib was also to edit interactive page title in place. I've implemented simple React component that does the same, so Jeditable could be removed.
6. Jeditable lib removed.
7. A better approach to sidebar title editing. Now, when you click "edit", it will edit both title and content.
8. I've made sure that custom HTML doesn't break page and sidebar titles (we've seen that during demo). It will be escaped and html tags displayed, instead of being interpreted as before.

Screenshots:
1. Introduction:
    <img width="972" alt="screen shot 2018-04-03 at 12 21 37" src="https://user-images.githubusercontent.com/767857/38278722-09cfe73a-3752-11e8-94dc-96f5ee52d63f.png">
2. Sidebar editing:
    <img width="968" alt="screen shot 2018-04-03 at 12 21 52" src="https://user-images.githubusercontent.com/767857/38278735-19ed236c-3752-11e8-9bfe-4d57d6dad4b9.png">
3. Page title:
    <img width="424" alt="screen shot 2018-04-03 at 12 22 11" src="https://user-images.githubusercontent.com/767857/38278740-2143da16-3752-11e8-8997-823fd2822ad2.png">
4. Question edit dialog (minimal TinyMCE config):
    <img width="459" alt="screen shot 2018-04-03 at 15 06 49" src="https://user-images.githubusercontent.com/767857/38278752-34e3d0b2-3752-11e8-87b1-dc9424e44e4c.png">
5. Activity edit form (I made it a bit wider):
    <img width="660" alt="screen shot 2018-04-03 at 15 06 24" src="https://user-images.githubusercontent.com/767857/38278770-435e8e48-3752-11e8-85e0-bf797f05000a.png">

There are more places where TinyMCE is used, but these above are perhaps the most important.