### PR TITLE
Changes to Interactive Iframe Layout

### DIFF
--- a/app/assets/javascripts/components/authoring/mw_interactive.js.coffee
+++ b/app/assets/javascripts/components/authoring/mw_interactive.js.coffee
@@ -42,8 +42,9 @@ modulejs.define 'components/authoring/mw_interactive',
     handleSupportedFeatures: (info) ->
       @setState {authoringSupported: !!info.features.authoredState}
       if (info.features.aspectRatio?)
-        iframe = ReactDOM.findDOMNode(@interactive.current)
-        iframe.style.height = Math.round(iframe.offsetWidth / info.features.aspectRatio) + 'px'
+        if (@props.interactive.aspect_ratio_method == "DEFAULT")
+          iframe = ReactDOM.findDOMNode(@interactive.current)
+          iframe.style.height = Math.round(iframe.offsetWidth / info.features.aspectRatio) + 'px'
 
     save: ->
       data = {

--- a/app/assets/javascripts/components/common/aspect_ratio_chooser.js.coffee
+++ b/app/assets/javascripts/components/common/aspect_ratio_chooser.js.coffee
@@ -2,10 +2,8 @@
 
 modulejs.define 'components/common/aspect_ratio_chooser', [], () ->
 
-  SpecialNumericField = createReactClass
-
+  FormattedField = createReactClass
     getDefaultProps: ->
-      disabled: true
       inputWidth: '3em'
       value: 10
       label: 'input'
@@ -21,7 +19,6 @@ modulejs.define 'components/common/aspect_ratio_chooser', [], () ->
     value: ->
       (input {
         value: @props.value,
-        disabled: @props.disabled,
         onChange: @props.onChange,
         style: {
           width: @props.inputWidth
@@ -37,7 +34,7 @@ modulejs.define 'components/common/aspect_ratio_chooser', [], () ->
         @value()
       )
 
-  numerberInput = React.createFactory SpecialNumericField
+  numberInput = React.createFactory FormattedField
 
   AspectRatioChooser = createReactClass
 
@@ -58,48 +55,46 @@ modulejs.define 'components/common/aspect_ratio_chooser', [], () ->
         {key: 'MAX', value: "Use all available space for the interactive …"}
       ]
 
-      updateValues: (newValues) ->
-        console.log(newValues)
+      updateValues: (newValues) -> console.log(newValues)
 
+    # Update the internal state, then call this.props.updateValues(state)
     myUpdate: (changes) ->
       @setState(changes)
       delayedUpdate = () =>
         @props.updateValues(@state)
-
-      setTimeout(delayedUpdate,1)
+      # Wait for the end of the event loop:
+      setTimeout(delayedUpdate, 1)
 
     render: ->
       { mode, width, height } = @state
       { availableAspectRatios } = @props
-      disabledInputs = if mode == 'MANUAL' then false else true
+      enabledInputs = if mode == 'MANUAL' then true else false
       inputStyle =
         'display': 'flex'
         'flex-direction': 'row'
         'flex-wrap': 'wrap'
         'margin-right': '0.5em'
-        'opacity': if disabledInputs then '0.5' else '1.0'
-      (div {style: {'padding': '1em', 'background-color': 'hsl(0,0%,95%'}},
+      (div {style: {'display': 'flex', 'flex-direction': 'row', 'padding': '0.5em'}},
         (select {
             style:{'margin': '.2em'}
             onChange: (e) => @myUpdate(mode: e.target.value)
           },
           availableAspectRatios.map (m) ->
             (option {value:m.key, label:m.value, selected: m.key==mode} )
-
         )
-        (div {style: inputStyle},
-          (numerberInput {
-            disabled: disabledInputs
-            value: width,
-            label: 'width'
-            onChange: (e) => @myUpdate({width: e.target.value})
-          })
-          (numerberInput {
-            disabled: disabledInputs
-            value: height,
-            label: 'height',
-            onChange: (e) => @myUpdate({height: e.target.value})
-          })
-        )
+        if enabledInputs
+          (div {style: inputStyle},
+            (numberInput {
+              value: width,
+              label: 'width'
+              onChange: (e) => @myUpdate({width: e.target.value})
+            })
+            (numberInput {
+              value: height,
+              label: 'height',
+              onChange: (e) => @myUpdate({height: e.target.value})
+            })
+          )
+        else ""
       )
 

--- a/app/assets/javascripts/components/common/aspect_ratio_chooser.js.coffee
+++ b/app/assets/javascripts/components/common/aspect_ratio_chooser.js.coffee
@@ -1,0 +1,105 @@
+{div, input, label, br, select, option} = ReactFactories
+
+modulejs.define 'components/common/aspect_ratio_chooser', [], () ->
+
+  SpecialNumericField = createReactClass
+
+    getDefaultProps: ->
+      disabled: true
+      inputWidth: '3em'
+      value: 10
+      label: 'input'
+
+    label: ->
+      (label {style:{
+          'text-align': 'right'
+          'padding': '0.2em'
+        }},
+        @props.label
+      )
+
+    value: ->
+      (input {
+        value: @props.value,
+        disabled: @props.disabled,
+        onChange: @props.onChange,
+        style: {
+          width: @props.inputWidth
+        }
+      })
+
+    render: ->
+      (div {style: {
+        'display': 'flex'
+        'flex-direction': 'row'
+        }} ,
+        @label()
+        @value()
+      )
+
+  numerberInput = React.createFactory SpecialNumericField
+
+  AspectRatioChooser = createReactClass
+
+    getInitialState: ->
+      width:  @props.initialState.width
+      height: @props.initialState.height
+      mode: @props.initialState.mode
+
+    getDefaultProps: ->
+      initialState:
+        width: 10,
+        height: 10,
+        mode: 'DEFAULT'
+
+      availableAspectRatios: [
+        {key: 'DEFAULT', value: "Default aspect ratio, or set by interactive …"},
+        {key: 'MANUAL', value: "Manually set the native width & height …"},
+        {key: 'MAX', value: "Use all available space for the interactive …"}
+      ]
+
+      updateValues: (newValues) ->
+        console.log(newValues)
+
+    myUpdate: (changes) ->
+      @setState(changes)
+      delayedUpdate = () =>
+        @props.updateValues(@state)
+
+      setTimeout(delayedUpdate,1)
+
+    render: ->
+      { mode, width, height } = @state
+      { availableAspectRatios } = @props
+      disabledInputs = if mode == 'MANUAL' then false else true
+      inputStyle =
+        'display': 'flex'
+        'flex-direction': 'row'
+        'flex-wrap': 'wrap'
+        'margin-right': '0.5em'
+        'opacity': if disabledInputs then '0.5' else '1.0'
+      (div {style: {'padding': '1em', 'background-color': 'hsl(0,0%,95%'}},
+        (select {
+            style:{'margin': '.2em'}
+            onChange: (e) => @myUpdate(mode: e.target.value)
+          },
+          availableAspectRatios.map (m) ->
+            (option {value:m.key, label:m.value, selected: m.key==mode} )
+
+        )
+        (div {style: inputStyle},
+          (numerberInput {
+            disabled: disabledInputs
+            value: width,
+            label: 'width'
+            onChange: (e) => @myUpdate({width: e.target.value})
+          })
+          (numerberInput {
+            disabled: disabledInputs
+            value: height,
+            label: 'height',
+            onChange: (e) => @myUpdate({height: e.target.value})
+          })
+        )
+      )
+

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -48,6 +48,8 @@ class IFrameSaver
     @get_firebase_jwt_url = $data_div.data('get-firebase-jwt-url')
 
     @save_indicator = SaveIndicator.instance()
+    @optionally_resize()
+    window.addEventListener('resize', ()=> @optionally_resize() )
 
     @$delete_button.click () =>
       @delete_data()
@@ -64,6 +66,13 @@ class IFrameSaver
 
   @default_success: ->
     console.log "saved"
+
+  optionally_resize: () ->
+    resizeMethod = @$iframe.data('aspect-ratio-method')
+    if resizeMethod == 'MAX'
+      magicNumber = 125
+      newHeight = window.innerHeight - magicNumber
+      @$iframe.attr('height', newHeight)
 
   phone_answered: ->
     # Workaround IframePhone problem - phone_answered cabllack can be triggered multiple times:

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -82,9 +82,12 @@ class IFrameSaver
       @iframePhone.post('authInfo', authInfo)
     @iframePhone.addListener 'supportedFeatures', (info) =>
       if info.features?.aspectRatio?
-        # Iframe can provide suggested aspect-ratio.
-        @$iframe.data('aspect-ratio', info.features.aspectRatio)
-        @$iframe.trigger('sizeUpdate')
+        # If the author specifies the aspect-ratio-method as "DEFAULT"
+        # then the Interactive can provide suggested aspect-ratio.
+        if(@$iframe.data('aspect-ratio-method') == "DEFAULT")
+          @$iframe.data('aspect-ratio', info.features.aspectRatio)
+          @$iframe.trigger('sizeUpdate')
+
     @iframePhone.addListener 'navigation', (opts={})=>
       if opts.hasOwnProperty('enableForwardNav')
         if opts.enableForwardNav

--- a/app/assets/javascripts/iframe-saver.coffee
+++ b/app/assets/javascripts/iframe-saver.coffee
@@ -48,8 +48,6 @@ class IFrameSaver
     @get_firebase_jwt_url = $data_div.data('get-firebase-jwt-url')
 
     @save_indicator = SaveIndicator.instance()
-    @optionally_resize()
-    window.addEventListener('resize', ()=> @optionally_resize() )
 
     @$delete_button.click () =>
       @delete_data()
@@ -66,13 +64,6 @@ class IFrameSaver
 
   @default_success: ->
     console.log "saved"
-
-  optionally_resize: () ->
-    resizeMethod = @$iframe.data('aspect-ratio-method')
-    if resizeMethod == 'MAX'
-      magicNumber = 125
-      newHeight = window.innerHeight - magicNumber
-      @$iframe.attr('height', newHeight)
 
   phone_answered: ->
     # Workaround IframePhone problem - phone_answered cabllack can be triggered multiple times:

--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -5,17 +5,22 @@ function interactiveSizing () {
     var $iframe = $(this);
     var aspectRatio = $iframe.data('aspect-ratio');
     var resizeMethod = $iframe.data('aspect-ratio-method');
-    var currWidth = $iframe.width();
+    var magicNumber = 125;
+    var maxHeight = window.innerHeight - magicNumber;
 
     if(resizeMethod === 'MAX') {
-      magicNumber = 125;
-      newHeight = window.innerHeight - magicNumber;
-      $iframe.attr('height', newHeight);
+      $iframe.height(maxHeight);
+      $iframe.attr('width', '100%');
     }
     else {
-      $iframe.attr('height', currWidth / aspectRatio);
+      $iframe.attr('width', '100%');
+      $iframe.height($iframe.width() / aspectRatio);
+      if ($iframe.height() > maxHeight) {
+        var scale = maxHeight / $iframe.height();
+        $iframe.attr('width', scale * 100 + '%');
+        $iframe.height(maxHeight);
+      }
     }
-    $iframe.attr('width', '100%');
   }
 
   $('[data-aspect-ratio]').each(function () {
@@ -23,6 +28,7 @@ function interactiveSizing () {
     $iframe.on('sizeUpdate', setSize);
     $iframe.trigger('sizeUpdate');
   });
+
 }
 
 $(document).ready(interactiveSizing);

--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -4,9 +4,18 @@ function interactiveSizing () {
   function setSize () {
     var $iframe = $(this);
     var aspectRatio = $iframe.data('aspect-ratio');
-    var currWidth = $iframe.width()
+    var resizeMethod = $iframe.data('aspect-ratio-method');
+    var currWidth = $iframe.width();
+
+    if(resizeMethod === 'MAX') {
+      magicNumber = 125;
+      newHeight = window.innerHeight - magicNumber;
+      $iframe.attr('height', newHeight);
+    }
+    else {
+      $iframe.attr('height', currWidth / aspectRatio);
+    }
     $iframe.attr('width', '100%');
-    $iframe.attr('height', currWidth / aspectRatio);
   }
 
   $('[data-aspect-ratio]').each(function () {

--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -75,6 +75,7 @@ module InteractiveRunHelper
 
     data = {
       :aspect_ratio => interactive.aspect_ratio,
+      :aspect_ratio_method => interactive.aspect_ratio_method,
       :id => interactive.id,
       :iframe_mouseover => "false"
     }

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -40,6 +40,15 @@ class MwInteractive < ActiveRecord::Base
     "iframe interactive"
   end
 
+  def available_aspect_ratios
+    [
+      MwInteractive::ASPECT_RATIO_DEFAULT_METHOD,
+      MwInteractive::ASPECT_RATIO_MANUAL_METHOD,
+      MwInteractive::ASPECT_RATIO_MAX_METHOD
+    ].map do |key|
+      { key: key, value: I18n.t("INTERACTIVE.ASPECT_RATIO.#{key}") }
+    end
+  end
   # returns the aspect ratio of the interactive, dividing the width by the height.
   # For an interactive with a native width of 400 and native height of 200,
   # the aspect_ratio will be 2.

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -68,12 +68,7 @@ class MwInteractive < ActiveRecord::Base
   end
 
   def height(avail_width, avail_height=nil)
-    case self.aspect_ratio
-      when ASPECT_RATIO_MAX_METHOD
-        return avail_width / aspect_ratio(avail_width, avail_height)
-      else
-        return avail_width / self.aspect_ratio(avail_width, avail_height)
-    end
+    return avail_width / aspect_ratio(avail_width, avail_height)
   end
 
   def to_hash

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -9,14 +9,13 @@
     = f.text_field :name
   = field_set_tag 'URL' do
     = f.text_area :url, size: "45x4"
-  = field_set_tag 'Dimensions' do
-    = f.label :native_width, 'Width'
-    = f.text_field :native_width
+
+  = field_set_tag 'Aspect Ratio' do
+    %div{id:"aspect_ratio"}
+    = f.hidden_field :native_width,  :id => 'width'
+    = f.hidden_field :native_height, :id => 'height'
+    = f.hidden_field :aspect_ratio_method, :id => 'method'
     .clear
-    = f.label :native_height, 'Height'
-    = f.text_field :native_height
-    .clear
-    This width and height will be used to maintain a fixed aspect ratio for the interactive.
   %br
   = f.label :click_to_play, 'Click to play'
   = f.check_box :click_to_play, :id => "click_to_play_#{@interactive.id}"
@@ -110,4 +109,23 @@
     }
 
     $("#click_to_play_#{@interactive.id}").click(click_to_play);
+
+    var available_ratios = #{@interactive.available_aspect_ratios.to_json}
+    var props = {
+      initialState: {
+        width: "#{@interactive.native_width}",
+        height: "#{@interactive.native_height}",
+        mode: "#{@interactive.aspect_ratio_method}"
+      },
+      availableAspectRatios: available_ratios,
+      updateValues: function(aspect_ratio_values) {
+        $('#width').val( aspect_ratio_values.width);
+        $('#height').val(aspect_ratio_values.height);
+        $('#method').val(aspect_ratio_values.mode);
+      }
+    };
+
+    Chooser = React.createElement(modulejs.require('components/common/aspect_ratio_chooser'), props);
+    ReactDOM.render(Chooser, $("#aspect_ratio")[0]);
+
   });

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -12,8 +12,8 @@
 
   = field_set_tag 'Aspect Ratio' do
     %div{id:"aspect_ratio"}
-    = f.hidden_field :native_width,  :id => 'mw_interactive_native_width'
-    = f.hidden_field :native_height, :id => 'mw_interactive_native_height'
+    = f.hidden_field :native_width,  :id => 'width'
+    = f.hidden_field :native_height, :id => 'height'
     = f.hidden_field :aspect_ratio_method, :id => 'method'
     .clear
   %br

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -12,8 +12,8 @@
 
   = field_set_tag 'Aspect Ratio' do
     %div{id:"aspect_ratio"}
-    = f.hidden_field :native_width,  :id => 'width'
-    = f.hidden_field :native_height, :id => 'height'
+    = f.hidden_field :native_width,  :id => 'mw_interactive_native_width'
+    = f.hidden_field :native_height, :id => 'mw_interactive_native_height'
     = f.hidden_field :aspect_ratio_method, :id => 'method'
     .clear
   %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,3 +160,8 @@ en:
     GLOBAL_ID: "Plugin Identifier"
     DESCRIPTION: "Description:"
     AUTHORING_DATA: "Authoring Data:"
+  INTERACTIVE:
+    ASPECT_RATIO:
+      DEFAULT: 'Default aspect ratio, or set by interactive.'
+      MANUAL: 'Manually set the aspect ratio.'
+      MAX: 'Use all available space.'

--- a/spec/controllers/mw_interactives_controller_spec.rb
+++ b/spec/controllers/mw_interactives_controller_spec.rb
@@ -34,8 +34,8 @@ describe MwInteractivesController do
 
           expect(response.body).to match /<input[^<]+id="mw_interactive_name"[^<]+name="mw_interactive\[name\]"[^<]+type="text"[^>]+value="#{int.name}"[^<]*\/>/
           expect(response.body).to match /<textarea[^<]+id="mw_interactive_url"[^<]+name="mw_interactive\[url\]"[^<]*>[^<]*#{int.url}[^<]*<\/textarea>/
-          expect(response.body).to match /<input[^<]+id="mw_interactive_native_width"[^<]+name="mw_interactive\[native_width\]"[^<]+type="hidden"[^<]+value="#{int.native_width}"[^<]*\/>/
-          expect(response.body).to match /<input[^<]+id="mw_interactive_native_height"[^<]+name="mw_interactive\[native_height\]"[^<]+type="hidden"[^<]+value="#{int.native_height}"[^<]*\/>/
+          expect(response.body).to match /<input[^<]+id="width"[^<]+name="mw_interactive\[native_width\]"[^<]+type="hidden"[^<]+value="#{int.native_width}"[^<]*\/>/
+          expect(response.body).to match /<input[^<]+id="height"[^<]+name="mw_interactive\[native_height\]"[^<]+type="hidden"[^<]+value="#{int.native_height}"[^<]*\/>/
         end
 
         it 'responds to js-format requests with JSON' do

--- a/spec/controllers/mw_interactives_controller_spec.rb
+++ b/spec/controllers/mw_interactives_controller_spec.rb
@@ -34,8 +34,8 @@ describe MwInteractivesController do
 
           expect(response.body).to match /<input[^<]+id="mw_interactive_name"[^<]+name="mw_interactive\[name\]"[^<]+type="text"[^>]+value="#{int.name}"[^<]*\/>/
           expect(response.body).to match /<textarea[^<]+id="mw_interactive_url"[^<]+name="mw_interactive\[url\]"[^<]*>[^<]*#{int.url}[^<]*<\/textarea>/
-          expect(response.body).to match /<input[^<]+id="mw_interactive_native_width"[^<]+name="mw_interactive\[native_width\]"[^<]+type="text"[^<]+value="#{int.native_width}"[^<]*\/>/
-          expect(response.body).to match /<input[^<]+id="mw_interactive_native_height"[^<]+name="mw_interactive\[native_height\]"[^<]+type="text"[^<]+value="#{int.native_height}"[^<]*\/>/
+          expect(response.body).to match /<input[^<]+id="mw_interactive_native_width"[^<]+name="mw_interactive\[native_width\]"[^<]+type="hidden"[^<]+value="#{int.native_width}"[^<]*\/>/
+          expect(response.body).to match /<input[^<]+id="mw_interactive_native_height"[^<]+name="mw_interactive\[native_height\]"[^<]+type="hidden"[^<]+value="#{int.native_height}"[^<]*\/>/
         end
 
         it 'responds to js-format requests with JSON' do


### PR DESCRIPTION

## Interactive Authoring form changes: 
* Dropdown select for the aspect_ratio_method
* Hide native_width & native_height fields when using "DEFAULT" or "MAX" `aspect_ratio_method`, but make visible for "MANUAL" `aspect_ratio_method`.
* I18n for aspect ratio method names.

## Update the scaling logic in `interactive-sizing.js`

* Take into account `aspect_ratio_method`
* Limit the iFrame interactive height to the visible viewport and scale width accordingly to maintain aspect ratio.


PT Stories:
* https://www.pivotaltracker.com/story/show/160601693
* https://www.pivotaltracker.com/story/show/160601386