### PR TITLE
Fix: external-scripts block plugin editing.

### DIFF
--- a/app/models/embeddable/external_script.rb
+++ b/app/models/embeddable/external_script.rb
@@ -57,6 +57,10 @@ module Embeddable
       false
     end
 
+    def is_hidden?
+      is_hidden
+    end
+
     def export
       return self.as_json(only:[:name, :url, :configuration, :description])
     end

--- a/spec/models/embeddable/external_script_spec.rb
+++ b/spec/models/embeddable/external_script_spec.rb
@@ -1,0 +1,15 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe Embeddable::ExternalScript do
+  let (:props)  { {} }
+  let (:script) { Embeddable::ExternalScript.create(props) }
+
+  # address bug:  undefined method `is_hidden?'
+  describe '#is_hidden?' do
+    it "should be a method returning false" do
+      expect(script).to respond_to(:is_hidden?)
+      expect(script.is_hidden?).to eq(false)
+    end
+  end
+
+end


### PR DESCRIPTION
🐞 FIX for this exception:

```
  An ActionView::Template::Error occurred in embeddable_plugins#edit:
  undefined method `is_hidden?' for #<Embeddable::ExternalScript:0x00000004573178>
```

Triggered when an author tries to edit a plugin on a page with an `Embeddable::ExternalScript`

These are the old style plugins such as the model feedback plugin.

They implemented `is_hidden` instead of `is_hidden?`.

New plugin edit pages need to find a list of all embeddables in the page that aren't hidden.  It sends `is_hidden?` to each embeddable.
This caused the above exception.

The fix was to add the method `is_hidden?` to `Embeddable::ExternalScript`

[#164970025]

https://www.pivotaltracker.com/story/show/164970025