### PR TITLE
Create explicit Delayed::Job to send dirty answers to Portal

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -186,10 +186,10 @@ class Run < ActiveRecord::Base
 
   # return true if we want to take this run out of the queue: either for success, or any
   # other case where retrying is pointless (e.g. nowhere to send the data, no data to send).
-  def send_to_portal(answers)
+  def send_to_portal(answers, start_time = Time.now)
     return true if remote_endpoint.nil? || remote_endpoint.blank? # Drop it on the floor
     return true if answers.blank? # Pretend we sent it, nobody will notice
-    is_success = PortalSender::Protocol.instance(remote_endpoint).post_answers(answers,remote_endpoint)
+    is_success = PortalSender::Protocol.instance(remote_endpoint).post_answers(answers, remote_endpoint, start_time)
     Rails.logger.info("Run sent to portal, success:#{is_success}, " +
       "num_answers:#{answers.count}, #{run_info_string}")
     # TODO: better error detection?
@@ -204,7 +204,7 @@ class Run < ActiveRecord::Base
       # no-op: only queue one time
     else
       mark_dirty
-      submit_dirty_answers #will happen asyncronously sometime in the future...
+      submit_dirty_answers
     end
   end
 
@@ -232,25 +232,8 @@ class Run < ActiveRecord::Base
   end
 
   def submit_dirty_answers
-    # Find array of dirty answers and send them to the portal
-    da = dirty_answers
-    return if da.empty?
-    if send_to_portal(da)
-      set_answers_clean(da) # We're only cleaning the same set we sent to the portal
-      self.reload
-      if dirty_answers.empty?
-        self.mark_clean
-      else
-        # I'm not sure about using this method here, because it raises an error when the
-        # "problem" may just be that (a) new dirty answer(s) were submitted between the
-        # send_to_portal call and the check here.
-        abort_job_and_requeue
-      end
-    else
-      abort_job_and_requeue
-    end
+    Delayed::Job.enqueue(SubmitDirtyAnswersJob.new(self.id, Time.now))
   end
-  handle_asynchronously :submit_dirty_answers, :run_at => Proc.new { 30.seconds.from_now }
 
   def set_answers_clean(answers=[])
     # Takes an array of answers and sets their is_dirty bits to clean

--- a/app/services/submit_dirty_answers_job.rb
+++ b/app/services/submit_dirty_answers_job.rb
@@ -1,0 +1,26 @@
+class SubmitDirtyAnswersJob < Struct.new(:run_id, :start_time)
+  def enqueue(job)
+    job.run_at = 30.seconds.from_now
+  end
+
+  def perform
+    run = Run.find(run_id)
+    # Find array of dirty answers and send them to the portal
+    da = run.dirty_answers
+    return if da.empty?
+    if run.send_to_portal(da, start_time)
+      run.set_answers_clean(da) # We're only cleaning the same set we sent to the portal
+      run.reload
+      if run.dirty_answers.empty?
+        run.mark_clean
+      else
+        # I'm not sure about using this method here, because it raises an error when the
+        # "problem" may just be that (a) new dirty answer(s) were submitted between the
+        # send_to_portal call and the check here.
+        run.abort_job_and_requeue
+      end
+    else
+      run.abort_job_and_requeue
+    end
+  end
+end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -469,7 +469,7 @@ describe Run do
         stub_http_request(:post, remote_endpoint).to_return(
           :body   => "OK", # TODO: What returns?
           :status => result_status)
-        allow(run).to receive_messages(:answers => answers)
+        allow_any_instance_of(Run).to receive(:answers).and_return(answers)
         run.mark_dirty
       end
       describe 'when there are no dirty answers' do
@@ -494,8 +494,8 @@ describe Run do
           let(:result_status) { 200 }
 
           it "calls send_to_portal with the dirty answers as argument" do
-            allow(run).to receive_messages(:send_to_portal => true)
-            expect(run).to receive(:send_to_portal).with(answers)
+            allow_any_instance_of(Run).to receive_messages(:send_to_portal => true)
+            expect_any_instance_of(Run).to receive(:send_to_portal).with(answers, instance_of(Time))
             expect(run.submit_dirty_answers).to be_truthy
           end
 
@@ -508,6 +508,7 @@ describe Run do
 
           it "marks itself as clean after a successful update" do
             run.submit_dirty_answers
+            run.reload
             expect(run).not_to be_dirty
           end
 
@@ -538,7 +539,7 @@ describe Run do
             answers.each do |a|
               expect(a).to receive(:mark_clean).and_return false
             end
-            allow(run).to receive_messages(:dirty_answers => answers)
+            allow_any_instance_of(Run).to receive(:dirty_answers).and_return(answers)
           end
 
           it "Raises PortalUpdateIncomplete to keep the job in the queue" do


### PR DESCRIPTION
[#158009368]

This change is fairly simple. I was struggling a bit with failing tests. Initially, I thought it was Delayed::Job not being executed as everything worked fine while testing manually. However, the problem was related to run_spec itself and the way it stubs various methods. Stubbing works only for given instance (e.g. Run instance). However, this new delayed job needs to get the Run instance again using `Run.find`, so the stubs were not applied there.