### PR TITLE
Add new data format export for report service

### DIFF
--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -90,4 +90,9 @@ module Embeddable
   def embeddable_dom_id
     "embeddable-#{self.class.to_s.demodulize.underscore}_#{self.id}"
   end
+
+  def report_service_hash
+    # Once LARA doesn't publish to portal, we can just rename portal_hash to report_service_hash
+    respond_to?(:portal_hash) ? portal_hash : nil
+  end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -140,6 +140,18 @@ class Sequence < ActiveRecord::Base
     data
   end
 
+  def serialize_for_report_service(host)
+    local_url = "#{host}#{Rails.application.routes.url_helpers.sequence_path(self)}"
+    data = {
+      id: self.id,
+      type: 'sequence',
+      name: self.title,
+      url: local_url
+    }
+    data[:children] = self.activities.map { |a| a.serialize_for_report_service(host) }
+    data
+  end
+
   def self.extact_from_hash(sequence_json_object)
     {
       abstract: sequence_json_object[:abstract],

--- a/spec/models/embeddable/image_question_spec.rb
+++ b/spec/models/embeddable/image_question_spec.rb
@@ -52,6 +52,19 @@ describe Embeddable::ImageQuestion do
     end
   end
 
+  describe "#report_service_hash" do
+    it 'returns properties supported by the report service' do
+      expect(image_question.report_service_hash).to eq(
+        type: "image_question",
+        id: image_question.id,
+        prompt: image_question.prompt,
+        drawing_prompt: image_question.drawing_prompt,
+        is_required: image_question.is_prediction,
+        show_in_featured_question_report: image_question.show_in_featured_question_report
+      )
+    end
+  end
+
   describe '#duplicate' do
     it 'returns a new instance with copied attributes' do
       expect(image_question.duplicate).to be_a_new(Embeddable::ImageQuestion).with( name: image_question.name, prompt: image_question.prompt, drawing_prompt: image_question.drawing_prompt, bg_source: image_question.bg_source, bg_url: image_question.bg_url )
@@ -82,7 +95,7 @@ describe Embeddable::ImageQuestion do
 
   describe "import" do
     let(:json_with_promt){ image_question.export.as_json.symbolize_keys }
-    let(:json_without_promt){ 
+    let(:json_without_promt){
       img_ques = image_question.export.as_json.symbolize_keys
       img_ques.except(:prompt)
     }


### PR DESCRIPTION
[#166187624]

It might get updated soon, but the basic idea is simple.

All the containers have id, type, name, url and children.
Questions reuse portal_hash format, as it seems useful and good enough for now.

