### PR TITLE
Guard: Don't run all tests by default

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -3,7 +3,7 @@
 
 guard :rspec,
   cmd: 'bundle exec spring rspec --tag ~slow --tag ~js',
-  # To run all tets, just hit "<return>" in the console.
+  # To run all tests, just hit "<return>" in the console.
   all_after_pass: false,
   all_on_start: false do
 

--- a/Guardfile
+++ b/Guardfile
@@ -3,8 +3,9 @@
 
 guard :rspec,
   cmd: 'bundle exec spring rspec --tag ~slow --tag ~js',
-  all_after_pass: true,
-  all_on_start: true do
+  # To run all tets, just hit "<return>" in the console.
+  all_after_pass: false,
+  all_on_start: false do
 
   watch(%r{^spec/.+_spec\.rb$})
   watch('spec/spec_helper.rb')  { "spec" }


### PR DESCRIPTION
This is for developers convenience.

Instead of running the entire test suite, manually re-run suite when needed.

We were getting bogged down doing TDD because every time  a focus test passed, the entire suite would re-run.