### PR TITLE
160129986 responsive layout question column 320px

### DIFF
--- a/app/assets/stylesheets/partials/_responsive-layout.scss
+++ b/app/assets/stylesheets/partials/_responsive-layout.scss
@@ -46,7 +46,7 @@
   .question {
     display: block;
     vertical-align: top;
-    width: 250px;
+    width: 320px;
   }
 
   .embeddables {

--- a/app/assets/stylesheets/partials/_runtime-interactives.scss
+++ b/app/assets/stylesheets/partials/_runtime-interactives.scss
@@ -58,6 +58,9 @@
 .question {
   margin: 0 0 20px;
   @extend .cf;
+  .question-txt {
+    overflow: hidden;
+  }
   .answer_text {
     font-style: italic;
     font-size: 0.9em;

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -284,6 +284,9 @@ button.disabled, .btn-primary.disabled, span.edit_trigger.disabled {
     font-weight: bold;
     margin-top: 1em;
   }
+  .prompt {
+    overflow: hidden;
+  }
 }
 .questions.full-width {
   .embeddable {


### PR DESCRIPTION
As per this PT story: https://www.pivotaltracker.com/story/show/160129986

This PR is a simple style change for responsive layout.   We change the fixed-width question column from 250px to 320px in 850bd59.

I also added an content overflow fix in 84fff53.

It wasn't part of the request story, but it was simple to fix, and seemed related.

This is such a small PR I assigned it to both @scytacki  and @dougmartin 

But seriously -- if you can think of any reason a question-prompt should be allowed to overflow, let me know.  That is the main reason I am looking  for a review at all.