### PR TITLE
Copy publication status

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -78,12 +78,12 @@ class LightweightActivity < ActiveRecord::Base
 
   def to_hash
     # We're intentionally not copying:
-    # - Publication status (the copy should start as draft like everything else)
     # - user_id (the copying user should be the owner)
     # - Pages (associations will be done differently)
     {
       name: name,
       related: related,
+      publication_status: publication_status,
       description: description,
       time_to_complete: time_to_complete,
       project_id: project_id,

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -41,12 +41,12 @@ class Sequence < ActiveRecord::Base
 
   def to_hash
     # We're intentionally not copying:
-    # - publication status (the copy should start as draft like everything else)
     # - is_official (defaults to false, can be changed)
     # - user_id (the copying user should be the owner)
     {
       title: title,
       description: description,
+      publication_status: publication_status,
       abstract: abstract,
       theme_id: theme_id,
       project_id: project_id,

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -170,7 +170,20 @@ describe LightweightActivity do
 
   describe '#to_hash' do
     it 'returns a hash with relevant values for activity duplication' do
-      expected = { name: activity.name, related: activity.related, :external_report_url => nil, :student_report_enabled => true, description: activity.description, time_to_complete: activity.time_to_complete, project_id: activity.project_id, theme_id: activity.theme_id, thumbnail_url: activity.thumbnail_url, notes: activity.notes, layout: activity.layout, editor_mode: activity.editor_mode }
+      expected = {
+        name: activity.name,
+        related: activity.related,
+        publication_status: activity.publication_status,
+        external_report_url: nil,
+        student_report_enabled: true,
+        description: activity.description,
+        time_to_complete: activity.time_to_complete,
+        project_id: activity.project_id,
+        theme_id: activity.theme_id,
+        thumbnail_url: activity.thumbnail_url,
+        notes: activity.notes,
+        layout: activity.layout,
+        editor_mode: activity.editor_mode }
       expect(activity.to_hash).to eq(expected)
     end
   end

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 describe Sequence do
   let (:user) { FactoryGirl.create(:user) }
   let (:sequence_opts) { {} }
-  let (:sequence) { 
+  let (:sequence) {
       sequence = FactoryGirl.create(:sequence, sequence_opts)
       sequence.user = user
       sequence.save
       sequence
     }
-  let (:activity1) { 
+  let (:activity1) {
      activity = FactoryGirl.create(:activity, :time_to_complete => 45)
      activity.user = user
      activity.save
      activity
     }
-  let (:activity2) { 
+  let (:activity2) {
      activity = FactoryGirl.create(:activity, :time_to_complete => 40)
      activity.user = user
      activity.save
@@ -75,17 +75,17 @@ describe Sequence do
     let(:user) { FactoryGirl.create(:user) }
     let(:report_url)    { "https://foo.bar.report/" }
     let(:sequence_opts) { {external_report_url: report_url } }
-    let(:act1) { 
+    let(:act1) {
       activity = FactoryGirl.build(:activity_with_page)
       activity.user = user
       activity.save
       activity
     }
-    let(:act2) { 
+    let(:act2) {
       activity = FactoryGirl.build(:activity_with_page)
       activity.user = user
       activity.save
-      activity 
+      activity
     }
     let(:sequence_with_activities) do
       seq = FactoryGirl.build(:sequence, sequence_opts)
@@ -179,7 +179,7 @@ describe Sequence do
       sequence_json = JSON.parse(sequence.export)
       expect(sequence_json['activities'].length).to eq(sequence.activities.count)
       expect(sequence_json['external_report_url']).to eq(report_url)
-    end 
+    end
   end
 
   describe '#import' do
@@ -202,23 +202,23 @@ describe Sequence do
     let(:report_url)    { "https://reports.concord.org/" }
     let(:sequence_opts) { { external_report_url: report_url} }
     let(:owner)         { FactoryGirl.create(:user) }
-    let(:act1) { 
+    let(:act1) {
       activity = FactoryGirl.build(:activity_with_page)
       activity.user = owner
       activity.save
-      activity 
+      activity
     }
-    let(:act2) { 
+    let(:act2) {
       activity = FactoryGirl.build(:activity_with_page)
       activity.user = owner
       activity.save
-      activity 
+      activity
     }
-    let(:act3) { 
+    let(:act3) {
       activity = FactoryGirl.build(:activity_with_page)
       activity.user = owner
       activity.save
-      activity 
+      activity
     }
     let(:sequence_with_activities) do
       seq = FactoryGirl.build(:sequence)

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -156,9 +156,17 @@ describe Sequence do
     let(:report_url)    { "https://foo.bar.report/" }
     let(:sequence_opts) { {external_report_url: report_url } }
     it 'returns a hash with relevant values for sequence duplication' do
-      expected = { title: sequence.title, description: sequence.description, abstract: sequence.abstract, theme_id: sequence.theme_id, project_id: sequence.project_id,
-                   logo: sequence.logo, display_title: sequence.display_title, thumbnail_url: sequence.thumbnail_url,
-                   external_report_url: report_url
+      expected = {
+        title: sequence.title,
+        description: sequence.description,
+        publication_status: sequence.publication_status,
+        abstract: sequence.abstract,
+        theme_id: sequence.theme_id,
+        project_id: sequence.project_id,
+        logo: sequence.logo,
+        display_title: sequence.display_title,
+        thumbnail_url: sequence.thumbnail_url,
+        external_report_url: report_url
       }
       expect(sequence.to_hash).to eq(expected)
     end


### PR DESCRIPTION
This fixes some long running issues in LARA by relaxing some rules.

Previously we tried to keep the publication_status in LARA private as much as possible and authors always had to explicitly make the activities public. This way an author would not expose something they didn't intend.  However in practice this hasn't been worth the problems it causes. In almost all cases authors are fine with their activities being public. It is only in rare cases they want them to be truly private.

In terms of code what we previously did was to not copy the publication status and use the default for activities which is 'private'.  What we do in this PR is to copy the publication status.

In terms of user experience:

This solves a long running issue: An author would copy a sequence. Then the would see the sequence is public and thing everything was fine. But actually all of the copied activities would be private. Now if the activities of the original are public then the copy will also be public.

Also if an activity is private in LARA students from the portal can not run it. In ITSI authoring mode the publicaton_status is not exposed. So for ITSI teachers after they copy activities they wouldn't be able to make them public for the students to run them. And even if they could make them public they probably wouldn't realize they needed to.