### PR TITLE
Plugin learner state

### DIFF
--- a/app/models/plugin_learner_state.rb
+++ b/app/models/plugin_learner_state.rb
@@ -1,0 +1,82 @@
+
+class PluginLearnerState < ActiveRecord::Base
+
+  class LookupStrategy
+    def self.get_lookup_strategy(plugin, run)
+      if plugin.shared_learner_state_key.present?
+        if run.user
+          return SharedStateKeyAndUser.new(plugin, run)
+        end
+        return SharedStateKeyAndRun.new(plugin, run)
+      end
+      return PluginAndRun.new(plugin, run)
+    end
+
+    def initialize(plugin, run)
+      @run = run
+      @plugin = plugin
+    end
+
+    def opts
+      {}
+    end
+
+    def find
+      PluginLearnerState.where(self.opts).first
+    end
+
+    def create
+      PluginLearnerState.create(self.opts)
+    end
+
+    def find_or_create
+      self.find || self.create
+    end
+  end
+
+  class PluginAndRun < LookupStrategy
+    def opts
+      {
+        plugin_id: @plugin.id,
+        run_id: @run.id
+      }
+    end
+  end
+
+  class SharedStateKeyAndRun < LookupStrategy
+    def opts
+      {
+        shared_learner_state_key: @plugin.shared_learner_state_key,
+        run_id: @run.id
+      }
+    end
+  end
+
+  class SharedStateKeyAndUser < LookupStrategy
+    def opts
+      {
+        shared_learner_state_key: @plugin.shared_learner_state_key,
+        user_id: @run.user.id
+      }
+    end
+  end
+
+  belongs_to :plugin
+  belongs_to :run
+  belongs_to :user
+  belongs_to :shared_plugin,
+    class_name: 'Plugin',
+    foreign_key: 'shared_learner_state_key',
+    primary_key: 'shared_learner_state_key'
+
+  attr_accessible :shared_learner_state_key, :user_id, :run_id, :plugin_id
+
+  def self.get_lookup_strategy(plugin, run)
+    LookupStrategy.get_lookup_strategy(plugin,run)
+  end
+
+  def self.find_or_create(plugin, run)
+    self.get_lookup_strategy(plugin,run).find_or_create()
+  end
+
+end

--- a/app/models/plugin_learner_state.rb
+++ b/app/models/plugin_learner_state.rb
@@ -69,7 +69,7 @@ class PluginLearnerState < ActiveRecord::Base
     foreign_key: 'shared_learner_state_key',
     primary_key: 'shared_learner_state_key'
 
-  attr_accessible :shared_learner_state_key, :user_id, :run_id, :plugin_id
+  attr_accessible :shared_learner_state_key, :user_id, :run_id, :plugin_id, :state
 
   def self.get_lookup_strategy(plugin, run)
     LookupStrategy.get_lookup_strategy(plugin,run)

--- a/db/migrate/20180910174230_add_shared_learner_state_key_to_plugins.rb
+++ b/db/migrate/20180910174230_add_shared_learner_state_key_to_plugins.rb
@@ -1,0 +1,5 @@
+class AddSharedLearnerStateKeyToPlugins < ActiveRecord::Migration
+  def change
+    add_column :plugins, :shared_learner_state_key, :string
+  end
+end

--- a/db/migrate/20180910174604_create_plugin_learner_states.rb
+++ b/db/migrate/20180910174604_create_plugin_learner_states.rb
@@ -1,0 +1,16 @@
+class CreatePluginLearnerStates < ActiveRecord::Migration
+  def change
+    create_table :plugin_learner_states do |t|
+      t.integer :plugin_id
+      t.integer :user_id
+      t.integer :run_id
+      t.string  :shared_learner_state_key
+      t.timestamps
+    end
+
+    add_index :plugin_learner_states, [:plugin_id, :run_id], name: 'plugin_run__states'
+    add_index :plugin_learner_states, [:shared_learner_state_key, :run_id], name: 'shared_run_plugin_states'
+    add_index :plugin_learner_states, [:shared_learner_state_key, :user_id], name: 'shared_user_plugin_states'
+  end
+
+end

--- a/db/migrate/20180910194602_add_state_to_plugin_learner_states.rb
+++ b/db/migrate/20180910194602_add_state_to_plugin_learner_states.rb
@@ -1,0 +1,5 @@
+class AddStateToPluginLearnerStates < ActiveRecord::Migration
+  def change
+    add_column :plugin_learner_states, :state, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180905185210) do
+ActiveRecord::Schema.define(:version => 20180910174604) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -467,14 +467,28 @@ ActiveRecord::Schema.define(:version => 20180905185210) do
 
   add_index "pending_portal_publications", ["portal_publication_id"], :name => "unique_publications_per_portal", :unique => true
 
+  create_table "plugin_learner_states", :force => true do |t|
+    t.integer  "plugin_id"
+    t.integer  "user_id"
+    t.integer  "run_id"
+    t.string   "shared_learner_state_key"
+    t.datetime "created_at",               :null => false
+    t.datetime "updated_at",               :null => false
+  end
+
+  add_index "plugin_learner_states", ["plugin_id", "run_id"], :name => "plugin_run__states"
+  add_index "plugin_learner_states", ["shared_learner_state_key", "run_id"], :name => "shared_run_plugin_states"
+  add_index "plugin_learner_states", ["shared_learner_state_key", "user_id"], :name => "shared_user_plugin_states"
+
   create_table "plugins", :force => true do |t|
     t.string   "approved_script_id"
     t.integer  "plugin_scope_id"
     t.string   "plugin_scope_type"
     t.text     "author_data"
     t.text     "description"
-    t.datetime "created_at",         :null => false
-    t.datetime "updated_at",         :null => false
+    t.datetime "created_at",               :null => false
+    t.datetime "updated_at",               :null => false
+    t.string   "shared_learner_state_key"
   end
 
   add_index "plugins", ["plugin_scope_id", "plugin_scope_type"], :name => "plugin_scopes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180910174604) do
+ActiveRecord::Schema.define(:version => 20180910194602) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -474,6 +474,7 @@ ActiveRecord::Schema.define(:version => 20180910174604) do
     t.string   "shared_learner_state_key"
     t.datetime "created_at",               :null => false
     t.datetime "updated_at",               :null => false
+    t.text     "state"
   end
 
   add_index "plugin_learner_states", ["plugin_id", "run_id"], :name => "plugin_run__states"

--- a/spec/models/plugin_learner_state_spec.rb
+++ b/spec/models/plugin_learner_state_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe PluginLearnerState do
+
+  let(:user)        { double "user", {id: 42} }
+  let(:run_opts)    { {user: user, id: 4242} }
+  let(:run)         { double "Run", run_opts }
+
+  let(:shared_learner_state_key)  {'global-plugin-id'}
+
+  let(:plugin_opts) do
+    {
+      id: 3,
+      shared_learner_state_key: shared_learner_state_key,
+      run: run
+    }
+  end
+
+  let(:plugin)      { double "Plugin", plugin_opts}
+
+  before(:each) do
+    @plugin_learner_state = PluginLearnerState.find_or_create(plugin, run)
+    @strategy = PluginLearnerState.get_lookup_strategy(plugin, run)
+  end
+
+  describe "With a plugin that shares data across unlinked activities" do
+    describe "When the user is logged in" do
+      it "should find the learner's data using the shared_learner_state_key and user_id" do
+        expect(@strategy).to be_instance_of(PluginLearnerState::SharedStateKeyAndUser)
+        expect(@plugin_learner_state).to be_instance_of(PluginLearnerState)
+      end
+    end
+
+    describe "When the user is anonymous" do
+      let(:user) { nil }
+      it "should find the learner's data using the shared_learner_state_key and run_id" do
+        expect(@strategy).to be_instance_of(PluginLearnerState::SharedStateKeyAndRun)
+        expect(@plugin_learner_state).to be_instance_of(PluginLearnerState)
+      end
+    end
+  end
+
+  describe "With a plugin that silos data between assignments" do
+    let(:shared_learner_state_key) { '' }
+    # or this let(:shared_learner_state_key) { nil }
+    describe "When the user is logged in" do
+      it "should find the learner's data using the plugin_id and run_id" do
+        expect(@strategy).to be_instance_of(PluginLearnerState::PluginAndRun)
+        expect(@plugin_learner_state).to be_instance_of(PluginLearnerState)
+      end
+    end
+ 
+    describe "When the user is anonymous" do
+      it "should find the learner's data using the plugin_id and run_id" do
+        expect(@strategy).to be_instance_of(PluginLearnerState::PluginAndRun)
+        expect(@plugin_learner_state).to be_instance_of(PluginLearnerState)
+      end
+    end
+  end
+
+end

--- a/spec/models/plugin_learner_state_spec.rb
+++ b/spec/models/plugin_learner_state_spec.rb
@@ -56,6 +56,20 @@ describe PluginLearnerState do
         expect(@plugin_learner_state).to be_instance_of(PluginLearnerState)
       end
     end
+
+    describe "loading and saving data" do
+      let(:state) do
+        {testing: 1, two: 2, three: 3}.to_json()
+      end
+
+      before(:each) do
+        @plugin_learner_state.update_attribute(:state, state)
+      end
+
+      it "should be able to load state" do
+        expect(@plugin_learner_state.reload.state).to eql(state)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Adding support for saving PluginLearnerState to LARA.

These commits add the data models required to save a PluginLearnerState for a learner or user under various scenarios.  There are two basic strategies.

The first strategy uses the `plugin.id`, that is the instance of the plugin as part of a key.

The second strategy uses an authorable identifier to share state between unrelated activities and sequences, using a unique string.

In addition to the main strategy, we have to handle cases when users are not logged in.

To see more details review `spec/models/plugin_learner_state_spec.rb` which tests the various cases.

