### PR TITLE
Authors can add Plugins to an activity

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -7,7 +7,7 @@ $(function () {
         .data('type', 'html')
         .on('ajax:success', function (event, data) {
             var $this = $(this);
-            $($this.data('replace')).html(data.html);
+            $($this.data('replace')).html(JSON.parse(data).html);
             $this.trigger('ajax:replaced');
         });
 });

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -583,6 +583,47 @@ form.new_lightweight_activity {
     padding-top: 0;
   }
 }
+#plugins {
+  margin-top: 1em;
+  background: #c9e9e6;
+  padding: 15px;
+  border-radius: 8px;
+    width: 100%;
+  #plugin_list {
+    grid-template-columns: 3fr 1fr 1fr;
+    display: grid;
+    div {
+      margin: 0.5em;
+    }
+    .edit a {
+      background: transparent url(/assets/icons/edit.png) 0 0 no-repeat;
+      background-size: 14px;
+      color: #333;
+      height: 14px;
+      padding-left: 18px;
+      text-decoration: none;
+    }
+    .delete a {
+      background: transparent url(/assets/icons/delete.png) 0 0 no-repeat;
+      background-size: 14px;
+      color: #333;
+      height: 14px;
+      padding-left: 18px;
+      text-decoration: none;
+    }
+  }
+  #add_plugin {
+    margin-top: 10px;
+    a {
+      background: transparent url(/assets/icons/add.png) 0 0 no-repeat;
+      background-size: 14px;
+      color: #333;
+      height: 14px;
+      padding-left: 18px;
+       text-decoration: none;
+    }
+  }
+}
 ul#new {
    margin-top: 1em;
   li#add a {

--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -1,0 +1,70 @@
+class PluginsController < ApplicationController
+
+  private
+  def _list_plugins(plugin)
+    all_plugins = plugin.plugin_scope.reload.plugins
+    render_to_string('_list_plugins', layout: false, locals: {plugins: all_plugins})
+  end
+
+  def _form(plugin)
+    render_to_string('_form', layout: false, locals: { plugin: @plugin })
+  end
+
+  public
+  def edit
+    @plugin = Plugin.find(params[:id])
+    authorize! :manage, @plugin
+    respond_to do |format|
+      format.js {
+        render :json => {
+          html: _form(@plugin)
+        }
+      }
+    end
+  end
+
+  def new
+    authorize! :create, Plugin
+    @activity = LightweightActivity.find(params[:activity_id])
+    @plugin = @activity.plugins.create()
+    respond_to do |format|
+      format.js {
+        render :json => {
+          html: _form(@plugin)
+        }
+      }
+    end
+  end
+
+  # PUT /plugins/1
+  def update
+    cancel = params[:commit] == "Cancel"
+    @params = params
+    @plugin = Plugin.find(params[:id])
+    authorize! :manage, @plugin
+    if !cancel
+      @plugin.update_attributes(params['plugin'])
+      @plugin.reload
+    end
+
+    @plugin_list = _list_plugins(@plugin)
+    respond_to do |format|
+      format.js do
+        # will render update.js.erb
+      end
+    end
+  end
+
+  # DELETE /plugins/1
+  def destroy
+    @plugin = Plugin.find(params[:id])
+    authorize! :manage, @plugin
+    @plugin.destroy
+    @plugin_list = _list_plugins(@plugin)
+    respond_to do |format|
+      format.js do
+        # will render destroy.js.erb
+      end
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -20,9 +20,13 @@ class Ability
       can :create, Sequence
       can :create, LightweightActivity
       can :create, InteractivePage
+      can :create, Plugin
       can :manage, Sequence, :user_id => user.id
       can :manage, LightweightActivity, :user_id => user.id
       can :manage, InteractivePage, :lightweight_activity => { :user_id => user.id }
+      can :manage, Plugin do |plugin|
+        plugin.plugin_scope.user_id == user.id
+      end
       # and duplicate unlocked activities and sequences
       can :duplicate, LightweightActivity, :is_locked => false, :publication_status => ['public', 'hidden']
       can :duplicate, Sequence, :publication_status => ['public', 'hidden']

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -23,6 +23,7 @@ class LightweightActivity < ActiveRecord::Base
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
 
+  has_many :plugins, as: :plugin_scope
   has_many :pages, :foreign_key => 'lightweight_activity_id', :class_name => 'InteractivePage', :order => :position
   has_many :visible_pages, :foreign_key => 'lightweight_activity_id', :class_name => 'InteractivePage', :order => :position,
              :conditions => {interactive_pages: {is_hidden: false}}

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -1,0 +1,45 @@
+
+class Plugin < ActiveRecord::Base
+
+  attr_accessible :description, :author_data, :approved_script_id, :approved_script
+
+  belongs_to :approved_script
+  belongs_to :plugin_scope, polymorphic: true
+
+  delegate :name,  to: :approved_script, allow_nil: true
+  delegate :label, to: :approved_script, allow_nil: true
+  delegate :url,   to: :approved_script, allow_nil: true
+
+  # TODO: Import / export / to_hash &etc for duplicating ...
+  #
+  # def self.import(import_hash)
+  #   return self.new(import_hash)
+  # end
+
+  # def to_hash
+  #   {
+  #     approved_script_id: approved_script_id,
+  #     author_data: author_data,
+  #     description: description
+  #   }
+  # end
+
+  # def portal_hash
+  #   {
+  #     type: "lara_plugin",
+  #     id: id,
+  #     url: url,
+  #     author_data: author_data,
+  #     name: name
+  #   }
+  # end
+
+  # def duplicate
+  #   return Plugin.new(self.to_hash)
+  # end
+
+  # def export
+  #   return self.as_json(only:[:name, :url, :author_data, :description])
+  # end
+
+end

--- a/app/views/interactive_pages/show.html.haml
+++ b/app/views/interactive_pages/show.html.haml
@@ -16,7 +16,8 @@
   .content-hdr
     %h2.h2
       = @page.lightweight_activity.name
-
+  - @page.lightweight_activity.plugins.each do |p|
+    = render partial: 'plugins/show', locals: {plugin: p }
   = render :partial => 'show', :locals => {:page => @page, :layout => @page.layout}
 
   .bottom-buttons

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -108,3 +108,5 @@
               %li.drag_handle
                 &nbsp;
         %li#add= link_to "Add Page", new_activity_page_path(@activity)
+    #plugins
+      =render partial: 'plugins/list', locals: {activity: @activity}

--- a/app/views/lightweight_activities/single_page.html.haml
+++ b/app/views/lightweight_activities/single_page.html.haml
@@ -6,6 +6,8 @@
 = content_for :body_class do
   = 'l-single-page'
 
+- @activity.plugins.each do |p|
+  = render partial: 'plugins/show', locals: {plugin: p }
 - @activity.visible_pages.each do |p|
   -# Enforce full-width layout for each page rendering.
   = render partial: "interactive_pages/show", locals: {page: p, layout: 'l-full-width'}

--- a/app/views/plugins/_form.html.haml
+++ b/app/views/plugins/_form.html.haml
@@ -1,0 +1,17 @@
+%div{style: "margin-top: 0.5em; padding: 0.5em; background: white;" }
+
+  %h3 #{t("PLUGIN.ACTIVITY_PLUGIN")} <em>#{plugin.name}</em>
+  = form_for plugin, remote: true do |f|
+    = f.error_messages
+    %div{style: "display: flex; flex-direction: column;"}
+      %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
+        = f.label t("PLUGIN.APPROVED_SCRIPT")
+        = f.collection_select(:approved_script_id, ApprovedScript.all, :id, :name)
+      %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
+        = f.label t("PLUGIN.DESCRIPTION")
+        = f.text_field :description
+      %div{style: "margin-top: 0.5em; flex-direction: column; align-items: stretch;"}
+        = f.label t("PLUGIN.AUTHORING_DATA")
+        = f.text_area :author_data
+    = f.submit t("CANCEL"), :class => 'close'
+    = f.submit t("SAVE"), :class => 'embeddable-save'

--- a/app/views/plugins/_list.html.haml
+++ b/app/views/plugins/_list.html.haml
@@ -1,0 +1,7 @@
+%h2=t("PLUGIN.ACTIVITY_LIST_TITLE")
+
+#plugin_list
+  =render partial: 'plugins/list_plugins', locals: {plugins: activity.plugins}
+
+#add_plugin= link_to t("PLUGIN.ADD"), new_plugin_path(params: {activity_id: activity.id}), remote: true, :"data-replace" => '#plugin_form'
+#plugin_form

--- a/app/views/plugins/_list_plugins.html.haml
+++ b/app/views/plugins/_list_plugins.html.haml
@@ -1,0 +1,5 @@
+- plugins.each do |plugin|
+  .item
+    #{plugin.name} –
+  .edit= link_to t("PLUGIN.EDIT"), edit_plugin_path(plugin), remote: true, :"data-replace" => '#plugin_form'
+  .delete= link_to t("PLUGIN.DELETE"), plugin_path(plugin), remote: true,  method: :delete, data: { confirm: t("PLUGIN.DELETE_WARNING") }

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -1,0 +1,19 @@
+- runtimeDiv = "output-#{plugin.id}"
+= content_for :external_scripts do
+  %script{src:plugin.url}
+
+.output{id:runtimeDiv}
+
+:javascript
+  // Begin script for #{plugin.name}
+  $(document).ready( function() {
+    env = {
+      name: '#{plugin.name}',
+      scriptLabel: '#{plugin.label}',
+      scriptUrl: '#{plugin.url}',
+      pluginId: '#{plugin.id}',
+      config: '#{ j plugin.author_data }',
+      div: $('##{runtimeDiv}')
+    }
+    ExternalScripts.init('#{plugin.label}', env);
+  });

--- a/app/views/plugins/destroy.js.erb
+++ b/app/views/plugins/destroy.js.erb
@@ -1,0 +1,8 @@
+
+$('#plugin_list').html('<%= j @plugin_list.html_safe %>')
+$('#plugin_list [data-remote][data-replace]')
+  .data('type', 'html')
+  .on('ajax:success', function (event, data) {
+      var $this = $(this);
+      $($this.data('replace')).html(JSON.parse(data).html);
+  });

--- a/app/views/plugins/update.js.erb
+++ b/app/views/plugins/update.js.erb
@@ -1,0 +1,10 @@
+
+$('#plugin_list').html('<%= j @plugin_list.html_safe %>')
+
+$('#plugin_list [data-remote][data-replace]')
+  .data('type', 'html')
+  .on('ajax:success', function (event, data) {
+      var $this = $(this);
+      $($this.data('replace')).html(JSON.parse(data).html);
+  });
+$('#plugin_form').html('')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
   MAKE_DRAWING: "Make drawing"
   DONE: "Done"
   CANCEL: "Cancel"
+  SAVE: "Save"
   PREDICTION_BUTTON: "Submit"
   ANSWER_IS_FINAL: "Your answer is now locked."
   IS_PREDICTION_QUESTION: "Answer required?"
@@ -148,3 +149,13 @@ en:
   PRINT_BLANK:
     PRINT: "Print \"%{activity}\""
     PRINT_WARNING: "Close this window when you are done printing \"%{activity}\"."
+  PLUGIN:
+    DELETE_WARNING: "Are you sure you want to remove this plugin?"
+    ACTIVITY_LIST_TITLE: "Activity Plugins"
+    ACTIVITY_PLUGIN: "Activity Plugin"
+    EDIT: "Edit"
+    DELETE: "Delete"
+    ADD: "Add Plugin"
+    APPROVED_SCRIPT: "Approved Plugin:"
+    DESCRIPTION: "Description:"
+    AUTHORING_DATA: "Authoring Data:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ LightweightStandalone::Application.routes.draw do
   # the in-place editor needed interactive_page_path
   resources :pages, :as => 'interactive_pages', :controller => 'interactive_pages', :constraints => { :id => /\d+/ }, :except => [:new, :create]
 
+  resources :plugins
   namespace :embeddable do
     # When new embeddables are supported, they should be added here.
     resources :multiple_choices do

--- a/db/migrate/20180830181911_create_plugin.rb
+++ b/db/migrate/20180830181911_create_plugin.rb
@@ -1,0 +1,14 @@
+class CreatePlugin < ActiveRecord::Migration
+  def change
+    create_table :plugins do |t|
+      t.string  :approved_script_id
+      t.integer :plugin_scope_id
+      t.string  :plugin_scope_type
+      t.text    :author_data
+      t.text    :description
+      t.timestamps
+    end
+ 
+    add_index :plugins, [:plugin_scope_id, :plugin_scope_type], name: 'plugin_scopes', uniq: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180703131647) do
+ActiveRecord::Schema.define(:version => 20180830181911) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -465,6 +465,18 @@ ActiveRecord::Schema.define(:version => 20180703131647) do
   end
 
   add_index "pending_portal_publications", ["portal_publication_id"], :name => "unique_publications_per_portal", :unique => true
+
+  create_table "plugins", :force => true do |t|
+    t.string   "approved_script_id"
+    t.integer  "plugin_scope_id"
+    t.string   "plugin_scope_type"
+    t.text     "author_data"
+    t.text     "description"
+    t.datetime "created_at",         :null => false
+    t.datetime "updated_at",         :null => false
+  end
+
+  add_index "plugins", ["plugin_scope_id", "plugin_scope_type"], :name => "plugin_scopes"
 
   create_table "portal_publications", :force => true do |t|
     t.string   "portal_url"


### PR DESCRIPTION
Includes modeling and views for authors to add plugins to their activities.

After consulting with @scytacki I decided to use simple remote form pattern for this feature instead of react components.  We recognize that react might be a better long term solution, but continuing the existing authoring patterns would be sufficient for this.

Pages initialize the activity plugins on every page, except in the case of single page  activities, in which case the Plugins are only initialized once.

There was an old bug in a ajax function in `common.js`. We never noticed it because this function  wasn't actually every invoked, because none of our remote forms used the `data-replace` attribute, so updating it was low-risk.  I verified authoring  and runtime continued  to work as expected.  



