### PR TITLE
Fixed routing error for url helper for newly created runs [#159208846]

### DIFF
--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -39,7 +39,9 @@ module InteractiveRunHelper
       data['authprovider'] = (Concord::AuthPortal.url_for_strategy_name(run.user.most_recent_authentication.provider) rescue nil) if data['loggedin'] == "true"
       data['user-email'] = run.user.email if data['loggedin'] == "true"
       data['class-info-url'] = run.class_info_url
-      data['get-firebase-jwt-url'] = api_v1_get_firebase_jwt_url(run.id)
+      if run.id
+        data['get-firebase-jwt-url'] = api_v1_get_firebase_jwt_url(run.id)
+      end
     end
     data['enable-learner-state'] = interactive.enable_learner_state.to_s
     data['authored-state'] = interactive.authored_state

--- a/docker/dev/run-spec.sh
+++ b/docker/dev/run-spec.sh
@@ -8,6 +8,8 @@
 
 export RAILS_ENV=test
 
+bundle check || bundle install
+
 #
 # Prepare spec tests
 #

--- a/spec/helpers/interactive_run_helper_spec.rb
+++ b/spec/helpers/interactive_run_helper_spec.rb
@@ -14,6 +14,7 @@ describe InteractiveRunHelper do
   let(:activity)     { mock_model(LightweightActivity, act_stubs) }
   let(:page)         { mock_model(InteractivePage, page_stubs)    }
   let(:run)          { mock_model(Run, run_stubs)                 }
+  let(:new_run)      { stub_model(Run).as_new_record }
   let(:sequence_run) { nil }
   let(:interactive)  { mock_model(MwInteractive, interactive_stubs) }
   let(:user_stubs)   { {
@@ -78,6 +79,14 @@ describe InteractiveRunHelper do
         expect(subject).to include("data-authored-state")
         expect(subject).to include("data-interactive-id")
         expect(subject).to include("data-interactive-name")
+      end
+    end
+
+    describe "with a new unsaved run" do
+      subject {helper.interactive_data_div(interactive,new_run)}
+
+      it "should not include firebase jwt url" do
+        expect(subject).not_to include("data-get-firebase-jwt-url")
       end
     end
   end

--- a/spec/helpers/interactive_run_helper_spec.rb
+++ b/spec/helpers/interactive_run_helper_spec.rb
@@ -14,7 +14,6 @@ describe InteractiveRunHelper do
   let(:activity)     { mock_model(LightweightActivity, act_stubs) }
   let(:page)         { mock_model(InteractivePage, page_stubs)    }
   let(:run)          { mock_model(Run, run_stubs)                 }
-  let(:new_run)      { stub_model(Run).as_new_record }
   let(:sequence_run) { nil }
   let(:interactive)  { mock_model(MwInteractive, interactive_stubs) }
   let(:user_stubs)   { {
@@ -43,9 +42,11 @@ describe InteractiveRunHelper do
     }
   end
 
+  subject {helper.interactive_data_div(interactive,run)}
+
   describe "#interactive_data_div(interactive,run)" do
     describe "without a run" do
-      subject {helper.interactive_data_div(interactive,nil)}
+      let(:run) { nil }
 
       it "should not include run specific info" do
         expect(subject).not_to include("data-interactive-run-state-url")
@@ -64,7 +65,6 @@ describe InteractiveRunHelper do
     end
 
     describe "with a run" do
-      subject {helper.interactive_data_div(interactive,run)}
 
       it "should include run specific info" do
         expect(subject).to include("data-interactive-run-state-url")
@@ -83,7 +83,7 @@ describe InteractiveRunHelper do
     end
 
     describe "with a new unsaved run" do
-      subject {helper.interactive_data_div(interactive,new_run)}
+      let(:run)      { stub_model(Run).as_new_record }
 
       it "should not include firebase jwt url" do
         expect(subject).not_to include("data-get-firebase-jwt-url")


### PR DESCRIPTION
Adds a check for the `run.id` being nil as an additional fix for this PR: https://github.com/concord-consortium/lara/pull/315

The `print_blank` controller method used `Run.new()` to create the @run variable which meant the `id` was nil - this caused the `api_v1_get_firebase_jwt_url(run.id)` helper to break.