### PR TITLE
Configure GA using  ENV vars.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,7 +57,7 @@
 </div>
 <div id="overlay"></div>
 <%= render :partial => 'shared/modal' %>
-<%= render :partial => 'shared/analytics' if Rails.env == 'production' && !request.host.match(/staging/) %>
+<%= render :partial => 'shared/analytics' %>
 <%= yield :extra_javascript %>
 </body>
 </html>

--- a/app/views/layouts/runtime.html.erb
+++ b/app/views/layouts/runtime.html.erb
@@ -113,7 +113,7 @@
 <!-- eo #container -->
 <%= render :partial => "shared/i18njs" %>
 <%= render :partial => 'shared/loading' %>
-<%= render :partial => 'shared/analytics' if Rails.env == 'production' && !request.host.match(/staging/) %>
+<%= render :partial => 'shared/analytics' %>
 
 <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 <!-- Scripts					-->

--- a/app/views/shared/_analytics.html.haml
+++ b/app/views/shared/_analytics.html.haml
@@ -1,12 +1,13 @@
-:javascript
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+- if ENV['GOOGLE_ANALYTICS_ACCOUNT'].present?
+  :javascript
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics_debug.js','ga');
 
-  ga('create', 'UA-6899787-36', 'concord.org');
+    ga('create', '#{ENV['GOOGLE_ANALYTICS_ACCOUNT']}', 'auto');
 
-= yield :google_analytics_setup
+  = yield :google_analytics_setup
 
-:javascript
-  ga('send', 'pageview');
+  :javascript
+    ga('send', 'pageview');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       SECRET_TOKEN: b30c94c7-81b7-4f20-8df9-686b079a616a
       C_RATER_FAKE:
       LARA_VERSION: Local Docker
+      GOOGLE_ANALYTICS_ACCOUNT:
     # no ports are published, see below for details
     depends_on:
       - db

--- a/spec/views/shared/_analytics.html.haml_spec.rb
+++ b/spec/views/shared/_analytics.html.haml_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'shared/_analytics' do
+
+  describe "Google analytics support" do
+    let(:script_regex) { "ga('send', 'pageview');"}
+
+    describe "With a GA token" do
+      before(:each) do
+        ENV['GOOGLE_ANALYTICS_ACCOUNT'] = 'fake-ga-account'
+      end
+
+      it "should render the analytics javascript" do
+        render
+        expect(rendered).to include script_regex
+      end
+    end
+    describe "without a GA token" do
+      before(:each) do
+        ENV['GOOGLE_ANALYTICS_ACCOUNT'] = nil
+      end
+      it "should not render the analytics javascript" do
+        render
+        expect(rendered).to_not include script_regex
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of hard-coding GA information in the view templates, use the same technique and ENV vars used by portal: GOOGLE_ANALYTICS_ACCOUNT

NOTE: A new GA account was setup for "Development Sites"
so that we can use a GA token for staging servers.

[#161965279]

https://www.pivotaltracker.com/story/show/161965279