### PR TITLE
Add is_full_width attribute to all embeddable items

### DIFF
--- a/app/assets/stylesheets/mw-runtime-base.scss
+++ b/app/assets/stylesheets/mw-runtime-base.scss
@@ -432,7 +432,12 @@ div.intra-page-nav {
     // 960/2 = 480, 480 - margins = 440, then there is 2 px of padding somewhere
     width: 438px;
     vertical-align: top;
- }
+
+    &.full-width-item {
+      width: 100%;
+      margin: 20px 0;
+    }
+  }
 
  .question.likert{
     width: 95%;
@@ -588,12 +593,6 @@ div.intra-page-nav {
     font-style: italic;
     font-size: 0.9em;
   }
-}
-
-.embedded-interactive {
-  width: 200px;
-  height: 200px;
-  background: red;
 }
 
 .challenge {

--- a/app/assets/stylesheets/partials/_runtime-layouts.scss
+++ b/app/assets/stylesheets/partials/_runtime-layouts.scss
@@ -61,12 +61,11 @@
     display: inline-block;
     width: 45%;
     vertical-align: top;
-  }
 
-  .question.embedded-interactive {
-    margin: 0 20px;
-    display: block;
-    width: auto;
+    &.full-width-item {
+      width: 100%;
+      margin: 20px 0;
+    }
   }
 
   .jcarousel .question {

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -74,4 +74,10 @@ module Embeddable
   def index_in_activity(activity)
     activity.reportable_items.index(self) + 1
   end
+
+  # This can be implemented by subclass.
+  # If it's true, embeddable will stretch across the whole page in full-width layout.
+  def full_width?
+    false
+  end
 end

--- a/app/models/embeddable/answer.rb
+++ b/app/models/embeddable/answer.rb
@@ -11,6 +11,7 @@ module Embeddable::Answer
       delegate :give_prediction_feedback, :to => :question
       delegate :prediction_feedback,      :to => :question
       delegate :show_in_runtime?,         :to => :question
+      delegate :is_full_width,            :to  => :question
 
       def self.by_run(r)
         where(:run_id => r.id)

--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -1,5 +1,5 @@
 class Embeddable::ImageQuestion < ActiveRecord::Base
-  attr_accessible :name, :prompt, :hint, :bg_source, :bg_url, :drawing_prompt,
+  attr_accessible :name, :prompt, :hint, :bg_source, :bg_url, :drawing_prompt, :is_full_width,
     :is_prediction, :is_featured, :give_prediction_feedback, :prediction_feedback, :is_hidden
 
   include Embeddable
@@ -39,6 +39,7 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
       give_prediction_feedback: give_prediction_feedback,
       prediction_feedback: prediction_feedback,
       is_hidden: is_hidden,
+      is_full_width: is_full_width,
       hint: hint
     }
   end
@@ -69,6 +70,7 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
                               :give_prediction_feedback,
                               :prediction_feedback,
                               :is_hidden,
+                              :is_full_width,
                               :hint])
   end
 

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -17,7 +17,7 @@ module Embeddable
     attr_accessible :action_type, :name, :prompt,
       :custom_action_label, :is_hidden, :is_featured,
       :interactive_type, :interactive_id, :interactive,
-      :interactive_select_value, :hint
+      :interactive_select_value, :hint, :is_full_width
 
     attr_writer :interactive_select_value
 
@@ -80,6 +80,7 @@ module Embeddable
         prompt: prompt,
         custom_action_label: custom_action_label,
         is_hidden: is_hidden,
+        is_full_width: is_full_width,
         hint: hint,
         is_featured: is_featured
       }
@@ -96,6 +97,7 @@ module Embeddable
         :prompt,
         :custom_action_label,
         :is_hidden,
+        :is_full_width,
         :hint,
         :is_featured
       ])

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -24,7 +24,7 @@ module Embeddable
       :dependent => :destroy
 
     attr_accessible :name, :prompt, :hint, :custom, :choices_attributes,
-      :enable_check_answer, :multi_answer, :show_as_menu, :is_prediction,
+      :enable_check_answer, :multi_answer, :show_as_menu, :is_prediction, :is_full_width,
       :is_featured, :give_prediction_feedback, :prediction_feedback, :layout, :is_hidden
     accepts_nested_attributes_for :choices, :allow_destroy => true
 
@@ -98,6 +98,7 @@ module Embeddable
         prediction_feedback: prediction_feedback,
         layout: layout,
         is_hidden: is_hidden,
+        is_full_width: is_full_width,
         hint: hint
       }
     end
@@ -138,6 +139,7 @@ module Embeddable
                                 :prediction_feedback,
                                 :layout,
                                 :is_hidden,
+                                :is_full_width,
                                 :hint])
 
       mc_export[:choices] = []

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -3,7 +3,8 @@ module Embeddable
     include Embeddable
 
 
-    attr_accessible :name, :prompt, :hint, :is_prediction, :is_featured, :give_prediction_feedback, :prediction_feedback, :default_text, :is_hidden
+    attr_accessible :name, :prompt, :hint, :is_prediction, :is_featured, :give_prediction_feedback, :prediction_feedback,
+      :default_text, :is_hidden, :is_full_width
 
     # PageItem instances are join models, so if the embeddable is gone the join should go too.
     has_many :page_items, :as => :embeddable, :dependent => :destroy
@@ -29,6 +30,7 @@ module Embeddable
         prediction_feedback: prediction_feedback,
         default_text: default_text,
         is_hidden: is_hidden,
+        is_full_width: is_full_width,
         hint: hint
       }
     end
@@ -77,6 +79,7 @@ module Embeddable
                                 :prediction_feedback,
                                 :default_text,
                                 :is_hidden,
+                                :is_full_width,
                                 :hint])
     end
 

--- a/app/models/embeddable/xhtml.rb
+++ b/app/models/embeddable/xhtml.rb
@@ -1,6 +1,6 @@
 module Embeddable
   class Xhtml < ActiveRecord::Base
-    attr_accessible :name, :content, :is_hidden
+    attr_accessible :name, :content, :is_hidden, :is_full_width
 
     include Embeddable
 
@@ -16,7 +16,8 @@ module Embeddable
       {
         name: name,
         content: content,
-        is_hidden: is_hidden
+        is_hidden: is_hidden,
+        is_full_width: is_full_width
       }
     end
 
@@ -25,7 +26,7 @@ module Embeddable
     end
 
     def export
-      self.as_json(only:[:name, :content, :is_hidden])
+      self.as_json(only:[:name, :content, :is_hidden, :is_full_width])
     end
 
     def reportable?

--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -1,5 +1,5 @@
 class ImageInteractive < ActiveRecord::Base
-  attr_accessible :url, :caption, :credit, :show_lightbox, :credit_url, :is_hidden
+  attr_accessible :url, :caption, :credit, :show_lightbox, :credit_url, :is_hidden, :is_full_width
 
   has_one :page_item, :as => :embeddable, :dependent => :destroy
   # PageItem is a join model; if this is deleted, that instance should go too
@@ -32,7 +32,8 @@ class ImageInteractive < ActiveRecord::Base
       caption: caption,
       credit: credit,
       credit_url: credit_url,
-      is_hidden: is_hidden
+      is_hidden: is_hidden,
+      is_full_width: is_full_width
     }
   end
 
@@ -51,6 +52,7 @@ class ImageInteractive < ActiveRecord::Base
                               :url,
                               :credit,
                               :credit_url,
+                              :is_full_width,
                               :is_hidden])
   end
 

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -2,7 +2,7 @@ class MwInteractive < ActiveRecord::Base
   DEFAULT_CLICK_TO_PLAY_PROMPT = "Click here to start the interactive."
   attr_accessible :name, :url, :native_width, :native_height, :enable_learner_state, :has_report_url, :click_to_play,
                   :click_to_play_prompt, :image_url, :is_hidden, :linked_interactive_id, :full_window, :model_library_url,
-                  :authored_state, :no_snapshots, :show_delete_data_button, :is_featured
+                  :authored_state, :no_snapshots, :show_delete_data_button, :is_featured, :is_full_width
 
   default_value_for :native_width, 576
   default_value_for :native_height, 435
@@ -59,6 +59,7 @@ class MwInteractive < ActiveRecord::Base
       full_window: full_window,
       image_url: image_url,
       is_hidden: is_hidden,
+      is_full_width: is_full_width,
       is_featured: is_featured,
       model_library_url: model_library_url,
       authored_state: authored_state
@@ -101,6 +102,7 @@ class MwInteractive < ActiveRecord::Base
                               :is_featured,
                               :image_url,
                               :is_hidden,
+                              :is_full_width,
                               :model_library_url,
                               :authored_state])
   end

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -9,7 +9,7 @@ class VideoInteractive < ActiveRecord::Base
   # TODO: Not sure if labbooks work with video interactives.
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'
 
-  attr_accessible :poster_url, :caption, :credit, :height, :width, :sources_attributes, :is_hidden
+  attr_accessible :poster_url, :caption, :credit, :height, :width, :sources_attributes, :is_hidden, :is_full_width
 
   accepts_nested_attributes_for :sources, :allow_destroy => true
 
@@ -65,7 +65,8 @@ class VideoInteractive < ActiveRecord::Base
       credit: credit,
       height: height,
       width: width,
-      is_hidden: is_hidden
+      is_hidden: is_hidden,
+      is_full_width: is_full_width
     }
   end
 
@@ -81,6 +82,7 @@ class VideoInteractive < ActiveRecord::Base
                                                   :credit,
                                                   :height,
                                                   :width,
+                                                  :is_full_width,
                                                   :is_hidden])
 
     video_interactive_export[:sources] =  []

--- a/app/views/embeddable/image_questions/_form.html.haml
+++ b/app/views/embeddable/image_questions/_form.html.haml
@@ -33,6 +33,7 @@
 
       = render :partial => 'shared/edit_prediction', :locals => { :f => f }
       = render :partial => 'shared/edit_featured', :locals => { :f => f }
+      = render :partial => 'shared/edit_full_width', :locals => { :f => f }
   :javascript
     $(function() {
       initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);

--- a/app/views/embeddable/labbooks/edit.html.haml
+++ b/app/views/embeddable/labbooks/edit.html.haml
@@ -16,6 +16,7 @@
         = f.label 'Interactive'
         = f.select :interactive_select_value, @embeddable.interactives_for_select
       = render :partial => 'shared/edit_featured', :locals => { :f => f }
+      = render :partial => 'shared/edit_full_width', :locals => { :f => f }
   = field_set_tag 'Hint' do
     .help
       If this is provided, the user will be able to see expandable hint next to the question title.

--- a/app/views/embeddable/multiple_choices/_form.html.haml
+++ b/app/views/embeddable/multiple_choices/_form.html.haml
@@ -39,6 +39,7 @@
           = t(:LET_USERS_CHECK_MC_ANSWERS)
         = render :partial => 'shared/edit_prediction', :locals => { :f => f }
         = render :partial => 'shared/edit_featured', :locals => { :f => f }
+        = render :partial => 'shared/edit_full_width', :locals => { :f => f }
 
   = field_set_tag 'Choices' do
     %ul.choices

--- a/app/views/embeddable/open_responses/_form.html.haml
+++ b/app/views/embeddable/open_responses/_form.html.haml
@@ -11,10 +11,11 @@
       If this is provided, the user will be able to see expandable hint next to the question title.
       = f.text_area :hint, :rows => 5, :class => 'wysiwyg-minimal'
   .options
-    = field_set_tag "options" do
+    = field_set_tag "Options" do
       .ul
         = render :partial => 'shared/edit_prediction', :locals => { :f => f }
         = render :partial => 'shared/edit_featured', :locals => { :f => f }
+        = render :partial => 'shared/edit_full_width', :locals => { :f => f }
 
   = f.submit "Cancel", :class => 'close'
   = f.submit "Save", :class => 'embeddable-save'

--- a/app/views/embeddable/xhtmls/edit.html.haml
+++ b/app/views/embeddable/xhtmls/edit.html.haml
@@ -8,5 +8,9 @@
       $(function() {
         initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);
       });
+  .options
+    = field_set_tag "Options" do
+      .ul
+        = render :partial => 'shared/edit_full_width', :locals => { :f => f }
   = f.submit "Cancel", :class => 'close'
   = f.submit "Save", :class => 'embeddable-save'

--- a/app/views/image_interactives/edit.html.haml
+++ b/app/views/image_interactives/edit.html.haml
@@ -4,8 +4,9 @@
   =# f.hidden_field 'investigation_id', :value =>@activity.investigation.id # LightweightActivities currently don't belong_to Investigations
   = field_set_tag 'URL' do
     = f.text_field :url
-  = field_set_tag 'Allow image to be shown in lightbox?' do
-    = f.check_box :show_lightbox
+  = f.check_box :show_lightbox
+  Allow image to be shown in lightbox?
+  = render :partial => 'shared/edit_full_width', :locals => { :f => f }
   = field_set_tag 'Caption' do
     = f.text_area :caption
   = field_set_tag 'Credit' do

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -1,17 +1,17 @@
 .embeddables
   - unless embeddables.blank?
     - embeddables.each do |e|
-      - if Embeddable::is_interactive?(e)
-        .question.embedded-interactive
+      - css_class = e.respond_to?(:is_full_width) && e.is_full_width ? "full-width-item" : ""
+      - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
+      - css_class += e.is_a?(Embeddable::Xhtml) ? " challenge" : (is_likert ? " likert" : "")
+      .question{ class: css_class }
+        - if Embeddable::is_interactive?(e)
           = render_interactive(e)
-      - else
-        -# Embeddable is a question.
-        -# If a labbooks is included within the interactives section,
-        -# dont also display that item here.
-        - unless show_labbook_in_assessment_block?(e)
-          - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
-          - css_class = e.is_a?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : ""
-          - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
-          - if e.show_in_runtime?
-            .question{ class: css_class }
+        - else
+          -# Embeddable is a question.
+          -# If a labbooks is included within the interactives section,
+          -# dont also display that item here.
+          - unless show_labbook_in_assessment_block?(e)
+            - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
+            - if e.show_in_runtime?
               = render(partial: partial_name, locals: { embeddable: e })

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -32,10 +32,11 @@
   .image_url
     = f.label :image_url, 'Image_url'
     = f.text_field :image_url
+  = f.label :is_full_width, t(:IS_FULL_WIDTH_ASSESMENT_ITEM)
+  = f.check_box :is_full_width
   %br
   = f.label :no_snapshots, 'Snapshots Not Supported'
   = f.check_box :no_snapshots
-  %br
   %br
   = field_set_tag 'Save Interactive state' do
     = f.label :enable_learner_state, 'Save State'

--- a/app/views/shared/_edit_full_width.html.haml
+++ b/app/views/shared/_edit_full_width.html.haml
@@ -1,0 +1,3 @@
+.li
+  = f.check_box :is_full_width
+  = t(:IS_FULL_WIDTH_ASSESMENT_ITEM)

--- a/app/views/video_interactives/edit.html.haml
+++ b/app/views/video_interactives/edit.html.haml
@@ -6,8 +6,11 @@
   = field_set_tag 'Size in pixels' do
     Width:
     = f.text_field :width
+    %br
     Height:
     = f.text_field :height
+  %br
+  = render :partial => 'shared/edit_full_width', :locals => { :f => f }
   = field_set_tag 'Caption' do
     = f.text_area :caption
   = field_set_tag 'Credit' do
@@ -25,4 +28,4 @@
     = f.link_to_add "Add source", :sources
 
   = f.button "Cancel", :class => 'close', :type => 'button'
-  = f.submit "Save", :default => 'default'
+  = f.submit "Save", :class => 'embeddable-save', :default => 'default'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
   ANSWER_IS_FINAL: "Your answer is now locked."
   IS_PREDICTION_QUESTION: "Answer required?"
   IS_FEATURED_QUESTION: "Featured in report?"
+  IS_FULL_WIDTH_ASSESMENT_ITEM: "Full width? (Full width layout only)"
   LET_USERS_CHECK_MC_ANSWERS: "Allow users to check answers?"
   GIVE_PREDICTION_FEEDBACK: "Provide prediction feedback?"
   PREDICTION_FEEDBACK: "Prediction feedback"

--- a/db/migrate/20180628101909_add_full_width_to_embeddables.rb
+++ b/db/migrate/20180628101909_add_full_width_to_embeddables.rb
@@ -1,0 +1,14 @@
+class AddFullWidthToEmbeddables < ActiveRecord::Migration
+  def change
+    add_column :embeddable_multiple_choices, :is_full_width, :boolean, :default => false
+    add_column :embeddable_open_responses, :is_full_width, :boolean, :default => false
+    add_column :embeddable_image_questions, :is_full_width, :boolean, :default => false
+    add_column :embeddable_labbooks, :is_full_width, :boolean, :default => false
+    add_column :embeddable_xhtmls, :is_full_width, :boolean, :default => false
+
+    # Interactives were always full width, so set appropriate default value.
+    add_column :mw_interactives, :is_full_width, :boolean, :default => true
+    add_column :image_interactives, :is_full_width, :boolean, :default => true
+    add_column :video_interactives, :is_full_width, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180622123906) do
+ActiveRecord::Schema.define(:version => 20180628101909) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -173,6 +173,7 @@ ActiveRecord::Schema.define(:version => 20180622123906) do
     t.boolean  "is_hidden",                :default => false
     t.text     "hint"
     t.boolean  "is_featured",              :default => false
+    t.boolean  "is_full_width",            :default => false
   end
 
   create_table "embeddable_labbook_answers", :force => true do |t|
@@ -198,6 +199,7 @@ ActiveRecord::Schema.define(:version => 20180622123906) do
     t.string   "interactive_type"
     t.text     "hint"
     t.boolean  "is_featured",         :default => false
+    t.boolean  "is_full_width",       :default => false
   end
 
   add_index "embeddable_labbooks", ["interactive_id"], :name => "labbook_interactive_i_idx"
@@ -242,6 +244,7 @@ ActiveRecord::Schema.define(:version => 20180622123906) do
     t.boolean  "is_hidden",                :default => false
     t.text     "hint"
     t.boolean  "is_featured",              :default => false
+    t.boolean  "is_full_width",            :default => false
   end
 
   create_table "embeddable_open_response_answers", :force => true do |t|
@@ -270,14 +273,16 @@ ActiveRecord::Schema.define(:version => 20180622123906) do
     t.boolean  "is_hidden",                :default => false
     t.text     "hint"
     t.boolean  "is_featured",              :default => false
+    t.boolean  "is_full_width",            :default => false
   end
 
   create_table "embeddable_xhtmls", :force => true do |t|
     t.string   "name"
     t.text     "content"
-    t.datetime "created_at",                    :null => false
-    t.datetime "updated_at",                    :null => false
-    t.boolean  "is_hidden",  :default => false
+    t.datetime "created_at",                       :null => false
+    t.datetime "updated_at",                       :null => false
+    t.boolean  "is_hidden",     :default => false
+    t.boolean  "is_full_width", :default => false
   end
 
   create_table "global_interactive_states", :force => true do |t|
@@ -298,6 +303,7 @@ ActiveRecord::Schema.define(:version => 20180622123906) do
     t.boolean  "show_lightbox", :default => true
     t.string   "credit_url"
     t.boolean  "is_hidden",     :default => false
+    t.boolean  "is_full_width", :default => true
   end
 
   create_table "imports", :force => true do |t|
@@ -432,6 +438,7 @@ ActiveRecord::Schema.define(:version => 20180622123906) do
     t.string   "click_to_play_prompt"
     t.boolean  "show_delete_data_button", :default => true
     t.boolean  "is_featured",             :default => false
+    t.boolean  "is_full_width",           :default => true
   end
 
   add_index "mw_interactives", ["linked_interactive_id"], :name => "index_mw_interactives_on_linked_interactive_id"
@@ -598,11 +605,12 @@ ActiveRecord::Schema.define(:version => 20180622123906) do
     t.string   "poster_url"
     t.text     "caption"
     t.text     "credit"
-    t.datetime "created_at",                    :null => false
-    t.datetime "updated_at",                    :null => false
-    t.integer  "width",      :default => 556,   :null => false
-    t.integer  "height",     :default => 240,   :null => false
-    t.boolean  "is_hidden",  :default => false
+    t.datetime "created_at",                       :null => false
+    t.datetime "updated_at",                       :null => false
+    t.integer  "width",         :default => 556,   :null => false
+    t.integer  "height",        :default => 240,   :null => false
+    t.boolean  "is_hidden",     :default => false
+    t.boolean  "is_full_width", :default => true
   end
 
   create_table "video_sources", :force => true do |t|

--- a/spec/models/embeddable/image_question_spec.rb
+++ b/spec/models/embeddable/image_question_spec.rb
@@ -19,6 +19,7 @@ describe Embeddable::ImageQuestion do
         bg_url: image_question.bg_url,
         is_prediction: image_question.is_prediction,
         is_featured: image_question.is_featured,
+        is_full_width: image_question.is_full_width,
         give_prediction_feedback: image_question.give_prediction_feedback,
         prediction_feedback: image_question.prediction_feedback,
         is_hidden: image_question.is_hidden,

--- a/spec/models/embeddable/labbook_spec.rb
+++ b/spec/models/embeddable/labbook_spec.rb
@@ -17,6 +17,7 @@ describe Embeddable::Labbook do
         custom_action_label: labbook.custom_action_label,
         is_hidden: labbook.is_hidden,
         is_featured: labbook.is_featured,
+        is_full_width: labbook.is_full_width,
         hint: labbook.hint
       }
       expect(labbook.to_hash).to eq(expected)

--- a/spec/models/embeddable/multiple_choice_spec.rb
+++ b/spec/models/embeddable/multiple_choice_spec.rb
@@ -120,6 +120,7 @@ describe Embeddable::MultipleChoice do
         show_as_menu: multichoice.show_as_menu,
         is_prediction: multichoice.is_prediction,
         is_featured: multichoice.is_featured,
+        is_full_width: multichoice.is_full_width,
         give_prediction_feedback: multichoice.give_prediction_feedback,
         prediction_feedback: multichoice.prediction_feedback,
         layout: multichoice.layout,

--- a/spec/models/embeddable/open_response_spec.rb
+++ b/spec/models/embeddable/open_response_spec.rb
@@ -20,6 +20,7 @@ describe Embeddable::OpenResponse do
         default_text: open_response.default_text,
         is_hidden: open_response.is_hidden,
         is_featured: open_response.is_featured,
+        is_full_width: open_response.is_full_width,
         hint: open_response.hint
       }
       expect(open_response.to_hash).to eq(expected)

--- a/spec/models/embeddable/xhtml_spec.rb
+++ b/spec/models/embeddable/xhtml_spec.rb
@@ -28,7 +28,8 @@ describe Embeddable::Xhtml do
       expected = {
         name: xhtml.name,
         content: xhtml.content,
-        is_hidden: xhtml.is_hidden
+        is_hidden: xhtml.is_hidden,
+        is_full_width: xhtml.is_full_width
       }
       expect(xhtml.to_hash).to eq(expected)
     end

--- a/spec/models/image_interactive_spec.rb
+++ b/spec/models/image_interactive_spec.rb
@@ -24,7 +24,8 @@ describe ImageInteractive do
         caption: image_interactive.caption,
         credit: image_interactive.credit,
         credit_url: image_interactive.credit_url,
-        is_hidden: image_interactive.is_hidden
+        is_hidden: image_interactive.is_hidden,
+        is_full_width: image_interactive.is_full_width
       }
       expect(image_interactive.to_hash).to eq(expected)
     end

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -46,6 +46,7 @@ describe MwInteractive do
         model_library_url: interactive.model_library_url,
         image_url: interactive.image_url,
         is_hidden: interactive.is_hidden,
+        is_full_width: interactive.is_full_width,
         authored_state: interactive.authored_state,
         is_featured: interactive.is_featured
        }
@@ -66,6 +67,7 @@ describe MwInteractive do
         model_library_url: interactive.model_library_url,
         image_url: interactive.image_url,
         is_hidden: interactive.is_hidden,
+        is_full_width: interactive.is_full_width,
         authored_state: interactive.authored_state
       })
     end

--- a/spec/models/video_interactive_spec.rb
+++ b/spec/models/video_interactive_spec.rb
@@ -50,7 +50,8 @@ describe VideoInteractive do
         credit: video_interactive.credit,
         width: video_interactive.width,
         height: video_interactive.height,
-        is_hidden: video_interactive.is_hidden
+        is_hidden: video_interactive.is_hidden,
+        is_full_width: video_interactive.is_full_width
       }
       expect(video_interactive.to_hash).to eq(expected)
     end


### PR DESCRIPTION
[#158189820]

Mostly straightforward changes, I've added `is_full_width` to eight embeddable items, updated forms and specs.

I've set the default value to `true` for all the interactives. It lets me replicate the previous behavior of all the interactives being full width in the full-width layout without implementing special case. Now it's just different default value, but all the embeddables are rendered in the same container and same classes.

I'm not sure about labels and wording though. Also, this property is obviously ignored in all the other layouts. Perhaps there's a way to disable it using layout value, although not sure if it's worth it (this UI isn't user-friendly anyway and I guess we need some info that it works in full-width mode anyway).