### PR TITLE
Import arg block section

### DIFF
--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -264,7 +264,8 @@ class InteractivePage < ActiveRecord::Base
       :show_sidebar,
       :show_interactive,
       :show_info_assessment,
-      :embeddable_display_mode
+      :embeddable_display_mode,
+      :additional_sections
     ]
 
     attributes = {}

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -264,8 +264,7 @@ class InteractivePage < ActiveRecord::Base
       :show_sidebar,
       :show_interactive,
       :show_info_assessment,
-      :embeddable_display_mode,
-      :additional_sections
+      :embeddable_display_mode
     ]
 
     attributes = {}
@@ -282,6 +281,16 @@ class InteractivePage < ActiveRecord::Base
 
     InteractivePage.transaction do
       import_page.save!(validate: false)
+
+      # import :additional_sections from page_json_object.
+      # It will be a hash looking like this {:arg_block => true }
+      # but we need string keys, eg: {"arg_block" => true }
+      if page_json_object[:additional_sections]
+        page_json_object[:additional_sections].each do |k,v|
+          import_page.additional_sections ||= {}
+          import_page.additional_sections[k.to_s] = v
+        end
+      end
 
       # First, import and cache all the embeddables.
       page_json_object[:embeddables].each do |embed_hash|

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -15,10 +15,10 @@ test environments that you are planning to use:
  - staging
  - production
  
-Note that these credentials must work on `/user/sign_in` page, e.g. http://authoring.staging.concord.org/users/sign_in. 
+Note that these credentials must work on `/users/sign_in` page, e.g. http://authoring.staging.concord.org/users/sign_in.
 You **can't** use Portal to login (tests should not depend on Portal).
 
-These credentials and any other user-specific configuration should be specified in `config/user-config.json`. 
+These credentials and any other user-specific configuration should be specified in `config/user-config.json`.
 Copy existing sample and modify it:
 
 ```

--- a/cypress/cypress/fixtures/activities/activity_with_arg_block_section.json
+++ b/cypress/cypress/fixtures/activities/activity_with_arg_block_section.json
@@ -1,0 +1,279 @@
+{
+    "description": "",
+    "editor_mode": 0,
+    "external_report_url": null,
+    "layout": 0,
+    "name": "[Cypress] Arg Block Test",
+    "notes": "",
+    "project_id": 2,
+    "related": "",
+    "student_report_enabled": true,
+    "thumbnail_url": "",
+    "time_to_complete": 3,
+    "version": 1,
+    "theme_name": "HAS National Geographic: Water",
+    "pages": [
+        {
+            "additional_sections": {},
+            "embeddable_display_mode": "stacked",
+            "is_completion": false,
+            "is_hidden": false,
+            "layout": "l-6040",
+            "name": "page 1",
+            "position": 1,
+            "show_info_assessment": true,
+            "show_interactive": false,
+            "show_introduction": true,
+            "show_sidebar": false,
+            "sidebar": null,
+            "sidebar_title": "Did you know?",
+            "text": null,
+            "embeddables": [
+                {
+                    "embeddable": {
+                        "aspect_ratio_method": "DEFAULT",
+                        "authored_state": null,
+                        "click_to_play": true,
+                        "click_to_play_prompt": "",
+                        "enable_learner_state": true,
+                        "full_window": false,
+                        "has_report_url": false,
+                        "image_url": "https://www.catster.com/wp-content/uploads/2017/12/A-gray-kitten-meowing.jpg",
+                        "is_full_width": true,
+                        "is_hidden": false,
+                        "model_library_url": null,
+                        "name": "codap test",
+                        "native_height": 435,
+                        "native_width": 576,
+                        "show_delete_data_button": true,
+                        "show_in_featured_question_report": true,
+                        "url": "https://document-store.concord.org/v2/documents/86253/autolaunch?server=https%3A%2F%2Fcodap.concord.org%2Freleases%2Flatest%2F&scaling",
+                        "type": "MwInteractive",
+                        "ref_id": "86-MwInteractive"
+                    },
+                    "section": null
+                },
+                {
+                    "embeddable": {
+                        "plugin": {
+                            "description": "LaraSharingPlugin",
+                            "author_data": "",
+                            "approved_script_label": "LaraSharingPlugin"
+                        },
+                        "is_hidden": false,
+                        "is_full_width": false,
+                        "type": "Embeddable::EmbeddablePlugin",
+                        "ref_id": "54-Embeddable::EmbeddablePlugin",
+                        "embeddable_ref_id": "86-MwInteractive"
+                    },
+                    "section": null
+                }
+            ]
+        },
+        {
+            "additional_sections": {
+                "arg_block": true
+            },
+            "embeddable_display_mode": "stacked",
+            "is_completion": false,
+            "is_hidden": false,
+            "layout": "l-6040",
+            "name": "page 2",
+            "position": 2,
+            "show_info_assessment": false,
+            "show_interactive": false,
+            "show_introduction": false,
+            "show_sidebar": false,
+            "sidebar": null,
+            "sidebar_title": "Did you know?",
+            "text": null,
+            "embeddables": [
+                {
+                    "embeddable": {
+                        "custom": true,
+                        "enable_check_answer": false,
+                        "give_prediction_feedback": false,
+                        "hint": "<p><strong>Step 1: Select a claim.</strong></p>\r\n<ul>\r\n<li>A good claim is based on the evidence.</li>\r\n<li>Evidence may come from graphs and charts.</li>\r\n<li>Evidence may also come from models that you run.</li>\r\n</ul>",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "layout": "vertical",
+                        "multi_answer": false,
+                        "name": "Multiple Choice Question element",
+                        "prediction_feedback": "",
+                        "prompt": "<p>WHAT IS YOUR FAVORITE COLOR ??? ??! ?! ?!?</p>",
+                        "show_as_menu": false,
+                        "show_in_featured_question_report": true,
+                        "choices": [
+                            {
+                                "choice": "Blue",
+                                "is_correct": false,
+                                "prompt": ""
+                            },
+                            {
+                                "choice": "African",
+                                "is_correct": false,
+                                "prompt": ""
+                            },
+                            {
+                                "choice": "European",
+                                "is_correct": false,
+                                "prompt": ""
+                            }
+                        ],
+                        "type": "Embeddable::MultipleChoice",
+                        "ref_id": "144-Embeddable::MultipleChoice"
+                    },
+                    "section": "arg_block"
+                },
+                {
+                    "embeddable": {
+                        "default_text": null,
+                        "give_prediction_feedback": false,
+                        "hint": "\n  <b>Step 2: Write an explanation.</b>\n  <ul>\n  <li>A good explanation will cite specific evidence that backs up the claim.</li>\n  <li>When there is a graph or table, you can cite evidence directly from the source.</li>\n  <li>When there is a model, you can describe what happened in the model.</li>\n  <li>A good explanation combines evidence with scientific knowledge.</li>\n  </ul>\n  ",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "name": null,
+                        "prediction_feedback": null,
+                        "prompt": "Explain your answer.",
+                        "show_in_featured_question_report": true,
+                        "item_settings": {
+                            "item_id": "CARBON_X",
+                            "score_mapping_id": 1
+                        },
+                        "type": "Embeddable::OpenResponse",
+                        "ref_id": "207-Embeddable::OpenResponse"
+                    },
+                    "section": "arg_block"
+                },
+                {
+                    "embeddable": {
+                        "custom": false,
+                        "enable_check_answer": false,
+                        "give_prediction_feedback": false,
+                        "hint": "\n  <b>Step 3: Select a certainty rating.</b>\n  <ul>\n  <li>Picking a certainty rating is a way to signal how certain you are with your claim.</li>\n  <li>Your certainty rating can be based on how well the scientific knowledge fits the evidence from models, charts, or graphs.</li>\n  <li>Your certainty rating can also reflect on the quality of the evidence or investigation that produced the evidence.</li>\n  </ul>\n  ",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "layout": "vertical",
+                        "multi_answer": false,
+                        "name": "Multiple Choice Question element",
+                        "prediction_feedback": null,
+                        "prompt": "How certain are you about your claim based on your explanation?",
+                        "show_as_menu": true,
+                        "show_in_featured_question_report": true,
+                        "choices": [
+                            {
+                                "choice": "(1) Not at all certain",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(2)",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(3)",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(4)",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(5) Very certain",
+                                "is_correct": null,
+                                "prompt": null
+                            }
+                        ],
+                        "type": "Embeddable::MultipleChoice",
+                        "ref_id": "145-Embeddable::MultipleChoice"
+                    },
+                    "section": "arg_block"
+                },
+                {
+                    "embeddable": {
+                        "default_text": null,
+                        "give_prediction_feedback": false,
+                        "hint": "\n  <b>Step 4: Write a certainty explanation.</b>\n  <ul>\n  <li>A good certainty explanation will explain why you are certain or uncertain about your response.</li>\n  <li>Some topics are more certain than others.</li>\n  <li>Consider the completeness of the evidence, biases in the evidence, and changes that could affect the trends over time.</li>\n  </ul>\n  ",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "name": null,
+                        "prediction_feedback": null,
+                        "prompt": "Explain what influenced your certainty rating.",
+                        "show_in_featured_question_report": true,
+                        "item_settings": {
+                            "item_id": "CARBON_R",
+                            "score_mapping_id": 2
+                        },
+                        "type": "Embeddable::OpenResponse",
+                        "ref_id": "208-Embeddable::OpenResponse"
+                    },
+                    "section": "arg_block"
+                }
+            ]
+        },
+        {
+            "additional_sections": {},
+            "embeddable_display_mode": "stacked",
+            "is_completion": true,
+            "is_hidden": false,
+            "layout": "l-6040",
+            "name": "page 3",
+            "position": 3,
+            "show_info_assessment": false,
+            "show_interactive": false,
+            "show_introduction": false,
+            "show_sidebar": false,
+            "sidebar": null,
+            "sidebar_title": "Did you know?",
+            "text": null,
+            "embeddables": [ {
+                "embeddable": {
+                  "custom": false,
+                  "enable_check_answer": true,
+                  "give_prediction_feedback": false,
+                  "hint": null,
+                  "is_full_width": false,
+                  "is_hidden": false,
+                  "is_prediction": false,
+                  "layout": "vertical",
+                  "multi_answer": false,
+                  "name": "Multiple Choice Question element",
+                  "prediction_feedback": null,
+                  "prompt": "why does ...",
+                  "show_as_menu": false,
+                  "show_in_featured_question_report": true,
+                  "choices": [
+                    {
+                      "choice": "a",
+                      "is_correct": true,
+                      "prompt": null
+                    },
+                    {
+                      "choice": "b",
+                      "is_correct": null,
+                      "prompt": null
+                    },
+                    {
+                      "choice": "c",
+                      "is_correct": null,
+                      "prompt": null
+                    }
+                  ],
+                  "type": "Embeddable::MultipleChoice"
+                },
+                "section": null
+              }
+            ]
+        }
+    ],
+    "plugins": [],
+    "type": "LightweightActivity",
+    "export_site": "Lightweight Activities Runtime and Authoring"
+}

--- a/cypress/cypress/integration/runtime/act-with-arg-block.js
+++ b/cypress/cypress/integration/runtime/act-with-arg-block.js
@@ -1,0 +1,80 @@
+
+/* global context, cy, afterEach, beforeEach, it */
+const enabled = true;
+const disabled = false;
+
+const submitShouldBe = (enabledOrDisabled) => {
+  cy.get(".ab-submit.button").should( ($p) => {
+    enabledOrDisabled ? expect($p).to.not.have.class('disabled')
+    : expect($p).to.have.class('disabled')
+  })
+}
+
+const buttonAndFeedbackAssert = () => {
+  cy.get(".ab-submit-prompt").should( ($p) => {
+    expect($p).to.exist
+  })
+  cy.get(".button.next").should( ($p) => {
+    expect($p).to.have.class('disabled')
+  })
+  cy.get(".ab-submit.button").should( ($p) => {
+    expect($p).to.have.class('disabled')
+    expect($p).to.have.value('Submit')
+  })
+  cy.get(".ab-feedback").should( ($p) => {
+    expect($p).to.be.hidden
+  })
+  cy.get(".ab-feedback-header").should(($p) => {
+    expect($p).to.be.hidden
+  })
+}
+
+context('Interactive embeddables', function () {
+  let activityUrl
+  beforeEach(() => {
+    cy.login()
+    cy.importMaterial('activities/activity_with_arg_block_section.json').then(url => {
+      activityUrl = url
+    })
+  })
+  afterEach(() => {
+    cy.deleteMaterial(activityUrl)
+  })
+
+  // 1: Visit the page
+  // 2: Fill in our text boxes
+  // 3: Change the pulldown / multiple choice answers
+  // 4: Check our messages:
+  // 5: When the answers are changed we need to see something about "feedback …"
+  // xx: Forward navigation should be disbled.
+  // 6: Check the text of the submit button
+  // 8: Click the "submit" button
+  // 9: Check for feedback on open respones
+  // 10:  Forward navigation should be enabled.
+
+  it('should add headers to interactive questions that save state', () => {
+    cy.visitActivityPage(activityUrl, 1)
+    cy.wait(300)
+    buttonAndFeedbackAssert()
+
+    cy.get(".choice-container").first().find(".choice input").eq(1).click()
+    cy.get("textarea").eq(1).first().type("first answer");
+    cy.get("textarea").eq(2).type("second answer");
+    cy.get("select").select("(2)");
+    submitShouldBe(enabled);
+    // cy.wait(2000)
+    // buttonAndFeedbackAssert()
+    // cy.wait(300)
+    // cy.get(".sequence_title").click()
+    // cy.get(".embeddables div:nth-child(2) .interactive-container").should("exist")
+    // cy.get(".embeddables div:nth-child(2) .question-hdr").should(($p) => {
+    //   expect($p.length).to.equal(1)
+    //   const text = $p[0].innerText.trim();
+    //   expect(text).to.equal("Question #2");
+    // })
+
+    // the first interactive saves state so it should have a header
+    // cy.get(".interactive-mod div:nth-child(1) .interactive-container").should("exist")
+    // cy.get(".interactive-mod div:nth-child(1) .question-hdr").should("contain", "Question #4: Saves state #1")
+  })
+})

--- a/spec/import_examples/activity_with_arg_block_section.json
+++ b/spec/import_examples/activity_with_arg_block_section.json
@@ -1,0 +1,242 @@
+{
+    "description": "",
+    "editor_mode": 0,
+    "external_report_url": null,
+    "layout": 0,
+    "name": "Sharing test",
+    "notes": "",
+    "project_id": 2,
+    "related": "",
+    "student_report_enabled": true,
+    "thumbnail_url": "",
+    "time_to_complete": 3,
+    "version": 1,
+    "theme_name": "HAS National Geographic: Water",
+    "pages": [
+        {
+            "additional_sections": {},
+            "embeddable_display_mode": "stacked",
+            "is_completion": false,
+            "is_hidden": false,
+            "layout": "l-6040",
+            "name": "page 1",
+            "position": 1,
+            "show_info_assessment": true,
+            "show_interactive": false,
+            "show_introduction": true,
+            "show_sidebar": false,
+            "sidebar": null,
+            "sidebar_title": "Did you know?",
+            "text": null,
+            "embeddables": [
+                {
+                    "embeddable": {
+                        "aspect_ratio_method": "DEFAULT",
+                        "authored_state": null,
+                        "click_to_play": true,
+                        "click_to_play_prompt": "",
+                        "enable_learner_state": true,
+                        "full_window": false,
+                        "has_report_url": false,
+                        "image_url": "https://www.catster.com/wp-content/uploads/2017/12/A-gray-kitten-meowing.jpg",
+                        "is_full_width": true,
+                        "is_hidden": false,
+                        "model_library_url": null,
+                        "name": "codap test",
+                        "native_height": 435,
+                        "native_width": 576,
+                        "show_delete_data_button": true,
+                        "show_in_featured_question_report": true,
+                        "url": "https://document-store.concord.org/v2/documents/86253/autolaunch?server=https%3A%2F%2Fcodap.concord.org%2Freleases%2Flatest%2F&scaling",
+                        "type": "MwInteractive",
+                        "ref_id": "86-MwInteractive"
+                    },
+                    "section": null
+                },
+                {
+                    "embeddable": {
+                        "plugin": {
+                            "description": "LaraSharingPlugin",
+                            "author_data": "",
+                            "approved_script_label": "LaraSharingPlugin"
+                        },
+                        "is_hidden": false,
+                        "is_full_width": false,
+                        "type": "Embeddable::EmbeddablePlugin",
+                        "ref_id": "54-Embeddable::EmbeddablePlugin",
+                        "embeddable_ref_id": "86-MwInteractive"
+                    },
+                    "section": null
+                }
+            ]
+        },
+        {
+            "additional_sections": {
+                "arg_block": true
+            },
+            "embeddable_display_mode": "stacked",
+            "is_completion": false,
+            "is_hidden": false,
+            "layout": "l-6040",
+            "name": "page 2",
+            "position": 2,
+            "show_info_assessment": false,
+            "show_interactive": false,
+            "show_introduction": false,
+            "show_sidebar": false,
+            "sidebar": null,
+            "sidebar_title": "Did you know?",
+            "text": null,
+            "embeddables": [
+                {
+                    "embeddable": {
+                        "custom": true,
+                        "enable_check_answer": false,
+                        "give_prediction_feedback": false,
+                        "hint": "<p><strong>Step 1: Select a claim.</strong></p>\r\n<ul>\r\n<li>A good claim is based on the evidence.</li>\r\n<li>Evidence may come from graphs and charts.</li>\r\n<li>Evidence may also come from models that you run.</li>\r\n</ul>",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "layout": "vertical",
+                        "multi_answer": false,
+                        "name": "Multiple Choice Question element",
+                        "prediction_feedback": "",
+                        "prompt": "<p>WHAT IS YOUR FAVORITE COLOR ??? ??! ?! ?!?</p>",
+                        "show_as_menu": false,
+                        "show_in_featured_question_report": true,
+                        "choices": [
+                            {
+                                "choice": "Blue",
+                                "is_correct": false,
+                                "prompt": ""
+                            },
+                            {
+                                "choice": "African",
+                                "is_correct": false,
+                                "prompt": ""
+                            },
+                            {
+                                "choice": "European",
+                                "is_correct": false,
+                                "prompt": ""
+                            }
+                        ],
+                        "type": "Embeddable::MultipleChoice",
+                        "ref_id": "144-Embeddable::MultipleChoice"
+                    },
+                    "section": "arg_block"
+                },
+                {
+                    "embeddable": {
+                        "default_text": null,
+                        "give_prediction_feedback": false,
+                        "hint": "\n  <b>Step 2: Write an explanation.</b>\n  <ul>\n  <li>A good explanation will cite specific evidence that backs up the claim.</li>\n  <li>When there is a graph or table, you can cite evidence directly from the source.</li>\n  <li>When there is a model, you can describe what happened in the model.</li>\n  <li>A good explanation combines evidence with scientific knowledge.</li>\n  </ul>\n  ",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "name": null,
+                        "prediction_feedback": null,
+                        "prompt": "Explain your answer.",
+                        "show_in_featured_question_report": true,
+                        "item_settings": {
+                            "item_id": "CARBON_X",
+                            "score_mapping_id": 1
+                        },
+                        "type": "Embeddable::OpenResponse",
+                        "ref_id": "207-Embeddable::OpenResponse"
+                    },
+                    "section": "arg_block"
+                },
+                {
+                    "embeddable": {
+                        "custom": false,
+                        "enable_check_answer": false,
+                        "give_prediction_feedback": false,
+                        "hint": "\n  <b>Step 3: Select a certainty rating.</b>\n  <ul>\n  <li>Picking a certainty rating is a way to signal how certain you are with your claim.</li>\n  <li>Your certainty rating can be based on how well the scientific knowledge fits the evidence from models, charts, or graphs.</li>\n  <li>Your certainty rating can also reflect on the quality of the evidence or investigation that produced the evidence.</li>\n  </ul>\n  ",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "layout": "vertical",
+                        "multi_answer": false,
+                        "name": "Multiple Choice Question element",
+                        "prediction_feedback": null,
+                        "prompt": "How certain are you about your claim based on your explanation?",
+                        "show_as_menu": true,
+                        "show_in_featured_question_report": true,
+                        "choices": [
+                            {
+                                "choice": "(1) Not at all certain",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(2)",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(3)",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(4)",
+                                "is_correct": null,
+                                "prompt": null
+                            },
+                            {
+                                "choice": "(5) Very certain",
+                                "is_correct": null,
+                                "prompt": null
+                            }
+                        ],
+                        "type": "Embeddable::MultipleChoice",
+                        "ref_id": "145-Embeddable::MultipleChoice"
+                    },
+                    "section": "arg_block"
+                },
+                {
+                    "embeddable": {
+                        "default_text": null,
+                        "give_prediction_feedback": false,
+                        "hint": "\n  <b>Step 4: Write a certainty explanation.</b>\n  <ul>\n  <li>A good certainty explanation will explain why you are certain or uncertain about your response.</li>\n  <li>Some topics are more certain than others.</li>\n  <li>Consider the completeness of the evidence, biases in the evidence, and changes that could affect the trends over time.</li>\n  </ul>\n  ",
+                        "is_full_width": false,
+                        "is_hidden": false,
+                        "is_prediction": false,
+                        "name": null,
+                        "prediction_feedback": null,
+                        "prompt": "Explain what influenced your certainty rating.",
+                        "show_in_featured_question_report": true,
+                        "item_settings": {
+                            "item_id": "CARBON_R",
+                            "score_mapping_id": 2
+                        },
+                        "type": "Embeddable::OpenResponse",
+                        "ref_id": "208-Embeddable::OpenResponse"
+                    },
+                    "section": "arg_block"
+                }
+            ]
+        },
+        {
+            "additional_sections": {},
+            "embeddable_display_mode": "stacked",
+            "is_completion": true,
+            "is_hidden": false,
+            "layout": "l-6040",
+            "name": "page 3",
+            "position": 3,
+            "show_info_assessment": false,
+            "show_interactive": false,
+            "show_introduction": false,
+            "show_sidebar": false,
+            "sidebar": null,
+            "sidebar_title": "Did you know?",
+            "text": null,
+            "embeddables": []
+        }
+    ],
+    "plugins": [],
+    "type": "LightweightActivity",
+    "export_site": "Lightweight Activities Runtime and Authoring"
+}


### PR DESCRIPTION
Import serialized field `additional_sections`.

`additional_sections` This is where `arg_block` sections are defined.

Because `additional_sections` is a serialized field of type hash, and not a simple string attribute we had to handle it differently.  Its keys must be converted to symbols first in the import.


[#164584021]

https://www.pivotaltracker.com/story/show/164584021