### PR TITLE
Lara plugin changes.

### DIFF
--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -149,5 +149,119 @@ window.LARA = {
   ****************************************************************************/
   saveUserState: function (pluginInstance, state) {
     console.log('Plugin', pluginInstance, 'wants to save a state:', state);
+  },
+
+
+  /****************************************************************************
+  @function decorateContent: Ask LARA to decorate authored content (text / html)
+  @arg {string[]} words - a list of case-insensitive words to be decorated
+      can use limited regex
+  @arg {string} replace - the replacement string.
+      Can include '$1' representing the matched word.
+  @arg {IEventListeners} listeners - one or more { type, listener } tuples
+  interface IEventListener {
+    type: string;
+    listener: (evt: Event) => void;
   }
+
+  type IEventListeners = IEventListener | IEventListener[];
+  @returns void
+  ****************************************************************************/
+  decorateContent: function (words, replace, wordClass, listeners) {
+    var domClasses = ['question-txt', 'intro-txt'];
+    var options = {
+      words: words,
+      replace: replace
+    }
+    TextDecorator.decorateDOMClasses(domClasses, options, wordClass, listeners);
+    var debuggingListener = {
+      type: 'click',
+      listener: function (evt)  {
+        alert("You clicked: ", evt.target.textContent, "!");
+      }
+    };
+    TextDecorator.addEventListeners(wordClass, [debuggingListener]);
+  },
+
+
+
+
+  /****************************************************************************
+   private variables to keep track of our plugins.
+  ****************************************************************************/
+  _pluginClasses: {},
+  _plugins:[],
+  _plugin_labels:[],
+
+  _pluginError: function(e, other) {
+    console.group("LARA Plugin Error");
+    console.error(e);
+    console.dir(other);
+    console.groupEnd();
+  },
+
+  _nameForPlugin: function(plugin) {
+    return(plugin.name || "(unknown)");
+  },
+
+  /**************************************************************
+  @function init
+  This method is called to initialize the external scripts
+  Called at runtime by LARA to create an instance of the plugin
+  as would happen in `views/plugin/_show.html.haml`
+  @arg {string} label - the the script identifier.
+  @arg {IRuntimContext} runtimeContext - context for the plugin
+
+  // Its likely we dont need most of these context values. TBD.
+  Interface IRuntimeContext {
+    name: string;         // Name of the plugin
+    url: string;          // Url from which the plugin was loaded
+    pluginId: string;     // Active record ID of the plugin scope id
+    authorData: string;   // The authored configuration for this instance
+    learnerData: string;  // The saved learner data for this instance
+    div: DomNode;         // reserved DomNode for the plugin in ther runtime.
+  }
+  **************************************************************/
+  initPlugin: function(_label, runtimeContext) {
+    var constructor = this._pluginClasses[_label];
+    var config = {};
+    var plugin = null;
+    if (typeof constructor == 'function') {
+      try {
+        if (typeof runtimeContext.config == 'string'){
+          config = JSON.parse(runtimeContext.config);
+          delete runtimeContext.config;
+        }
+        plugin = new constructor(config, runtimeContext);
+        this._plugins.push(plugin);
+        this._plugin_labels.push(_label);
+      }
+      catch(e) {
+        this._pluginError(e, runtimeContext);
+      }
+      console.log('Plugin', _label, 'is now registered');
+    }
+    else {
+      console.error("No plugin registered for label:", _label);
+    }
+  },
+
+
+  /**************************************************************
+   @function register
+   Register a new external script as `label` with `_class `
+   @arg label - the identifier of the sctipt
+   @arg Class - the Plugin Class being associated with the identifier
+   @example: `ExternalScripts.register('debugger', Dubugger)`
+   **************************************************************/
+  registerPlugin: function(_label, _class) {
+    if(typeof _class == 'function') {
+      if(this._pluginClasses[_label]) {
+        console.error("Duplicate Plugin for label " + _label);
+      }
+      else {
+        this._pluginClasses[_label] = _class;
+      }
+    }
+  },
 };

--- a/app/models/approved_script.rb
+++ b/app/models/approved_script.rb
@@ -1,5 +1,5 @@
 class ApprovedScript < ActiveRecord::Base
-  attr_accessible :name, :url, :label, :description
+  attr_accessible :name, :url, :label, :description, :version
   validates :name, presence: true
   validates :label, format: {
     with: /^([A-Za-z0-9]+)$/,

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -9,6 +9,7 @@ class Plugin < ActiveRecord::Base
   delegate :name,  to: :approved_script, allow_nil: true
   delegate :label, to: :approved_script, allow_nil: true
   delegate :url,   to: :approved_script, allow_nil: true
+  delegate :version, to: :approved_script, allow_nil: true
 
   # TODO: Import / export / to_hash &etc for duplicating ...
   #

--- a/app/views/approved_scripts/_form.html.haml
+++ b/app/views/approved_scripts/_form.html.haml
@@ -22,6 +22,10 @@
       %br
       = f.text_field :url
     .field{style: "margin: 1em 0px;"}
+      = f.label :version
+      %br
+      = f.select :version, ['1','2']
+    .field{style: "margin: 1em 0px;"}
       = f.label :description
       %br
       = f.text_area :description

--- a/app/views/approved_scripts/index.html.haml
+++ b/app/views/approved_scripts/index.html.haml
@@ -7,7 +7,7 @@
   .breadcrumbs
     %ul
       %li= link_to "Home", root_path
-      %li= link_to "Approved Scripts", approved_scripts_path
+      %li= link_to "Approved Plugins", approved_scripts_path
 
 .action_menu#activity-actions
   .action_menu_header
@@ -18,7 +18,7 @@
           %li#add= link_to 'create new approved_script', new_approved_script_path
 
 #official_listing_heading
-  %h1 ApprovedScripts
+  %h1 Approved Plugins
 %ul.quiet_list.official_listing
   - @approved_scripts.each do |approved_script|
     %li{ :id => dom_id_for(approved_script, :item), :class => 'item' }

--- a/app/views/embeddable/external_scripts/_lightweight.html.haml
+++ b/app/views/embeddable/external_scripts/_lightweight.html.haml
@@ -15,7 +15,7 @@
       scriptLabel: '#{embeddable.label}',
       scriptUrl: '#{embeddable.url}',
       embeddableId: '#{embeddable.id}',
-      config: '#{embeddable.configuration.gsub(/'/, "").gsub(/\s+/i, " " )}',
+      config: '#{escape_javascript(embeddable.configuration)}',
       div: $('#{runtimeDiv}')
     }
     ExternalScripts.init('#{embeddable.label}', env);

--- a/app/views/layouts/runtime.html.erb
+++ b/app/views/layouts/runtime.html.erb
@@ -43,6 +43,8 @@
   <!-- TODO: CDN or include? Lab is using 2.0.x but self-hosting. -->
   <%= javascript_include_tag '//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js' %>
   <%= javascript_include_tag '//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js' %>
+  <!-- TODO: Better way to include text decorator (local build) -->
+  <%= javascript_include_tag '//concord-consortium.github.io/text-plugins/dist/text-decorator.js' %>
 </head>
 
 <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -2,18 +2,36 @@
 = content_for :external_scripts do
   %script{src:plugin.url}
 
-.output{id:runtimeDiv}
+.plugin-output{id:runtimeDiv}
 
-:javascript
-  // Begin script for #{plugin.name}
-  $(document).ready( function() {
-    env = {
-      name: '#{plugin.name}',
-      scriptLabel: '#{plugin.label}',
-      scriptUrl: '#{plugin.url}',
-      pluginId: '#{plugin.id}',
-      config: '#{ j plugin.author_data }',
-      div: $('##{runtimeDiv}')
-    }
-    ExternalScripts.init('#{plugin.label}', env);
-  });
+- if plugin.version < 2
+  :javascript
+    // Begin script for #{plugin.name}
+    $(document).ready( function() {
+      env = {
+        name: '#{plugin.name}',
+        scriptLabel: '#{plugin.label}',
+        scriptUrl: '#{plugin.url}',
+        pluginId: '#{plugin.id}',
+        config: '#{ escape_javascript(plugin.author_data) }',
+        div: $('##{runtimeDiv}')
+      }
+      console.log("Adding script #{plugin.label} with V1 (ExternalScript) API");
+      ExternalScripts.init('#{plugin.label}', env);
+
+    });
+- else
+  :javascript
+    // Begin script for #{plugin.name}
+    $(document).ready( function() {
+      env = {
+        name: '#{plugin.name}',
+        url: '#{plugin.url}',
+        pluginId: '#{plugin.id}',
+        authoredState: '#{ escape_javascript(plugin.author_data) }',
+        learnerState: '{ warning: "TBD"}',
+        div: $('##{runtimeDiv}')[0]
+      }
+      console.log("Adding script #{plugin.label} with V2 LARA Plugin API")
+      LARA.initPlugin('#{plugin.label}', env);
+    });

--- a/app/views/shared/_session.html.haml
+++ b/app/views/shared/_session.html.haml
@@ -16,7 +16,7 @@
     = link_to "QuestionTrackers", question_trackers_path
   -if can? :manage, ApprovedScript
     |
-    = link_to "Scripts", approved_scripts_path
+    = link_to "Plugins", approved_scripts_path
   -if can? :manage, User
     |
     = link_to "Failed runs", dirty_runs_path

--- a/db/migrate/20180905185210_add_version_to_approved_script.rb
+++ b/db/migrate/20180905185210_add_version_to_approved_script.rb
@@ -1,0 +1,5 @@
+class AddVersionToApprovedScript < ActiveRecord::Migration
+  def change
+    add_column :approved_scripts, :version, :decimal, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180830181911) do
+ActiveRecord::Schema.define(:version => 20180905185210) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -24,9 +24,10 @@ ActiveRecord::Schema.define(:version => 20180830181911) do
     t.string   "name"
     t.string   "url"
     t.text     "description"
-    t.datetime "created_at",  :null => false
-    t.datetime "updated_at",  :null => false
+    t.datetime "created_at",                                                :null => false
+    t.datetime "updated_at",                                                :null => false
     t.string   "label"
+    t.decimal  "version",     :precision => 10, :scale => 0, :default => 1
   end
 
   create_table "authentications", :force => true do |t|
@@ -173,9 +174,9 @@ ActiveRecord::Schema.define(:version => 20180830181911) do
     t.boolean  "is_hidden",                        :default => false
     t.text     "hint"
     t.boolean  "is_full_width",                    :default => false
+    t.boolean  "show_in_featured_question_report", :default => true
     t.integer  "interactive_id"
     t.string   "interactive_type"
-    t.boolean  "show_in_featured_question_report", :default => true
   end
 
   create_table "embeddable_labbook_answers", :force => true do |t|

--- a/docs/lara-plugin-api.md
+++ b/docs/lara-plugin-api.md
@@ -89,10 +89,11 @@ interface IPopupController {
     can use limited regex
 @arg {string} replace - the replacement string.
      Can include '$1' representing the matched word.
+@arg {string} wordClass - class used for the enclosing tag (e.g. 'cc-glossary-word')
 @arg {IEventListeners} listeners - one or more { type, listener } tuples
 @returns void
 ****************************************************************************/
-LARA.decorateContent = function (words: string[], replace: string, listeners: IEventListeners): void;
+LARA.decorateContent = function (words: string[], replace: string, wordClass: string. listeners: IEventListeners): void;
 
 interface IEventListener {
   type: string;


### PR DESCRIPTION

* Adds version to approved_script model.  Version 1 expects old ExternalScript API.  Version 2 expects new LARA Plugin Api.

* Adds registration methods in `lara-api.js`
* Adds API for decorating text in `lara-api.js`
* Renames labels in the UI to be more "plugin"-ish and less "External Script"-ish.

TODO: The way the text-decoration library was added was simply with a javascript include tag.  This must of course be cleaned up.

@pjanik 
This entire PR will require more cleanup later, but I wanted to get it in your hands before I had to leave this evening, incase you have some time to review / test.
