### PR TITLE
CRater::APIWrapper when url  is blank use default API gateway .

### DIFF
--- a/lib/c_rater/api_wrapper.rb
+++ b/lib/c_rater/api_wrapper.rb
@@ -10,7 +10,7 @@ class CRater::APIWrapper
     @client_id = client_id
     @username  = username
     @password  = password
-    @url       = url || C_RATER_URI
+    @url       = url.present? ? url : C_RATER_URI
   end
 
   def request_xml(item_id, response_id, response_text)

--- a/spec/libs/c_rater/api_wrapper_spec.rb
+++ b/spec/libs/c_rater/api_wrapper_spec.rb
@@ -137,4 +137,34 @@ describe CRater::APIWrapper do
       end
     end
   end
+
+  describe "The Constructor params" do
+
+    describe "The url param" do
+      let(:crater) { CRater::APIWrapper.new(client_id, username, password, url) }
+      let(:default_url) { CRater::APIWrapper::C_RATER_URI }
+
+      describe "When blank" do
+        # See: https://www.pivotaltracker.com/story/show/164411237
+        let(:url) { "" }
+        it "Will set @url to the default value" do
+          expect(crater.instance_variable_get(:@url)).to eql(default_url)
+        end
+      end
+
+      describe "When a nil" do
+        let(:url) { nil }
+        it "should use the default value of CRater::APIWrapper::C_RATER_URI" do
+          expect(crater.instance_variable_get(:@url)).to eql(default_url)
+        end
+      end
+
+      describe "When a valid URL" do
+        let(:url) { "https://some.place.com" }
+        it "should use the param url" do
+          expect(crater.instance_variable_get(:@url)).to eql(url)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
For now the default value `CRater::APIWrapper:: C_RATER_URI` remains C-Rater

🐞 Fixes:

https://www.pivotaltracker.com/story/show/164411237

[#164411237]