### PR TITLE
Reimplement copying

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -351,17 +351,17 @@ class ApplicationController < ActionController::Base
       user = "Anonymous"
     end
 
-    className = resource.class.name
+    className = resource && resource.class.name
     if className == "LightweightActivity" || className == "Sequence"
       message = "#{user}, you don't have permission to #{action} the #{className} with id : #{resource.id}"
     else
       message = "#{user}, you don't have permission to access this page."
     end
 
-    data = {
+    {
       :user => user,
       :className => className,
-      :id => resource.respond_to?(:id) ? resource.id : 'n/a',
+      :id => resource && resource.respond_to?(:id) ? resource.id : 'n/a',
       :message => message
     }
   end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -2,12 +2,6 @@ class ImportController < ApplicationController
 
   include PeerAccess
 
-  skip_before_filter :verify_authenticity_token, if: :verified_json_request?
-
-  def verified_json_request?
-    verify_request_is_peer
-  end
-
   def import_status
     @message = params[:message] || ''
     respond_to do |format|
@@ -36,6 +30,8 @@ class ImportController < ApplicationController
   end
 
   def import_portal_activity
+    authorize_peer!
+
     request_json = JSON.parse "#{request.body.read}", :symbolize_names => true
 
     unless User.find_by_email request_json[:activity][:user_email]

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -11,6 +11,9 @@ class LightweightActivitiesController < ApplicationController
 
   layout :set_layout
 
+  # Adds remote_duplicate handler (POST remote_duplicate)
+  include RemoteDuplicateSupport
+
   def index
     @filter  = CollectionFilter.new(current_user, LightweightActivity, params[:filter] || {})
     @community_activities = @filter.collection.includes(:user,:changed_by,:portal_publications).community

--- a/app/controllers/peer_access.rb
+++ b/app/controllers/peer_access.rb
@@ -1,19 +1,28 @@
-
 module PeerAccess
 
-protected
-def get_auth_token(request)
-  header = request.headers["Authorization"]
-  if header && header =~ /^Bearer (.*)$/
-    return $1
+  def self.included klass
+    klass.class_eval do
+      skip_before_filter :verify_authenticity_token, if: :verified_json_request?
+    end
   end
-  return ""
-end
 
-def verify_request_is_peer
-  auth_token = get_auth_token(request)
-  peer_tokens = Concord::AuthPortal.all.values.map { |c| c.secret }.uniq
-  peer_tokens.include?(auth_token)
-end
+  protected
 
+  def get_auth_token(request)
+    header = request.headers["Authorization"]
+    if header && header =~ /^Bearer (.*)$/
+      return $1
+    end
+    ""
+  end
+
+  def verified_json_request?
+    auth_token = get_auth_token(request)
+    peer_tokens = Concord::AuthPortal.all.values.map {|c| c.secret}.uniq
+    peer_tokens.include?(auth_token)
+  end
+
+  def authorize_peer!
+    raise CanCan::AccessDenied unless verified_json_request?
+  end
 end

--- a/app/controllers/remote_duplicate_support.rb
+++ b/app/controllers/remote_duplicate_support.rb
@@ -1,0 +1,52 @@
+module RemoteDuplicateSupport
+
+  def self.included klass
+    klass.class_eval do
+      # Include PeerAccess module so authorize_peer! method is available.
+      # It checks whether request is coming from trusted Portal instance.
+      include PeerAccess
+    end
+  end
+
+  # Action triggered by Portal. Duplicates an activity or sequence and returns its publication data.
+  # It excepts @activity or @sequence to be available.
+  def remote_duplicate
+    authorize_peer!
+    request_json = JSON.parse(request.body.read, symbolize_names: true)
+
+    resource = @activity || @sequence
+
+    # Make sure that user exists. It might not if he never opened LARA before and it's just copying an activity using Portal.
+    user = User.find_by_email request_json[:user_email]
+    unless user
+      user = User.create(
+        email: request_json[:user_email],
+        password: User.get_random_password,
+        is_author: true
+      )
+    end
+
+    new_resource = resource.duplicate(user)
+
+    if new_resource.save(validations: false) # in case the old resource was invalid
+      self_url = "#{request.protocol}#{request.host_with_port}"
+      publication_data = new_resource.serialize_for_portal(self_url)
+      # We need to manually create publication data. Since this path is a bit different than typical,
+      # not all the field make so much sense. Also, we don't get response from Portal whether it has been
+      # successful or not, so we have to assume it was.
+      auth_portal = Concord::AuthPortal.portal_for_url(params['add_to_portal'])
+      new_resource.portal_publications.create({
+        portal_url: auth_portal.publishing_url,
+        sent_data: publication_data,
+        response: nil,
+        success: true,
+        publishable: new_resource,
+        publication_hash: publication_data,
+        publication_time: nil
+      })
+      render status: 200, json: { publication_data: publication_data }, content_type: 'text/json'
+    else
+      render status: 500, json: { error: "Remote duplicate failed" }, content_type: 'text/json'
+    end
+  end
+end

--- a/app/controllers/remote_duplicate_support.rb
+++ b/app/controllers/remote_duplicate_support.rb
@@ -35,15 +35,13 @@ module RemoteDuplicateSupport
       # not all the field make so much sense. Also, we don't get response from Portal whether it has been
       # successful or not, so we have to assume it was.
       auth_portal = Concord::AuthPortal.portal_for_url(params['add_to_portal'])
-      new_resource.portal_publications.create({
-        portal_url: auth_portal.publishing_url,
-        sent_data: publication_data,
-        response: nil,
-        success: true,
-        publishable: new_resource,
-        publication_hash: publication_data,
-        publication_time: nil
-      })
+      new_resource.add_portal_publication(auth_portal) do
+        {
+          publication_data: publication_data.to_json,
+          response: "published during copy, we don't really know if it is succeeded",
+          success: true
+        }
+      end
       render status: 200, json: { publication_data: publication_data }, content_type: 'text/json'
     else
       render status: 500, json: { error: "Remote duplicate failed" }, content_type: 'text/json'

--- a/app/controllers/remote_duplicate_support.rb
+++ b/app/controllers/remote_duplicate_support.rb
@@ -12,15 +12,14 @@ module RemoteDuplicateSupport
   # It excepts @activity or @sequence to be available.
   def remote_duplicate
     authorize_peer!
-    request_json = JSON.parse(request.body.read, symbolize_names: true)
 
     resource = @activity || @sequence
 
     # Make sure that user exists. It might not if he never opened LARA before and it's just copying an activity using Portal.
-    user = User.find_by_email request_json[:user_email]
+    user = User.find_by_email params[:user_email]
     unless user
       user = User.create(
-        email: request_json[:user_email],
+        email: params[:user_email],
         password: User.get_random_password,
         is_author: true
       )
@@ -34,7 +33,7 @@ module RemoteDuplicateSupport
       # We need to manually create publication data. Since this path is a bit different than typical,
       # not all the field make so much sense. Also, we don't get response from Portal whether it has been
       # successful or not, so we have to assume it was.
-      auth_portal = Concord::AuthPortal.portal_for_url(params['add_to_portal'])
+      auth_portal = Concord::AuthPortal.portal_for_url(params[:add_to_portal])
       new_resource.add_portal_publication(auth_portal) do
         {
           publication_data: publication_data.to_json,

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -5,6 +5,9 @@ class SequencesController < ApplicationController
 
   before_filter :enable_js_logger, :only => [:show]
 
+  # Adds remote_duplicate handler (POST remote_duplicate)
+  include RemoteDuplicateSupport
+
   # GET /sequences
   # GET /sequences.json
   def index

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -197,7 +197,8 @@ class LightweightActivity < ActiveRecord::Base
     author_url = "#{local_url}/edit"
     print_url = "#{local_url}/print_blank"
     data = {
-      'type' => "Activity",
+      "source_type" => "LARA",
+      "type" => "Activity",
       "name" => self.name,
       # Description is not used by new Portal anymore. However, we still need to send it to support older Portal instances.
       # Otherwise, the old Portal code would reset its description copy each time the activity was published.

--- a/app/models/publishable.rb
+++ b/app/models/publishable.rb
@@ -94,8 +94,6 @@ module Publishable
     result = yield
     end_time = Time.now.to_f
 
-    puts 'PUBADD'
-
     Rails.logger.info "Response Time: #{end_time - start_time}"
     Rails.logger.info "Response: #{result[:response].inspect}"
 

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -117,7 +117,8 @@ class Sequence < ActiveRecord::Base
     print_url = "#{local_url}/print_blank"
 
     data = {
-      'type' => "Sequence",
+      'source_type' => 'LARA',
+      'type' => 'Sequence',
       'name' => self.title,
       # Description is not used by new Portal anymore. However, we still need to send it to support older Portal instances.
       # Otherwise, the old Portal code would reset its description copy each time the sequence was published.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ LightweightStandalone::Application.routes.draw do
     member do
       post :add_activity
       post :remove_activity
+      post :remote_duplicate
       get :reorder_activities
       get :print_blank
       get :publish
@@ -76,6 +77,7 @@ LightweightStandalone::Application.routes.draw do
       get 'resubmit_answers'
       get 'publish'
       get 'duplicate'
+      post 'remote_duplicate'
       get 'preview'
       get 'export'
       get 'show_status'

--- a/spec/controllers/lightweight_activity_controller_spec.rb
+++ b/spec/controllers/lightweight_activity_controller_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 # There's a slow test in here somewhere.
 describe LightweightActivitiesController do
   render_views
+
+  it_behaves_like "remote duplicate support" do
+    let(:resource) { FactoryGirl.create(:activity) }
+  end
   
   before(:each) do
     @user ||= FactoryGirl.create(:admin)

--- a/spec/controllers/publication_controller_spec.rb
+++ b/spec/controllers/publication_controller_spec.rb
@@ -42,25 +42,28 @@ describe PublicationsController do
   end
 
   describe "#add_portal" do
-    let(:activity_hash) {
-      {"type"          =>"Activity",
-       "name"          =>"Activity One",
-       "description"   =>"Activity One Description",
-       "url"           =>"http://test.host/activities/#{act_one.id}",
-       "create_url"    =>"http://test.host/activities/#{act_one.id}",
-       "author_url"    =>"http://test.host/activities/#{act_one.id}/edit",
-       "print_url"     =>"http://test.host/activities/#{act_one.id}/print_blank",
-       "external_report_url"  => act_one.external_report_url,
-       "student_report_enabled" => act_one.student_report_enabled,
-       "thumbnail_url" =>"thumbnail",
-       "author_email"  => @user.email,
-       "is_locked"     =>false,
-       "sections"      => [
+    let(:activity_hash) do
+      {
+        "source_type"   => "LARA",
+        "type"          =>"Activity",
+        "name"          =>"Activity One",
+        "description"   =>"Activity One Description",
+        "url"           =>"http://test.host/activities/#{act_one.id}",
+        "create_url"    =>"http://test.host/activities/#{act_one.id}",
+        "author_url"    =>"http://test.host/activities/#{act_one.id}/edit",
+        "print_url"     =>"http://test.host/activities/#{act_one.id}/print_blank",
+        "external_report_url"  => act_one.external_report_url,
+        "student_report_enabled" => act_one.student_report_enabled,
+        "thumbnail_url" =>"thumbnail",
+        "author_email"  => @user.email,
+        "is_locked"     =>false,
+        "sections"      => [
            {"name"  => "Activity One Section",
             "pages" => []
            }
-       ]}
-    }
+        ]
+      }
+    end
     let(:good_body) { activity_hash.to_json }
     let(:publishing_url) { "http://foo.bar/publish/v2/blarg"}
     let(:url) { "http://foo.bar/"}

--- a/spec/controllers/sequences_controller_spec.rb
+++ b/spec/controllers/sequences_controller_spec.rb
@@ -4,6 +4,10 @@ describe SequencesController do
   let(:sequence) { FactoryGirl.create(:sequence) }
   let(:activity) { FactoryGirl.create(:public_activity) }
 
+  it_behaves_like "remote duplicate support" do
+    let(:resource) { FactoryGirl.create(:sequence) }
+  end
+
   # This should return the minimal set of attributes required to create a valid
   # Sequence. As you add validations to Sequence, be sure to
   # update the return value of this method accordingly.

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -347,6 +347,7 @@ describe LightweightActivity do
       author_url = "#{url}/edit"
       print_url = "#{url}/print_blank"
       {
+        "source_type"   => "LARA",
         "type"          =>"Activity",
         "name"          => activity.name,
         "description"   => activity.description,

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -104,7 +104,9 @@ describe Sequence do
       url = "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence)}"
       author_url = "#{url}/edit"
       print_url = "#{url}/print_blank"
-      {"type"=>"Sequence", "name"=> sequence.title, "description"=> sequence.description,
+      {
+        "source_type" => "LARA",
+        "type"=>"Sequence", "name"=> sequence.title, "description"=> sequence.description,
         "abstract" => sequence.abstract,
         "url"=> url,
         "create_url"=> url,
@@ -122,6 +124,7 @@ describe Sequence do
       author_url = "#{url}/edit"
       print_url = "#{url}/print_blank"
       {
+        "source_type" => "LARA",
         "type"=>"Sequence", "name"=> sequence_with_activities.title, "description"=> sequence_with_activities.description,
         "abstract" => sequence_with_activities.abstract,
         "url"=> url,

--- a/spec/support/shared_examples/remote_duplicate_support.rb
+++ b/spec/support/shared_examples/remote_duplicate_support.rb
@@ -1,0 +1,72 @@
+shared_examples "remote duplicate support" do
+  describe '#remote_duplicate' do
+    describe "when request is coming from normal user (even admin)" do
+      before(:each) do
+        user = FactoryGirl.create(:admin)
+        sign_in user
+      end
+      it "should return 403 unauthorized" do
+        post :remote_duplicate, { :id => resource.id }
+        expect(response.status).to be(403)
+      end
+    end
+
+    describe "when request is coming from peer (trusted Portal)" do
+      let(:user) { FactoryGirl.create(:author) }
+      let(:secret) { 'very secure secret' }
+      let(:portal_url) { 'http://portal.concord.org' }
+      let(:portal_name) { 'test portal' }
+      let(:fake_portal_struct) { Struct.new(:name, :url, :publishing_url, :secret) }
+      let(:fake_portal) { fake_portal_struct.new(portal_name, portal_url, portal_url, secret) }
+      let(:user_email) { 'test@email.com' }
+      let(:self_url) { "#{request.protocol}#{request.host_with_port}" }
+      let(:headers) { { 'Authorization' => "Bearer #{secret}" } }
+
+      before(:each) do
+        allow(Concord::AuthPortal).to receive(:all).and_return({ test: fake_portal })
+        @request.env['Authorization'] = "Bearer #{secret}"
+        resource.user = user
+        resource.save
+      end
+
+      def make_request
+        post :remote_duplicate, id: resource.id, user_email: user_email, add_to_portal: portal_url
+      end
+
+      def get_copy
+        owner = User.find_by_email(user_email)
+        resource.class.where(user_id: owner.id).first
+      end
+
+      it "should duplicate resource and return 200 OK + publication data" do
+        make_request
+
+        copy = get_copy
+        expect(copy).not_to be_nil
+        expect(copy.user.email).not_to eq(resource.user.email)
+        expect(copy.user.email).to eq(user_email)
+
+        expect(response.status).to be(200)
+        expect(JSON.parse(response.body)['publication_data']).to eq(copy.serialize_for_portal(self_url))
+      end
+
+      it "should create a new user when necessary" do
+        expect(User.find_by_email(user_email)).to be_nil
+        make_request
+        expect(User.find_by_email(user_email)).not_to be_nil
+      end
+
+      it "should create portal publication entry" do
+        old_count = PortalPublication.count
+        make_request
+        expect(PortalPublication.count).to eq(old_count + 1)
+        copy = get_copy
+        expect(copy.portal_publications.count).to eq(1)
+        expect(copy.publication_hash).not_to be_nil
+        pub = copy.portal_publications.first
+        expect(pub.success).to eq(true)
+        expect(pub.sent_data).to eq(copy.serialize_for_portal(self_url).to_json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@scytacki, I'm opening this PR so you can take a look at the code and it's easier for me to address your comments tomorrow. I'll fix and add tests tomorrow.

Related to this PR: https://github.com/concord-consortium/rigse/pull/538

The old duplication method still exists so old Portals are supported. This one seems to be simpler to understand. The same code is reused for Activities and Sequences. The only thing that I don't like is this manual call to `portal_publications.create(...` and generally that we "publish" resource in a bit different way than we used to before. Also, `portal_publications` structure is designed to include response details, sucess or failure status, and so on. We can't provide most of these information here. I wouldn't say it's a big problem, though.

I've tested a use case when user never visted LARA before and it seems to work. It's created in remote_dulicate and when he visits LARA, the correct account seems to be recognized. However that might be a good use case for Evangeline to double check on staging too.