### PR TITLE
Fix text decoration (LARA API) and wrapped plugin logic

### DIFF
--- a/app/assets/javascripts/lara-api.js
+++ b/app/assets/javascripts/lara-api.js
@@ -228,7 +228,7 @@ window.LARA = {
   type IEventListeners = IEventListener | IEventListener[];
   ****************************************************************************/
   decorateContent: function (words, replace, wordClass, listeners) {
-    var domClasses = ['question-txt', 'intro-txt'];
+    var domClasses = ['question-txt', 'help-content', 'intro-txt'];
     var options = {
       words: words,
       replace: replace

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -24,9 +24,11 @@
 - else
   -# Version 2
   - learner_state = PluginLearnerState.find_or_create(plugin, @run).state
-  - if wrapped_embeddable
+  -# wrapped_embeddable template variable might be undefined when the activity level plugins are rendered
+  - wrapped_embedd = defined?(wrapped_embeddable) && wrapped_embeddable
+  - if wrapped_embedd
     -# Plugin is wrapping some other embeddable. It's injected into its div and gets question content.
-    - runtime_div_selector = "##{wrapped_embeddable.embeddable_dom_id}"
+    - runtime_div_selector = "##{wrapped_embedd.embeddable_dom_id}"
     - wrapped_selector = "#{runtime_div_selector} .embeddable-container"
   - else
     -# Typical case. Plugin renders its own output.
@@ -53,7 +55,7 @@
         learnerState: learner_state,
         div: $('#{runtime_div_selector}')[0],
         wrappedEmbeddableDiv: $('#{wrapped_selector}')[0],
-        wrappedEmbeddableContext: #{wrapped_embeddable ? (LaraSerializationHelper.new).export(wrapped_embeddable).to_json : 'null'}
+        wrappedEmbeddableContext: #{wrapped_embedd ? (LaraSerializationHelper.new).export(wrapped_embedd).to_json : 'null'}
       }
       console.log("Adding script #{plugin.label} with V2 LARA Plugin API")
       Plugins.initPlugin('#{plugin.label}', env, pluginStatePaths);


### PR DESCRIPTION
Changes:
1. Let plugins decorate text in question help.
2. Fix a bug which was crashing LARA when the activity-level plugin was used (non-embeddable one).