### PR TITLE
164972779 fix external script export

### DIFF
--- a/app/models/embeddable/external_script.rb
+++ b/app/models/embeddable/external_script.rb
@@ -57,6 +57,10 @@ module Embeddable
       false
     end
 
+    def is_hidden?
+      is_hidden
+    end
+
     def export
       return self.as_json(only:[:name, :url, :configuration, :description])
     end

--- a/app/models/embeddable/external_script.rb
+++ b/app/models/embeddable/external_script.rb
@@ -61,6 +61,11 @@ module Embeddable
       is_hidden
     end
 
+    def page_section
+      # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+      page_items.count > 0 && page_items.first.section
+    end
+
     def export
       return self.as_json(only:[:name, :url, :configuration, :description])
     end

--- a/spec/models/embeddable/external_script_spec.rb
+++ b/spec/models/embeddable/external_script_spec.rb
@@ -4,6 +4,10 @@ describe Embeddable::ExternalScript do
   let (:props)  { {} }
   let (:script) { Embeddable::ExternalScript.create(props) }
 
+  let (:page) do
+    p = FactoryGirl.create(:interactive_page)
+  end
+
   # address bug:  undefined method `is_hidden?'
   describe '#is_hidden?' do
     it "should be a method returning false" do
@@ -11,5 +15,49 @@ describe Embeddable::ExternalScript do
       expect(script.is_hidden?).to eq(false)
     end
   end
+
+  describe '#page_section'  do
+
+    describe 'when the embeddable is not in a page' do
+      it "the section should be false" do
+        expect(script.page_section).to eql(false)
+      end
+    end
+
+    describe 'When the embeddable is added to a page' do
+      let(:section) { nil }
+      before(:each) do
+        page.add_embeddable(script,0, section)
+        page.reload
+        script.reload
+      end
+
+      describe 'when there is no section' do
+        it "the page_section should be returned as nil" do
+          expect(script.reload.page_section).to eql(nil)
+        end
+        describe 'the page export' do
+          it "should include an ebmeddables section" do
+            expect(page.export).to include(:embeddables)
+          end
+        end
+      end
+
+      describe 'when the embeddable is added to the C-RATER section' do
+        let(:section) { CRater::ARG_SECTION_NAME }
+        it "The section should be returned as CRater::ARG_SECTION_NAME" do
+          expect(script.reload.page_section).to eql(CRater::ARG_SECTION_NAME)
+        end
+
+        describe 'the page export' do
+          it "should include an ebmeddables section" do
+            expect(page.export).to include(:embeddables)
+          end
+        end
+      end
+
+    end
+  end
+
 
 end

--- a/spec/models/embeddable/external_script_spec.rb
+++ b/spec/models/embeddable/external_script_spec.rb
@@ -1,0 +1,15 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe Embeddable::ExternalScript do
+  let (:props)  { {} }
+  let (:script) { Embeddable::ExternalScript.create(props) }
+
+  # address bug:  undefined method `is_hidden?'
+  describe '#is_hidden?' do
+    it "should be a method returning false" do
+      expect(script).to respond_to(:is_hidden?)
+      expect(script.is_hidden?).to eq(false)
+    end
+  end
+
+end


### PR DESCRIPTION
( the first commit here -- 9d5e0be -- is in its own PR, please see that one first. Both PRs are for the same two files. )

Fix: ExternalScript Plugins (v1) not exporting.

ExternalScript style plugins (v1) didn't report their page_section.

This was causing page export/import and copy to fail as in the following stack trace:

```
A NoMethodError occurred in sequences#export:
undefined method `page_section' for #<Embeddable::ExternalScript:0x00000008483c00>

```

see PT story: https://www.pivotaltracker.com/story/show/164972779
