### PR TITLE
Fix initialization of V2 plugins

### DIFF
--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -49,12 +49,12 @@
   - else
     - click_to_play_id = nil
   :javascript
-    // Begin script for #{plugin.name}
-    var pluginStatePaths = {
-      savePath: `#{escape_javascript(api_v1_update_plugin_learner_state_path(plugin.id, @run.id))}`,
-      loadPath: `#{escape_javascript(api_v1_show_plugin_learner_state_path(plugin.id, @run.id))}`
-    };
     $(document).ready( function() {
+      // Begin script for #{plugin.name}
+      var pluginStatePaths = {
+        savePath: `#{escape_javascript(api_v1_update_plugin_learner_state_path(plugin.id, @run.id))}`,
+        loadPath: `#{escape_javascript(api_v1_show_plugin_learner_state_path(plugin.id, @run.id))}`
+      };
       var getFirebaseJwtUrl = function(appName) {
         var laraJwtGettingUrl = '#{escape_javascript(firebase_jwt_url)}';
         return laraJwtGettingUrl.replace('_FIREBASE_APP_', appName);


### PR DESCRIPTION
This PR fixes this problem:
https://www.pivotaltracker.com/story/show/165578207

The previous code was incorrect. Note that `pluginStatePaths` was defined outside the document ready handler function. Also, it wasn't limited to any local scope. So, multiple plugins were defining a global variable with the same name (`pluginStatePaths`). Then, when multiple doc-ready handlers were called and they were using only the last `pluginStatePaths` instance - the same one. The previous ones were overwritten and lost. So, all the plugins were saving state using the same URL (URL of the last plugin initialized by LARA).

Note that V3 API isn't affected by this bug, as it handles state saving in a different way. We don't really have to merge this PR if we're going to drop V2 soon. But I'm opening this PR so it's clear why we used to have problems with multiple plugins vs state saving.