### PR TITLE
Fix wrapping of embeddables, let authors wrap the next interactive on the same page

### DIFF
--- a/app/models/attached_to_embeddable.rb
+++ b/app/models/attached_to_embeddable.rb
@@ -23,16 +23,17 @@ module AttachedToEmbeddable
   NEXT_EMBEDDABLE_SELECT = [NEXT_EMBEDDABLE_LABEL, NEXT_EMBEDDABLE_VALUE]
 
   def embeddable
-    if attached_to_next_interactive
-      embeddables = page.embeddables
-      self_index = embeddables.index(self)
-      embeddables[self_index + 1]
+    if attached_to_next_embeddable
+      # p_item is a page item, which `acts as a list`. That lets us quickly get the next item and embeddable
+      # without loading all the embeddables and manually checking index.
+      next_page_item = p_item.lower_item
+      next_page_item && next_page_item.embeddable
     else
       super
     end
   end
 
-  def attached_to_next_interactive
+  def attached_to_next_embeddable
     embeddable_type == NEXT_EMBEDDABLE_VALUE
   end
 
@@ -40,7 +41,7 @@ module AttachedToEmbeddable
     # Note that it's not enough to check embeddable value. If this item is the last one in the page and is attached
     # to the next interactive, #embeddable will return nil. However, we still should consider this item as attached
     # to something (e.g. in authoring forms).
-    attached_to_next_interactive || !!embeddable
+    attached_to_next_embeddable || !!embeddable
   end
 
   def possible_embeddables
@@ -59,7 +60,7 @@ module AttachedToEmbeddable
 
   def embeddable_select_value
     return @embeddable_select_value if @embeddable_select_value
-    if attached_to_next_interactive
+    if attached_to_next_embeddable
       NEXT_EMBEDDABLE_VALUE
     else
       make_embeddable_select_value(embeddable) if embeddable
@@ -67,7 +68,7 @@ module AttachedToEmbeddable
   end
 
   def embeddable_select_label
-    if attached_to_next_interactive
+    if attached_to_next_embeddable
       NEXT_EMBEDDABLE_LABEL
     else
       make_embeddable_select_label(embeddable) if embeddable

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -81,7 +81,7 @@ module Embeddable
   end
 
   # ID which is unique among all the embeddable types.
-  def embeddable_id
-    "#{self.class.to_s.demodulize.underscore}_#{self.id}"
+  def embeddable_dom_id
+    "embeddable-#{self.class.to_s.demodulize.underscore}_#{self.id}"
   end
 end

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -46,9 +46,15 @@ module Embeddable
     return nil
   end
 
+  def p_item
+    # Some embeddables define page_item, some page_items.
+    # In practice, there's always just one page, so many to many relationship isn't necessary.
+    respond_to?(:page_item) ? page_item : page_items.first
+  end
+
   def page
     # Some embeddables define interactive_page, some interactive_pages.
-    # In pratice, there's always just one page, so many to many relationship isn't necessary.
+    # In practice, there's always just one page, so many to many relationship isn't necessary.
     respond_to?(:interactive_page) ? interactive_page : interactive_pages.first
   end
 

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -46,12 +46,14 @@ module Embeddable
     return nil
   end
 
+  def page
+    # Some embeddables define interactive_page, some interactive_pages.
+    # In pratice, there's always just one page, so many to many relationship isn't necessary.
+    respond_to?(:interactive_page) ? interactive_page : interactive_pages.first
+  end
+
   def activity
-    if interactive_pages.length > 0 && interactive_pages.first.lightweight_activity.present?
-      return interactive_pages.first.lightweight_activity
-    else
-      return nil
-    end
+    page && page.lightweight_activity
   end
 
   # A unique key to use for local storage

--- a/app/models/embeddable/embeddable_plugin.rb
+++ b/app/models/embeddable/embeddable_plugin.rb
@@ -88,15 +88,9 @@ module Embeddable
       page_items.count > 0 && page_items.first.section
     end
 
-    def page
-      # Return first page (note that in practice it's impossible that this model has more
-      # than one page, even though it's many-to-many association).
-      interactive_pages.first
-    end
-
     def wrapping_plugin?
       # It is if it's attached to some other embeddable.
-      !!embeddable
+      attached_to_embeddable
     end
   end
 end

--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -90,12 +90,6 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
     true
   end
 
-  def page
-    # Return first page (note that in practice it's impossible that this model has more
-    # than one page, even though it's many-to-many association).
-    interactive_pages.first
-  end
-
   def page_section
     # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
     page_items.count > 0 && page_items.first.section

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -106,12 +106,6 @@ module Embeddable
       action_type == SNAPSHOT_ACTION
     end
 
-    def page
-      # Return first page (note that in practice it's impossible that this model has more
-      # than one page, even though it's many-to-many association).
-      interactive_pages.first
-    end
-
     def page_section
       # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
       page_items.count > 0 && page_items.first.section

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -182,8 +182,4 @@ class MwInteractive < ActiveRecord::Base
   def page_section
     page_item && page_item.section
   end
-
-  def index_in_activity
-    interactive_page.interactives.index(self) + 1
-  end
 end

--- a/app/views/embeddable/embeddable_plugins/_author.html.haml
+++ b/app/views/embeddable/embeddable_plugins/_author.html.haml
@@ -12,5 +12,4 @@
   - if embeddable.wrapping_plugin?
     .wrapped-embeddable
       Wrapped embeddable:
-      - wrapped = embeddable.embeddable
-      = "#{wrapped.class.model_name.human} (#{wrapped.index_in_activity})"
+      = embeddable.embeddable_select_label

--- a/app/views/interactive_pages/_interactive.html.haml
+++ b/app/views/interactive_pages/_interactive.html.haml
@@ -1,3 +1,6 @@
 .interactive-mod{class: layout == 'l-full-width' ? nil : 'pinned'}
   - page.interactive_box_visible_embeddables.each do |interactive|
-    = render_interactive(interactive)
+    %div{ id: interactive.embeddable_dom_id }
+      -# This CSS class is important, as it might be referenced by plugins and passed to a plugin instance.
+      .embeddable-container
+        = render_interactive(interactive)

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -12,8 +12,9 @@
           -# e variable is actually either embeddable (for interactives, plugins, etc.) or embeddable answer
           -# (open response, multiple choice and all the question types). If the latter, get a real question object.
           - question = e.respond_to?(:question) ? e.question : e
-          .question{ class: css_class, id: "question-#{question.embeddable_id}" }
-            .question-container
+          .question{ class: css_class, id: question.embeddable_dom_id }
+            -#This CSS class is important, as it might be referenced by plugins and passed to a plugin instance.
+            .embeddable-container
               - if Embeddable::is_interactive?(e)
                 = render_interactive(e)
               - else

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -26,8 +26,8 @@
   - learner_state = PluginLearnerState.find_or_create(plugin, @run).state
   - if wrapped_embeddable
     -# Plugin is wrapping some other embeddable. It's injected into its div and gets question content.
-    - runtime_div_selector = "#question-#{wrapped_embeddable.embeddable_id}"
-    - wrapped_selector = "#question-#{wrapped_embeddable.embeddable_id} .question-container"
+    - runtime_div_selector = "##{wrapped_embeddable.embeddable_dom_id}"
+    - wrapped_selector = "#{runtime_div_selector} .embeddable-container"
   - else
     -# Typical case. Plugin renders its own output.
     - output_id = "output-#{plugin.id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
   WELCOME: "Welcome"
   NO_INTERACTIVE: "No Interactive"
   NO_EMBEDDABLE: "No Embeddable"
+  NEXT_EMBEDDABLE: "Next Embeddable"
   SNAPSHOT_WITHOUT_INTERACTIVE: "Snapshot won't work, as the interactive is not selected"
   ARG_BLOCK:
     PLEASE_ANSWER: "Please answer all questions in the argumentation block."

--- a/spec/support/shared_examples/attached_to_embeddable.rb
+++ b/spec/support/shared_examples/attached_to_embeddable.rb
@@ -34,21 +34,42 @@ shared_examples "attached to embeddable" do
     end
   end
 
+  describe "#embeddable" do
+    it "when regular reference is used, it should return correct embeddable item" do
+      test_embeddable.embeddable_select_value = test_embeddable.make_embeddable_select_value(open_response_embeddable)
+      expect(test_embeddable.save).to eql(true)
+      expect(test_embeddable.attached_to_embeddable).to eql(true)
+      expect(test_embeddable.embeddable).to eql(open_response_embeddable)
+    end
+
+    it "when 'next embeddable' special value is used, it should return next embeddable from the same page" do
+      test_embeddable.embeddable_select_value = AttachedToEmbeddable::NEXT_EMBEDDABLE_VALUE
+      expect(test_embeddable.save).to eql(true)
+      expect(test_embeddable.attached_to_embeddable).to eql(true)
+      expect(test_embeddable.embeddable).to eql(nil) # no other embeddables on this page yet
+
+      page.add_embeddable(open_response_embeddable)
+      expect(test_embeddable.embeddable).to eql(open_response_embeddable)
+    end
+  end
+
   describe "#embeddables_for_select" do
     let(:embeddable_a)         { FactoryGirl.create(:open_response) }
     let(:embeddable_b)         { FactoryGirl.create(:open_response) }
 
     let(:expected_identifier_1) { AttachedToEmbeddable::NO_EMBEDDABLE_SELECT }
-    let(:expected_identifier_2) { ["Open response (1)", "#{embeddable_a.id}-Embeddable::OpenResponse"]}
-    let(:expected_identifier_3) { ["Open response (2)", "#{embeddable_b.id}-Embeddable::OpenResponse"]}
-    let(:expected_identifier_4) { ["Open response (hidden)(3)", "#{hidden_open_response_embeddable.id}-Embeddable::OpenResponse"]}
+    let(:expected_identifier_2) { AttachedToEmbeddable::NEXT_EMBEDDABLE_SELECT }
+    let(:expected_identifier_3) { ["Open response (1)", "#{embeddable_a.id}-Embeddable::OpenResponse"]}
+    let(:expected_identifier_4) { ["Open response (2)", "#{embeddable_b.id}-Embeddable::OpenResponse"]}
+    let(:expected_identifier_5) { ["Open response (hidden)(3)", "#{hidden_open_response_embeddable.id}-Embeddable::OpenResponse"]}
 
     let(:embeddables) { [embeddable_a, embeddable_b, hidden_open_response_embeddable] }
     it "should have good options" do
       expect(test_embeddable.embeddables_for_select).to include expected_identifier_1
       expect(test_embeddable.embeddables_for_select).to include expected_identifier_2
       expect(test_embeddable.embeddables_for_select).to include expected_identifier_3
-      expect(test_embeddable.embeddables_for_select).to include expected_identifier_3
+      expect(test_embeddable.embeddables_for_select).to include expected_identifier_4
+      expect(test_embeddable.embeddables_for_select).to include expected_identifier_5
     end
   end
 end

--- a/spec/support/shared_examples/attached_to_embeddable_form.rb
+++ b/spec/support/shared_examples/attached_to_embeddable_form.rb
@@ -29,10 +29,10 @@ shared_examples "attached to embeddable form" do
 
   describe "with two embeddables on the page" do
     let(:embeddables)  {[embeddable_a,embeddable_b]}
-    it "includes three choices" do
+    it "includes four choices (no interactive, next interactive, and two embeddables)" do
       assign(:embeddable, test_embeddable)
       render
-      expect(rendered).to have_css embeddable_choice_select_css, count: 3
+      expect(rendered).to have_css embeddable_choice_select_css, count: 4
     end
   end
 end


### PR DESCRIPTION
1. Cleanup of `Embeddable#page` implementation (1st commit)
2. Fixed numbering / labeling of the attachable embeddables. Now, I always use index based on the position of embeddable on the given page. Before, in some places (authoring view, after the form is closed) I was using "index_in_activity" which works only for questions/reportable_items only. So, if user tried to wrap the non-reportable item, it was crashing LARA edit page. It was also causing some mismatch between labels. Now, the same method is used in pulldown and authing view.
3. I've added a possibility to wrap the next embeddable on the same page. It was very simple so I went ahead. I intentionally reused existing DB fields, so we don't have to run migrations back and forth if we don't like this idea for some reason (and it works fine). I think it's pretty simple and it makes authoring way easier. When I was setting up the example on staging yesterday, it was pretty hard to find the right question when we had 15 of them + a bunch of plugins that also get listed in the pulldown. I've addes some tests of this feature too.