### PR TITLE
Random API improvements (mostly for Cypress testing)

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -985,7 +985,7 @@ ul#new-menu {
 }
 
 .import_activity_sequence, .export {
-    padding: 0px;
+    padding: 0;
     .title{
       font-weight: bold;
     }
@@ -998,8 +998,10 @@ ul#new-menu {
       padding: 0px;
       min-height: 1.1em;
       height: auto;
-      border-bottom: 2px solid;
       margin-bottom: 10px;
+    }
+    form {
+      margin-top: 30px;
     }
     .info {
       margin-top: 10px;

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,38 @@
+class API::APIController < ApplicationController
+  layout false
+
+  protected
+
+  def error(message, status = 500)
+    render status: status, json: {
+      response_type: "ERROR",
+      message: message
+    }
+  end
+
+  def not_authorized(message = "Not authorized")
+    error(message, 403)
+  end
+
+  public
+
+  def show
+    error("Show not configured for this resource")
+  end
+
+  def create
+    error("create not configured for this resource")
+  end
+
+  def update
+    error("update not configured for this resource")
+  end
+
+  def index
+    error("index not configured for this resource")
+  end
+
+  def destroy
+    error("destroy not configured for this resource")
+  end
+end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,8 +1,6 @@
 class API::APIController < ApplicationController
   layout false
 
-  protected
-
   def error(message, status = 500)
     render status: status, json: {
       response_type: "ERROR",
@@ -10,8 +8,12 @@ class API::APIController < ApplicationController
     }
   end
 
-  def not_authorized(message = "Not authorized")
-    error(message, 403)
+  rescue_from CanCan::AccessDenied do
+    error("Not authorized", 403)
+  end
+
+  rescue_from API::APIError do |e|
+    error(e.message, 500)
   end
 
   public

--- a/app/controllers/api/api_error.rb
+++ b/app/controllers/api/api_error.rb
@@ -1,0 +1,2 @@
+class API::APIError < StandardError
+end

--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -1,18 +1,14 @@
 class Api::V1::ImportController < API::APIController
   def import
-    begin
-      authorize! :create, LightweightActivity
-      import_result = Import.import(params[:import], current_user)
-      if import_result[:success]
-        url = import_result[:type] === "Sequence" ?
-          sequence_url(import_result[:import_item]) :
-          activity_url(import_result[:import_item])
-        render json: { success: true, url: url }
-      else
-        error(import_result[:error], 500)
-      end
-    rescue CanCan::AccessDenied => err
-      not_authorized(err.message)
+    authorize! :create, LightweightActivity
+    import_result = Import.import(params[:import], current_user)
+    if import_result[:success]
+      url = import_result[:type] === "Sequence" ?
+        sequence_url(import_result[:import_item]) :
+        activity_url(import_result[:import_item])
+      render json: { success: true, url: url }
+    else
+      raise API::APIError, import_result[:error]
     end
   end
 end

--- a/app/controllers/api/v1/import_controller.rb
+++ b/app/controllers/api/v1/import_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::ImportController < API::APIController
+  def import
+    begin
+      authorize! :create, LightweightActivity
+      import_result = Import.import(params[:import], current_user)
+      if import_result[:success]
+        url = import_result[:type] === "Sequence" ?
+          sequence_url(import_result[:import_item]) :
+          activity_url(import_result[:import_item])
+        render json: { success: true, url: url }
+      else
+        error(import_result[:error], 500)
+      end
+    rescue CanCan::AccessDenied => err
+      not_authorized(err.message)
+    end
+  end
+end

--- a/app/controllers/api/v1/lightweight_activities_controller.rb
+++ b/app/controllers/api/v1/lightweight_activities_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::LightweightActivitiesController < API::APIController
+  def destroy
+    begin
+      activity = LightweightActivity.find(params[:id])
+      authorize! :destroy, activity
+      activity.destroy
+      render :json => { success: true }
+    rescue CanCan::AccessDenied => err
+      not_authorized(err.message)
+    end
+  end
+end

--- a/app/controllers/api/v1/lightweight_activities_controller.rb
+++ b/app/controllers/api/v1/lightweight_activities_controller.rb
@@ -1,12 +1,8 @@
 class Api::V1::LightweightActivitiesController < API::APIController
   def destroy
-    begin
-      activity = LightweightActivity.find(params[:id])
-      authorize! :destroy, activity
-      activity.destroy
-      render :json => { success: true }
-    rescue CanCan::AccessDenied => err
-      not_authorized(err.message)
-    end
+    activity = LightweightActivity.find(params[:id])
+    authorize! :destroy, activity
+    activity.destroy
+    render :json => { success: true }
   end
 end

--- a/app/controllers/api/v1/sequences_controller.rb
+++ b/app/controllers/api/v1/sequences_controller.rb
@@ -1,12 +1,8 @@
 class Api::V1::SequencesController < API::APIController
   def destroy
-    begin
-      sequence = Sequence.find(params[:id])
-      authorize! :destroy, sequence
-      Sequence.find(params[:id]).destroy
-      render :json => { success: true }
-    rescue CanCan::AccessDenied => err
-      not_authorized(err.message)
-    end
+    sequence = Sequence.find(params[:id])
+    authorize! :destroy, sequence
+    Sequence.find(params[:id]).destroy
+    render :json => { success: true }
   end
 end

--- a/app/controllers/api/v1/sequences_controller.rb
+++ b/app/controllers/api/v1/sequences_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::SequencesController < API::APIController
+  def destroy
+    begin
+      sequence = Sequence.find(params[:id])
+      authorize! :destroy, sequence
+      Sequence.find(params[:id]).destroy
+      render :json => { success: true }
+    rescue CanCan::AccessDenied => err
+      not_authorized(err.message)
+    end
+  end
+end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -23,14 +23,14 @@ class LightweightActivity < ActiveRecord::Base
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
 
-  has_many :plugins, as: :plugin_scope
-  has_many :pages, :foreign_key => 'lightweight_activity_id', :class_name => 'InteractivePage', :order => :position
+  has_many :plugins, as: :plugin_scope, :dependent => :destroy
+  has_many :pages, :foreign_key => 'lightweight_activity_id', :class_name => 'InteractivePage', :order => :position, :dependent => :destroy
   has_many :visible_pages, :foreign_key => 'lightweight_activity_id', :class_name => 'InteractivePage', :order => :position,
              :conditions => {interactive_pages: {is_hidden: false}}
 
   has_many :lightweight_activities_sequences, :dependent => :destroy
   has_many :sequences, :through => :lightweight_activities_sequences
-  has_many :runs, :foreign_key => 'activity_id'
+  has_many :runs, :foreign_key => 'activity_id', :dependent => :destroy
   belongs_to :theme
   belongs_to :project
 

--- a/app/views/import/import.html.haml
+++ b/app/views/import/import.html.haml
@@ -3,7 +3,7 @@
     %span.title Import Activity/Sequence :
     %span.close.close_link
       close (✖)
-  
+
   = form_tag import_path, :method => :post, :remote => true, :multipart => true, :id => "import" do
     .info
       %table

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,12 @@ LightweightStandalone::Application.routes.draw do
       resources :question_trackers, only: [:index] do
         match 'report' =>  "question_trackers#report", via: ['get','post', 'put'], defaults: { format: 'json' }
       end
+
+      resources :activities, :controller => 'lightweight_activities', only: [:destroy]
+      resources :sequences, only: [:destroy]
+
+      match 'import' => 'import#import', :via => 'post'
+
       match 'question_trackers/find_by_activity/:activity_id' =>  "question_trackers#find_by_activity", via: ['get'], defaults: { format: 'json' }
       match 'question_trackers/find_by_sequence/:sequence_id' =>  "question_trackers#find_by_sequence", via: ['get'], defaults: { format: 'json' }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20181001211438) do
+ActiveRecord::Schema.define(:version => 20181031151100) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -174,9 +174,9 @@ ActiveRecord::Schema.define(:version => 20181001211438) do
     t.boolean  "is_hidden",                        :default => false
     t.text     "hint"
     t.boolean  "is_full_width",                    :default => false
-    t.boolean  "show_in_featured_question_report", :default => true
     t.integer  "interactive_id"
     t.string   "interactive_type"
+    t.boolean  "show_in_featured_question_report", :default => true
   end
 
   create_table "embeddable_labbook_answers", :force => true do |t|
@@ -278,6 +278,16 @@ ActiveRecord::Schema.define(:version => 20181001211438) do
     t.boolean  "is_full_width",                    :default => false
     t.boolean  "show_in_featured_question_report", :default => true
   end
+
+  create_table "embeddable_plugins", :force => true do |t|
+    t.integer  "plugin_id"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
+    t.integer  "embeddable_id"
+    t.string   "embeddable_type"
+  end
+
+  add_index "embeddable_plugins", ["plugin_id"], :name => "index_embeddable_plugins_on_plugin_id"
 
   create_table "embeddable_xhtmls", :force => true do |t|
     t.string   "name"
@@ -424,8 +434,8 @@ ActiveRecord::Schema.define(:version => 20181001211438) do
   create_table "mw_interactives", :force => true do |t|
     t.string   "name"
     t.text     "url"
-    t.datetime "created_at",                                          :null => false
-    t.datetime "updated_at",                                          :null => false
+    t.datetime "created_at",                                              :null => false
+    t.datetime "updated_at",                                              :null => false
     t.integer  "native_width"
     t.integer  "native_height"
     t.boolean  "enable_learner_state",             :default => false

--- a/spec/controllers/api/v1/import_controller_spec.rb
+++ b/spec/controllers/api/v1/import_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Api::V1::ImportController do
+  let (:user) { FactoryGirl.create(:author) }
+  let (:valid_activity_import_json) { JSON.parse(File.read(Rails.root + 'spec/import_examples/valid_lightweight_activity_import.json'), symbolize_keys: true) }
+
+  describe "when user is logged in and allowed to import activity" do
+    before(:each) do
+      sign_in user
+    end
+
+    it "returns 200 and activity URL" do
+      xhr :post, "import", {import: valid_activity_import_json}
+      expect(response.status).to eq(200)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to eql({
+        success: true,
+        url: activity_url(LightweightActivity.last)
+      }.to_json)
+    end
+  end
+
+  describe "when user is not allowed to import activity" do
+    it "returns 403" do
+      xhr :post, "import", {import: valid_activity_import_json}
+      expect(response.status).to eq(403)
+      expect(response.content_type).to eq("application/json")
+    end
+  end
+end

--- a/spec/controllers/api/v1/import_controller_spec.rb
+++ b/spec/controllers/api/v1/import_controller_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Api::V1::ImportController do
   let (:user) { FactoryGirl.create(:author) }
   let (:valid_activity_import_json) { JSON.parse(File.read(Rails.root + 'spec/import_examples/valid_lightweight_activity_import.json'), symbolize_keys: true) }
+  let (:invalid_activity_import_json) { JSON.parse(File.read(Rails.root + 'spec/import_examples/invalid_lightweight_activity_import.json'), symbolize_keys: true) }
 
   describe "when user is logged in and allowed to import activity" do
     before(:each) do
@@ -17,6 +18,14 @@ describe Api::V1::ImportController do
         success: true,
         url: activity_url(LightweightActivity.last)
       }.to_json)
+    end
+
+    describe "when import fails for some reason" do
+      it "returns 500" do
+        xhr :post, "import", {import: invalid_activity_import_json}
+        expect(response.status).to eq(500)
+        expect(response.content_type).to eq("application/json")
+      end
     end
   end
 

--- a/spec/controllers/api/v1/lighweight_activity_controller_spec.rb
+++ b/spec/controllers/api/v1/lighweight_activity_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Api::V1::LightweightActivitiesController do
+  let (:admin) { FactoryGirl.create(:admin) }
+  let (:author1) { FactoryGirl.create(:author) }
+  let (:author2) { FactoryGirl.create(:author) }
+  let (:activity) { FactoryGirl.create(:activity, user: author1) }
+
+  describe "#destroy" do
+    def expect_success_for(user)
+      if user
+        sign_in user
+      end
+      xhr :delete, "destroy", id: activity.id
+      expect(LightweightActivity.exists?(activity)).to eq(false)
+      expect(response.status).to eq(200)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to eql({
+        success: true
+      }.to_json)
+    end
+
+    def expect_fail_for(user)
+      if user
+        sign_in user
+      end
+      xhr :delete, "destroy", id: activity.id
+      expect(LightweightActivity.exists?(activity)).to eq(true)
+      expect(response.status).to eq(403)
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it "when user is an admin, destroys an activity" do
+      expect_success_for(admin)
+    end
+
+    it "when user is an author, destroys an activity" do
+      expect_success_for(author1)
+    end
+
+    it "when user is not an author, does not destroy an activity" do
+      expect_fail_for(author2)
+    end
+
+    it "when user is anonymous, does not destroy an activity" do
+      expect_fail_for(nil)
+    end
+  end
+end

--- a/spec/controllers/api/v1/sequences_controller_spec.rb
+++ b/spec/controllers/api/v1/sequences_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Api::V1::SequencesController do
+  let (:admin) { FactoryGirl.create(:admin) }
+  let (:author1) { FactoryGirl.create(:author) }
+  let (:author2) { FactoryGirl.create(:author) }
+  let (:sequence) { FactoryGirl.create(:sequence, user: author1) }
+
+  describe "#destroy" do
+    def expect_success_for(user)
+      if user
+        sign_in user
+      end
+      xhr :delete, "destroy", id: sequence.id
+      expect(Sequence.exists?(sequence)).to eq(false)
+      expect(response.status).to eq(200)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to eql({
+        success: true
+      }.to_json)
+    end
+
+    def expect_fail_for(user)
+      if user
+        sign_in user
+      end
+      xhr :delete, "destroy", id: sequence.id
+      expect(Sequence.exists?(sequence)).to eq(true)
+      expect(response.status).to eq(403)
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it "when user is an admin, destroys an sequence" do
+      expect_success_for(admin)
+    end
+
+    it "when user is an author, destroys an sequence" do
+      expect_success_for(author1)
+    end
+
+    it "when user is not an author, does not destroy an sequence" do
+      expect_fail_for(author2)
+    end
+
+    it "when user is anonymous, does not destroy an sequence" do
+      expect_fail_for(nil)
+    end
+  end
+end

--- a/spec/controllers/import_controller_spec.rb
+++ b/spec/controllers/import_controller_spec.rb
@@ -1,34 +1,31 @@
 require 'spec_helper'
 describe ImportController do
-  
+
   before(:each) do
     @user ||= FactoryGirl.create(:admin)
     sign_in @user
   end
 
   describe 'routing' do
-    
     it 'recognizes and generates #import_status' do
       expect({:get => "/import"}).
         to route_to({
-          :controller       => 'import', 
+          :controller       => 'import',
           :action           => 'import_status'
       })
     end
-    
-  end  
-  
+  end
+
   describe '#import' do
-    
-    context "lightweight activity" do 
-      
+
+    context "lightweight activity" do
+
       valid_activity_import_json = File.new(Rails.root + 'spec/import_examples/valid_lightweight_activity_import.json', :symbolize_names => true)
       let(:params1) do
             {
                import:{
                  import:ActionDispatch::Http::UploadedFile.new(tempfile: valid_activity_import_json, filename: File.basename(valid_activity_import_json), content_type: "application/json")
-               } 
-               
+               }
             }
       end
       invalid_activity_import_json = File.new(Rails.root + 'spec/import_examples/invalid_lightweight_activity_import.json', :symbolize_names => true)
@@ -36,35 +33,32 @@ describe ImportController do
             {
                import:{
                  import:ActionDispatch::Http::UploadedFile.new(tempfile: invalid_activity_import_json, filename: File.basename(invalid_activity_import_json), content_type: "application/json")
-               } 
-               
+               }
             }
       end
-      
+
       it "can import a lightweight activity from a valid lightweight activity json and redirect to edit page" do
         xhr :post, "import", params1
-        expect(assigns(:import_item)).to be_a(LightweightActivity)
         expect(response.content_type).to eq("text/javascript")
-        expect(response.body).to eq("window.location.href = 'activities/#{assigns(:import_item).id}/edit'\;")
+        expect(response.body).to eq("window.location.href = '/activities/#{LightweightActivity.last.id}/edit';")
       end
-      
+
       it "response status 500 error if import fails" do
         xhr :post, "import", params2
         response.status == 500
-        expect(response.body).to eq("{\"error\":\"Import failed because of invalid JSON file.\"}")
+        expect(response.body).to eq("{\"error\":\"Import failed: unknown type\"}")
       end
-      
+
     end
-    
-     context "Sequence" do 
-      
+
+     context "sequence" do
+
       valid_sequence_import_json = File.new(Rails.root + 'spec/import_examples/valid_sequence_import.json')
       let(:params1) do
             {
                import:{
                  import:ActionDispatch::Http::UploadedFile.new(tempfile: valid_sequence_import_json, filename: File.basename(valid_sequence_import_json), content_type: "application/json")
-               } 
-               
+               }
             }
       end
       invalid_sequence_import_json = File.new(Rails.root + 'spec/import_examples/invalid_sequence_import.json')
@@ -72,24 +66,22 @@ describe ImportController do
             {
                import:{
                  import:ActionDispatch::Http::UploadedFile.new(tempfile: invalid_sequence_import_json, filename: File.basename(invalid_sequence_import_json), content_type: "application/json")
-               } 
-               
+               }
             }
       end
-      
+
       it "can import a sequence from a valid sequence json and redirect to edit page" do
         xhr :post, "import", params1
-        expect(assigns(:import_item)).to be_a(Sequence)
         expect(response.content_type).to eq("text/javascript")
-        expect(response.body).to eq("window.location.href = 'sequences/#{assigns(:import_item).id}/edit'\;")
+        expect(response.body).to eq("window.location.href = '/sequences/#{Sequence.last.id}/edit';")
       end
-      
+
       it "response status 500 error if import fails" do
         xhr :post, "import", params2
         response.status == 500
-        expect(response.body).to eq("{\"error\":\"Import failed because of invalid JSON file.\"}")
+        expect(response.body).to eq("{\"error\":\"Import failed: unknown type\"}")
       end
     end
-    
+
   end
 end

--- a/spec/import_examples/invalid_lightweight_activity_import.json
+++ b/spec/import_examples/invalid_lightweight_activity_import.json
@@ -6,5 +6,5 @@
 	"related": "Contains all interactivities and embeddables.",
 	"theme_id": null,
 	"thumbnail_url": "",
-	"time_to_complete": null,
+	"time_to_complete": null
 }

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+describe Import do
+
+  let (:user) { FactoryGirl.create(:admin) }
+  let (:valid_activity_import_json) { File.read(Rails.root + 'spec/import_examples/valid_lightweight_activity_import.json') }
+  let (:invalid_activity_import_json) { File.read(Rails.root + 'spec/import_examples/invalid_lightweight_activity_import.json') }
+  let (:valid_sequence_import_json) { File.read(Rails.root + 'spec/import_examples/valid_sequence_import.json') }
+  let (:invalid_sequence_import_json) { File.read(Rails.root + 'spec/import_examples/invalid_sequence_import.json') }
+
+  describe '#import' do
+    context "lightweight activity" do
+      it "can import a lightweight activity from a valid lightweight activity json" do
+        result = Import.import(valid_activity_import_json, user)
+        expect(result[:success]).to eq(true)
+        expect(result[:import_item]).to be_a(LightweightActivity)
+        expect(result[:type]).to eq("LightweightActivity")
+      end
+
+      it "returns error if input is incorrect" do
+        result = Import.import(invalid_activity_import_json, user)
+        expect(result[:success]).to eq(false)
+        expect(result[:error]).to be_a(String)
+      end
+    end
+
+    context "sequence" do
+      it "can import a sequence from a valid lightweight activity json" do
+        result = Import.import(valid_sequence_import_json, user)
+        expect(result[:success]).to eq(true)
+        expect(result[:import_item]).to be_a(Sequence)
+        expect(result[:type]).to eq("Sequence")
+      end
+
+      it "returns error if input is incorrect" do
+        result = Import.import(invalid_sequence_import_json, user)
+        expect(result[:success]).to eq(false)
+        expect(result[:error]).to be_a(String)
+      end
+    end
+
+    it "handles Hash object as an input" do
+      hash = JSON.parse(valid_activity_import_json, :symbolize_names => true)
+      result = Import.import(hash, user)
+      expect(result[:success]).to eq(true)
+      expect(result[:import_item]).to be_a(LightweightActivity)
+      expect(result[:type]).to eq("LightweightActivity")
+    end
+
+    it "creates an Import instance in DB" do
+      expect(Import.count).to eq(0)
+      result = Import.import(valid_activity_import_json, user)
+      expect(Import.count).to eq(1)
+      expect(Import.first.import_item).to eq(result[:import_item])
+    end
+  end
+end


### PR DESCRIPTION
I've added a common base for our API controllers that should unify at least error messages. I guess I can't fix old ones, as they are used externally.

Also, a few new controllers:
 - import
 - activity (destroy only)
 - sequence (destroy only)

And I tried to clean up import code and tests a bit.

Some of these actions could be handled by old controllers if we checked for xhr request, although I'm trying to follow a pattern where new, non-rails-template-base code should call api/v1 methods instead. I guess it'll be a bit easier to clean up things or remove dead code in the future (e.g. if we get rid of the old UI and want to leave API only).