### PR TITLE
Fix sizing of the interactives

### DIFF
--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -5,22 +5,37 @@ function interactiveSizing () {
     var $iframe = $(this);
     var aspectRatio = $iframe.data('aspect-ratio');
     var resizeMethod = $iframe.data('aspect-ratio-method');
-    var magicNumber = 125;
-    var maxHeight = window.innerHeight - magicNumber;
+    var maxHeight = window.innerHeight;
+
+    var $pinned = $iframe.parents('.pinned');
+    if ($pinned.length > 0) {
+      // If interactive is pinned, make sure that maxHeight calculations don't cause interactive to become unpinned
+      // (as it gets too tall). Calculate the current difference between height of the interactive and its container.
+      // That will automatically handle question header (when interactive saves state) and all the possible margins
+      // and padding. Also, take into account a pinned interactive offset (space between the window top border and
+      // the interactive container top edge).
+      var headersHeight = $pinned.height() - $iframe.height();
+      maxHeight -= headersHeight + window.SCROLL_INTERACTIVE_MOD_OFFSET;
+    }
     $iframe.attr('width', '100%');
 
-    if(resizeMethod === 'MAX') {
+    if (resizeMethod === 'MAX') {
       $iframe.height(maxHeight);
     }
-    else if(resizeMethod === 'MANUAL') {
+    else if (resizeMethod === 'MANUAL') {
       $iframe.height($iframe.width() / aspectRatio);
     }
-    else  /* (resizeMethod === 'DEFAULT') */ {
+    else /* (resizeMethod === 'DEFAULT') */ {
       $iframe.height($iframe.width() / aspectRatio);
       if ($iframe.height() > maxHeight) {
-        var scale = maxHeight / $iframe.height();
-        $iframe.attr('width', scale * 100 + '%');
+        var scale = (maxHeight / $iframe.height()) * 100 + '%';
+        $iframe.attr('width', scale);
         $iframe.height(maxHeight);
+        // Rescale question header too (it's present when interactive saves state).
+        var $header = $iframe.parents(".embeddable-container").find(".question-hdr")
+        if ($header.length > 0) {
+          $header.css('width', scale);
+        }
       }
     }
   }

--- a/app/assets/javascripts/scroll-interactive-mod.js
+++ b/app/assets/javascripts/scroll-interactive-mod.js
@@ -1,5 +1,8 @@
+// Space between window top border and the interactive container.
+window.SCROLL_INTERACTIVE_MOD_OFFSET = 75; // px
+
 $(window).ready(function () {
-  var offset = 75;
+  var offset = window.SCROLL_INTERACTIVE_MOD_OFFSET;
   var $sticky = $('.pinned');
   if ($sticky.length === 0) {
     return;


### PR DESCRIPTION
[#165150685]

This PR fixes issues described here:
https://www.pivotaltracker.com/story/show/165150685

In particular, it fixes these two uses cases:
- default aspect ratio + state saving (header)
- use all available space + state saving

Interactive sizing was broken and there's a variable literally named `magicNumber`. It's gone now. I didn't add it, but I believe the calculations below are what the author wanted to achieve there. I've also added rescaling of question header to avoid this:

<img width="1153" alt="Screenshot 2019-05-13 at 20 59 35" src="https://user-images.githubusercontent.com/767857/57647409-2f0d8b00-75c3-11e9-85c4-c1705a8e92c4.png">

Note that multiple interactives in the interactive box + some aspect ratio settings + responsive layout won't work well. This PR shouldn't make things worse, but it also doesn't improve that. Just something to keep in mind. I didn't try to fix it, as first, we would need to think how these cases should be handled.