### PR TITLE
Fix importing of the interactives

### DIFF
--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -19,11 +19,13 @@ module Embeddable
   Types = QuestionTypes.merge(InteractiveTypes)
 
   def self.is_question?(e)
-    QuestionTypes.keys.include?(e.class)
+    # Support both instance and class.
+    QuestionTypes.keys.include?(e.class) || QuestionTypes.keys.include?(e)
   end
 
   def self.is_interactive?(e)
-    InteractiveTypes.keys.include?(e.class)
+    # Support both instance and class.
+    InteractiveTypes.keys.include?(e.class) || InteractiveTypes.keys.include?(e)
   end
 
   def self.table_name_prefix

--- a/spec/import_examples/valid_lightweight_activity_import.json
+++ b/spec/import_examples/valid_lightweight_activity_import.json
@@ -169,16 +169,6 @@
     "text": null,
     "is_hidden": false,
     "embeddables": [{
-      "embeddable": {
-        "caption": "page 3",
-        "credit": "page3",
-        "credit_url": "",
-        "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
-        "type": "ImageInteractive",
-        "ref_id":"1164-ImageInteractive"
-      },
-      "section": "interactive_box"
-      }, {
         "embeddable": {
           "name": null,
           "native_height": 435,
@@ -220,8 +210,17 @@
         "interactive_ref_id":"1164-ImageInteractive"
       },
       "section": null
-    }
-    ]
+    }, {
+      "embeddable": {
+        "caption": "page 3",
+        "credit": "page3",
+        "credit_url": "",
+        "url": "http://imagens.ailhadometal.com/2013/02/black-sabbath-logo.jpg",
+        "type": "ImageInteractive",
+        "ref_id":"1164-ImageInteractive"
+      },
+      "section": "interactive_box"
+    }]
   }],
   "type":"LightweightActivity"
 }

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -411,9 +411,11 @@ describe InteractivePage do
         expect(p[:position]).to be(page.position)
       end
       # Test last page for interactive and labbook combo
+      # Note that interactive is positioned AFTER labbook in embeddables list.
+      # This case used to cause problems before, so test it explicitly.
       page = InteractivePage.import(activity_json[:pages].last).reload
-      expect(page.interactives.first).to be_a ImageInteractive
-      expect(page.embeddables.first.interactive).to eq page.interactives.first
+      expect(page.interactives.last).to be_a ImageInteractive
+      expect(page.embeddables.first.interactive).to eq page.interactives.last
     end
   end
 


### PR DESCRIPTION
[#158822514]

It's related to https://github.com/concord-consortium/lara/pull/310
While I was testing duplication and import/export of image questions referencing interactives, I've noticed that sometimes it doesn't work even for Labbooks. This fixes that and modifies tests to check this particular case.