### PR TITLE
flush stdout by default

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,3 +69,7 @@ end
 # On a mac, you will need to use this tool, or something similar:
 # https://github.com/dhoulb/subl
 BetterErrors.editor = :subl
+
+# Flush stdout which is used for logging, in some cases docker was not seeing the
+# output. There might be a better way to handle this.
+$stdout.sync = true


### PR DESCRIPTION
stdout is used by the logging system and it was getting buffered by linux inside of docker
So log messages were not seen until the buffer was full.