### PR TITLE
In `interactiveSizing.js`: check for fullwidth pages before scaling.

### DIFF
--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -7,18 +7,20 @@ function interactiveSizing () {
     var resizeMethod = $iframe.data('aspect-ratio-method');
     var magicNumber = 125;
     var maxHeight = window.innerHeight - magicNumber;
+    var isFullWidth = $('.content-mod').hasClass('l-full-width');
+    $iframe.attr('width', '100%');
+    $iframe.height($iframe.width() / aspectRatio);
 
-    if(resizeMethod === 'MAX') {
-      $iframe.height(maxHeight);
-      $iframe.attr('width', '100%');
-    }
-    else {
-      $iframe.attr('width', '100%');
-      $iframe.height($iframe.width() / aspectRatio);
-      if ($iframe.height() > maxHeight) {
-        var scale = maxHeight / $iframe.height();
-        $iframe.attr('width', scale * 100 + '%');
+    if (!isFullWidth) {
+      if(resizeMethod === 'MAX') {
         $iframe.height(maxHeight);
+      }
+      else {
+        if ($iframe.height() > maxHeight) {
+          var scale = maxHeight / $iframe.height();
+          $iframe.attr('width', scale * 100 + '%');
+          $iframe.height(maxHeight);
+        }
       }
     }
   }


### PR DESCRIPTION
This commit sets `isFullWidth`  based on the existence of div classes used
in full-width page Layout.

If we are in fullWidth mode, then don't set the maxHeight.