### PR TITLE
Rename is_featured to show_in_featured_question_report

### DIFF
--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -1,6 +1,6 @@
 class Embeddable::ImageQuestion < ActiveRecord::Base
   attr_accessible :name, :prompt, :hint, :bg_source, :bg_url, :drawing_prompt, :is_full_width,
-    :is_prediction, :is_featured, :give_prediction_feedback, :prediction_feedback, :is_hidden
+    :is_prediction, :show_in_featured_question_report, :give_prediction_feedback, :prediction_feedback, :is_hidden
 
   include Embeddable
 
@@ -35,7 +35,7 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
       bg_source: bg_source,
       bg_url: bg_url,
       is_prediction: is_prediction,
-      is_featured: is_featured,
+      show_in_featured_question_report: show_in_featured_question_report,
       give_prediction_feedback: give_prediction_feedback,
       prediction_feedback: prediction_feedback,
       is_hidden: is_hidden,
@@ -51,7 +51,7 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
       prompt: prompt,
       drawing_prompt: drawing_prompt,
       is_required: is_prediction,
-      is_featured: is_featured
+      show_in_featured_question_report: show_in_featured_question_report
     }
   end
 
@@ -66,7 +66,7 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
                               :bg_source,
                               :bg_url,
                               :is_prediction,
-                              :is_featured,
+                              :show_in_featured_question_report,
                               :give_prediction_feedback,
                               :prediction_feedback,
                               :is_hidden,

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -15,7 +15,7 @@ module Embeddable
     NO_INTERACTIVE_VALUE = "no-interactive"
     NO_INTERACTIVE_SELECT = [NO_INTERACTIVE_LABLE, NO_INTERACTIVE_VALUE];
     attr_accessible :action_type, :name, :prompt,
-      :custom_action_label, :is_hidden, :is_featured,
+      :custom_action_label, :is_hidden, :show_in_featured_question_report,
       :interactive_type, :interactive_id, :interactive,
       :interactive_select_value, :hint, :is_full_width
 
@@ -62,7 +62,7 @@ module Embeddable
         type: self.class.portal_type.gsub(' ', '_'),
         id: portal_id,
         name: name,
-        is_featured: is_featured,
+        show_in_featured_question_report: show_in_featured_question_report,
         # This info can be used by Portal to generate an iframe with album in teacher report.
         display_in_iframe: true,
         # These dimensions are pretty random at the moment. Labbook album doesn't look good
@@ -82,7 +82,7 @@ module Embeddable
         is_hidden: is_hidden,
         is_full_width: is_full_width,
         hint: hint,
-        is_featured: is_featured
+        show_in_featured_question_report: show_in_featured_question_report
       }
     end
 
@@ -99,7 +99,7 @@ module Embeddable
         :is_hidden,
         :is_full_width,
         :hint,
-        :is_featured
+        :show_in_featured_question_report
       ])
     end
 

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -25,7 +25,7 @@ module Embeddable
 
     attr_accessible :name, :prompt, :hint, :custom, :choices_attributes,
       :enable_check_answer, :multi_answer, :show_as_menu, :is_prediction, :is_full_width,
-      :is_featured, :give_prediction_feedback, :prediction_feedback, :layout, :is_hidden
+      :show_in_featured_question_report, :give_prediction_feedback, :prediction_feedback, :layout, :is_hidden
     accepts_nested_attributes_for :choices, :allow_destroy => true
 
     has_one :tracked_question, :as => :question, :dependent => :delete
@@ -93,7 +93,7 @@ module Embeddable
         multi_answer: multi_answer,
         show_as_menu: show_as_menu,
         is_prediction: is_prediction,
-        is_featured: is_featured,
+        show_in_featured_question_report: show_in_featured_question_report,
         give_prediction_feedback: give_prediction_feedback,
         prediction_feedback: prediction_feedback,
         layout: layout,
@@ -114,7 +114,7 @@ module Embeddable
           correct: choice.is_correct
         } },
         is_required: is_prediction,
-        is_featured: is_featured
+        show_in_featured_question_report: show_in_featured_question_report
       }
     end
 
@@ -134,7 +134,7 @@ module Embeddable
                                 :multi_answer,
                                 :show_as_menu,
                                 :is_prediction,
-                                :is_featured,
+                                :show_in_featured_question_report,
                                 :give_prediction_feedback,
                                 :prediction_feedback,
                                 :layout,

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -3,7 +3,7 @@ module Embeddable
     include Embeddable
 
 
-    attr_accessible :name, :prompt, :hint, :is_prediction, :is_featured, :give_prediction_feedback, :prediction_feedback,
+    attr_accessible :name, :prompt, :hint, :is_prediction, :show_in_featured_question_report, :give_prediction_feedback, :prediction_feedback,
       :default_text, :is_hidden, :is_full_width
 
     # PageItem instances are join models, so if the embeddable is gone the join should go too.
@@ -25,7 +25,7 @@ module Embeddable
         name: name,
         prompt: prompt,
         is_prediction: is_prediction,
-        is_featured: is_featured,
+        show_in_featured_question_report: show_in_featured_question_report,
         give_prediction_feedback: give_prediction_feedback,
         prediction_feedback: prediction_feedback,
         default_text: default_text,
@@ -41,7 +41,7 @@ module Embeddable
         id: id,
         prompt: prompt,
         is_required: is_prediction,
-        is_featured: is_featured
+        show_in_featured_question_report: show_in_featured_question_report
       }
     end
 
@@ -74,7 +74,7 @@ module Embeddable
       return self.as_json(only:[:name,
                                 :prompt,
                                 :is_prediction,
-                                :is_featured,
+                                :show_in_featured_question_report,
                                 :give_prediction_feedback,
                                 :prediction_feedback,
                                 :default_text,

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -2,7 +2,7 @@ class MwInteractive < ActiveRecord::Base
   DEFAULT_CLICK_TO_PLAY_PROMPT = "Click here to start the interactive."
   attr_accessible :name, :url, :native_width, :native_height, :enable_learner_state, :has_report_url, :click_to_play,
                   :click_to_play_prompt, :image_url, :is_hidden, :linked_interactive_id, :full_window, :model_library_url,
-                  :authored_state, :no_snapshots, :show_delete_data_button, :is_featured, :is_full_width
+                  :authored_state, :no_snapshots, :show_delete_data_button, :show_in_featured_question_report, :is_full_width
 
   default_value_for :native_width, 576
   default_value_for :native_height, 435
@@ -60,7 +60,7 @@ class MwInteractive < ActiveRecord::Base
       image_url: image_url,
       is_hidden: is_hidden,
       is_full_width: is_full_width,
-      is_featured: is_featured,
+      show_in_featured_question_report: show_in_featured_question_report,
       model_library_url: model_library_url,
       authored_state: authored_state
     }
@@ -99,7 +99,7 @@ class MwInteractive < ActiveRecord::Base
                               :click_to_play,
                               :click_to_play_prompt,
                               :full_window,
-                              :is_featured,
+                              :show_in_featured_question_report,
                               :image_url,
                               :is_hidden,
                               :is_full_width,

--- a/app/views/shared/_edit_featured.html.haml
+++ b/app/views/shared/_edit_featured.html.haml
@@ -1,3 +1,3 @@
 .li
-  = f.check_box :is_featured
-  = t(:IS_FEATURED_QUESTION)
+  = f.check_box :show_in_featured_question_report
+  = t(:SHOW_IN_FEATURED_QUESTION_REPORT)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
   PREDICTION_BUTTON: "Submit"
   ANSWER_IS_FINAL: "Your answer is now locked."
   IS_PREDICTION_QUESTION: "Answer required?"
-  IS_FEATURED_QUESTION: "Featured in report?"
+  SHOW_IN_FEATURED_QUESTION_REPORT: "Show in featured question report?"
   IS_FULL_WIDTH_ASSESMENT_ITEM: "Full width? (Full width layout only)"
   LET_USERS_CHECK_MC_ANSWERS: "Allow users to check answers?"
   GIVE_PREDICTION_FEEDBACK: "Provide prediction feedback?"

--- a/db/migrate/20180702132852_change_is_featured_to_show_in_featured_question_report.rb
+++ b/db/migrate/20180702132852_change_is_featured_to_show_in_featured_question_report.rb
@@ -1,0 +1,29 @@
+class ChangeIsFeaturedToShowInFeaturedQuestionReport < ActiveRecord::Migration
+  def up
+    remove_column :embeddable_multiple_choices, :is_featured
+    remove_column :embeddable_open_responses, :is_featured
+    remove_column :embeddable_image_questions, :is_featured
+    remove_column :embeddable_labbooks, :is_featured
+    remove_column :mw_interactives, :is_featured
+
+    add_column :embeddable_multiple_choices, :show_in_featured_question_report, :boolean, default: true
+    add_column :embeddable_open_responses, :show_in_featured_question_report, :boolean, default: true
+    add_column :embeddable_image_questions,:show_in_featured_question_report, :boolean, default: true
+    add_column :embeddable_labbooks, :show_in_featured_question_report, :boolean, default: true
+    add_column :mw_interactives, :show_in_featured_question_report, :boolean, default: true
+  end
+
+  def down
+    remove_column :embeddable_multiple_choices, :show_in_featured_question_report
+    remove_column :embeddable_open_responses, :show_in_featured_question_report
+    remove_column :embeddable_image_questions, :show_in_featured_question_report
+    remove_column :embeddable_labbooks, :show_in_featured_question_report
+    remove_column :mw_interactives, :show_in_featured_question_report
+
+    add_column :embeddable_multiple_choices, :is_featured, :boolean, default: false
+    add_column :embeddable_open_responses, :is_featured, :boolean, default: false
+    add_column :embeddable_image_questions,:is_featured, :boolean, default: false
+    add_column :embeddable_labbooks, :is_featured, :boolean, default: false
+    add_column :mw_interactives, :is_featured, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180628101909) do
+ActiveRecord::Schema.define(:version => 20180702132852) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -162,18 +162,18 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
   create_table "embeddable_image_questions", :force => true do |t|
     t.string   "name"
     t.text     "prompt"
-    t.datetime "created_at",                                         :null => false
-    t.datetime "updated_at",                                         :null => false
-    t.string   "bg_source",                :default => "Shutterbug"
+    t.datetime "created_at",                                                 :null => false
+    t.datetime "updated_at",                                                 :null => false
+    t.string   "bg_source",                        :default => "Shutterbug"
     t.string   "bg_url"
     t.text     "drawing_prompt"
-    t.boolean  "is_prediction",            :default => false
-    t.boolean  "give_prediction_feedback", :default => false
+    t.boolean  "is_prediction",                    :default => false
+    t.boolean  "give_prediction_feedback",         :default => false
     t.text     "prediction_feedback"
-    t.boolean  "is_hidden",                :default => false
+    t.boolean  "is_hidden",                        :default => false
     t.text     "hint"
-    t.boolean  "is_featured",              :default => false
-    t.boolean  "is_full_width",            :default => false
+    t.boolean  "is_full_width",                    :default => false
+    t.boolean  "show_in_featured_question_report", :default => true
   end
 
   create_table "embeddable_labbook_answers", :force => true do |t|
@@ -188,18 +188,18 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
   add_index "embeddable_labbook_answers", ["run_id"], :name => "index_embeddable_labbook_answers_on_run_id"
 
   create_table "embeddable_labbooks", :force => true do |t|
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
-    t.integer  "action_type",         :default => 0,     :null => false
+    t.datetime "created_at",                                          :null => false
+    t.datetime "updated_at",                                          :null => false
+    t.integer  "action_type",                      :default => 0,     :null => false
     t.string   "name"
     t.text     "prompt"
     t.string   "custom_action_label"
-    t.boolean  "is_hidden",           :default => false
+    t.boolean  "is_hidden",                        :default => false
     t.integer  "interactive_id"
     t.string   "interactive_type"
     t.text     "hint"
-    t.boolean  "is_featured",         :default => false
-    t.boolean  "is_full_width",       :default => false
+    t.boolean  "is_full_width",                    :default => false
+    t.boolean  "show_in_featured_question_report", :default => true
   end
 
   add_index "embeddable_labbooks", ["interactive_id"], :name => "labbook_interactive_i_idx"
@@ -231,20 +231,20 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
   create_table "embeddable_multiple_choices", :force => true do |t|
     t.string   "name"
     t.text     "prompt"
-    t.datetime "created_at",                                       :null => false
-    t.datetime "updated_at",                                       :null => false
-    t.boolean  "custom",                   :default => false
-    t.boolean  "enable_check_answer",      :default => true
-    t.boolean  "multi_answer",             :default => false
-    t.boolean  "show_as_menu",             :default => false
-    t.boolean  "is_prediction",            :default => false
-    t.boolean  "give_prediction_feedback", :default => false
+    t.datetime "created_at",                                               :null => false
+    t.datetime "updated_at",                                               :null => false
+    t.boolean  "custom",                           :default => false
+    t.boolean  "enable_check_answer",              :default => true
+    t.boolean  "multi_answer",                     :default => false
+    t.boolean  "show_as_menu",                     :default => false
+    t.boolean  "is_prediction",                    :default => false
+    t.boolean  "give_prediction_feedback",         :default => false
     t.text     "prediction_feedback"
-    t.string   "layout",                   :default => "vertical"
-    t.boolean  "is_hidden",                :default => false
+    t.string   "layout",                           :default => "vertical"
+    t.boolean  "is_hidden",                        :default => false
     t.text     "hint"
-    t.boolean  "is_featured",              :default => false
-    t.boolean  "is_full_width",            :default => false
+    t.boolean  "is_full_width",                    :default => false
+    t.boolean  "show_in_featured_question_report", :default => true
   end
 
   create_table "embeddable_open_response_answers", :force => true do |t|
@@ -264,16 +264,16 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
   create_table "embeddable_open_responses", :force => true do |t|
     t.string   "name"
     t.text     "prompt"
-    t.datetime "created_at",                                  :null => false
-    t.datetime "updated_at",                                  :null => false
-    t.boolean  "is_prediction",            :default => false
-    t.boolean  "give_prediction_feedback", :default => false
+    t.datetime "created_at",                                          :null => false
+    t.datetime "updated_at",                                          :null => false
+    t.boolean  "is_prediction",                    :default => false
+    t.boolean  "give_prediction_feedback",         :default => false
     t.text     "prediction_feedback"
     t.string   "default_text"
-    t.boolean  "is_hidden",                :default => false
+    t.boolean  "is_hidden",                        :default => false
     t.text     "hint"
-    t.boolean  "is_featured",              :default => false
-    t.boolean  "is_full_width",            :default => false
+    t.boolean  "is_full_width",                    :default => false
+    t.boolean  "show_in_featured_question_report", :default => true
   end
 
   create_table "embeddable_xhtmls", :force => true do |t|
@@ -421,24 +421,24 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
   create_table "mw_interactives", :force => true do |t|
     t.string   "name"
     t.text     "url"
-    t.datetime "created_at",                                 :null => false
-    t.datetime "updated_at",                                 :null => false
+    t.datetime "created_at",                                          :null => false
+    t.datetime "updated_at",                                          :null => false
     t.integer  "native_width"
     t.integer  "native_height"
-    t.boolean  "enable_learner_state",    :default => false
-    t.boolean  "has_report_url",          :default => false
+    t.boolean  "enable_learner_state",             :default => false
+    t.boolean  "has_report_url",                   :default => false
     t.boolean  "click_to_play"
     t.string   "image_url"
-    t.boolean  "is_hidden",               :default => false
+    t.boolean  "is_hidden",                        :default => false
     t.integer  "linked_interactive_id"
-    t.boolean  "full_window",             :default => false
+    t.boolean  "full_window",                      :default => false
     t.text     "authored_state"
     t.string   "model_library_url"
-    t.boolean  "no_snapshots",            :default => false
+    t.boolean  "no_snapshots",                     :default => false
     t.string   "click_to_play_prompt"
-    t.boolean  "show_delete_data_button", :default => true
-    t.boolean  "is_featured",             :default => false
-    t.boolean  "is_full_width",           :default => true
+    t.boolean  "show_delete_data_button",          :default => true
+    t.boolean  "is_full_width",                    :default => true
+    t.boolean  "show_in_featured_question_report", :default => true
   end
 
   add_index "mw_interactives", ["linked_interactive_id"], :name => "index_mw_interactives_on_linked_interactive_id"

--- a/spec/models/embeddable/image_question_spec.rb
+++ b/spec/models/embeddable/image_question_spec.rb
@@ -18,7 +18,7 @@ describe Embeddable::ImageQuestion do
         bg_source: image_question.bg_source,
         bg_url: image_question.bg_url,
         is_prediction: image_question.is_prediction,
-        is_featured: image_question.is_featured,
+        show_in_featured_question_report: image_question.show_in_featured_question_report,
         is_full_width: image_question.is_full_width,
         give_prediction_feedback: image_question.give_prediction_feedback,
         prediction_feedback: image_question.prediction_feedback,
@@ -46,7 +46,7 @@ describe Embeddable::ImageQuestion do
         prompt: image_question.prompt,
         drawing_prompt: image_question.drawing_prompt,
         is_required: image_question.is_prediction,
-        is_featured: image_question.is_featured
+        show_in_featured_question_report: image_question.show_in_featured_question_report
       )
     end
   end

--- a/spec/models/embeddable/labbook_spec.rb
+++ b/spec/models/embeddable/labbook_spec.rb
@@ -16,7 +16,7 @@ describe Embeddable::Labbook do
         prompt: labbook.prompt,
         custom_action_label: labbook.custom_action_label,
         is_hidden: labbook.is_hidden,
-        is_featured: labbook.is_featured,
+        show_in_featured_question_report: labbook.show_in_featured_question_report,
         is_full_width: labbook.is_full_width,
         hint: labbook.hint
       }
@@ -45,7 +45,7 @@ describe Embeddable::Labbook do
         type: 'iframe_interactive',
         id: labbook.portal_id,
         name: labbook.name,
-        is_featured: labbook.is_featured,
+        show_in_featured_question_report: labbook.show_in_featured_question_report,
         display_in_iframe: true,
         native_width: 600,
         native_height: 500

--- a/spec/models/embeddable/multiple_choice_spec.rb
+++ b/spec/models/embeddable/multiple_choice_spec.rb
@@ -119,7 +119,7 @@ describe Embeddable::MultipleChoice do
         multi_answer: multichoice.multi_answer,
         show_as_menu: multichoice.show_as_menu,
         is_prediction: multichoice.is_prediction,
-        is_featured: multichoice.is_featured,
+        show_in_featured_question_report: multichoice.show_in_featured_question_report,
         is_full_width: multichoice.is_full_width,
         give_prediction_feedback: multichoice.give_prediction_feedback,
         prediction_feedback: multichoice.prediction_feedback,
@@ -149,7 +149,7 @@ describe Embeddable::MultipleChoice do
         id: multichoice.id,
         prompt: multichoice.prompt,
         is_required: multichoice.is_prediction,
-        is_featured: multichoice.is_featured,
+        show_in_featured_question_report: multichoice.show_in_featured_question_report,
         choices: multichoice.choices.map { |choice|
           {
             id: choice.id,

--- a/spec/models/embeddable/open_response_spec.rb
+++ b/spec/models/embeddable/open_response_spec.rb
@@ -19,7 +19,7 @@ describe Embeddable::OpenResponse do
         prediction_feedback: open_response.prediction_feedback,
         default_text: open_response.default_text,
         is_hidden: open_response.is_hidden,
-        is_featured: open_response.is_featured,
+        show_in_featured_question_report: open_response.show_in_featured_question_report,
         is_full_width: open_response.is_full_width,
         hint: open_response.hint
       }
@@ -43,7 +43,7 @@ describe Embeddable::OpenResponse do
         id: open_response.id,
         prompt: open_response.prompt,
         is_required: open_response.is_prediction,
-        is_featured: open_response.is_featured
+        show_in_featured_question_report: open_response.show_in_featured_question_report
       )
     end
   end

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -48,7 +48,7 @@ describe MwInteractive do
         is_hidden: interactive.is_hidden,
         is_full_width: interactive.is_full_width,
         authored_state: interactive.authored_state,
-        is_featured: interactive.is_featured
+        show_in_featured_question_report: interactive.show_in_featured_question_report
        }
       expect(interactive.to_hash).to eq(expected)
     end
@@ -83,7 +83,7 @@ describe MwInteractive do
         native_width: interactive.native_width,
         native_height: interactive.native_height,
         display_in_iframe: interactive.reportable_in_iframe?,
-        is_featured: interactive.is_featured
+        show_in_featured_question_report: interactive.show_in_featured_question_report
       )
     end
   end


### PR DESCRIPTION
[#158190868]

is_featured -> show_in_featured_question_report

Migration is removing old columns and adding new ones to handle default value correctly. The previous column was false by default, this needs to be true. If I used only rename_column and change_column to change defaults, it wouldn't update existing values (set by initial migration that added is_featured). We don't have to care about existing settings, as this was never deployed.