### PR TITLE
Cleanup _list_embeddables.html.haml code

### DIFF
--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -74,10 +74,4 @@ module Embeddable
   def index_in_activity(activity)
     activity.reportable_items.index(self) + 1
   end
-
-  # This can be implemented by subclass.
-  # If it's true, embeddable will stretch across the whole page in full-width layout.
-  def full_width?
-    false
-  end
 end

--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -1,4 +1,6 @@
 class ImageInteractive < ActiveRecord::Base
+  include Embeddable
+
   attr_accessible :url, :caption, :credit, :show_lightbox, :credit_url, :is_hidden, :is_full_width
 
   has_one :page_item, :as => :embeddable, :dependent => :destroy

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -1,4 +1,6 @@
 class MwInteractive < ActiveRecord::Base
+  include Embeddable
+
   DEFAULT_CLICK_TO_PLAY_PROMPT = "Click here to start the interactive."
   attr_accessible :name, :url, :native_width, :native_height, :enable_learner_state, :has_report_url, :click_to_play,
                   :click_to_play_prompt, :image_url, :is_hidden, :linked_interactive_id, :full_window, :model_library_url,

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -1,4 +1,6 @@
 class VideoInteractive < ActiveRecord::Base
+  include Embeddable
+
   has_one :page_item, :as => :embeddable, :dependent => :destroy
   # PageItem is a join model; if this is deleted, that instance should go too
   has_one :interactive_page, :through => :page_item

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -1,17 +1,16 @@
 .embeddables
   - unless embeddables.blank?
     - embeddables.each do |e|
-      - css_class = e.respond_to?(:is_full_width) && e.is_full_width ? "full-width-item" : ""
-      - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
-      - css_class += e.is_a?(Embeddable::Xhtml) ? " challenge" : (is_likert ? " likert" : "")
-      .question{ class: css_class }
-        - if Embeddable::is_interactive?(e)
-          = render_interactive(e)
-        - else
-          -# Embeddable is a question.
-          -# If a labbooks is included within the interactives section,
-          -# dont also display that item here.
-          - unless show_labbook_in_assessment_block?(e)
-            - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
-            - if e.show_in_runtime?
+      -# If a labbooks is included within the interactives section,
+      -# dont also display that item here.
+      - unless show_labbook_in_assessment_block?(e)
+        - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
+        - css_class = e.is_a?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : ""
+        - css_class += e.respond_to?(:is_full_width) && e.is_full_width ? " full-width-item" : ""
+        - if e.show_in_runtime?
+          .question{ class: css_class }
+            - if Embeddable::is_interactive?(e)
+              = render_interactive(e)
+            - else
+              - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
               = render(partial: partial_name, locals: { embeddable: e })


### PR DESCRIPTION
Reorganize rendering of embeddables. Previous change in https://github.com/concord-consortium/lara/pull/307 was meant to remove unnecessary `.embeddable-interactive` CSS class and avoid duplication of CSS classes geneartion. However, I didn't notice that I was creating unnecessary divs in some cases. Changes in this PR:

1. Don't create empty `div.question` tags for Labbooks in ITSI layout
2. Include `Embeddable` in interactives, mostly to provide `show_in_runtime?` implementation, but it also seems to make sense in general. Interactives are now real embeddables.