### PR TITLE
[DL/NP] Improve performance of the responsive layout migration can be improved

### DIFF
--- a/db/migrate/20181001211438_add_fill_available_space_to_mw_interactives.rb
+++ b/db/migrate/20181001211438_add_fill_available_space_to_mw_interactives.rb
@@ -1,46 +1,24 @@
 class AddFillAvailableSpaceToMwInteractives < ActiveRecord::Migration
-
-  class MwInteractive < ActiveRecord::Base
-    ASPECT_RATIO_DEFAULT_WIDTH = 576
-    ASPECT_RATIO_DEFAULT_HEIGHT =  435
-    ASPECT_RATIO_DEFAULT_METHOD = 'DEFAULT'
-    ASPECT_RATIO_MANUAL_METHOD  = 'MANUAL'
-    ASPECT_RATIO_MAX_METHOD = 'MAX'
-
-    def is_codap_scaled_document
-      # https://regexr.com/40h8k
-      codap_scaling_regex = /http.+document-store.+codap\.concord.+&scaling/i
-      return self.url && self.url.match(codap_scaling_regex)
-    end
-
-    def has_manually_specified_aspect_ratio
-      if (self.native_width  != ASPECT_RATIO_DEFAULT_WIDTH)  ||
-         (self.native_width  != ASPECT_RATIO_DEFAULT_HEIGHT)
-          return true
-      end
-      return false
-    end
-
-    def set_aspect_ratio_method
-      new_method=MwInteractive::ASPECT_RATIO_DEFAULT_METHOD
-      if has_manually_specified_aspect_ratio
-        unless is_codap_scaled_document
-          new_method = MwInteractive::ASPECT_RATIO_MANUAL_METHOD
-        end
-      end
-      if (self.aspect_ratio_method != new_method)
-        self.update_attribute(:aspect_ratio_method, new_method)
-      end
-    end
-  end
+  ASPECT_RATIO_DEFAULT_WIDTH = 576
+  ASPECT_RATIO_DEFAULT_HEIGHT =  435
+  ASPECT_RATIO_DEFAULT_METHOD = 'DEFAULT'
+  ASPECT_RATIO_MANUAL_METHOD  = 'MANUAL'
 
   def up
     add_column :mw_interactives, :aspect_ratio_method, :string,
     default: MwInteractive::ASPECT_RATIO_DEFAULT_METHOD
 
-    MwInteractive.find_each(batch_size: 25) do |interactive|
-      interactive.set_aspect_ratio_method
-    end
+    # 1. Update ALL documents to use "DEFAULT"
+    MwInteractive.update_all("aspect_ratio_method = 'DEFAULT'")
+
+    # 2. Documents that specify native_width or native_height set to anything beside default values: MANUAL
+    like_has_custom_sizes = "native_width !=#{ASPECT_RATIO_DEFAULT_WIDTH} or native_height != #{ASPECT_RATIO_DEFAULT_HEIGHT}"
+
+    MwInteractive.where(like_has_custom_sizes).update_all("aspect_ratio_method = 'MANUAL'")
+
+    # 3. All codap documents that specify scaling=true use 'DEFAULT'
+    like_in_codap = "url like '%http%document-store%&scaling%'"
+    MwInteractive.where(like_in_codap).update_all("aspect_ratio_method = 'DEFAULT'")
   end
 
   def down


### PR DESCRIPTION
@scytacki 

This should be much faster.

We ran this against local testing data that included 3 test classes:  1: Manual set Width and Height. 2. Manually set width and height CODAP document with scaling=true, 3: CODAP document without manually set width and height.

You are going to have to rollback the last migration on staging, or manually drop the `aspect_ratio_method` column on `mw_interactives` to test it out, otherwise the migration won't run.


[#161231519
https://www.pivotaltracker.com/story/show/161231519