### PR TITLE
Aspect Ratio dropdown menu displays aspect ratio description.

### DIFF
--- a/app/assets/javascripts/components/common/aspect_ratio_chooser.js.coffee
+++ b/app/assets/javascripts/components/common/aspect_ratio_chooser.js.coffee
@@ -80,7 +80,7 @@ modulejs.define 'components/common/aspect_ratio_chooser', [], () ->
             onChange: (e) => @myUpdate(mode: e.target.value)
           },
           availableAspectRatios.map (m) ->
-            (option {value:m.key, label:m.value, selected: m.key==mode} )
+            (option {value:m.key, label:m.value, selected: m.key==mode}, m.value)
         )
         if enabledInputs
           (div {style: inputStyle},


### PR DESCRIPTION
Select Option was setting label attribute, but not the child content to the setting description. 


For some reason this works in Chrome. ¯\_(ツ)_/¯

Thanks for catching this @dougmartin 