### PR TITLE
Description properties update

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -199,6 +199,9 @@ class LightweightActivity < ActiveRecord::Base
     data = {
       'type' => "Activity",
       "name" => self.name,
+      # Description is not used by new Portal anymore. However, we still need to send it to support older Portal instances.
+      # Otherwise, the old Portal code would reset its description copy each time the activity was published.
+      # When all Portals are upgraded to v1.31 we can stop sending this property.
       "description" => self.description,
       "url" => local_url,
       "create_url" => local_url,

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -123,6 +123,9 @@ class Sequence < ActiveRecord::Base
       # Otherwise, the old Portal code would reset its description copy each time the sequence was published.
       # When all Portals are upgraded to v1.31 we can stop sending this property.
       'description' => self.description,
+      # Abstract is not used by new Portal anymore. However, we still need to send it to support older Portal instances.
+      # Otherwise, the old Portal code would reset its abstract copy each time the sequence was published.
+      # When all Portals are upgraded to v1.31 we can stop sending this property.
       'abstract' => self.abstract,
       "url" => local_url,
       "create_url" => local_url,

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -119,6 +119,9 @@ class Sequence < ActiveRecord::Base
     data = {
       'type' => "Sequence",
       'name' => self.title,
+      # Description is not used by new Portal anymore. However, we still need to send it to support older Portal instances.
+      # Otherwise, the old Portal code would reset its description copy each time the sequence was published.
+      # When all Portals are upgraded to v1.31 we can stop sending this property.
       'description' => self.description,
       'abstract' => self.abstract,
       "url" => local_url,

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -41,7 +41,7 @@
         = f.label :publication_status, 'Publication status'
         = f.select :publication_status, options_for_select(LightweightActivity::PUB_STATUSES_OPTIONS, @activity.publication_status)
       .field
-        = f.label :description, 'Activity Description'
+        = f.label :description, 'Text for index page'
         = f.text_area :description, :class => 'wysiwyg'
       .field
         = f.label :related, 'Related Content'

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -52,7 +52,7 @@
       %br
       = f.text_area :description, { :class => 'wysiwyg', :cols => 60, :rows => 10 }
     .field
-      = f.label :abstract, "Abstract [DEPRECIATED] Works only with old Portals"
+      = f.label :abstract, "Abstract [DEPRECATED] Works only with old Portals"
       %br
       = f.text_area :abstract, { :class => 'wysiwyg', :cols => 60, :rows => 10 }
     .actions

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -48,7 +48,7 @@
       = f.check_box :is_official
 
     .field
-      = f.label :description
+      = f.label :description, "Text for index page"
       %br
       = f.text_area :description, { :class => 'wysiwyg', :cols => 60, :rows => 10 }
     .field

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -52,7 +52,7 @@
       %br
       = f.text_area :description, { :class => 'wysiwyg', :cols => 60, :rows => 10 }
     .field
-      = f.label :abstract
+      = f.label :abstract, "Abstract [DEPRECIATED] Works only with old Portals"
       %br
       = f.text_area :abstract, { :class => 'wysiwyg', :cols => 60, :rows => 10 }
     .actions


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158870433
https://www.pivotaltracker.com/story/show/158870340
https://www.pivotaltracker.com/story/show/158870718

1. "Activity Description" -> "Text for index page" (only in UI)
2. "Sequence Description" -> "Text for index page" (only in UI)
3. The sequence abstract should be removed, but we can't do it as long as the Portal expects it. We still need to show it in the authoring UI, as that is the only (correct) way to manage abstract value in old Portals. I've added a note for authors that this property is depreciated.

We still need to send all the properties to Portal. I've added some comments to make it clear that they are there only for backward compatibility. Once all the Portals are upgraded to version 1.31 or bigger, we can clean up these things. Here's a PT story that describes necessary cleanup:
https://www.pivotaltracker.com/story/show/158910688

Related Portal PR: https://github.com/concord-consortium/rigse/pull/523
