### PR TITLE
hack fix for debian repository change.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 FROM concordconsortium/docker-rails-base-ruby-2.2.6
 
+# Debian 8 (jessie) is no longer supported
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN sed -i '/deb http:\/\/\(deb\|httpredir\).debian.org\/debian jessie.* main/d' /etc/apt/sources.list
+RUN apt-get -o Acquire::Check-Valid-Until=false update
+
+#
 # update apt libraries
-RUN apt-get update
+# RUN apt-get update
 
 # install nginx
 RUN apt-get install -qq -y nginx


### PR DESCRIPTION
Correct fix is to switch to debian version 9, and update the docker-rails-base-ruby image

[#164992701]