### PR TITLE
Let authors pick interactive for the image question

### DIFF
--- a/app/models/attached_to_interactive.rb
+++ b/app/models/attached_to_interactive.rb
@@ -1,0 +1,53 @@
+module AttachedToInteractive
+  def self.included(clazz)
+    clazz.class_eval do
+      # That requires model that includes this module to have interactive_id (integer) and interactive_type (string) attributes.
+      belongs_to :interactive, :polymorphic => true
+
+      attr_accessible :interactive_select_value
+      attr_writer :interactive_select_value
+
+      before_validation :parse_interactive_select_value
+    end
+  end
+
+  NO_INTERACTIVE_LABEL =   I18n.t('NO_INTERACTIVE')
+  NO_INTERACTIVE_VALUE = "no-interactive"
+  NO_INTERACTIVE_SELECT = [NO_INTERACTIVE_LABEL, NO_INTERACTIVE_VALUE]
+
+  def possible_interactives
+    page ? page.interactives : []
+  end
+
+  def interactives_for_select
+    # Because interactive is polymorphic association, normal AR options for select don't work.
+    options = [NO_INTERACTIVE_SELECT]
+    possible_interactives.each_with_index do |pi, i|
+      hidden_text =  pi.is_hidden? ? "(hidden)" : ""
+      options << ["#{pi.class.model_name.human} #{hidden_text}(#{i+1})", make_interactive_select_value(pi)]
+    end
+    options
+  end
+
+  def interactive_select_value
+    return @interactive_select_value if @interactive_select_value
+    return make_interactive_select_value(interactive) if interactive
+  end
+
+  def make_interactive_select_value(interactive)
+    "#{interactive.id}-#{interactive.class.name}"
+  end
+
+  def parse_interactive_select_value
+    # Parse the interactive form select input value
+    # Turn it into a type of interactive, or nil.
+    if interactive_select_value
+      _interactive = nil
+      if interactive_select_value != NO_INTERACTIVE_VALUE
+        id, model = self.interactive_select_value.split('-')
+        _interactive = Kernel.const_get(model).send(:find, id) rescue nil
+      end
+      self.interactive = _interactive
+    end
+  end
+end

--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -1,8 +1,9 @@
 class Embeddable::ImageQuestion < ActiveRecord::Base
+  include Embeddable
+  include AttachedToInteractive
+
   attr_accessible :name, :prompt, :hint, :bg_source, :bg_url, :drawing_prompt, :is_full_width,
     :is_prediction, :is_featured, :give_prediction_feedback, :prediction_feedback, :is_hidden
-
-  include Embeddable
 
   has_many :page_items, :as => :embeddable, :dependent => :destroy
   has_many :interactive_pages, :through => :page_items
@@ -17,14 +18,6 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
   has_one :master_for_tracker, :class_name => 'QuestionTracker', :as => :master_question
 
   default_value_for :prompt, "why does ..."
-
-  def interactive
-    # Return first interactive available on the page (note that in practice it's impossible that this model has more
-    # than one page, even though it's many-to-many association).
-    # In the future we can let authors explicitly select which interactive an image question is connected to.
-    page = interactive_pages.first
-    page && page.visible_interactives.first
-  end
 
   # NOTE: publishing to portal doesn't use this hash. portal_hash is used instead
   def to_hash
@@ -97,9 +90,20 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
     true
   end
 
+  def page
+    # Return first page (note that in practice it's impossible that this model has more
+    # than one page, even though it's many-to-many association).
+    interactive_pages.first
+  end
+
   def page_section
     # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
     page_items.count > 0 && page_items.first.section
+  end
+
+  def configuration_error
+    return I18n.t('SNAPSHOT_WITHOUT_INTERACTIVE') if is_shutterbug? && interactive.nil?
+    nil
   end
 
   def self.name_as_param

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -2,6 +2,7 @@
 module Embeddable
   class Labbook < ActiveRecord::Base
     include Embeddable
+    include AttachedToInteractive
 
     UPLOAD_ACTION = 0
     SNAPSHOT_ACTION = 1
@@ -11,22 +12,13 @@ module Embeddable
       ['Snapshot', SNAPSHOT_ACTION]
     ]
 
-    NO_INTERACTIVE_LABLE =   I18n.t('LABBOOK.NO_INTERACTIVE')
-    NO_INTERACTIVE_VALUE = "no-interactive"
-    NO_INTERACTIVE_SELECT = [NO_INTERACTIVE_LABLE, NO_INTERACTIVE_VALUE];
     attr_accessible :action_type, :name, :prompt,
       :custom_action_label, :is_hidden, :is_featured,
       :interactive_type, :interactive_id, :interactive,
-      :interactive_select_value, :hint, :is_full_width
-
-    attr_writer :interactive_select_value
-
-    before_validation :parse_interactive_select_value
+      :hint, :is_full_width
 
     has_many :page_items, :as => :embeddable, :dependent => :destroy
     has_many :interactive_pages, :through => :page_items
-
-    belongs_to :interactive, :polymorphic => true
 
     # "Answer" isn't the best word probably, but it fits the rest of names and convention.
     # LabbookAnswer is an instance related to particular activity run and user.
@@ -127,32 +119,6 @@ module Embeddable
       page_items.count > 0 && page_items.first.section
     end
 
-    def possible_interactives
-      # Only the visible_interactives should be used when selecting an interactive
-      return page.interactives if page
-      return []
-    end
-
-    def interactives_for_select
-      # Because interactive is ploymorphic association, normal AR optinons
-      # for select don't work.
-      options = [NO_INTERACTIVE_SELECT]
-      possible_interactives.each_with_index do |pi,i|
-        hidden_text =  pi.is_hidden? ? "(hidden)" : ""
-        options << ["#{pi.class.model_name.human} #{hidden_text}(#{i+1})", make_interactive_select_value(pi)]
-      end
-      options
-    end
-
-    def interactive_select_value
-      return @interactive_select_value if @interactive_select_value
-      return make_interactive_select_value(interactive) if interactive
-    end
-
-    def make_interactive_select_value(interactive)
-      "#{interactive.id}-#{interactive.class.name}"
-    end
-
     def action_label
       return custom_action_label unless custom_action_label.blank?
       case action_type
@@ -216,20 +182,5 @@ module Embeddable
       report_string = "updated #{changed_snapshot_count} snapshot prompts, and #{changed_upload_count} upload labbook prompts"
       Rails.logger.info report_string
     end
-
-    private
-    def parse_interactive_select_value
-      # Parse the interactive form select input value
-      # Turn it into a type of interactive, or nil.
-      if interactive_select_value
-        _interactive = nil
-        if interactive_select_value != NO_INTERACTIVE_VALUE
-          id, model = self.interactive_select_value.split('-')
-          _interactive = Kernel.const_get(model).send(:find, id) rescue nil
-        end
-        self.interactive = _interactive
-      end
-    end
-
   end
 end

--- a/app/services/lara_serialization_helper.rb
+++ b/app/services/lara_serialization_helper.rb
@@ -27,10 +27,10 @@ class LaraSerializationHelper
   def wrap_export(item)
     results = item.export
     results[:type] = item.class.name
-    case item
-    when MwInteractive, ImageInteractive, VideoInteractive
+    if Embeddable::is_interactive?(item)
       results[:ref_id] = key(item)
-    when Embeddable::Labbook
+    end
+    if item.respond_to?(:interactive) && item.interactive
       results[:interactive_ref_id] = key(item.interactive) if item.interactive
     end
     results

--- a/app/views/embeddable/image_questions/_author.html.haml
+++ b/app/views/embeddable/image_questions/_author.html.haml
@@ -6,6 +6,9 @@
     = embeddable.drawing_prompt.html_safe unless embeddable.drawing_prompt.blank?
     = image_tag embeddable.bg_url, { :style => "width: 100%;" } unless embeddable.bg_url.blank?
     = embeddable.prompt.html_safe unless embeddable.prompt.blank?
+  - if embeddable.configuration_error
+    .warning
+      = embeddable.configuration_error
   - if embeddable.is_shutterbug?
     %button.image_question.button{:type => 'submit', :id => 'image_snapshot_button'}
       %i.fa.fa-camera

--- a/app/views/embeddable/image_questions/_form.html.haml
+++ b/app/views/embeddable/image_questions/_form.html.haml
@@ -21,11 +21,17 @@
         %label
           Source
           = f.select :bg_source, ['Shutterbug', 'Drawing', 'Upload']
+      %li.interactive_choice
+        %label
+          Interactive
+          = f.select :interactive_select_value, @embeddable.interactives_for_select
+          .help
+            Optional, should be set when Shutterbug (snapshot) is used as a source.
       %li
         %label
           Background image URL
           = f.text_field :bg_url
-          %span.help
+          .help
             Optional, will be ignored for Shutterbug questions. The drawing
             canvas is 648 pixels wide by 496 pixels high.  Smaller images will
             be centered in the canvas; larger images will be scaled to fit in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
   CHECK_ANSWER: "Check answer"
   PAGES_IN_THIS_ACTIVITY: "Pages in this Activity"
   WELCOME: "Welcome"
+  NO_INTERACTIVE: "No Interactive"
+  SNAPSHOT_WITHOUT_INTERACTIVE: "Snapshot won't work, as the interactive is not selected"
   ARG_BLOCK:
     PLEASE_ANSWER: "Please answer all questions in the argumentation block."
     ANSWERS_NOT_CHANGED: "Answers have not been changed."
@@ -84,7 +86,6 @@ en:
     USEFUL_2: "Very"
   LABBOOK:
     ALBUM: "Labbook album"
-    NO_INTERACTIVE: "No Interactive"
     WONT_DISPLAY: "Labbook will not be shown."
     NO_INTERACTIVE_SET: "Interactive is not set."
     INTERACTIVE_HIDDEN: "Interactive is set but is hidden."

--- a/db/migrate/20180703131647_add_interactive_to_image_question.rb
+++ b/db/migrate/20180703131647_add_interactive_to_image_question.rb
@@ -1,0 +1,23 @@
+class AddInteractiveToImageQuestion < ActiveRecord::Migration
+  def up
+    add_column :embeddable_image_questions, :interactive_id, :integer
+    add_column :embeddable_image_questions, :interactive_type, :string
+
+    Embeddable::ImageQuestion.find_each(batch_size: 10) do |iq|
+      # Previously, image question was always referring the first interactive on the page.
+      # Follow this logic to pick the right interactive and set it explicitly using new columns.
+      page = iq.interactive_pages.first
+      interactive = page && page.visible_interactives.first
+      if interactive
+        # update_column shouldn't trigger any callbacks. Safer than iq.interactive = interactive.
+        iq.update_column('interactive_id', interactive.id)
+        iq.update_column('interactive_type', interactive.class.to_s)
+      end
+    end
+  end
+
+  def down
+    remove_column :embeddable_image_questions, :interactive_id
+    remove_column :embeddable_image_questions, :interactive_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180628101909) do
+ActiveRecord::Schema.define(:version => 20180703131647) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -172,8 +172,10 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
     t.text     "prediction_feedback"
     t.boolean  "is_hidden",                :default => false
     t.text     "hint"
-    t.boolean  "is_featured",              :default => false
     t.boolean  "is_full_width",            :default => false
+    t.boolean  "is_featured",              :default => false
+    t.integer  "interactive_id"
+    t.string   "interactive_type"
   end
 
   create_table "embeddable_labbook_answers", :force => true do |t|
@@ -198,8 +200,8 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
     t.integer  "interactive_id"
     t.string   "interactive_type"
     t.text     "hint"
-    t.boolean  "is_featured",         :default => false
     t.boolean  "is_full_width",       :default => false
+    t.boolean  "is_featured",         :default => false
   end
 
   add_index "embeddable_labbooks", ["interactive_id"], :name => "labbook_interactive_i_idx"
@@ -243,8 +245,8 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
     t.string   "layout",                   :default => "vertical"
     t.boolean  "is_hidden",                :default => false
     t.text     "hint"
-    t.boolean  "is_featured",              :default => false
     t.boolean  "is_full_width",            :default => false
+    t.boolean  "is_featured",              :default => false
   end
 
   create_table "embeddable_open_response_answers", :force => true do |t|
@@ -272,8 +274,8 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
     t.string   "default_text"
     t.boolean  "is_hidden",                :default => false
     t.text     "hint"
-    t.boolean  "is_featured",              :default => false
     t.boolean  "is_full_width",            :default => false
+    t.boolean  "is_featured",              :default => false
   end
 
   create_table "embeddable_xhtmls", :force => true do |t|
@@ -437,8 +439,8 @@ ActiveRecord::Schema.define(:version => 20180628101909) do
     t.boolean  "no_snapshots",            :default => false
     t.string   "click_to_play_prompt"
     t.boolean  "show_delete_data_button", :default => true
-    t.boolean  "is_featured",             :default => false
     t.boolean  "is_full_width",           :default => true
+    t.boolean  "is_featured",             :default => false
   end
 
   add_index "mw_interactives", ["linked_interactive_id"], :name => "index_mw_interactives_on_linked_interactive_id"

--- a/spec/models/embeddable/image_question_spec.rb
+++ b/spec/models/embeddable/image_question_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Embeddable::ImageQuestion do
   it_behaves_like "a question"
+  it_behaves_like "attached to interactive"
 
   let (:image_question) { FactoryGirl.create(:image_question) }
 

--- a/spec/models/embeddable/labbook_spec.rb
+++ b/spec/models/embeddable/labbook_spec.rb
@@ -2,6 +2,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Embeddable::Labbook do
   it_behaves_like "a question"
+  it_behaves_like "attached to interactive"
 
   let(:labbook) { Embeddable::Labbook.new }
 
@@ -146,102 +147,47 @@ describe Embeddable::Labbook do
     end
   end
 
-  describe "interactive methods" do
-    let(:hidden_mw_interactive) { FactoryGirl.create(:hidden_mw_interactive) }
-    let(:mw_interactive)        { FactoryGirl.create(:mw_interactive) }
-    let(:interactives) { [] }
-    let(:page)         { FactoryGirl.create(:page_with_or, interactives: interactives) }
-    let(:args)         { {} }
-    let(:labbook)      do
-      lb = Embeddable::Labbook.create(args)
-      page.add_embeddable(lb)
-      lb
+  describe "#update_itsi_prompts" do
+    let(:labbook) { Embeddable::Labbook.create(prompt: prompt) }
+
+    before(:each) do
+      labbook
+      Embeddable::Labbook.update_itsi_prompts
+      labbook.reload
     end
-    describe "#possible_interactives" do
-      describe "when there aren't any interactives" do
-        it "should return an empty list" do
-          expect(labbook.possible_interactives).to be_empty
-        end
-      end
 
-      describe "when there is one invisible interactives" do
-        let(:interactives) { [hidden_mw_interactive] }
-        it "should return the hidden interactive" do
-          expect(labbook.possible_interactives).to include hidden_mw_interactive
-        end
-      end
-
-      describe "when there is one visibile and one invisible interactive" do
-        let(:interactives) { [hidden_mw_interactive, mw_interactive] }
-        it "should return both of them" do
-            expect(labbook.possible_interactives).to include mw_interactive
-            expect(labbook.possible_interactives).to include hidden_mw_interactive
-        end
+    describe "when the prompt is nil" do
+      let(:prompt) { nil }
+      it "the prompt should not be changed" do
+        expect(labbook.prompt).to eql prompt
       end
     end
 
-    describe "#interactives_for_select" do
-      let(:interactive_a)         { FactoryGirl.create(:mw_interactive) }
-      let(:interactive_b)         { FactoryGirl.create(:mw_interactive) }
-
-      let(:expected_identifier_1) { Embeddable::Labbook::NO_INTERACTIVE_SELECT }
-      let(:expected_identifier_2) { ["Mw interactive (1)", "#{interactive_a.id}-MwInteractive"]}
-      let(:expected_identifier_3) { ["Mw interactive (2)", "#{interactive_b.id}-MwInteractive"]}
-      let(:expected_identifier_4) { ["Mw interactive (hidden)(3)", "#{hidden_mw_interactive.id}-MwInteractive"]}
-
-      let(:interactives) { [interactive_a, interactive_b, hidden_mw_interactive] }
-      it "should have good options" do
-        expect(labbook.interactives_for_select).to include expected_identifier_1
-        expect(labbook.interactives_for_select).to include expected_identifier_2
-        expect(labbook.interactives_for_select).to include expected_identifier_3
-        expect(labbook.interactives_for_select).to include expected_identifier_3
+    describe "when the prompt is empty" do
+      let(:prompt) { "" }
+      it "the prompt should not be changed" do
+        expect(labbook.prompt).to eql prompt
       end
     end
 
-    describe "#update_itsi_prompts" do
-      let(:labbook) { Embeddable::Labbook.create(prompt: prompt) }
-
-      before(:each) do
-        labbook
-        Embeddable::Labbook.update_itsi_prompts
-        labbook.reload
+    describe "when the promt is something random" do
+      let(:prompt) { "describe why these two things look so similar "}
+      it "the prompt should not be changed" do
+        expect(labbook.prompt).to eql prompt
       end
+    end
 
-      describe "when the prompt is nil" do
-        let(:prompt) { nil }
-        it "the prompt should not be changed" do
-          expect(labbook.prompt).to eql prompt
-        end
+    describe "when the promt is the old snapshot prompt" do
+      let(:prompt) { I18n.t("LABBOOK.OLD_ITSI.SNAPSHOT_PROMPT") }
+      it "the prompt should be updated to the new snapshot prompt" do
+        expect(labbook.prompt).to eql I18n.t("LABBOOK.ITSI.SNAPSHOT_PROMPT")
       end
-
-      describe "when the prompt is empty" do
-        let(:prompt) { "" }
-        it "the prompt should not be changed" do
-          expect(labbook.prompt).to eql prompt
-        end
+    end
+    describe "when the promt is the old itsi upload prompt" do
+      let(:prompt) { I18n.t("LABBOOK.OLD_ITSI.UPLOAD_PROMPT") }
+      it "the prompt should be updated to the new upload prompt" do
+        expect(labbook.prompt).to eql I18n.t("LABBOOK.ITSI.UPLOAD_PROMPT")
       end
-
-      describe "when the promt is something random" do
-        let(:prompt) { "describe why these two things look so similar "}
-        it "the prompt should not be changed" do
-          expect(labbook.prompt).to eql prompt
-        end
-      end
-
-      describe "when the promt is the old snapshot prompt" do
-        let(:prompt) { I18n.t("LABBOOK.OLD_ITSI.SNAPSHOT_PROMPT") }
-        it "the prompt should be updated to the new snapshot prompt" do
-          expect(labbook.prompt).to eql I18n.t("LABBOOK.ITSI.SNAPSHOT_PROMPT")
-        end
-      end
-      describe "when the promt is the old itsi upload prompt" do
-        let(:prompt) { I18n.t("LABBOOK.OLD_ITSI.UPLOAD_PROMPT") }
-        it "the prompt should be updated to the new upload prompt" do
-          expect(labbook.prompt).to eql I18n.t("LABBOOK.ITSI.UPLOAD_PROMPT")
-        end
-      end
-
-
     end
   end
 end

--- a/spec/support/shared_examples/attached_to_interactive.rb
+++ b/spec/support/shared_examples/attached_to_interactive.rb
@@ -1,0 +1,53 @@
+shared_examples "attached to interactive" do
+  let(:hidden_mw_interactive) { FactoryGirl.create(:hidden_mw_interactive) }
+  let(:mw_interactive)        { FactoryGirl.create(:mw_interactive) }
+  let(:interactives) { [] }
+  let(:page)         { FactoryGirl.create(:page_with_or, interactives: interactives) }
+  let(:args)         { {} }
+  let(:test_embeddable) do
+    e = described_class.create(args)
+    page.add_embeddable(e)
+    e
+  end
+
+  describe "#possible_interactives" do
+    describe "when there aren't any interactives" do
+      it "should return an empty list" do
+        expect(test_embeddable.possible_interactives).to be_empty
+      end
+    end
+
+    describe "when there is one invisible interactives" do
+      let(:interactives) { [hidden_mw_interactive] }
+      it "should return the hidden interactive" do
+        expect(test_embeddable.possible_interactives).to include hidden_mw_interactive
+      end
+    end
+
+    describe "when there is one visibile and one invisible interactive" do
+      let(:interactives) { [hidden_mw_interactive, mw_interactive] }
+      it "should return both of them" do
+        expect(test_embeddable.possible_interactives).to include mw_interactive
+        expect(test_embeddable.possible_interactives).to include hidden_mw_interactive
+      end
+    end
+  end
+
+  describe "#interactives_for_select" do
+    let(:interactive_a)         { FactoryGirl.create(:mw_interactive) }
+    let(:interactive_b)         { FactoryGirl.create(:mw_interactive) }
+
+    let(:expected_identifier_1) { AttachedToInteractive::NO_INTERACTIVE_SELECT }
+    let(:expected_identifier_2) { ["Mw interactive (1)", "#{interactive_a.id}-MwInteractive"]}
+    let(:expected_identifier_3) { ["Mw interactive (2)", "#{interactive_b.id}-MwInteractive"]}
+    let(:expected_identifier_4) { ["Mw interactive (hidden)(3)", "#{hidden_mw_interactive.id}-MwInteractive"]}
+
+    let(:interactives) { [interactive_a, interactive_b, hidden_mw_interactive] }
+    it "should have good options" do
+      expect(test_embeddable.interactives_for_select).to include expected_identifier_1
+      expect(test_embeddable.interactives_for_select).to include expected_identifier_2
+      expect(test_embeddable.interactives_for_select).to include expected_identifier_3
+      expect(test_embeddable.interactives_for_select).to include expected_identifier_3
+    end
+  end
+end

--- a/spec/support/shared_examples/attached_to_interactive_form.rb
+++ b/spec/support/shared_examples/attached_to_interactive_form.rb
@@ -1,0 +1,38 @@
+shared_examples "attached to interactive form" do
+  def interactive_choice_select_css
+    "li.interactive_choice select option"
+  end
+
+  def no_interactive_text
+    AttachedToInteractive::NO_INTERACTIVE_LABEL
+  end
+
+  let(:interactive_a)  { FactoryGirl.create(:mw_interactive) }
+  let(:interactive_b)  { FactoryGirl.create(:mw_interactive) }
+  let(:interactives)   { [] }
+  let(:page)           { FactoryGirl.create(:page_with_or, interactives: interactives) }
+  let(:args)           { {} }
+
+  before :each do
+    page.add_embeddable(test_embeddable)
+  end
+
+  describe "without any interactives on the page" do
+    it "includes one choice for 'no interactive'" do
+      assign(:embeddable, test_embeddable)
+      render
+      expect(rendered).to have_css(
+        interactive_choice_select_css,
+        text: no_interactive_text)
+    end
+  end
+
+  describe "with two interactives on the page" do
+    let(:interactives)  {[interactive_a,interactive_b]}
+    it "includes three choices" do
+      assign(:embeddable, test_embeddable)
+      render
+      expect(rendered).to have_css interactive_choice_select_css, count: 3
+    end
+  end
+end

--- a/spec/views/embeddable/image_questions/edit.html.haml_spec.rb
+++ b/spec/views/embeddable/image_questions/edit.html.haml_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe "embeddable/image_questions/edit.html.haml" do
+  it_behaves_like "attached to interactive form" do
+    let(:test_embeddable) { Embeddable::ImageQuestion.create(args) }
+  end
+end

--- a/spec/views/embeddable/labbooks/edit.html.haml_spec.rb
+++ b/spec/views/embeddable/labbooks/edit.html.haml_spec.rb
@@ -1,44 +1,7 @@
 require 'spec_helper'
 
 describe "embeddable/labbooks/edit.html.haml" do
-
-  def interactive_choice_select_css
-    "li.interactive_choice > select > option"
+  it_behaves_like "attached to interactive form" do
+    let(:test_embeddable) { Embeddable::Labbook.create(args) }
   end
-
-  def no_interactive_text
-    Embeddable::Labbook::NO_INTERACTIVE_LABLE
-  end
-
-  let(:interactive_a)  { FactoryGirl.create(:mw_interactive) }
-  let(:interactive_b)  { FactoryGirl.create(:mw_interactive) }
-  let(:interactives)   { [] }
-  let(:page)           { FactoryGirl.create(:page_with_or, interactives: interactives) }
-  let(:args)           { {} }
-
-  let(:labbook)      do
-    lbook = Embeddable::Labbook.create(args)
-    page.add_embeddable(lbook)
-    lbook
-  end
-
-  describe "without any interactives on the page" do
-    it "includes one choice for 'no interactive'" do
-      assign(:embeddable, labbook)
-      render
-      expect(rendered).to have_css(
-        interactive_choice_select_css,
-        text: no_interactive_text)
-    end
-  end
-
-  describe "with two interactives on the page" do
-    let(:interactives)  {[interactive_a,interactive_b]}
-    it "includes three choices" do
-      assign(:embeddable, labbook)
-      render
-      expect(rendered).to have_css interactive_choice_select_css, count: 3
-    end
-  end
-
 end


### PR DESCRIPTION
[#158702375]

I pretty much extracted necessary functionality from Labbook, added to a separate module and reused it in ImageQuestion. I did a similar thing with tests (added `shared_examples`).

I've also added a warning if ImageQuestion is set to shutterbug, but without referencing any interactive:
<img width="380" alt="screen shot 2018-07-04 at 15 40 52" src="https://user-images.githubusercontent.com/767857/42280319-b148f1c8-7fa0-11e8-8d21-7c984b200d4f.png">

Migration ensures that new DB attributes will be set to the first interactive on a given page. I've used update_column to avoid any callbacks and so on.