### PR TITLE
Update `run-ci.sh` script for continuously running rspec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ On a local development instance, you can make an admin user by registering a new
 Some details about the relative authorization privileges of the author, admin and anonymous roles can be found by looking at the Ability class at `app/models/ability.rb`.
 
 ## Running RSpec tests
+While developing, you might wish to run continuous integration tests inside a
+Docker container.  
+
+Run `docker-compose up`  followed by
+`docker-compose exec app docker/dev/run-ci.sh` from your local machine.
+
+### Older non-docker instructions:
+
 If you haven't run tests on this project before, you first need to initialize the test database.
 
       RAILS_ENV=test rake db:setup

--- a/docker/dev/run-ci.sh
+++ b/docker/dev/run-ci.sh
@@ -6,7 +6,15 @@
 #        then type `dci` to start Continuous Integration Testing.
 #   – Or run from shell in docker (`docker-compose run --rm bash` … ./docker/dev/run-ci.sh`)
 
+
 export RAILS_ENV=test
+export BUNDLE_PATH=/bundle
+export GEMPATH_PATH=/bundle
+export GEM_HOME=/bundle
+
+bundle binstubs spring
+spring stop
+spring binstub
 
 #
 # Prepare spec tests


### PR DESCRIPTION
This commit should fix a problem where Guard was unable to run rspec tests because of confusion interactions of spring  and bundler.

@DALove1025 -- please have a look at this and see if it works in your local development environment.