### PR TITLE
Plugin learner state saving

### DIFF
--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -1,6 +1,5 @@
 
 window.LARA = {
-  PluginsApi: function() { return window.Plugins} ,
 
   /****************************************************************************
    @function addPopup: Ask LARA to add a new popup window
@@ -163,13 +162,7 @@ window.LARA = {
    @returns Promise
   ****************************************************************************/
   saveLearnerPluginState: function (pluginId, state) {
-    var pluginsApi = window.Plugins;
-    if (pluginsApi && typeof pluginsApi.saveLearnerPluginState === 'function') {
-      return pluginsApi.saveLearnerPluginState(pluginId, state);
-    }
-    return new Promise( function(resolve, reject) {
-      reject('pluginApi not defined. saveLearnerPluginState failed.')
-    });
+    return Plugins.saveLearnerPluginState(pluginId, state);
   },
 
   /****************************************************************************
@@ -208,10 +201,6 @@ window.LARA = {
    @example: `LARA.registerPlugin('debugger', Dubugger);
    **************************************************************/
   registerPlugin: function(label, _class) {
-    var pluginsApi = window.Plugins;
-    if(pluginsApi && pluginsApi.registerPlugin){
-      return pluginsApi.registerPlugin(label, _class);
-    }
-    return false;
+    return Plugins.registerPlugin(label, _class);
   }
 };

--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -1,4 +1,7 @@
+
 window.LARA = {
+  PluginsApi: function() { return window.Plugins} ,
+
   /****************************************************************************
    @function addPopup: Ask LARA to add a new popup window
    @arg {IPopupOptions} popupOptions
@@ -142,30 +145,30 @@ window.LARA = {
   },
   /****************************************************************************
   @deprecated saveLearnerState
-  @see savePluginState
+  @see saveLearnerPluginState
   ****************************************************************************/
   saveLearnerState: function (pluginId, state) {
     var deprication =
-      'saveLearnerState is depricated, use `savePluginState` instead'
+      '⚠️ saveLearnerState is depricated, use `saveLearnerPluginState` instead'
     console.warn(deprication);
-    this.savePluginState(pluginId, state);
+    this.saveLearnerPluginState(pluginId, state);
   },
 
   /****************************************************************************
-   @function savePluginState: Ask LARA to save the users state for the plugin
+   @function saveLearnerPluginState: Ask LARA to save the users state for the plugin
    @arg {string} pluginId - ID of the plugin trying to save data, initially passed to plugin constructor in the context
    @arg {string} state - A JSON string representing serialized plugin state.
    @example
-    LARA.savePluginState(plugin, '{"one": 1}').then((data) => console.log(data))
+    LARA.saveLearnerPluginState(plugin, '{"one": 1}').then((data) => console.log(data))
    @returns Promise
   ****************************************************************************/
-  savePluginState: function (pluginId, state) {
+  saveLearnerPluginState: function (pluginId, state) {
     var pluginsApi = window.Plugins;
-    if (pluginsApi && typeof pluginsApi.savePluginState === 'function') {
-      return pluginsApi.savePluginState(pluginId, state);
+    if (pluginsApi && typeof pluginsApi.saveLearnerPluginState === 'function') {
+      return pluginsApi.saveLearnerPluginState(pluginId, state);
     }
     return new Promise( function(resolve, reject) {
-      reject('window.Plugins not defined. savePluginState failed.')
+      reject('pluginApi not defined. saveLearnerPluginState failed.')
     });
   },
 
@@ -196,14 +199,19 @@ window.LARA = {
 
 
   /**************************************************************
-   @function register
+   @function registerPlugin
    Register a new external script as `label` with `_class `
+   Deligates to this.PluginsApi
    @arg label - the identifier of the script
    @arg _class - the Plugin Class being associated with the identifier
-   @returns void
-   @example: `LARA.registerPlugin('debugger', Dubugger);`
+   @returns boolean - true if plugin was registered correctly.
+   @example: `LARA.registerPlugin('debugger', Dubugger);
    **************************************************************/
   registerPlugin: function(label, _class) {
-    Plugins.registerPlugin(label, _class);
+    var pluginsApi = window.Plugins;
+    if(pluginsApi && pluginsApi.registerPlugin){
+      return pluginsApi.registerPlugin(label, _class);
+    }
+    return false;
   }
 };

--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -142,12 +142,16 @@ window.LARA = {
   },
 
   /****************************************************************************
-   @function saveUserState: Ask LARA to save the users state for the plugin
+   @function saveLearnerState: Ask LARA to save the users state for the plugin
    @arg {ILaraPluginRef} pluginInstance - The plugin trying to save data
    @arg {string} state - A JSON string representing serialized plugin state.
    @returns Promise
+   TOOD:
+    * Rename to savePluginState (because of plugin instance argument)
+    * Add more generic function saving unspecified resources … ?
+    * Use Promise polyfill for IE support ?
   ****************************************************************************/
-  saveUserState: function (pluginInstance, state) {
+  saveLearnerState: function (pluginInstance, state) {
     console.log('Plugin', pluginInstance, 'wants to save a state:', state);
   },
 

--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -153,6 +153,26 @@ window.LARA = {
   ****************************************************************************/
   saveLearnerState: function (pluginInstance, state) {
     console.log('Plugin', pluginInstance, 'wants to save a state:', state);
+    var context = pluginInstance.__LaraPluginContext
+    if(context) {
+      var url = context.pluginUserStatePath
+      return new Promise(function(resolve, reject) {
+        $.ajax({
+          url: url,
+          type: 'PUT',
+          data: {state: state},
+          success: function(data) {
+            resolve(data);
+          },
+          error: function(jqXHR, textStatus, errorThrown) {
+            reject(textStatus);
+          }
+        });
+      });
+    }
+    else {
+      console.warn('Cant save. Plugin', pluginInstance, 'was incorrectly initialized. No __LaraPluginContext')
+    }
   },
 
   /****************************************************************************

--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -140,39 +140,33 @@ window.LARA = {
       remove: remove
     }
   },
-
   /****************************************************************************
-   @function saveLearnerState: Ask LARA to save the users state for the plugin
-   @arg {ILaraPluginRef} pluginInstance - The plugin trying to save data
-   @arg {string} state - A JSON string representing serialized plugin state.
-   @returns Promise
-   TOOD:
-    * Rename to savePluginState (because of plugin instance argument)
-    * Add more generic function saving unspecified resources … ?
-    * Use Promise polyfill for IE support ?
+  @deprecated saveLearnerState
+  @see savePluginState
   ****************************************************************************/
   saveLearnerState: function (pluginInstance, state) {
-    console.log('Plugin', pluginInstance, 'wants to save a state:', state);
-    var context = pluginInstance.__LaraPluginContext
-    if(context) {
-      var url = context.pluginUserStatePath
-      return new Promise(function(resolve, reject) {
-        $.ajax({
-          url: url,
-          type: 'PUT',
-          data: {state: state},
-          success: function(data) {
-            resolve(data);
-          },
-          error: function(jqXHR, textStatus, errorThrown) {
-            reject(textStatus);
-          }
-        });
-      });
+    var deprication =
+      'saveLearnerState is depricated, use `savePluginState` instead'
+    console.warn(deprication);
+    this.savePluginState(pluginInstance, state);
+  },
+
+  /****************************************************************************
+   @function savePluginState: Ask LARA to save the users state for the plugin
+   @arg {ILaraPluginRef} pluginInstance - The plugin trying to save data
+   @arg {string} state - A JSON string representing serialized plugin state.
+   @example
+    LARA.savePluginState(plugin, '{"one": 1}').then((data) => console.log(data))
+   @returns Promise
+  ****************************************************************************/
+  savePluginState: function (pluginInstance, state) {
+    var pluginsApi = window.Plugins;
+    if (pluginsApi && typeof pluginsApi.savePluginState === 'function') {
+      return pluginsApi.savePluginState(pluginInstance, state);
     }
-    else {
-      console.warn('Cant save. Plugin', pluginInstance, 'was incorrectly initialized. No __LaraPluginContext')
-    }
+    return new Promise( function(resolve, reject) {
+      reject('window.Plugins not defined. savePluginState failed.')
+    });
   },
 
   /****************************************************************************

--- a/app/assets/javascripts/plugins.js
+++ b/app/assets/javascripts/plugins.js
@@ -5,7 +5,7 @@ window.Plugins = {
       Note, we call these `classes` but any constructor function will do.
     @var Plugins._plugins: [PluginClass]
     @var Plugins._pluginLabels: [string]
-    @var Plugins._pluginStatePaths: {[PluginClass]:{savePath: string, loadPath: string}
+    @var Plugins._pluginStatePaths: {[string]:{savePath: string, loadPath: string}
   ****************************************************************************/
   _pluginClasses: {},
   _plugins:[],
@@ -61,16 +61,14 @@ window.Plugins = {
   },
 
   /****************************************************************************
-   @function savePluginState: Ask LARA to save the users state for the plugin
+   @function saveLearnerPluginState: Ask LARA to save the users state for the plugin
    @arg {string} pluginId - ID of the plugin trying to save data, initially passed to plugin constructor in the context
    @arg {string} state - A JSON string representing serialized plugin state.
-
    @example
-    LARA.savePluginState(pluginId, '{"one": 1}').then((data) => console.log(data))
-
+    LARA.saveLearnerPluginState(pluginId, '{"one": 1}').then((data) => console.log(data))
    @returns Promise resolve: <string>
   ****************************************************************************/
-  savePluginState: function(pluginId, state) {
+  saveLearnerPluginState: function(pluginId, state) {
     var paths = this._pluginStatePaths[pluginId];
     if(paths && paths.savePath) {
       return new Promise(function(resolve, reject) {
@@ -89,22 +87,25 @@ window.Plugins = {
   },
 
   /****************************************************************************
-   @function register
+   @function registerPlugin
    Register a new external script as `label` with `_class `
    @arg {string} label - the identifier of the script
    @arg {class} _class - the Plugin Class being associated with the identifier
    @example: `Plugins.register('debugger', Dubugger)`
+   @returns {boolean} – true if plugin was registered correctly.
    ***************************************************************************/
   registerPlugin: function(label, _class) {
     if (typeof _class !== 'function') {
-      return;
+      console.error('Plugin did not provide constructor', label);
+      return false;
     }
     if(this._pluginClasses[label]) {
       console.error('Duplicate Plugin for label', label);
+      return false
     } else {
       this._pluginClasses[label] = _class;
+      return true
     }
   }
-
 
 };

--- a/app/assets/javascripts/plugins.js
+++ b/app/assets/javascripts/plugins.js
@@ -1,10 +1,16 @@
 window.Plugins = {
   /****************************************************************************
-   private variables to keep track of our plugins.
+   Private variables to keep track of our plugins.
+    @var Plugins._pluginClasses: {[label:string]: ()=> PluginClass}
+      Note, we call these `classes` but any constructor function will do.
+    @var Plugins._plugins: [PluginClass]
+    @var Plugins._pluginLabels: [string]
+    @var Plugins._pluginStatePaths: {[PluginClass]:{savePath: string, loadPath: string}
   ****************************************************************************/
   _pluginClasses: {},
   _plugins:[],
   _pluginLabels:[],
+  _pluginStatePaths: {},
 
   _pluginError: function(e, other) {
     console.group('LARA Plugin Error');
@@ -13,26 +19,30 @@ window.Plugins = {
     console.groupEnd();
   },
 
-  /**************************************************************
+  /****************************************************************************
   @function initPlugin
   This method is called to initialize the external scripts
   Called at runtime by LARA to create an instance of the plugin
   as would happen in `views/plugin/_show.html.haml`
   @arg {string} label - the the script identifier.
   @arg {IRuntimContext} runtimeContext - context for the plugin
+  @arg {IPluginStatePath} pluginStatePaths – for saving & loading learner data
 
-  // Its likely we dont need most of these context values. TBD.
+  Interface IPluginStatePath {
+    savePath: string;
+    loadPath: string;
+  }
+
   Interface IRuntimeContext {
     name: string;               // Name of the plugin
     url: string;                // Url from which the plugin was loaded
     pluginId: string;           // Active record ID of the plugin scope id
     authorData: string;         // The authored configuration for this instance
     learnerData: string;        // The saved learner data for this instance
-    pluginUserStatePath: string // Where to save / load data from for this instance.
     div: HTMLElement;           // reserved HTMLElement for the plugin output
   }
-  **************************************************************/
-  initPlugin: function(label, runtimeContext) {
+  ****************************************************************************/
+  initPlugin: function(label, runtimeContext, pluginStatePaths) {
     var constructor = this._pluginClasses[label];
     var config = {};
     var plugin = null;
@@ -41,29 +51,51 @@ window.Plugins = {
         plugin = new constructor(runtimeContext);
         this._plugins.push(plugin);
         this._pluginLabels.push(label);
-        // FIXME: We need some way to costomize the save & load paths.
-        // This isn't great. Maybe we change how we store plugins so that
-        // we can save our own copy of `runtimeContext` without messing with the plugin.
-        plugin.__LaraPluginContext = runtimeContext;
+        this._pluginStatePaths[plugin] = pluginStatePaths;
       }
-      catch(e) {
-        this._pluginError(e, runtimeContext);
-      }
-      console.log('Plugin', label, 'is now registered');
+      catch(e) { this._pluginError(e, runtimeContext); }
+      console.info('Plugin', label, 'is now registered');
     }
     else {
       console.error('No plugin registered for label:', label);
     }
   },
 
+  /****************************************************************************
+   @function savePluginState: Ask LARA to save the users state for the plugin
+   @arg {ILaraPluginRef} pluginInstance - The plugin trying to save data
+   @arg {string} state - A JSON string representing serialized plugin state.
 
-  /**************************************************************
+   @example
+    LARA.savePluginState(plugin, '{"one": 1}').then((data) => console.log(data))
+
+   @returns Promise resolve: <string>
+  ****************************************************************************/
+  savePluginState: function(pluginInstance, state) {
+    var paths = this._pluginStatePaths[pluginInstance];
+    if(paths && paths.savePath) {
+      return new Promise(function(resolve, reject) {
+        $.ajax({
+          url: paths.savePath,
+          type: 'PUT',
+          data: {state: state},
+          success: function(data) { resolve(data); },
+          error: function(jqXHR, errText, err) { reject(errText); }
+        });
+      });
+    }
+    else {
+      console.warn('Not saved.`pluginStatePaths` missing for' , pluginInstance);
+    }
+  },
+
+  /****************************************************************************
    @function register
    Register a new external script as `label` with `_class `
-   @arg label - the identifier of the script
-   @arg Class - the Plugin Class being associated with the identifier
+   @arg {string} label - the identifier of the script
+   @arg {class} _class - the Plugin Class being associated with the identifier
    @example: `Plugins.register('debugger', Dubugger)`
-   **************************************************************/
+   ***************************************************************************/
   registerPlugin: function(label, _class) {
     if (typeof _class !== 'function') {
       return;
@@ -74,4 +106,6 @@ window.Plugins = {
       this._pluginClasses[label] = _class;
     }
   }
+
+
 };

--- a/app/assets/javascripts/plugins.js
+++ b/app/assets/javascripts/plugins.js
@@ -23,12 +23,13 @@ window.Plugins = {
 
   // Its likely we dont need most of these context values. TBD.
   Interface IRuntimeContext {
-    name: string;         // Name of the plugin
-    url: string;          // Url from which the plugin was loaded
-    pluginId: string;     // Active record ID of the plugin scope id
-    authorData: string;   // The authored configuration for this instance
-    learnerData: string;  // The saved learner data for this instance
-    div: HTMLElement;     // reserved HTMLElement for the plugin output
+    name: string;               // Name of the plugin
+    url: string;                // Url from which the plugin was loaded
+    pluginId: string;           // Active record ID of the plugin scope id
+    authorData: string;         // The authored configuration for this instance
+    learnerData: string;        // The saved learner data for this instance
+    pluginUserStatePath: string // Where to save / load data from for this instance.
+    div: HTMLElement;           // reserved HTMLElement for the plugin output
   }
   **************************************************************/
   initPlugin: function(label, runtimeContext) {
@@ -40,6 +41,9 @@ window.Plugins = {
         plugin = new constructor(runtimeContext);
         this._plugins.push(plugin);
         this._pluginLabels.push(label);
+        // FIXME: We need some way to costomize the save & load paths.
+        // This isn't great. Maybe we change how we store plugins so that
+        // we can save our own copy of `runtimeContext` without messing with the plugin.
         plugin.__LaraPluginContext = runtimeContext;
       }
       catch(e) {

--- a/app/assets/javascripts/plugins.js
+++ b/app/assets/javascripts/plugins.js
@@ -77,13 +77,13 @@ window.Plugins = {
           type: 'PUT',
           data: {state: state},
           success: function(data) { resolve(data); },
-          error: function(jqXHR, errText, err) { reject(errText); }
+          error: function(jqXHR, errText, err) { reject(err); }
         });
       });
     }
-    else {
-      console.warn('Not saved.`pluginStatePaths` missing for plugin ID:' , pluginId);
-    }
+    const msg = 'Not saved.`pluginStatePaths` missing for plugin ID:'
+    console.warn(msg , pluginId);
+    return Promise.reject(msg)
   },
 
   /****************************************************************************

--- a/app/assets/javascripts/plugins.js
+++ b/app/assets/javascripts/plugins.js
@@ -40,6 +40,7 @@ window.Plugins = {
         plugin = new constructor(runtimeContext);
         this._plugins.push(plugin);
         this._pluginLabels.push(label);
+        plugin.__LaraPluginContext = runtimeContext;
       }
       catch(e) {
         this._pluginError(e, runtimeContext);

--- a/app/controllers/api/v1/plugin_learner_states_controller.rb
+++ b/app/controllers/api/v1/plugin_learner_states_controller.rb
@@ -1,0 +1,48 @@
+class Api::V1::PluginLearnerStatesController < ApplicationController
+  STATUS_OK = 200
+  STATUS_ERROR = 500
+  STATUS_NOT_FOUND = 404
+
+  private
+  def fail(status, message, err)
+    render :json => {
+        response_type: "ERROR",
+        error: "#{message} #{err}"
+      }, status: status
+  end
+
+  def success(state_data)
+    render :json => { state: state_data }, status: STATUS_OK
+  end
+
+  def getPluginState
+    run_id = params[:run_id]
+    plugin_id = params[:plugin_id]
+    begin
+      run = Run.find(run_id)
+      plugin  = Plugin.find(plugin_id)
+      @p_state = PluginLearnerState.find_or_create(plugin, run)
+    rescue => err
+      fail(STATUS_NOT_FOUND, "No state for plugin_id: #{plugin_id}, run_id: #{run_id}", err)
+    end
+  end
+
+  public
+  def load
+    getPluginState
+    success(@p_state.state)
+  end
+
+  def save
+    getPluginState
+    begin
+      state = params[:state]
+      puts params
+      @p_state.update_attribute(:state, state)
+      success(@p_state.reload.state)
+    rescue => err
+      fail(STATUS_ERROR, "Couldn't update state for PluginLearnerState(#{@p_state.id})", err)
+    end
+  end
+
+end

--- a/app/controllers/api/v1/plugin_learner_states_controller.rb
+++ b/app/controllers/api/v1/plugin_learner_states_controller.rb
@@ -37,7 +37,6 @@ class Api::V1::PluginLearnerStatesController < ApplicationController
     getPluginState
     begin
       state = params[:state]
-      puts params
       @p_state.update_attribute(:state, state)
       success(@p_state.reload.state)
     rescue => err

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -1,7 +1,7 @@
 
 class Plugin < ActiveRecord::Base
 
-  attr_accessible :description, :author_data, :approved_script_id, :approved_script
+  attr_accessible :description, :author_data, :approved_script_id, :approved_script, :shared_learner_state_key
 
   belongs_to :approved_script
   belongs_to :plugin_scope, polymorphic: true
@@ -11,6 +11,11 @@ class Plugin < ActiveRecord::Base
   delegate :url,   to: :approved_script, allow_nil: true
   delegate :version, to: :approved_script, allow_nil: true
 
+  after_initialize :generate_rare_key
+
+  def generate_rare_key
+    self.shared_learner_state_key ||= SecureRandom.uuid()
+  end
   # TODO: Import / export / to_hash &etc for duplicating ...
   #
   # def self.import(import_hash)

--- a/app/views/plugins/_form.html.haml
+++ b/app/views/plugins/_form.html.haml
@@ -8,6 +8,9 @@
         = f.label t("PLUGIN.APPROVED_SCRIPT")
         = f.collection_select(:approved_script_id, ApprovedScript.all, :id, :name)
       %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
+        = f.label t("PLUGIN.GLOBAL_ID")
+        = f.text_field :shared_learner_state_key
+      %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
         = f.label t("PLUGIN.DESCRIPTION")
         = f.text_field :description
       %div{style: "margin-top: 0.5em; flex-direction: column; align-items: stretch;"}

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -24,7 +24,12 @@
   - learner_state = PluginLearnerState.find_or_create(plugin, @run).state
   :javascript
     // Begin script for #{plugin.name}
-    var pluginUserStatePath=`#{escape_javascript(api_v1_update_plugin_learner_state_path(plugin.id, @run.id))}`
+    var savePath = `#{escape_javascript(api_v1_update_plugin_learner_state_path(plugin.id, @run.id))}`
+    var loadPath = `#{escape_javascript(api_v1_show_plugin_learner_state_path(plugin.id, @run.id))}`
+    var pluginStatePaths = {
+      savePath: savePath,
+      loadPath: loadPath
+    };
     var learner_state  = '#{ escape_javascript(learner_state) }'
     $(document).ready( function() {
       env = {
@@ -33,9 +38,8 @@
         pluginId: '#{plugin.id}',
         authoredState: '#{ escape_javascript(plugin.author_data) }',
         learnerState: learner_state,
-        pluginUserStatePath: pluginUserStatePath,
         div: $('##{runtimeDiv}')[0]
       }
       console.log("Adding script #{plugin.label} with V2 LARA Plugin API")
-      Plugins.initPlugin('#{plugin.label}', env);
+      Plugins.initPlugin('#{plugin.label}', env, pluginStatePaths);
     });

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -21,15 +21,19 @@
 
     });
 - else
+  - learner_state = PluginLearnerState.find_or_create(plugin, @run).state
   :javascript
     // Begin script for #{plugin.name}
+    var pluginUserStatePath=`#{escape_javascript(api_v1_update_plugin_learner_state_path(plugin.id, @run.id))}`
+    var learner_state  = '#{ escape_javascript(learner_state) }'
     $(document).ready( function() {
       env = {
         name: '#{plugin.name}',
         url: '#{plugin.url}',
         pluginId: '#{plugin.id}',
         authoredState: '#{ escape_javascript(plugin.author_data) }',
-        learnerState: null,
+        learnerState: learner_state,
+        pluginUserStatePath: pluginUserStatePath,
         div: $('##{runtimeDiv}')[0]
       }
       console.log("Adding script #{plugin.label} with V2 LARA Plugin API")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,5 +157,6 @@ en:
     DELETE: "Delete"
     ADD: "Add Plugin"
     APPROVED_SCRIPT: "Approved Plugin:"
+    GLOBAL_ID: "Plugin Identifier"
     DESCRIPTION: "Description:"
     AUTHORING_DATA: "Authoring Data:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,6 +173,11 @@ LightweightStandalone::Application.routes.draw do
       match "user_check" => 'user_check#index', defaults: { format: 'json' }
 
       match 'get_firebase_jwt/:run_id' => 'jwt#get_firebase_jwt', :as => 'get_firebase_jwt', :via => 'post'
+
+      match 'plugin_learner_states/:plugin_id/:run_id' =>
+        'plugin_learner_states#load', as: 'show_plugin_learner_state', via: 'get'
+      match 'plugin_plugin_learner_state/:plugin_id/:run_id' =>
+        'plugin_learner_states#save', as: 'update_plugin_learner_state', via: 'put'
     end
   end
 

--- a/docs/lara-plugin-api.md
+++ b/docs/lara-plugin-api.md
@@ -104,12 +104,12 @@ type IEventListeners = IEventListener | IEventListener[];
 
 
 /****************************************************************************
-@function saveUserState: Ask lara to save the users state for the plugin
+@function saveLearnerState: Ask lara to save the users state for the plugin
 @arg {ILaraPluginRef} pluginInstance - The plugin trying to save data
 @arg {string} state - A JSON string representing serialized plugin state.
 @returns Promise
 ****************************************************************************/
-LARA.saveUserState = function(pluginInstance: ILaraPluginRef, state: string): Promise;
+LARA.saveLearnerState = function(pluginInstance: ILaraPluginRef, state: string): Promise;
 
 ```
 

--- a/jest/lara-api.spec.js
+++ b/jest/lara-api.spec.js
@@ -68,36 +68,31 @@ describe("LARA API", () => {
     const plugin = jest.fn()
     const state = JSON.toString({this: "is a test"});
 
+    let pluginFunction = jest.fn((plugin,state) => Promise.resolve(state))
+    beforeEach(()=> global.Plugins= { saveLearnerPluginState: pluginFunction})
+
     it("should exist", () => {
       expect(LARA.saveLearnerPluginState).toBeDefined();
     })
 
-    describe("when the global PluginApiis NOT available", () => {
-      it("should return a promise with a rejection", () => {
-        expect.assertions(1);
-        return LARA.saveLearnerPluginState(plugin, state)
-          .then((d) => {throw new Error("learner state should not be saved")})
-          .catch((e) => expect(e).toMatch("fail"))
+    it("should deligate the function to Plugins", () => {
+      expect.assertions(2);
+      return LARA.saveLearnerPluginState(plugin, state)
+        .then((d) => {
+          expect(d).toMatch(state)
+          expect(pluginFunction).toHaveBeenCalledTimes(1)
       })
     })
 
-    describe("when the global PluginApi IS available", () => {
-      const pluginFunction = jest.fn((plugin,state) => {
-        return Promise.resolve(state);
-      })
-      beforeEach(() => {
-        window.Plugins= {
-          saveLearnerPluginState: pluginFunction
-        }
-      })
-      it("should delegate saving to the plugin API", () => {
-        expect.assertions(4);
+    describe("when saving fails", () => {
+      let pluginFunction = jest.fn((plugin,state) => Promise.reject("fail"))
+      beforeEach(()=> global.Plugins= { saveLearnerPluginState: pluginFunction})
+      it("should throw an exception", () => {
+        expect.assertions(2);
         return LARA.saveLearnerPluginState(plugin, state)
-          .then((d) =>  {
-            expect(d).toMatch(state)
+          .catch((e) => {
+            expect(e).toMatch("fail")
             expect(pluginFunction).toHaveBeenCalledTimes(1)
-            expect(pluginFunction.mock.calls[0][0]).toBe(plugin)
-            expect(pluginFunction.mock.calls[0][1]).toBe(state)
           })
       })
     })
@@ -106,43 +101,17 @@ describe("LARA API", () => {
   describe("#registerPlugin", () => {
     const plugin = jest.fn()
     const label  = 'fakePlugin'
-    let pluginFunction = jest.fn((plugin,state) => false)
 
+    let pluginFunction = jest.fn((plugin,state) => true)
+    beforeEach(()=> global.Plugins= { registerPlugin: pluginFunction})
     it("should exist", () => {
       expect(LARA.registerPlugin).toBeDefined();
     })
 
-    describe("when the global PluginApiis NOT available", () => {
-      it("should fail", () => {
-        expect(LARA.registerPlugin(label, plugin)).toBe(false);
-      })
+    it("should deligate to Plugin", () => {
+      expect(LARA.registerPlugin(label, plugin)).toBeTruthy()
+      expect(pluginFunction).toHaveBeenCalledTimes(1)
     })
 
-    describe("when the global PluginApi IS available", () => {
-      beforeEach(() => {
-        pluginFunction = jest.fn((plugin,state) => true);
-        window.Plugins= {
-          registerPlugin: pluginFunction
-        }
-      })
-      describe("when the Plugin registration succeeds", () => {
-        it("should delegate registration to the PluginsApi", () => {
-          expect(LARA.registerPlugin(label, plugin)).toBe(true);
-          expect(pluginFunction).toHaveBeenCalledTimes(1);
-        })
-      })
-      describe("when the Plugin registration fails", () => {
-        beforeEach(() => {
-          pluginFunction = jest.fn((plugin,state) => false);
-          window.Plugins= {
-            registerPlugin: pluginFunction
-          }
-        })
-        it("should delegate registration to the PluginsApi", () => {
-          expect(LARA.registerPlugin(label, plugin)).toBe(false);
-          expect(pluginFunction).toHaveBeenCalledTimes(1);
-        })
-      })
-    })
   })
 })

--- a/jest/plugins.spec.js
+++ b/jest/plugins.spec.js
@@ -1,0 +1,89 @@
+// Manually setup dependencies for LARA API... For now, it's only jQuery and jQuery UI.
+// It's still possible, I'm not sure if it's possible long term. If it's only an interim solution,
+// a good side effect is that it documents dependencies for given module. It might get too annoying though.
+// Writing tests in Jest is awesome, but it requires proper setup of the JS code and dependencies management.
+const $ = require("../app/assets/javascripts/jquery-2.2.4");
+global.$ = $;
+global.jQuery = $;
+require("../app/assets/javascripts/plugins");
+
+describe("Plugins", () => {
+
+  it("should exist", () => {
+    expect(Plugins).toBeDefined();
+  })
+
+  describe("initPlugin", () => {
+    const learnerData = '{"answered": true }'
+    const authorData  = '{"configured": true }'
+    const name = 'myPlugin'
+    const div = '<div classname="myplugin" />'
+    const savePath = 'save/1/2'
+    const loadPath = 'load/1/2'
+
+    const pluginStatePaths = {
+      savePath: savePath,
+      loadPath: loadPath
+    }
+    const pluginConstructor = jest.fn()
+
+    const config = {
+      name: name,
+      url: "http://google.com/",
+      pluginId: name,
+      authorData: authorData,
+      learnerData: learnerData,
+      div: div
+    }
+    beforeAll(() => {
+      // Implicit test of registerPlugin
+      Plugins.registerPlugin(name,pluginConstructor)
+      Plugins.initPlugin(name, config, pluginStatePaths)
+    })
+
+    it('should call the plugins constructor with the config', () => {
+      expect(pluginConstructor).toHaveBeenCalledTimes(1)
+      expect(pluginConstructor).toHaveBeenCalledWith(config)
+    })
+    it('should maintain a list of plugins', () => {
+      expect(Plugins._pluginLabels).toContain(name)
+      expect(Plugins._pluginStatePaths[name]).toEqual(pluginStatePaths)
+      expect(Plugins._pluginClasses[name]).toEqual(pluginConstructor)
+    })
+
+    describe("saveLearnerPluginState", () => {
+      const state = '{"new": "state"}'
+      let ajax  = jest.fn()
+      beforeEach(()=> {
+        ajax = jest.fn((opts) => {
+          opts.success(state)
+        })
+        global.$.ajax = ajax
+      })
+
+      describe("When save succeeds", () => {
+        it('should save data', () => {
+          expect.assertions(1)
+          return Plugins.saveLearnerPluginState(name, state)
+            .then((d) => expect(d).toEqual(state))
+        })
+      })
+
+      describe("When save fails", () => {
+        beforeEach(()=> {
+          ajax = jest.fn((opts) => {
+            opts.error("jqXHR","error","boom")
+          })
+          global.$.ajax = ajax
+        })
+        it('should save data', () => {
+          expect.assertions(1)
+          return Plugins.saveLearnerPluginState(name, state)
+            .catch((e) => expect(e).toEqual("boom"))
+        })
+      })
+
+    })
+  })
+
+});

--- a/spec/controllers/api/v1/plugin_learner_states_controller_spec.rb
+++ b/spec/controllers/api/v1/plugin_learner_states_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+def json_response_body
+  return JSON.parse(response.body)
+end
+
+describe Api::V1::PluginLearnerStatesController do
+  let(:plugin_id)     { 400 }
+  let(:run_id)        { 442 }
+
+  let(:user_opts) do
+    { id: 42}
+  end
+
+  let(:run_opts) do
+    {
+      id: run_id,
+      user: user
+    }
+  end
+
+  let(:plugin_opts) do
+    {
+      id: plugin_id,
+      shared_learner_state_key: nil
+    }
+  end
+
+  let(:user)   { double("User",   user_opts) }
+  let(:run)    { double("Run",    run_opts) }
+  let(:plugin) { double("Plugin", plugin_opts) }
+  let(:state)  { 'state_value' }
+
+  before(:each) do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(Run).to receive(:find).and_return(run)
+    allow(Plugin).to receive(:find).and_return(plugin)
+    pstate = PluginLearnerState.find_or_create(plugin, run)
+    pstate.update_attribute(:state, state)
+  end
+
+  describe 'load' do
+    it "should load data" do
+      post :load, run_id: run_id, plugin_id: plugin_id
+      expect(response.status).to eq(200)
+      expect(json_response_body['state']).to eq("state_value")
+    end
+  end
+  
+  describe 'save' do
+    it "should save data, and return the same data" do
+      post :save, run_id: run_id, plugin_id: plugin_id, state: "new_state"
+      expect(response.status).to eq(200)
+      expect(json_response_body['state']).to eq("new_state")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds routes and controllers to save the PluginLearnerState.

A few strange thing:  

* The API changed.  In the GlossaryPlugin the function name for saving plugin data changed to `saveLearnerState` which actually seems like a better name.  So I changed it in LARA to match.
 
* When the plugin is registered and initialized, we save some configuration details in `__LaraPluginContext ` of the Plugin instance that is returned.  This is a gross violation of many expectations and norms.  Eventually I would prefer that we initialize the Plugin with customized API object instead.


It covers this PT Story: [#160096573](https://www.pivotaltracker.com/story/show/160096573)

> A Plugin can save and load user state (on page load) using the Lara Plugin API.
