### PR TITLE
Add better key names to exported runs and answers in `run_sender.rb`

### DIFF
--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -2,73 +2,79 @@ module ReportService
 
   class RunSender
     Version = "1"
+    DefaultClassHash = "anonymous-run"
+    DefaultUserName = "anonymous"
+    KeyRegex = /(\.|\/)+/
+    UrlRegex = /https?:\/\/([^\/]+)/
+    KeyReplacement = "_"
+    KeyJoiner = "-"
 
-    def hostname(url)
-      hostname = url.gsub(/https?:\/\/([^\/]+)/,'\1')
-      hostname.gsub(/(\.|\/)+/,'_')
+    def make_key(*values)
+      key = values.join(KeyJoiner)
+      key.gsub(KeyRegex, KeyReplacement)
     end
 
-    def answer_key(url, answer_hash)
+    def make_source_key(url)
+      make_key(url.gsub(UrlRegex, '\1'))
+    end
+
+    def question_key(answer_hash)
       question_type = answer_hash[:type] || answer_hash['type']
       question_id = answer_hash[:question_id] || answer_hash['question_id']
-      key ="#{hostname(url)}-#{question_type}-#{question_id}"
-      key = key.gsub(/(\.|\/)+/,'_')
-      puts key
-      key
+      make_key(question_type, question_id)
     end
 
     def get_class_hash(run)
       # TODO: Maybe we look this up?
-      run.class_info_url || "anonymous-run"
+      run.class_info_url || DefaultClassHash
+    end
+
+    def username_for_run(run)
+      run.user ? run.user.email : DefaultUserName
+    end
+
+    def add_meta_data(run, record, host)
+      record[:version] = RunSender::Version
+      record[:created] = Time.now.utc.to_s
+      record[:source_key] = make_source_key(host)
+      record[:class_hash] = get_class_hash(run)
+      record[:class_info_url] = run.class_info_url
+      record[:user_id] = username_for_run(run)
+      record[:remote_endpoint] = run.remote_endpoint
+      record[:run_key] = run.key
+    end
+
+    def serialized_answer(ans, run, host)
+      answer_hash = ans.portal_hash
+      answer_hash[:id] = ans.answer_id
+      answer_hash[:question_key] = question_key(answer_hash)
+      add_meta_data(run, answer_hash, host)
+      if(answer_hash[:url].blank?)
+        answer_hash[:url] = ""
+        answer_hash[:has_url] = false
+      end
+      answer_hash
     end
 
     def initialize(run, host)
       version = RunSender::Version
       created = Time.now.utc.to_s
       url = "#{host}#{Rails.application.routes.url_helpers.run_path(run)}"
-      class_hash = get_class_hash(run)
-      username = run.user ? run.user.email : 'anonymous'
-      key = run.key
-      hostname = hostname(host)
       @run_payload = {
-        key: key,
-        user_id: username,
-        class_hash: class_hash,
+        id: run.key,
         url: url,
-        host: host,
-        version: version,
-        created: created,
-        class_info_url: run.class_info_url,
         run_count: run.run_count,
         created_at: run.created_at,
         updated_at: run.updated_at,
         activity_id: run.activity_id,
         remote_id: run.remote_id,
         page_id: run.page_id,
-        remote_endpoint: run.remote_endpoint,
         sequence_id: run.sequence_id,
         sequence_run_id: run.sequence_run_id,
         collaboration_run_id: run.collaboration_run_id,
-        answers: run.answers.map do |ans|
-          answer_hash = ans.portal_hash
-          key = answer_key(host, answer_hash)
-          puts key
-          answer_hash[:id] = ans.answer_id
-          answer_hash[:host] = host
-          answer_hash[:key] = key
-          answer_hash[:run_key] = run.key
-          answer_hash[:class_hash] = class_hash
-          answer_hash[:user_id] = username
-          answer_hash[:version] = version
-          answer_hash[:created] = created
-          if(answer_hash[:url].blank?)
-            answer_hash[:url] = "#{url}/key"
-            answer_hash[:has_url] = false
-          end
-          answer_hash
-        end
+        answers: run.answers.map { |ans| serialized_answer(ans, run, host) }
       }
-
+      add_meta_data(run, @run_payload, host)
     end
 
     def to_json()

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -56,8 +56,7 @@ describe ReportService::RunSender do
   let(:sender) { ReportService::RunSender.new(run, host)     }
 
   before(:each) do
-    # allow(HTTParty).to receive(:post).and_return post_results
-    Rails.application.routes.url_helpers.stub(:run_path).and_return("runs/12345")
+    allow(Rails.application.routes.url_helpers).to receive(:run_path).and_return("runs/12345")
     Timecop.freeze(Time.new(2016))
   end
 
@@ -74,39 +73,39 @@ describe ReportService::RunSender do
       it "should have a key fields" do
         expect(json).to include(
           "version", "created", "user_id",
-          "answers", "class_hash", "key"
+          "answers", "class_hash", "run_key"
         )
       end
 
       describe "the encoded answers" do
         it "should also include the run_key, user_id, class_hash " do
           answers = json["answers"]
-          answers.each do |a,index|
-            expect(a).to include("key")
-            expect(a["key"]).to match("app_lara_docker")
-            expect(a["key"]).to match("mock-answer")
-            expect(a["key"]).to match("#{index}")
-            expect(a["key"]).to match(/\d+/)
-            expect(a["key"]).not_to match("/")
-            expect(a["key"]).not_to match(/\./)
+          answers.each_with_index do |a,index|
+            expect(a).to include("question_key")
+            expect(a["source_key"]).to match("app_lara_docker")
+            expect(a["source_key"]).not_to match("/")
+            expect(a["source_key"]).not_to match(/\./)
+
+            expect(a["id"]).to match("mock_question_answer")
+            expect(a["id"]).not_to match("/")
+            expect(a["id"]).not_to match(/\./)
+
+            expect(a["question_key"]).to match("mock-answer")
+            expect(a["question_key"]).to match("#{index+1}")
+            expect(a["question_key"]).not_to match("/")
+            expect(a["question_key"]).not_to match(/\./)
+
+            expect(a).to include("created")
             expect(a).to include("url")
             expect(a).to include("run_key")
             expect(a).to include("user_id")
             expect(a).to include("class_hash")
-            expect(a).to include("created")
+            expect(a).to include("class_info_url")
             expect(a).to include("version")
           end
         end
       end
     end
-
-    end
-
-
-    describe "send" do
-      describe "version 1 of the sending protocol" do
-      end
-    end
-
+  end
 
 end


### PR DESCRIPTION
This improves the key names and structure of data sent to FireStore.

It should also fix the  deprecation warning for the spec tests.

[#166063708]

https://www.pivotaltracker.com/story/show/166063708