### PR TITLE
163959056 arg block teacher edition fixes

### DIFF
--- a/app/views/c_rater/argumentation_block/_runtime.html.haml
+++ b/app/views/c_rater/argumentation_block/_runtime.html.haml
@@ -26,9 +26,14 @@
                 %div= t 'ARG_BLOCK.RESUBMIT_OR_MOVE'
 
     - embeddables.each_with_index do |m,index|
-      .question
-        = render :partial => "#{m.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => m}
-        = render :partial => "c_rater/argumentation_block/feedback",
+      - question = m.respond_to?(:question) ? m.question : m
+      -# The next two CSS selectors are important,they might be referenced
+      -# by plugins and passed to a plugin instance for wrapped content.
+      -# e.g. Teacher Edition
+      .question{ id: question.embeddable_dom_id }
+        .embeddable-container
+          = render :partial => "#{m.class.name.underscore.pluralize}/lightweight", :locals => {:embeddable => m}
+          = render :partial => "c_rater/argumentation_block/feedback",
                               :locals => { feedback: m.get_saved_feedback, emb_id: m.answer_id }
 
     - submission = last_submission(page, @run)

--- a/cypress/cypress/integration/runtime/act-with-arg-block.js
+++ b/cypress/cypress/integration/runtime/act-with-arg-block.js
@@ -18,8 +18,8 @@ const submitButtonShouldBe = (enabledOrDisabled) => {
 const submitPromptShouldBe = (shownOrHidden, text=DEFAULT_SUBMIT_PROMPT) => {
   cy.get('.ab-submit-prompt').should(($p) => {
     shownOrHidden
-      ? expect($p).to.exist
-      : expect($p).to.exist
+      ? expect($p).to.not.be.hidden
+      : expect($p).to.be.hidden
   })
 }
 
@@ -76,15 +76,16 @@ context('Arg block sections', function () {
     cy.deleteMaterial(activityUrl)
   })
 
-  // 1: Visit the page
-  // 2: Fill in our text boxes
-  // 3: Change the pulldown / multiple choice answers
+  // Roughly speaking, we want to test the following:
+  // 1: Visit the page.
+  // 2: Fill in our text boxes.
+  // 3: Change the pulldown / multiple choice answers.
   // 4: Check our messages:
-  // 5: When the answers are changed we need to see something about 'feedback …'
-  // xx: Forward navigation should be disbled.
-  // 6: Check the text of the submit button
-  // 8: Click the 'submit' button
-  // 9: Check for feedback on open respones
+  // 5:   When the answers are changed, we see something about 'feedback …'
+  // 6:   Forward navigation should be disabled.
+  // 7:   Check the text of the submit button
+  // 8:   Click the 'submit' button.
+  // 9:   Check for feedback on open responses.
   // 10:  Forward navigation should be enabled.
   describe('when first loaded', () => {
     it('Navigation and sumbit buttons should be disabled', () => {
@@ -96,6 +97,7 @@ context('Arg block sections', function () {
       feedbackShouldBe(HIDDEN)
     })
   })
+
   describe('after answering all one question', () => {
     beforeEach(() => {
       cy.visitActivityPage(activityUrl, 1)
@@ -109,6 +111,7 @@ context('Arg block sections', function () {
       feedbackShouldBe(HIDDEN)
     })
   })
+
   describe('after all the questions are answered', () => {
     beforeEach(() => {
       cy.visitActivityPage(activityUrl, 1)
@@ -118,36 +121,30 @@ context('Arg block sections', function () {
       answerOpenResponse(2, 'This is my other answer')
       cy.wait(5000)
     })
-    
     it('The submit button should be enabled', () => {
       submitButtonShouldBe(ENABLED)
       submitPromptShouldBe(HIDDEN)
       navButtonShouldBe(DISABLED)
-      navButtonShouldBe(DISABLED)
+      feedbackShouldBe(HIDDEN)
     })
-
-    //   navButtonShouldBe(DISABLED)
-    //   feedbackShouldBe(HIDDEN)
-    // })
   })
+
+  describe('after all the questions are answered and submitted', () => {
+    beforeEach(() => {
+      cy.visitActivityPage(activityUrl, 1)
+      answerRadioButton(1)
+      answerOpenResponse(1, 'This is my answer')
+      answerPullDown(1)
+      answerOpenResponse(2, 'This is my other answer')
+      cy.wait(5000)
+      cy.get('.ab-submit.button').click()
+      cy.wait(10000)
+    })    
+    it('should show the submission results', () => {
+      submitButtonShouldBe(ENABLED)
+      submitPromptShouldBe(HIDDEN)
+      navButtonShouldBe(ENABLED)
+    })
+  })
+
 })
-
-// cy.get('.choice-container').first().find('.choice input').eq(1).click()
-// cy.get('textarea').eq(1).first().type('first answer')
-// cy.get('textarea').eq(2).type('second answer')
-// cy.get('select').select('(2)')
-// submitShouldBe(enabled)
-// cy.wait(2000)
-// buttonAndFeedbackAssert()
-// cy.wait(300)
-// cy.get('.sequence_title').click()
-// cy.get('.embeddables div:nth-child(2) .interactive-container').should('exist')
-// cy.get('.embeddables div:nth-child(2) .question-hdr').should(($p) => {
-//   expect($p.length).to.equal(1)
-//   const text = $p[0].innerText.trim();
-//   expect(text).to.equal('Question #2');
-// })
-
-// the first interactive saves state so it should have a header
-// cy.get('.interactive-mod div:nth-child(1) .interactive-container').should('exist')
-// cy.get('.interactive-mod div:nth-child(1) .question-hdr').should('contain', 'Question #4: Saves state #1')

--- a/cypress/cypress/integration/runtime/act-with-arg-block.js
+++ b/cypress/cypress/integration/runtime/act-with-arg-block.js
@@ -61,7 +61,6 @@ const answerPullDown = (choiceNo = 2) => {
   ]
   const choice = choices[choiceNo - 1]
   cy.get('select').select(choice)
-  // cy.get('select').select(choice)
 }
 
 context('Arg block sections', function () {
@@ -139,7 +138,11 @@ context('Arg block sections', function () {
       cy.wait(5000)
       cy.get('.ab-submit.button').click()
       cy.wait(10000)
-    })    
+    })
+    // NOTE: C-RATER features won't work on Travis,
+    // Becuase C_RATER_FAKE isn't defined in the environment.
+    // So this test only asserts that the navigation still works.
+    // Even when C-Rater services isn't available.
     it('should show the submission results', () => {
       submitButtonShouldBe(ENABLED)
       submitPromptShouldBe(HIDDEN)

--- a/cypress/cypress/integration/runtime/act-with-arg-block.js
+++ b/cypress/cypress/integration/runtime/act-with-arg-block.js
@@ -1,35 +1,70 @@
 
-/* global context, cy, afterEach, beforeEach, it */
-const enabled = true;
-const disabled = false;
+/* global context, cy, expect, afterEach, beforeEach, it, describe */
+/* eslint-disable no-unused-expressions */
+const ENABLED = true
+const SHOWN = true
+const DISABLED = false
+const HIDDEN = false
+const DEFAULT_SUBMIT_PROMPT = 'Please answer all questions in the argumentation block.'
 
-const submitShouldBe = (enabledOrDisabled) => {
-  cy.get(".ab-submit.button").should( ($p) => {
-    enabledOrDisabled ? expect($p).to.not.have.class('disabled')
-    : expect($p).to.have.class('disabled')
+const submitButtonShouldBe = (enabledOrDisabled) => {
+  cy.get('.ab-submit.button').should(($p) => {
+    enabledOrDisabled
+      ? expect($p).to.not.have.class('disabled')
+      : expect($p).to.have.class('disabled')
   })
 }
 
-const buttonAndFeedbackAssert = () => {
-  cy.get(".ab-submit-prompt").should( ($p) => {
-    expect($p).to.exist
-  })
-  cy.get(".button.next").should( ($p) => {
-    expect($p).to.have.class('disabled')
-  })
-  cy.get(".ab-submit.button").should( ($p) => {
-    expect($p).to.have.class('disabled')
-    expect($p).to.have.value('Submit')
-  })
-  cy.get(".ab-feedback").should( ($p) => {
-    expect($p).to.be.hidden
-  })
-  cy.get(".ab-feedback-header").should(($p) => {
-    expect($p).to.be.hidden
+const submitPromptShouldBe = (shownOrHidden, text=DEFAULT_SUBMIT_PROMPT) => {
+  cy.get('.ab-submit-prompt').should(($p) => {
+    shownOrHidden
+      ? expect($p).to.exist
+      : expect($p).to.exist
   })
 }
 
-context('Interactive embeddables', function () {
+const navButtonShouldBe = (enabledOrDisabled) => {
+  cy.get('.button.next').should(($p) => {
+    enabledOrDisabled
+      ? expect($p).to.not.have.class('disabled')
+      : expect($p).to.have.class('disabled')
+  })
+}
+
+const feedbackShouldBe = (shownOrHidden) => {
+  cy.get('.ab-feedback').should(($p) => {
+    shownOrHidden
+      ? expect($p).to.not.be.hidden
+      : expect($p).to.be.hidden
+  })
+  cy.get('.ab-feedback-header').should(($p) => {
+    shownOrHidden
+      ? expect($p).to.not.be.hidden
+      : expect($p).to.be.hidden
+  })
+}
+
+const answerOpenResponse = (number = 1, answer = 'some answer') => {
+  cy.get('textarea').eq(number).type(answer)
+}
+
+const answerRadioButton = (choice = 1) => {
+  const index = choice - 1
+  cy.get('.choice-container').first().find('.choice input').eq(index).click()
+}
+
+const answerPullDown = (choiceNo = 2) => {
+  const choices = [
+    '(1) Not at all certain',
+    '(2)', '(3)', '(4)',
+    '(5) Very certain'
+  ]
+  const choice = choices[choiceNo - 1]
+  cy.get('select').select(choice)
+  // cy.get('select').select(choice)
+}
+
+context('Arg block sections', function () {
   let activityUrl
   beforeEach(() => {
     cy.login()
@@ -45,36 +80,90 @@ context('Interactive embeddables', function () {
   // 2: Fill in our text boxes
   // 3: Change the pulldown / multiple choice answers
   // 4: Check our messages:
-  // 5: When the answers are changed we need to see something about "feedback …"
+  // 5: When the answers are changed we need to see something about 'feedback …'
   // xx: Forward navigation should be disbled.
   // 6: Check the text of the submit button
-  // 8: Click the "submit" button
+  // 8: Click the 'submit' button
   // 9: Check for feedback on open respones
   // 10:  Forward navigation should be enabled.
+  describe('when first loaded', () => {
+    it('Navigation and sumbit buttons should be disabled', () => {
+      cy.visitActivityPage(activityUrl, 1)
+      cy.wait(500)
+      submitButtonShouldBe(DISABLED)
+      submitPromptShouldBe(SHOWN)
+      navButtonShouldBe(DISABLED)
+      feedbackShouldBe(HIDDEN)
+    })
+  })
+  describe('after answering all one question', () => {
+    beforeEach(() => {
+      cy.visitActivityPage(activityUrl, 1)
+      answerOpenResponse(1, 'This is my answer')
+      cy.wait(500)
+    })
+    it('Navigation should still be disabled', () => {
+      submitButtonShouldBe(DISABLED)
+      submitPromptShouldBe(SHOWN)
+      navButtonShouldBe(DISABLED)
+      feedbackShouldBe(HIDDEN)
+    })
+  })
+  describe('after all the questions are answered', () => {
+    beforeEach(() => {
+      cy.visitActivityPage(activityUrl, 1)
+      answerRadioButton(1)
+      answerOpenResponse(1, 'This is my answer')
+      answerPullDown(1)
+      answerOpenResponse(2, 'This is my other answer')
+      cy.wait(5000)
+    })
 
-  it('should add headers to interactive questions that save state', () => {
-    cy.visitActivityPage(activityUrl, 1)
-    cy.wait(300)
-    buttonAndFeedbackAssert()
+    describe('The submit button', () => {
+      it('should be enabled', () => {
+        submitButtonShouldBe(ENABLED)
+      })
+    })
 
-    cy.get(".choice-container").first().find(".choice input").eq(1).click()
-    cy.get("textarea").eq(1).first().type("first answer");
-    cy.get("textarea").eq(2).type("second answer");
-    cy.get("select").select("(2)");
-    submitShouldBe(enabled);
-    // cy.wait(2000)
-    // buttonAndFeedbackAssert()
-    // cy.wait(300)
-    // cy.get(".sequence_title").click()
-    // cy.get(".embeddables div:nth-child(2) .interactive-container").should("exist")
-    // cy.get(".embeddables div:nth-child(2) .question-hdr").should(($p) => {
-    //   expect($p.length).to.equal(1)
-    //   const text = $p[0].innerText.trim();
-    //   expect(text).to.equal("Question #2");
+    describe('The submit prompt', () => {
+      it('should be hidden', () => {
+        submitPromptShouldBe(HIDDEN)
+      })
+    })
+
+    describe('The navigation button', () => {
+      it('should be disabled', () => {
+        navButtonShouldBe(DISABLED)
+      })
+    })
+
+    describe('The navigation button', () => {
+      it('should be disabled', () => {
+        navButtonShouldBe(DISABLED)
+      })
+    })
+    //   navButtonShouldBe(DISABLED)
+    //   feedbackShouldBe(HIDDEN)
     // })
-
-    // the first interactive saves state so it should have a header
-    // cy.get(".interactive-mod div:nth-child(1) .interactive-container").should("exist")
-    // cy.get(".interactive-mod div:nth-child(1) .question-hdr").should("contain", "Question #4: Saves state #1")
   })
 })
+
+// cy.get('.choice-container').first().find('.choice input').eq(1).click()
+// cy.get('textarea').eq(1).first().type('first answer')
+// cy.get('textarea').eq(2).type('second answer')
+// cy.get('select').select('(2)')
+// submitShouldBe(enabled)
+// cy.wait(2000)
+// buttonAndFeedbackAssert()
+// cy.wait(300)
+// cy.get('.sequence_title').click()
+// cy.get('.embeddables div:nth-child(2) .interactive-container').should('exist')
+// cy.get('.embeddables div:nth-child(2) .question-hdr').should(($p) => {
+//   expect($p.length).to.equal(1)
+//   const text = $p[0].innerText.trim();
+//   expect(text).to.equal('Question #2');
+// })
+
+// the first interactive saves state so it should have a header
+// cy.get('.interactive-mod div:nth-child(1) .interactive-container').should('exist')
+// cy.get('.interactive-mod div:nth-child(1) .question-hdr').should('contain', 'Question #4: Saves state #1')

--- a/cypress/cypress/integration/runtime/act-with-arg-block.js
+++ b/cypress/cypress/integration/runtime/act-with-arg-block.js
@@ -118,30 +118,14 @@ context('Arg block sections', function () {
       answerOpenResponse(2, 'This is my other answer')
       cy.wait(5000)
     })
-
-    describe('The submit button', () => {
-      it('should be enabled', () => {
-        submitButtonShouldBe(ENABLED)
-      })
+    
+    it('The submit button should be enabled', () => {
+      submitButtonShouldBe(ENABLED)
+      submitPromptShouldBe(HIDDEN)
+      navButtonShouldBe(DISABLED)
+      navButtonShouldBe(DISABLED)
     })
 
-    describe('The submit prompt', () => {
-      it('should be hidden', () => {
-        submitPromptShouldBe(HIDDEN)
-      })
-    })
-
-    describe('The navigation button', () => {
-      it('should be disabled', () => {
-        navButtonShouldBe(DISABLED)
-      })
-    })
-
-    describe('The navigation button', () => {
-      it('should be disabled', () => {
-        navButtonShouldBe(DISABLED)
-      })
-    })
     //   navButtonShouldBe(DISABLED)
     //   feedbackShouldBe(HIDDEN)
     // })

--- a/spec/views/c_rater/_runtime.html.haml_spec.rb
+++ b/spec/views/c_rater/_runtime.html.haml_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+# This test enforces two CSS selectors that plugins need to wrap content
+# in the ArgBlock. See for example the Teacher Edition Plugin
+# https://www.pivotaltracker.com/story/show/163959056
+# [DL/NP] 2019-03-20
+
+describe "Rended DOM for Argblock sections" do
+  let(:page) { double("page double", layout: "big", id: 1) }
+  let(:embeddable_class) { double( "Answer Class", name: 'Embeddable::OpenResponseAnswer') }
+  let(:saved_feedback) do
+    double("Saved Feedback",
+      feedback_text: "",
+      error?: nil,
+      outdated?: false,
+      max_score: 0,
+      score: 0
+    )
+  end
+
+  let(:embeddable) do
+    double("Embeddable",
+      class: embeddable_class,
+      id: 1,
+      question_index: 1,
+      get_saved_feedback: saved_feedback,
+      answer_id: 1,
+      prompt: "what is the answer?",
+      embeddable_dom_id: 'foo-dom-id'
+    )
+  end
+  let(:last_sumission){ double("last submission", key: '1' ) }
+  let(:embeddables)   { [embeddable] }
+  let(:fake_run)      { double("Fake run", key: "111") }
+
+  before(:each) do
+    assign(:run, fake_run)
+    allow(view).to receive(:arg_block_embeddables).and_return(embeddables)
+    allow(view).to receive(:submission_count).and_return(3)
+    allow(view).to receive(:last_submission).and_return(nil)
+    allow(view).to receive(:form_for).and_return(last_sumission)
+    allow(view).to receive(:c_rater_arg_block_save_feedback_path).and_return("fake_path")
+
+    render partial: "c_rater/argumentation_block/runtime", locals: {page: page}
+
+  end
+
+  describe "Structure of the arg-block DOM" do
+    it "should follow a standard strucutre needed by plugins for wrapping embeddables" do
+      expect(rendered).to have_css("##{embeddable.embeddable_dom_id}.question .embeddable-container")
+    end
+  end
+
+end


### PR DESCRIPTION
This PR improves the arg-block section in several ways:

* finishes some cypress tests for arg-block behavior ( 74e0507 → 8fb20f0)
* fixes the incompatibility of arg-blocks and teacher edition mode ( f8b4404 )
* adds simple rspec view test to enforce wrapped-embeddable structure:  ( 9cee322 )
 
@scytacki 👀Could you review?

@kevinsantos-cc  you might want to look at commits 74e0507 → 8fb20f0 which are the cypress test changes.
