### PR TITLE
165077401 Fix empty plugin rendering

### DIFF
--- a/app/views/embeddable/embeddable_plugins/_lightweight.html.haml
+++ b/app/views/embeddable/embeddable_plugins/_lightweight.html.haml
@@ -1,3 +1,2 @@
-
-
-= render :partial => 'plugins/show',locals: {plugin: embeddable.plugin, wrapped_embeddable: embeddable.embeddable }
+- unless !embeddable.plugin.version
+  = render :partial => 'plugins/show',locals: {plugin: embeddable.plugin, wrapped_embeddable: embeddable.embeddable }

--- a/cypress/cypress/fixtures/activities/activity_with_empty_plugin.json
+++ b/cypress/cypress/fixtures/activities/activity_with_empty_plugin.json
@@ -1,0 +1,65 @@
+{
+  "description": "",
+  "editor_mode": 0,
+  "external_report_url": null,
+  "layout": 0,
+  "name": "[Cypress] Empty Plugin Test",
+  "notes": "",
+  "project_id": 2,
+  "related": "",
+  "student_report_enabled": true,
+  "thumbnail_url": "",
+  "time_to_complete": 3,
+  "version": 1,
+  "theme_name": "HAS National Geographic: Water",
+  "pages": [
+      {
+          "additional_sections": {},
+          "embeddable_display_mode": "stacked",
+          "is_completion": false,
+          "is_hidden": false,
+          "layout": "l-6040",
+          "name": "page 1",
+          "position": 1,
+          "show_info_assessment": true,
+          "show_interactive": false,
+          "show_introduction": true,
+          "show_sidebar": false,
+          "sidebar": null,
+          "sidebar_title": "Did you know?",
+          "text": null,
+          "embeddables": [
+            {
+              "embeddable": {
+                "default_text": null,
+                "give_prediction_feedback": false,
+                "hint": null,
+                "is_full_width": false,
+                "is_hidden": false,
+                "is_prediction": false,
+                "name": null,
+                "prediction_feedback": null,
+                "prompt": "why does ...",
+                "show_in_featured_question_report": true,
+                "type": "Embeddable::OpenResponse"
+              },
+              "section": null
+            },
+            {
+              "embeddable": {
+                "plugin": {},
+                "is_hidden": false,
+                "is_full_width": false,
+                "type": "Embeddable::EmbeddablePlugin",
+                "ref_id": "54-Embeddable::EmbeddablePlugin",
+                "embeddable_ref_id": "86-MwInteractive"
+              },
+              "section": null
+            }
+          ]
+      }
+  ],
+  "plugins": [],
+  "type": "LightweightActivity",
+  "export_site": "Lightweight Activities Runtime and Authoring"
+}

--- a/cypress/cypress/integration/plugins/empty_plugin-_spec.js
+++ b/cypress/cypress/integration/plugins/empty_plugin-_spec.js
@@ -1,0 +1,27 @@
+
+/* global context, cy, expect, afterEach, beforeEach, it, describe */
+/* eslint-disable no-unused-expressions */
+
+context('Arg block sections', function () {
+  let activityUrl
+  beforeEach(() => {
+    cy.login()
+    cy.importMaterial('activities/activity_with_empty_plugin.json').then(url => {
+      activityUrl = url
+    })
+  })
+  afterEach(() => {
+    cy.deleteMaterial(activityUrl)
+  })
+
+  const openResponseInput = () => cy.get("[name='embeddable_open_response_answer[answer_text]']")
+
+  describe('when first loaded', () => {
+    it('The page contents should be visible', () => {
+      cy.visitActivityPage(activityUrl, 1)
+      cy.wait(500)
+      openResponseInput.should("exist")
+    })
+  })
+
+})


### PR DESCRIPTION
This is a quick fix for an error that is thrown if a plugin is added to a page but no plugin is specified.

I am unable to get the Cypress tests working--I'm still working on that but submitted this PR with a test which should work, in case anyone has a functioning Cypress setup.