### PR TITLE
A rake task to import activities into report system.

### DIFF
--- a/lib/tasks/lightweight_tasks.rake
+++ b/lib/tasks/lightweight_tasks.rake
@@ -10,4 +10,52 @@ namespace :lightweight do
       puts "This script only runs in the development environment."
     end
   end
+
+  desc "Publish All activity structures to FireStore report serivce"
+  task :publish_to_firestore => :environment do
+    cli = HighLine.new
+
+    # eg: 'super-secret-key'
+    token = ENV["REPORT_SERVICE_TOKEN"] || cli.ask("Report bearer token: ")
+
+    # eg: https://us-central1-report-service-dev.cloudfunctions.net/api/import_structure
+    url   = ENV["REPORT_SERVICE_URL"]   || cli.ask("Report service URL: ")
+
+    # eg: 'http://app.lara.docker'
+    self_url = ENV["REPORT_SERVICE_SELF_URL"]  || cli.ask("URL for this host")
+
+    LightweightActivity
+      .find_in_batches(batch_size: 20) do |group|
+        group.each do |act|
+          puts "starting #{act.name}"
+          content = act.serialize_for_portal(self_url)
+          result = HTTParty.post(
+            url,
+            :body => content.to_json,
+            :headers => {
+              'Content-Type' => 'application/json',
+              'Authorization' => "Bearer #{token}"
+            })
+          puts result
+          puts "wrote #{act.name}"
+        end
+      end
+
+    Sequence
+      .find_in_batches(batch_size: 20) do |group|
+        group.each do |seq|
+          puts "starting #{seq.name}"
+          content = seq.serialize_for_portal(self_url)
+          result = HTTParty.post(
+            url,
+            :body => content.to_json,
+            :headers => {
+              'Content-Type' => 'application/json',
+              'Authorization' => "Bearer #{token}"
+            })
+          puts result
+          puts "wrote #{seq.name}"
+        end
+      end
+  end
 end


### PR DESCRIPTION
This uses task pushes data in the old export format into FireStore using a cloud function.

Update: This is no longer using any FireStore gem.  It just posts to our custom cloud function with HTTParty.  

To run this in a container just export these variables into the environment:

```
REPORT_SERVICE_TOKEN=super-secret-key
REPORT_SERVICE_URL="https://us-central1-report-service-dev.cloudfunctions.net/api/import_structure"
REPORT_SERVICE_SELF_URL="https://authoring.staging.concord.org"
```


[#165937226]
https://www.pivotaltracker.com/story/show/165937226