### PR TITLE
log the amount of time a request sits in the queue

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -79,6 +79,10 @@ module LightweightStandalone
         resource '/api/*', :headers => :any, :methods => [:get, :post, :put, :options]
       end
     end
+
+    # Add a middlewere to log more info about the response
+    config.middleware.insert_before 0, "Rack::ResponseLogger"
+
     # do not initialize on precompile so that the Dockerfile can run the precompile
     config.assets.initialize_on_precompile = false
 

--- a/lib/rack/response_logger.rb
+++ b/lib/rack/response_logger.rb
@@ -1,0 +1,54 @@
+class Rack::ResponseLogger
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    queue_time = measure_queue_time(env)
+    if queue_time.present?
+      Rails.logger.info "QueueTime #{queue_time} \"#{env['PATH_INFO']}\""
+    end
+
+    @app.call(env)
+  end
+
+  private
+
+  # this code was taken from the prometheus_exporter project:
+  # https://github.com/discourse/prometheus_exporter/blob/900a9f22e4724e68b1d83c7f2eacbbb143594f1e/lib/prometheus_exporter/middleware.rb#L57-L89
+  # it is licensed with an MIT license
+
+  # measures the queue time (= time between receiving the request in downstream
+  # load balancer and starting request in ruby process)
+  def measure_queue_time(env)
+    start_time = queue_start(env)
+
+    return unless start_time
+
+    queue_time = request_start.to_f - start_time.to_f
+    queue_time unless (queue_time < 0)
+  end
+
+  # need to use CLOCK_REALTIME, as nginx/apache write this also out as the unix timestamp
+  def request_start
+    Process.clock_gettime(Process::CLOCK_REALTIME)
+  end
+
+  # get the content of the x-queue-start or x-request-start header
+  def queue_start(env)
+    value = env['HTTP_X_REQUEST_START'] || env['HTTP_X_QUEUE_START']
+    unless value.nil? || value == ''
+      convert_header_to_ms(value.to_s)
+    end
+  end
+
+  # nginx returns time as milliseconds with 3 decimal places
+  # apache returns time as microseconds without decimal places
+  # this method takes care to convert both into a proper second + fractions timestamp
+  def convert_header_to_ms(str)
+    str = str.gsub(/t=|\./, '')
+    "#{str[0,10]}.#{str[10,13]}".to_f
+  end
+
+end


### PR DESCRIPTION
this should be a good metric for measuring the load on the server.
This metric is the time the request is waiting from when nginx receives it to when rack picks it up.
There could be additional queue time by the AWS load balancer, but that shouldn't be necessary
to get a good sense of how far behind the rack is getting.

[#162059682]  https://www.pivotaltracker.com/story/show/162059682

The format of the message is conducive to be picked up by a CloudWatch log metric filter so it can be used by the autoscaler.  It is not clear how much delay this `log -> metric filter` approach will introduce, but I think I'll be able to look at that once this is up on staging.