### PR TITLE
Add portal endpoints to Lara Plugin context

### DIFF
--- a/app/assets/javascripts/plugins.js
+++ b/app/assets/javascripts/plugins.js
@@ -33,13 +33,35 @@ window.Plugins = {
     loadPath: string;
   }
 
+  Interface IEmbeddableContext {
+    // TBD, can be almost anything, details of the wrapped embeddable, eg:
+    // Serialized form of the embeddable, eg:
+    aspect_ratio_method: "DEFAULT",
+    authored_state: null,
+    click_to_play: false,
+    enable_learner_state": true,
+    name: "Test Interactive",
+    native_height: 435,
+    native_width: 576,
+    url: "http://concord-consortium.github.io/lara-interactive-api/iframe.html",
+    type: "MwInteractive",
+    ref_id: "86-MwInteractive"
+  }
+
   Interface IRuntimeContext {
     name: string;               // Name of the plugin
     url: string;                // Url from which the plugin was loaded
     pluginId: string;           // Active record ID of the plugin scope id
-    authorData: string;         // The authored configuration for this instance
-    learnerData: string;        // The saved learner data for this instance
+    authoredState: string;      // The authored configuration for this instance
+    learnerState: string;       // The saved learner data for this instance
     div: HTMLElement;           // reserved HTMLElement for the plugin output
+    runID: integer,             // The run ID for the current run
+    userEmail: string,          // The current users email address if available
+    classInfoUrl: string,       // The portal URL for class details (if avail)
+    remoteEndpoint: string,     // The portal remote endpoint (if available)
+    getFirebaseJwtUrl: function,// A function that retuns the URL to use fetch a JWT
+    wrappedEmbeddableDiv: HTMLElement, // If we are wrapping an embeddable its DOM
+    wrappedEmbeddableContext: IEmbeddableContext // Data about our embeddable
   }
   ****************************************************************************/
   initPlugin: function(label, runtimeContext, pluginStatePaths) {

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -40,6 +40,10 @@
   - firebase_jwt_url = api_v1_get_firebase_jwt_url(@run.id, {firebase_app: '_FIREBASE_APP_'})
   - user_email = @run.user ? @run.user.email : 'anonymous'
   - class_info_url = @run.class_info_url
+  - interactive_state_url = ''
+  - if (wrapped_embedd && wrapped_embedd.respond_to?(:interactive_run_states))
+    - irs = InteractiveRunState.by_run_and_interactive(@run,wrapped_embedd)
+    - interactive_state_url = irs && irs.key ? api_v1_show_interactive_run_state_path({key: irs.key}) : ''
   :javascript
     // Begin script for #{plugin.name}
     var pluginStatePaths = {
@@ -63,6 +67,7 @@
         userEmail: '#{escape_javascript(user_email)}',
         classInfoUrl: '#{escape_javascript(class_info_url)}',
         remoteEndpoint: '#{escape_javascript(@run.remote_endpoint)}',
+        interactiveStateUrl: '#{escape_javascript(interactive_state_url)}',
         getFirebaseJwtUrl: getFirebaseJwtUrl,
         wrappedEmbeddableDiv: $('#{wrapped_selector}')[0],
         wrappedEmbeddableContext: #{wrapped_embedd ? (LaraSerializationHelper.new).export(wrapped_embedd).to_json : 'null'}

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -23,7 +23,8 @@
     });
 - else
   -# Version 2
-  - learner_state = PluginLearnerState.find_or_create(plugin, @run).state
+  - plugin_learner_state = PluginLearnerState.find_or_create(plugin, @run)
+  - learner_state = plugin_learner_state.state
   -# wrapped_embeddable template variable might be undefined when the activity level plugins are rendered
   - wrapped_embedd = defined?(wrapped_embeddable) && wrapped_embeddable
   - if wrapped_embedd
@@ -36,24 +37,33 @@
     .plugin-output{id: output_id}
     - runtime_div_selector = "##{output_id}"
     - wrapped_selector = nil
-
+  - firebase_jwt_url = api_v1_get_firebase_jwt_url(@run.id, {firebase_app: '_FIREBASE_APP_'})
+  - user_email = @run.user ? @run.user.email : 'anonymous'
+  - class_info_url = @run.class_info_url
   :javascript
     // Begin script for #{plugin.name}
-    var savePath = `#{escape_javascript(api_v1_update_plugin_learner_state_path(plugin.id, @run.id))}`
-    var loadPath = `#{escape_javascript(api_v1_show_plugin_learner_state_path(plugin.id, @run.id))}`
     var pluginStatePaths = {
-      savePath: savePath,
-      loadPath: loadPath
+      savePath: `#{escape_javascript(api_v1_update_plugin_learner_state_path(plugin.id, @run.id))}`,
+      loadPath: `#{escape_javascript(api_v1_show_plugin_learner_state_path(plugin.id, @run.id))}`
     };
-    var learner_state  = '#{ escape_javascript(learner_state) }'
     $(document).ready( function() {
+      var getFirebaseJwtUrl = function(appName) {
+        var laraJwtGettingUrl = '#{escape_javascript(firebase_jwt_url)}';
+        return laraJwtGettingUrl.replace('_FIREBASE_APP_', appName);
+      }
       env = {
         name: '#{plugin.name}',
         url: '#{plugin.url}',
         pluginId: '#{plugin.id}',
+        pluginStateKey:'#{ escape_javascript(plugin_learner_state.shared_learner_state_key)}',
         authoredState: '#{ escape_javascript(plugin.author_data) }',
-        learnerState: learner_state,
+        learnerState:  '#{ escape_javascript(learner_state) }',
         div: $('#{runtime_div_selector}')[0],
+        runID: #{@run.id},
+        userEmail: '#{escape_javascript(user_email)}',
+        classInfoUrl: '#{escape_javascript(class_info_url)}',
+        remoteEndpoint: '#{escape_javascript(@run.remote_endpoint)}',
+        getFirebaseJwtUrl: getFirebaseJwtUrl,
         wrappedEmbeddableDiv: $('#{wrapped_selector}')[0],
         wrappedEmbeddableContext: #{wrapped_embedd ? (LaraSerializationHelper.new).export(wrapped_embedd).to_json : 'null'}
       }

--- a/spec/views/plugins/_show.html.haml_spec.rb
+++ b/spec/views/plugins/_show.html.haml_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe "plugins/_show.html.haml" do
+  let(:version) { 2 }
+  let(:shared_learner_state_key) { 'shared-learner-state-key-is-a-string' }
+  let(:class_info_url) { 'http://class-info.url/'}
+  let(:email) { 'fake-user-name@fake-domain.com' }
+  let(:user_id)  { 123 }
+  let(:run_id)   { 123 }
+  let(:run_remote_endpoint) { nil }
+  let(:plugin_id){ 123 }
+  let(:plugin_name){ 'plugin-name' }
+  let(:plugin_label) {'plugin-label'}
+  let(:plugin_url) { 'http://plugin.com/plugin.js' }
+  let(:plugin_author_data){ "{'name': 'plugin-name'}" }
+  let(:user) do
+    double({
+      email: email,
+      id: user_id
+    })
+  end
+  let(:run) do
+    double({
+      user: user,
+      id: run_id,
+      class_info_url: class_info_url,
+      remote_endpoint: run_remote_endpoint
+    })
+  end
+  let(:_locals) do
+    {
+      # plugins: double(),
+      plugin: double({
+        name: plugin_name,
+        label: plugin_label,
+        id: plugin_id,
+        url: plugin_url,
+        version: version,
+        author_data: plugin_author_data,
+        shared_learner_state_key: shared_learner_state_key
+      })
+    }
+  end
+
+  before(:each) do
+    @run = run
+    render partial: "plugins/show", locals: _locals
+  end
+
+  it "should render a javascript to call Plugins.initPlugin with values" do
+    [
+      /url: '#{plugin_url}'/,
+      /pluginId: '#{plugin_id}'/,
+      /pluginStateKey:'#{shared_learner_state_key}'/,
+      /runID: #{run_id}/,
+      /userEmail: '#{email}'/,
+      /classInfoUrl: '#{class_info_url}'/,
+      /remoteEndpoint: '#{run_remote_endpoint}'/,
+      /getFirebaseJwtUrl: getFirebaseJwtUrl/,
+      /div:/,
+      /wrappedEmbeddableDiv:/,
+      /wrappedEmbeddableContext:/,
+      /Plugins\.initPlugin\('plugin-label', env, pluginStatePaths/
+    ].each do |expected_string|
+      expect(rendered).to match(expected_string)
+    end
+  end
+end


### PR DESCRIPTION
These URLS are required for the plugin to authenticate with firebase

[#163325279] -- Add Class Info URL
[#163325255] -- Add firebase JWT Fetching URL

https://www.pivotaltracker.com/story/show/163325255

I was looking for clever ways to put this into the LARA API instead of the initialization context, but the Plugin API doesn't know anything about the specific plugin, its configuration, or the run, it would have been problematic.  I documented and tested the additional the Plugin Context values

@scytacki or @dougmartin  could you have a look?
