### PR TITLE
164441051 crater resubmit limit 4

### DIFF
--- a/app/assets/javascripts/c_rater.coffee
+++ b/app/assets/javascripts/c_rater.coffee
@@ -71,7 +71,6 @@ class ArgumentationBlockController
     return if (@student_submission_attempts > MAX_STUDENT_SUBMISSIONS)
     @showWaiting()
     @service_attempts = 0
-    @student_submission_attempts = @student_submission_attempts + 1
 
     @issueRequest()
 
@@ -102,6 +101,7 @@ class ArgumentationBlockController
           # If we are here, it means that service_attempts >= MAX_ERROR_RETRIES. Can't do anything now, just display an error.
           alert(t('ARG_BLOCK.SUBMIT_ERROR'))
         else
+          @student_submission_attempts = @student_submission_attempts + 1
           LoggerUtils.craterResponseLogging(data)
 
         @submissionCount += 1
@@ -189,7 +189,7 @@ class ArgumentationBlockController
         $(q.errorMsgElement).slideUp()
 
   updateForwardNavigationBlocking: ->
-    if @allQuestionAnswered() && @noDirtyQuestions()
+    if @allQuestionAnswered() && (@noDirtyQuestions() || !@studentCanSubmit() )
       @enableForwardNavigation()
     else
       @disableForwardNavigation()

--- a/app/assets/stylesheets/partials/_cc-theme-template.scss
+++ b/app/assets/stylesheets/partials/_cc-theme-template.scss
@@ -75,8 +75,11 @@
   input[type="submit"],
   button[type="button"] {
     border: 0;
-    @include btn($theme-color-b, darken($theme-color-b, 10%))
+    @include btn($theme-color-b, darken($theme-color-b, 10%));
     /*@include btn(lighten($theme-color-a, 10%), $theme-color-a);*/
+    &.disabled {
+      cursor: not-allowed;
+    }
   }
 
   .related-hdr {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,7 +61,7 @@ en:
   SNAPSHOT_WITHOUT_INTERACTIVE: "Snapshot won't work, as the interactive is not selected"
   ARG_BLOCK:
     PLEASE_ANSWER: "Please answer all questions in the argumentation block."
-    MAX_SUMISSIONS_REACHED: "You have exceeded the allowed feedback retries."
+    MAX_SUMISSIONS_REACHED: "You have used up all of your tries. Please move on to the next page."
     ANSWERS_NOT_CHANGED: "Answers have not been changed."
     SUBMIT: "Submit"
     RESUBMIT: "Resubmit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
   SNAPSHOT_WITHOUT_INTERACTIVE: "Snapshot won't work, as the interactive is not selected"
   ARG_BLOCK:
     PLEASE_ANSWER: "Please answer all questions in the argumentation block."
+    MAX_SUMISSIONS_REACHED: "You have exceeded the allowed feedback retries."
     ANSWERS_NOT_CHANGED: "Answers have not been changed."
     SUBMIT: "Submit"
     RESUBMIT: "Resubmit"
@@ -71,6 +72,7 @@ en:
     RESUBMIT_OR_MOVE: "You may revise your answers and resubmit, or you may move to the next page."
     FEEDBACK: "Feedback"
     RESUBMIT_ANSWER: "Answer has been changed, please resubmit to update feedback!"
+    RESUBMIT_ANSWER_LIMIT_REACHED: "Answer has been changed, but you are out of feedback tries."
     TEST_MODEL: "C-Rater Item ID references test model"
     NO_FEEDBACK_TEXT: "No feedback text defined for score: %{score}"
     NO_SCORE_MAPPING: "Score: %{score} (score mapping undefined)"


### PR DESCRIPTION
[NP/DL] This PR addresses the PT story [Resubmit limit](https://www.pivotaltracker.com/story/show/164441051) that will limit a the number of times the student may send auto-scoring requests.

Note: Test coverage of this work is deferred until we can import activities with arg-blocks -- which currently appears to be broken. See [LARA Import code skips Arg Block sections](https://www.pivotaltracker.com/story/show/164584021).

Several things are worth noting about this code:

* The manifest constant MAX_ATTEMPTS was changed to MAX_ERROR_RETRIES so to reduce the conflict with the concept of MAX_STUDENT_SUBMISSIONS.

* A completely new activity will have the submit button labeled "Submit"; but once the student has submitted something, the button will be relabeled with "Resubmit" and the number of retries remaining to the student, from that point on, even when the page is refreshed and the reset count is reinitialized to 4.

* To avoid conflicting messages, from the perspective of the student, the dirty-message feedback has been adjusted to say things have been changed, but also informs the student that they are out of tries. Originally, it would have said something like "stuff changed; resubmit" and that seems confusing if you're out of resubmit tries.

* And finally, as a little fit-n-finish touch, the mouse cursor is changed to a "not-allowed" pointer when over the disabled submit button.