### PR TITLE
160836352 teacher edition

### DIFF
--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -13,7 +13,7 @@ class InteractivePagesController < ApplicationController
   def show
     authorize! :read, @page
     if !params[:response_key]
-      redirect_to page_with_response_path(@activity.id, @page.id, @session_key) and return
+      redirect_to page_with_response_path(@activity.id, @page.id, @session_key, request.query_parameters) and return
     end
 
     begin

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -53,7 +53,7 @@ class LightweightActivitiesController < ApplicationController
         Rails.logger.error("Page: #{@run.last_page.id}  wrong activity: #{@activity.id} right activity: #{@run.last_page.lightweight_activity.id}")
         @activity = @run.last_page.lightweight_activity
       end
-      redirect_to page_with_response_path(@activity.id, @run.last_page.id, @run.key) and return
+      redirect_to page_with_response_path(@activity.id, @run.last_page.id, @run.key, request.query_parameters) and return
     end
 
     setup_show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -198,7 +198,7 @@ module ApplicationHelper
   end
 
   def teacher_content
-    params['mode'] == 'teacher-view'
+    params['mode'] == 'teacher-edition'
   end
 
   def pass_white_list_params(url_or_path, whitelist=default_param_whitelist)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -190,4 +190,13 @@ module ApplicationHelper
     }.html_safe
   end
 
+  def pass_white_list_params(url_or_path)
+    mode = params[:mode]
+    if (url_or_path and mode)
+      "#{url_or_path}?mode=#{mode}"
+    else
+      url_or_path
+    end
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -197,6 +197,10 @@ module ApplicationHelper
       ["mode"]
   end
 
+  def teacher_content
+    params['mode'] == 'teacher-view'
+  end
+
   def pass_white_list_params(url_or_path, whitelist=default_param_whitelist)
     # Construct query string from the contents of a url and those parameters
     # that are whitelisted, passing thruough the ones in the whitelist and

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,7 +91,7 @@ module ApplicationHelper
   def default_footer
     <<-EOF
       <p class="footer-txt">
-        Copyright © 2018 <a href="http://concord.org/">The Concord Consortium</a>. 
+        Copyright © 2018 <a href="http://concord.org/">The Concord Consortium</a>.
         All rights reserved. This activity is licensed under a
         <a href="http://creativecommons.org/licenses/by/3.0/">
           Creative Commons Attribution 3.0 Unported License
@@ -190,13 +190,27 @@ module ApplicationHelper
     }.html_safe
   end
 
-  def pass_white_list_params(url_or_path)
-    mode = params[:mode]
-    if (url_or_path and mode)
-      "#{url_or_path}?mode=#{mode}"
-    else
-      url_or_path
-    end
+  # The default is hardcoded, here, in place, for the time being. If and
+  # when the functionality is extended, the white-list could be located in
+  # a more reasonable location in the code-base.
+  def default_param_whitelist
+      ["mode"]
+  end
+
+  def pass_white_list_params(url_or_path, whitelist=default_param_whitelist)
+    # Construct query string from the contents of a url and those parameters
+    # that are whitelisted, passing thruough the ones in the whitelist and
+    # stripping those that are not in the whitelist.
+    #
+    # eg:
+    #      url_or_path                   => url://localhost/activites/2/?foo=xx&bar=yy
+    #      whitelist                     => [:foo, :bar])
+    #      params (from the fails route) => {foo:'xx', bar:'yy', activity:2}
+    #
+    # yields:
+    #      `?foo=xx&bar=yy` (activity is missing)
+    q = params.select { |key| whitelist.include?(key) }.to_query
+    url_or_path + ( q.length > 0 ? "?" + q : "")
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -214,7 +214,11 @@ module ApplicationHelper
     # yields:
     #      `?foo=xx&bar=yy` (activity is missing)
     q = params.select { |key| whitelist.include?(key) }.to_query
-    url_or_path + ( q.length > 0 ? "?" + q : "")
+    if q.length > 0
+      sep = url_or_path.match(/\?/) ? '&' : '?'
+      url_or_path + sep + q
+    else
+      url_or_path
+    end
   end
-
 end

--- a/app/helpers/interactive_page_helper.rb
+++ b/app/helpers/interactive_page_helper.rb
@@ -1,6 +1,11 @@
 module InteractivePageHelper
   def runnable_activity_page_path(activity, page)
-    run = run_for_activity(activity,@run)
+    path_base = fetch_path_base(activity, @run, page)
+    pass_white_list_params(path_base) if path_base
+  end
+
+  def fetch_path_base(activity, run, page)  # move me to be private.
+    run = run_for_activity(activity, run)
     if run
       page_with_response_path(activity.id, page.id, run.key)
     elsif activity and page
@@ -8,9 +13,11 @@ module InteractivePageHelper
     elsif activity
       activity_path(activity)
     else
-      nil
+       nil
     end
   end
+
+
 
   def page_link(activity,page, opts={})
     name = "Page #{page.position}"

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -11,9 +11,9 @@ module LightweightActivityHelper
 
   def runnable_activity_path(activity, opts ={})
     if @sequence
-      sequence_activity_path(@sequence, activity, opts)
+      pass_white_list_params sequence_activity_path(@sequence, activity, opts)
     else
-      activity_path(activity, opts)
+      pass_white_list_params activity_path(activity, opts)
     end
   end
 

--- a/app/helpers/logo_helper.rb
+++ b/app/helpers/logo_helper.rb
@@ -20,12 +20,9 @@ module LogoHelper
     sequence = @sequence
     return nil unless sequence
     logo = sequence.logo
-
-    if @sequence_run
-      url = sequence_path(:id => sequence.id, :show_index => true, :sequence_run => @sequence_run.id)
-    else
-      url = sequence_path(:id => sequence.id, :show_index => true)
-    end
+    my_params = request.query_parameters.merge({id: sequence.id, show_index: true})
+    my_params = my_params.merge({sequence_run: @sequence_run.id}) if @sequence_run
+    url = sequence_path(my_params)
     buffer = ''.html_safe
     if logo.present?
       buffer << logo_tag(logo, sequence.display_title, url)

--- a/app/views/interactive_pages/_show_completion.html.haml
+++ b/app/views/interactive_pages/_show_completion.html.haml
@@ -147,7 +147,7 @@
         - case data[:prompt]
         - when 'next-activity-or-exit'
           .finish-links
-            %a{ :href => sequence_activity_path(@sequence, next_activity, show_index: true)}
+            %a{ :href => runnable_activity_path(next_activity, show_index: true)}
               %input.button{ :type => "submit", :value => t("COMPLETION_PAGE.START_NEXT")}
             or
             %a.exit{:href => exit_link}=exit_label_t

--- a/app/views/interactive_pages/show.html.haml
+++ b/app/views/interactive_pages/show.html.haml
@@ -35,11 +35,11 @@
     .button-right
       - if @page.last_visible? && next_activity
         .next-page
-          %a{ :href => sequence_activity_path(@sequence, next_activity), :title => next_activity.name, :class => 'next forward_nav'}
+          %a{ :href => runnable_activity_path(next_activity), :title => next_activity.name, :class => 'next forward_nav'}
             %input{ :class => 'button next forward_nav', :type => 'submit', :value => t("BEGIN_NEXT_ACTIVITY") }
       - elsif @page.next_visible_page
         .next-page
-          %a{ :href => runnable_activity_page_path(@page.lightweight_activity, @page.next_visible_page), :class => 'next forward_nav' }
+          %a{:href => runnable_activity_page_path(@page.lightweight_activity, @page.next_visible_page), :class => 'next forward_nav' }
             %input{ :class => 'button next forward_nav', :type => 'submit', :value => t("NEXT")}
 
 -# Set Google Analytics content group based on the project. Note that project might be undefined

--- a/app/views/layouts/runtime.html.erb
+++ b/app/views/layouts/runtime.html.erb
@@ -52,11 +52,7 @@
 <body class=<%= yield :body_class %>>
 
 <div id="container">
-  <% if teacher_content %>
-    <div style="width: 100%; height: 2em; background-color: purple; color: white; font-size: 14pt; text-align: right; padding:0.25em; font-weight: bold;">
-      Teacher View
-    </div>
-  <% end %>
+  <%= render :partial => "shared/teacher_banner" %>
 
   <header>
     <div class="site-logo-mod site-width">

--- a/app/views/layouts/runtime.html.erb
+++ b/app/views/layouts/runtime.html.erb
@@ -52,6 +52,11 @@
 <body class=<%= yield :body_class %>>
 
 <div id="container">
+  <% if teacher_content %>
+    <div style="width: 100%; height: 2em; background-color: purple; color: white; font-size: 14pt; text-align: right; padding:0.25em; font-weight: bold;">
+      Teacher View
+    </div>
+  <% end %>
 
   <header>
     <div class="site-logo-mod site-width">

--- a/app/views/layouts/sequence_run.html.erb
+++ b/app/views/layouts/sequence_run.html.erb
@@ -51,7 +51,7 @@
 
 <body>
 	<div id="container">
-
+    <%= render :partial => "shared/teacher_banner" %>
 		<header>
 			<div class="site-logo-mod site-width">
 				<div class="site-logo logo-l">

--- a/app/views/lightweight_activities/show.html.haml
+++ b/app/views/lightweight_activities/show.html.haml
@@ -27,7 +27,7 @@
 
     .nav-buttons
       - if @activity.visible_pages.length > 0
-        %a{ :href => runnable_activity_page_path(@activity, @activity.visible_pages.first ) }
+        %a{ id: 'begin_activity', :href => runnable_activity_page_path(@activity, @activity.visible_pages.first ) }
           .submit
             %input.button{ :type => "submit", :value => t("BEGIN_ACTIVITY")}
       - else

--- a/app/views/sequences/show.html.haml
+++ b/app/views/sequences/show.html.haml
@@ -49,9 +49,9 @@
           %span.position
             = las.position.to_s
           %span.title
-            = link_to activity.name, sequence_activity_path(@sequence, activity)
+            = link_to activity.name, pass_white_list_params(sequence_activity_path(@sequence, activity))
           .thumbnail
-            = link_to image_tag(activity.thumbnail_url), sequence_activity_path(@sequence, activity) unless activity.thumbnail_url.blank?
+            = link_to image_tag(activity.thumbnail_url), pass_white_list_params(sequence_activity_path(@sequence, activity)) unless activity.thumbnail_url.blank?
 
     = link_to 'Edit', edit_sequence_path(@sequence) if can? :update, @sequence
 

--- a/app/views/shared/_sequence_next_prev.html.haml
+++ b/app/views/shared/_sequence_next_prev.html.haml
@@ -3,11 +3,11 @@
 .intra-sequence-nav
   .next-activity{ :class => ('disabled' if next_activity.nil?) }
     - if next_href
-      = link_to 'Next Activity >', sequence_activity_path(sequence, next_activity), { :title => next_activity.name }
+      = link_to 'Next Activity >', runnable_activity_path(sequence, next_activity), { :title => next_activity.name }
     - else
       Next Activity >
   .last-activity{ :class => ('disabled' if previous_activity.nil?) }
     - if last_href
-      = link_to "< Last Activity", sequence_activity_path(sequence, previous_activity), { :title => previous_activity.name }
+      = link_to "< Last Activity", runnable_activity_path(sequence, previous_activity), { :title => previous_activity.name }
     - else
       &lt; Last Activity

--- a/app/views/shared/_sequence_next_prev.html.haml
+++ b/app/views/shared/_sequence_next_prev.html.haml
@@ -3,11 +3,11 @@
 .intra-sequence-nav
   .next-activity{ :class => ('disabled' if next_activity.nil?) }
     - if next_href
-      = link_to 'Next Activity >', runnable_activity_path(sequence, next_activity), { :title => next_activity.name }
+      = link_to 'Next Activity >', runnable_activity_path(next_activity), { :title => next_activity.name }
     - else
       Next Activity >
   .last-activity{ :class => ('disabled' if previous_activity.nil?) }
     - if last_href
-      = link_to "< Last Activity", runnable_activity_path(sequence, previous_activity), { :title => previous_activity.name }
+      = link_to "< Last Activity", runnable_activity_path(previous_activity), { :title => previous_activity.name }
     - else
       &lt; Last Activity

--- a/app/views/shared/_teacher_banner.html.erb
+++ b/app/views/shared/_teacher_banner.html.erb
@@ -2,6 +2,4 @@
     <div style="width: 100%; height: 2em; background-color: purple; color: white; font-size: 14pt; text-align: right; padding:0.25em; font-weight: bold;">
       Teacher View
     </div>
-<% else %>
-  <div style="width: 100%; font-size: 40pt;">NOT THE TEACHER</div>
 <% end %>

--- a/app/views/shared/_teacher_banner.html.erb
+++ b/app/views/shared/_teacher_banner.html.erb
@@ -1,0 +1,7 @@
+<% if teacher_content %>
+    <div style="width: 100%; height: 2em; background-color: purple; color: white; font-size: 14pt; text-align: right; padding:0.25em; font-weight: bold;">
+      Teacher View
+    </div>
+<% else %>
+  <div style="width: 100%; font-size: 40pt;">NOT THE TEACHER</div>
+<% end %>

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -5,5 +5,21 @@ FactoryGirl.define do
     title "MyString"
     description "MyText"
     abstract "short abstract"
+
+    factory :sequence_with_activity do
+      ignore do
+        pages_count 2
+        activities_count 2
+      end
+      publication_status 'public'
+      after(:create) do |sequence, evaluator|
+        # has_many
+        create_list(
+          :activity_with_pages, evaluator.activities_count,
+          pages_count: evaluator.pages_count,
+          sequences: [sequence]
+        )
+      end
+    end
   end
 end

--- a/spec/features/run_complete_sequence_spec.rb
+++ b/spec/features/run_complete_sequence_spec.rb
@@ -13,7 +13,7 @@ feature "Visiting all pages of a Sequence" do
   let(:sequence)          { FactoryGirl.create(:sequence_with_activity, seq_options) }
   let(:params)            { {} }
   let(:activities_count)  { 2 }
-  let(:name) { 'teacher-view mode test Sequence'}
+  let(:name) { 'teacher-edition mode test Sequence'}
   let(:seq_options) do
     {
       title: name,
@@ -90,16 +90,16 @@ feature "Visiting all pages of a Sequence" do
   feature "'mode' query parameter handling" do
 
     feature "not as a teacher..." do
-      scenario "We should NOT see 'teacher-view' in the url" do
-        verify_param_passed_through_sequence(absent: {mode:'teacher-view'})
+      scenario "We should NOT see 'teacher-edition' in the url" do
+        verify_param_passed_through_sequence(absent: {mode:'teacher-edition'})
       end
     end
 
     feature "as a teacher " do
-      feature "with `mode` set to `teacher-view` " do
-        let(:params) { {mode: 'teacher-view' } }
-        scenario "We should see 'mode=teacher-view' in the url" do
-          verify_param_passed_through_sequence(present: {mode:'teacher-view'})
+      feature "with `mode` set to `teacher-edition` " do
+        let(:params) { {mode: 'teacher-edition' } }
+        scenario "We should see 'mode=teacher-edition' in the url" do
+          verify_param_passed_through_sequence(present: {mode:'teacher-edition'})
         end
 
         scenario "We should see the Teacher View banner on the first page" do
@@ -120,7 +120,7 @@ feature "Visiting all pages of a Sequence" do
             # /sequence/:id/activity/:id/page/:id
             expected_url = "/activities/#{activity.id}/pages/#{run_page.id}"
             expect(current_url).to match(expected_url)
-            teacher_mode = "mode=teacher-view"
+            teacher_mode = "mode=teacher-edition"
             expect(current_url).to match(teacher_mode)
             expect(page.body).to match("Teacher View")
           end
@@ -129,24 +129,24 @@ feature "Visiting all pages of a Sequence" do
             visit activity_url
             selector = "#container > header > div > div.site-logo.logo-l > div > h2 > a"
             find(:css, selector, match: :first).click
-            teacher_mode = "mode=teacher-view"
+            teacher_mode = "mode=teacher-edition"
             expect(current_url).to match(teacher_mode)
             expect(page.body).to match("Teacher View")
           end
         end
 
         scenario "We should see the Teacher View banner on the last page" do
-          verify_param_passed_through_sequence(present: {mode:'teacher-view'})
+          verify_param_passed_through_sequence(present: {mode:'teacher-edition'})
           expect(page.body).to match("Teacher View")
-          expect(current_url).to match "mode=teacher-view"
+          expect(current_url).to match "mode=teacher-edition"
         end
       end
 
       feature "Combined with non-pass-through param `foo=bar` " do
-        let(:params) { {mode: 'teacher-view', foo: 'bar'} }
-        scenario "We should see 'mode=teacher-view' in the url, and not foo=bar" do
+        let(:params) { {mode: 'teacher-edition', foo: 'bar'} }
+        scenario "We should see 'mode=teacher-edition' in the url, and not foo=bar" do
           verify_param_passed_through_sequence(
-            present: { mode:'teacher-view' },
+            present: { mode:'teacher-edition' },
             absent:  { foo:'bar' }
           )
         end

--- a/spec/features/run_complete_sequence_spec.rb
+++ b/spec/features/run_complete_sequence_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 require 'uri'
 
+# 0: Clean up test
+# 2: Refactor the helper to use a white-list.
+# 3: Verifty proper URL formatting in all cases. (if ?mode is present, for example)
+# 4: Banner
+
 feature "Visiting all pages of a Sequence" do
   let(:sequence)          { FactoryGirl.create(:sequence_with_activity, seq_options) }
   let(:params)            { {} }
@@ -13,107 +18,99 @@ feature "Visiting all pages of a Sequence" do
     }
   end
 
-  let(:url) do
+  let(:sequence_url) do
     sequence_path(sequence, params: params)
   end
 
-  feature "not as a teacher" do
-
-    scenario "We shouldn't see 'teacher-view' in the url" do
-      expect(sequence.activities.length).to be(activities_count)
-      visit url
-      expect(page).to have_content name
-      expect(current_url).to_not match 'teacher-view'
-      expect(sequence.activities.length).to be(2)
-
-      sequence.activities.each do |activity|
-        expect(activity.pages.length).to be(2)
-        expect(page).to have_content activity.name
-      end
-      # expect(sequence.activities.first.pages.length).to be(2)
-      # expect(sequence.activities.last.pages.length).to be(2)
-      activity = sequence.activities.first
-      click_link(activity.name)
-      click_link "begin_activity"
-
-      # activity 1, page 1
-      save_page("capy.html")
-      expect(current_url).to_not match 'teacher-view'
-      expect(find("//h4")).to have_content(activity.pages.first.name)
+  def navigate(selector)
+    case selector
+    when :page
       find(:css, "a.next.forward_nav", match: :first).click
-
-      # activity 1, page 2
-      save_page("capy2.html")
-      find(:css, "a.next.forward_nav", match: :first).click
-
-      # activity 1, Summary Page, looks different
-      save_page("capy-a1-ps.html")
-      find(:css, ".next-page a.next.forward_nav", match: :first).click # next act link
-
-       # activity 2, Intro Page
-      activity = sequence.activities[1]
-      expect(page).to have_content activity.name
-      save_page("capy-a2-intro.html")
-      click_link "begin_activity"
-
-      # activity 2, Page 1
-      save_page("capy-a2-p1.html")
-      expect(current_url).to_not match 'teacher-view'
-      expect(find("//h4")).to have_content(activity.pages.first.name)
-      find(:css, "a.next.forward_nav", match: :first).click
-
+    when :activity
+      find(:css, ".next-page a.next.forward_nav", match: :first).click
     end
   end
 
-  feature "as a teacher..." do
-    let(:params) { {mode: 'teacher-view' } }
-    scenario "We should see 'teacher-view' in the url" do
-      expect(sequence.activities.length).to be(activities_count)
-      visit url
-      expect(page).to have_content name
-      expect(current_url).to match 'teacher-view'
-      expect(sequence.activities.length).to be(2)
-
-      sequence.activities.each do |activity|
-        expect(activity.pages.length).to be(2)
-        expect(page).to have_content activity.name
-      end
-      # expect(sequence.activities.first.pages.length).to be(2)
-      # expect(sequence.activities.last.pages.length).to be(2)
-      activity = sequence.activities.first
-
-      # Sequence page
-      click_link(activity.name)
-      expect(current_url).to match 'teacher-view'
-
-      # Activity 1 Intro page
-      click_link "begin_activity"
-      expect(current_url).to match 'teacher-view'
-
-      # activity 1, page 1
-      expect(current_url).to match 'teacher-view'
-      expect(find("//h4")).to have_content(activity.pages.first.name)
-      find(:css, "a.next.forward_nav", match: :first).click
-
-      # activity 1, page 2
-      find(:css, "a.next.forward_nav", match: :first).click
-
-      # activity 1, Summary Page, looks different
-      expect(current_url).to match 'teacher-view'
-      find(:css, ".next-page a.next.forward_nav", match: :first).click # next act link
-
-       # activity 2, Intro Page
-      activity = sequence.activities[1]
-      expect(current_url).to match 'teacher-view'
-      expect(page).to have_content activity.name
-      click_link "begin_activity"
-
-      # activity 2, Page 1
-      expect(current_url).to match 'teacher-view'
-      expect(find("//h4")).to have_content(activity.pages.first.name)
-      find(:css, "a.next.forward_nav", match: :first).click
-
+  def verify_param_assertions(assertions)
+    present = assertions[:present] || []
+    absent = assertions[:absent] || []
+    present.each do  |param, value|
+      expect(current_url).to match "#{param}=#{value}"
+    end
+    absent.each do |param, _value|
+      expect(current_url).to_not match "#{param}"
     end
   end
 
+  def navigate_and_verify(selector, presence)
+    navigate selector
+    verify_param_assertions presence
+  end
+
+  def verify_param_passed_through_sequence(param_assertions)
+    # Sequence page, which is an index of activities:
+    visit sequence_url
+
+    # Pre-test our test-case is what we expect.
+    expect(sequence.activities.length).to be(2)
+    # In our first url verify the current URL `present` params only.
+    verify_param_assertions(present: param_assertions[:present])
+
+    activity = sequence.activities.first
+    click_link(activity.name)
+
+    # activity 1, Intro Page
+    click_link "begin_activity"
+    verify_param_assertions(param_assertions)
+    
+    expect(find("//h4")).to have_content(activity.pages.first.name)
+
+    activity.pages.each do
+      navigate_and_verify :page, param_assertions
+    end
+
+    # activity 1, Summary Page, looks different
+    navigate_and_verify :activity, param_assertions
+    expect(page).to have_content sequence.activities[1].name
+
+    # activity 2, Intro Page
+    click_link "begin_activity"
+    verify_param_assertions(param_assertions)
+    expect(find("//h4")).to have_content(sequence.activities[1].pages.first.name)
+
+    sequence.activities[1].pages.each do
+      navigate_and_verify :page, param_assertions
+    end
+  end
+
+
+
+  feature "'mode' query parameter handling" do
+
+    feature "not as a teacher..." do
+      scenario "We should NOT see 'teacher-view' in the url" do
+        verify_param_passed_through_sequence(absent: {mode:'teacher-view'})
+      end
+    end
+
+    feature "as a teacher " do
+      feature "with `mode` set to `teacher-view` " do
+        let(:params) { {mode: 'teacher-view' } }
+        scenario "We should see 'mode=teacher-view' in the url" do
+          verify_param_passed_through_sequence(present: {mode:'teacher-view'})
+        end
+      end
+      feature "Combined with non-pass-through param `foo=bar` " do
+        let(:params) { {mode: 'teacher-view', foo: 'bar'} }
+        scenario "We should see 'mode=teacher-view' in the url, and not foo=bar" do
+          verify_param_passed_through_sequence(
+            present: { mode:'teacher-view' },
+            absent:  { foo:'bar' }
+          )
+        end
+      end
+    end
+  end
+
+  
 end

--- a/spec/features/run_complete_sequence_spec.rb
+++ b/spec/features/run_complete_sequence_spec.rb
@@ -1,19 +1,20 @@
 require 'spec_helper'
 require 'uri'
 
-feature "Visiting all pages of a Sequence", :js => true do
+feature "Visiting all pages of a Sequence" do
   let(:sequence)          { FactoryGirl.create(:sequence_with_activity, seq_options) }
   let(:params)            { {} }
   let(:activities_count)  { 2 }
   let(:name) { 'teacher-view mode test Sequence'}
   let(:seq_options) do
     {
-      title: name
+      title: name,
+      activities_count: activities_count
     }
   end
 
   let(:url) do
-    sequence_path(sequence, params: params, activities_count: activities_count)
+    sequence_path(sequence, params: params)
   end
 
   feature "not as a teacher" do
@@ -24,29 +25,95 @@ feature "Visiting all pages of a Sequence", :js => true do
       expect(page).to have_content name
       expect(current_url).to_not match 'teacher-view'
       expect(sequence.activities.length).to be(2)
-      expect(sequence.activities.first.pages.length).to be(2)
-      expect(sequence.activities.last.pages.length).to be(2)
-      expect(page).to have_content sequence.activities.first.name
-      click_link(sequence.activities.first.name)
-      click_button "Begin activity"
-      # click_button "Next" -- oops JS tests don't seem to be running
+
+      sequence.activities.each do |activity|
+        expect(activity.pages.length).to be(2)
+        expect(page).to have_content activity.name
+      end
+      # expect(sequence.activities.first.pages.length).to be(2)
+      # expect(sequence.activities.last.pages.length).to be(2)
+      activity = sequence.activities.first
+      click_link(activity.name)
+      click_link "begin_activity"
+
+      # activity 1, page 1
+      save_page("capy.html")
+      expect(current_url).to_not match 'teacher-view'
+      expect(find("//h4")).to have_content(activity.pages.first.name)
+      find(:css, "a.next.forward_nav", match: :first).click
+
+      # activity 1, page 2
+      save_page("capy2.html")
+      find(:css, "a.next.forward_nav", match: :first).click
+
+      # activity 1, Summary Page, looks different
+      save_page("capy-a1-ps.html")
+      find(:css, ".next-page a.next.forward_nav", match: :first).click # next act link
+
+       # activity 2, Intro Page
+      activity = sequence.activities[1]
+      expect(page).to have_content activity.name
+      save_page("capy-a2-intro.html")
+      click_link "begin_activity"
+
+      # activity 2, Page 1
+      save_page("capy-a2-p1.html")
+      expect(current_url).to_not match 'teacher-view'
+      expect(find("//h4")).to have_content(activity.pages.first.name)
+      find(:css, "a.next.forward_nav", match: :first).click
+
     end
   end
 
-  # TODO:
-  # feature "as a teacher" do
-  #   let(:params) { {mode: 'teacher-view' } }
-  #   let(:name) { 'teacher-view mode test activity '}
-  #   let(:act_options) { {name: name} }
-  #   let(:seq_options) { {title: name} }
+  feature "as a teacher..." do
+    let(:params) { {mode: 'teacher-view' } }
+    scenario "We should see 'teacher-view' in the url" do
+      expect(sequence.activities.length).to be(activities_count)
+      visit url
+      expect(page).to have_content name
+      expect(current_url).to match 'teacher-view'
+      expect(sequence.activities.length).to be(2)
 
-  #   scenario "We see teacher-view in the url" do
-  #     expect(sequence.activities).to have(6).activities
-  #     visit url
-  #     expect(page).to have_content name
-  #     click_button "Begin activity"
-  #     expect(current_url).to match 'teacher-view'
-  #   end
-  # end
+      sequence.activities.each do |activity|
+        expect(activity.pages.length).to be(2)
+        expect(page).to have_content activity.name
+      end
+      # expect(sequence.activities.first.pages.length).to be(2)
+      # expect(sequence.activities.last.pages.length).to be(2)
+      activity = sequence.activities.first
+
+      # Sequence page
+      click_link(activity.name)
+      expect(current_url).to match 'teacher-view'
+
+      # Activity 1 Intro page
+      click_link "begin_activity"
+      expect(current_url).to match 'teacher-view'
+
+      # activity 1, page 1
+      expect(current_url).to match 'teacher-view'
+      expect(find("//h4")).to have_content(activity.pages.first.name)
+      find(:css, "a.next.forward_nav", match: :first).click
+
+      # activity 1, page 2
+      find(:css, "a.next.forward_nav", match: :first).click
+
+      # activity 1, Summary Page, looks different
+      expect(current_url).to match 'teacher-view'
+      find(:css, ".next-page a.next.forward_nav", match: :first).click # next act link
+
+       # activity 2, Intro Page
+      activity = sequence.activities[1]
+      expect(current_url).to match 'teacher-view'
+      expect(page).to have_content activity.name
+      click_link "begin_activity"
+
+      # activity 2, Page 1
+      expect(current_url).to match 'teacher-view'
+      expect(find("//h4")).to have_content(activity.pages.first.name)
+      find(:css, "a.next.forward_nav", match: :first).click
+
+    end
+  end
 
 end

--- a/spec/features/run_complete_sequence_spec.rb
+++ b/spec/features/run_complete_sequence_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'uri'
+
+feature "Visiting all pages of a Sequence", :js => true do
+  let(:sequence)          { FactoryGirl.create(:sequence_with_activity, seq_options) }
+  let(:params)            { {} }
+  let(:activities_count)  { 2 }
+  let(:name) { 'teacher-view mode test Sequence'}
+  let(:seq_options) do
+    {
+      title: name
+    }
+  end
+
+  let(:url) do
+    sequence_path(sequence, params: params, activities_count: activities_count)
+  end
+
+  feature "not as a teacher" do
+
+    scenario "We shouldn't see 'teacher-view' in the url" do
+      expect(sequence.activities.length).to be(activities_count)
+      visit url
+      expect(page).to have_content name
+      expect(current_url).to_not match 'teacher-view'
+      expect(sequence.activities.length).to be(2)
+      expect(sequence.activities.first.pages.length).to be(2)
+      expect(sequence.activities.last.pages.length).to be(2)
+      expect(page).to have_content sequence.activities.first.name
+      click_link(sequence.activities.first.name)
+      click_button "Begin activity"
+      # click_button "Next" -- oops JS tests don't seem to be running
+    end
+  end
+
+  # TODO:
+  # feature "as a teacher" do
+  #   let(:params) { {mode: 'teacher-view' } }
+  #   let(:name) { 'teacher-view mode test activity '}
+  #   let(:act_options) { {name: name} }
+  #   let(:seq_options) { {title: name} }
+
+  #   scenario "We see teacher-view in the url" do
+  #     expect(sequence.activities).to have(6).activities
+  #     visit url
+  #     expect(page).to have_content name
+  #     click_button "Begin activity"
+  #     expect(current_url).to match 'teacher-view'
+  #   end
+  # end
+
+end

--- a/spec/features/run_complete_sequence_spec.rb
+++ b/spec/features/run_complete_sequence_spec.rb
@@ -1,11 +1,6 @@
 require 'spec_helper'
 require 'uri'
 
-# 0: Clean up test
-# 2: Refactor the helper to use a white-list.
-# 3: Verifty proper URL formatting in all cases. (if ?mode is present, for example)
-# 4: Banner
-
 feature "Visiting all pages of a Sequence" do
   let(:sequence)          { FactoryGirl.create(:sequence_with_activity, seq_options) }
   let(:params)            { {} }
@@ -81,9 +76,8 @@ feature "Visiting all pages of a Sequence" do
     sequence.activities[1].pages.each do
       navigate_and_verify :page, param_assertions
     end
+
   end
-
-
 
   feature "'mode' query parameter handling" do
 
@@ -98,6 +92,11 @@ feature "Visiting all pages of a Sequence" do
         let(:params) { {mode: 'teacher-view' } }
         scenario "We should see 'mode=teacher-view' in the url" do
           verify_param_passed_through_sequence(present: {mode:'teacher-view'})
+        end
+        scenario "We should see the Teacher View banner on the page" do
+          verify_param_passed_through_sequence(present: {mode:'teacher-view'})
+          expect(page.body).to match("Teacher View")
+
         end
       end
       feature "Combined with non-pass-through param `foo=bar` " do

--- a/spec/views/shared/_sequence_next_prev.html.haml_spec.rb
+++ b/spec/views/shared/_sequence_next_prev.html.haml_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "sequence_next_prev buttons" do
+  let(:seq_options) {{title: 'Test Sequence', activities_count: 3 }}
+
+  let(:sequence) { FactoryGirl.create(:sequence_with_activity, seq_options) }
+  let(:prev_act) { sequence.activities[0] }
+  let(:activity) { sequence.activities[1] }
+  let(:next_act) { sequence.activities[2] }
+
+  describe "when evaluated as part of a sequence" do
+    let(:partial_opts) do
+      {
+        activity: activity,
+        sequence: sequence,
+        next_href: true,
+        last_href: true,
+      }
+    end
+
+    it "returns navigation links that include sequence paths" do
+      assign(:sequence, sequence)
+      exp_next="href=\"/sequences/#{sequence.id}/activities/#{next_act.id}"
+      exp_prev="href=\"/sequences/#{sequence.id}/activities/#{prev_act.id}"
+  
+      render "shared/sequence_next_prev", partial_opts
+      expect(rendered).to match(exp_next)
+      expect(rendered).to match(exp_prev)
+    end
+  end
+
+end


### PR DESCRIPTION
[DL/NP] Initial LARA Teacher Edition.

<hr/>

[#160836352]
https://www.pivotaltracker.com/story/show/160836352

## Full Story:

Add a new mode to LARA for launching a teacher edition of an activity and sequence. Initially this edition will just include a banner saying 'Teacher Edition'. This banner needs to show on every single page of the activity. This includes sequence and activity home pages.

In the future stories this will be appended with:
- open response recommended answers
- html teacher notes
- interactive  teacher notes

It seems best to implement this using a URL parameter or path. And this parameter or path needs to be carried onto every page that is linked in an activity. 

## Implementation Details:

1. Banner display is very simplistic until final styling has been decided;
1. Added a technique to decorate links to pass through "white-listed" query params in the url's -- may need to be extended or revisited with follow on stories;
1. A particular complication was handling the `redirect_to` logic -- in the run controller -- to correctly continue to pass the pertinent URL data in addition to the white-listed params; and,
1. A fairly extensive Capybara spec test has been implemented for most of the obvious happy-paths.