### PR TITLE
LARA.save(Learner/Plugin)State: change plugin reference to plugin id

### DIFF
--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -144,25 +144,25 @@ window.LARA = {
   @deprecated saveLearnerState
   @see savePluginState
   ****************************************************************************/
-  saveLearnerState: function (pluginInstance, state) {
+  saveLearnerState: function (pluginId, state) {
     var deprication =
       'saveLearnerState is depricated, use `savePluginState` instead'
     console.warn(deprication);
-    this.savePluginState(pluginInstance, state);
+    this.savePluginState(pluginId, state);
   },
 
   /****************************************************************************
    @function savePluginState: Ask LARA to save the users state for the plugin
-   @arg {ILaraPluginRef} pluginInstance - The plugin trying to save data
+   @arg {string} pluginId - ID of the plugin trying to save data, initially passed to plugin constructor in the context
    @arg {string} state - A JSON string representing serialized plugin state.
    @example
     LARA.savePluginState(plugin, '{"one": 1}').then((data) => console.log(data))
    @returns Promise
   ****************************************************************************/
-  savePluginState: function (pluginInstance, state) {
+  savePluginState: function (pluginId, state) {
     var pluginsApi = window.Plugins;
     if (pluginsApi && typeof pluginsApi.savePluginState === 'function') {
-      return pluginsApi.savePluginState(pluginInstance, state);
+      return pluginsApi.savePluginState(pluginId, state);
     }
     return new Promise( function(resolve, reject) {
       reject('window.Plugins not defined. savePluginState failed.')

--- a/app/assets/javascripts/plugins.js
+++ b/app/assets/javascripts/plugins.js
@@ -44,14 +44,13 @@ window.Plugins = {
   ****************************************************************************/
   initPlugin: function(label, runtimeContext, pluginStatePaths) {
     var constructor = this._pluginClasses[label];
-    var config = {};
     var plugin = null;
     if (typeof constructor === 'function') {
       try {
         plugin = new constructor(runtimeContext);
         this._plugins.push(plugin);
         this._pluginLabels.push(label);
-        this._pluginStatePaths[plugin] = pluginStatePaths;
+        this._pluginStatePaths[runtimeContext.pluginId] = pluginStatePaths;
       }
       catch(e) { this._pluginError(e, runtimeContext); }
       console.info('Plugin', label, 'is now registered');
@@ -63,16 +62,16 @@ window.Plugins = {
 
   /****************************************************************************
    @function savePluginState: Ask LARA to save the users state for the plugin
-   @arg {ILaraPluginRef} pluginInstance - The plugin trying to save data
+   @arg {string} pluginId - ID of the plugin trying to save data, initially passed to plugin constructor in the context
    @arg {string} state - A JSON string representing serialized plugin state.
 
    @example
-    LARA.savePluginState(plugin, '{"one": 1}').then((data) => console.log(data))
+    LARA.savePluginState(pluginId, '{"one": 1}').then((data) => console.log(data))
 
    @returns Promise resolve: <string>
   ****************************************************************************/
-  savePluginState: function(pluginInstance, state) {
-    var paths = this._pluginStatePaths[pluginInstance];
+  savePluginState: function(pluginId, state) {
+    var paths = this._pluginStatePaths[pluginId];
     if(paths && paths.savePath) {
       return new Promise(function(resolve, reject) {
         $.ajax({
@@ -85,7 +84,7 @@ window.Plugins = {
       });
     }
     else {
-      console.warn('Not saved.`pluginStatePaths` missing for' , pluginInstance);
+      console.warn('Not saved.`pluginStatePaths` missing for plugin ID:' , pluginId);
     }
   },
 


### PR DESCRIPTION
@knowuh, this is a tiny PR against your recent branch.

I was naively thinking that passing plugin reference will help, as the plugin won't need to care about ID. It would work like this if the plugin was always just one class. If plugin creates some helper classes and some hierarchy of them, it needs to pass down its own instance (`this`) so helpers can later use it to call LARA API. Passing around this instance awkward and can cause that child classes will start calling parent directly (because they can if they have a reference). So, instead of passing `this` / reference, just pass regular ID string. Feels more natural. 