### PR TITLE
165217423 batch import class info for runs

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -4,7 +4,9 @@ class Run < ActiveRecord::Base
   class PortalUpdateIncomplete < StandardError; end
   class InvalidJobState < StandardError; end
 
-  attr_accessible :run_count, :user_id, :key, :activity, :user, :page_id, :remote_id, :remote_endpoint, :activity_id, :sequence_id
+  attr_accessible :run_count, :user_id, :key, :activity, :user, :page_id,
+  :remote_id, :remote_endpoint, :activity_id, :sequence_id, :class_hash,
+  :class_info_url
 
   belongs_to :activity, :class_name => LightweightActivity
 

--- a/app/models/sequence_run.rb
+++ b/app/models/sequence_run.rb
@@ -1,5 +1,6 @@
 class SequenceRun < ActiveRecord::Base
-  attr_accessible :remote_endpoint, :remote_id, :user_id, :sequence_id, :key
+  attr_accessible :remote_endpoint, :remote_id, :user_id, :sequence_id, :key,
+  :class_info_url, :class_hash
 
   has_many :runs
   belongs_to :sequence

--- a/db/migrate/20190528192009_add_class_hash_to_runs.rb
+++ b/db/migrate/20190528192009_add_class_hash_to_runs.rb
@@ -1,0 +1,5 @@
+class AddClassHashToRuns < ActiveRecord::Migration
+  def change
+    add_column :runs, :class_hash, :string
+  end
+end

--- a/db/migrate/20190528192812_add_class_hash_to_sequence_runs.rb
+++ b/db/migrate/20190528192812_add_class_hash_to_sequence_runs.rb
@@ -1,0 +1,6 @@
+class AddClassHashToSequenceRuns < ActiveRecord::Migration
+  def change
+    add_column :sequence_runs, :class_hash, :string
+    add_column :sequence_runs, :class_info_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190523183238) do
+ActiveRecord::Schema.define(:version => 20190528192812) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -560,6 +560,7 @@ ActiveRecord::Schema.define(:version => 20190523183238) do
     t.boolean  "is_dirty",             :default => false
     t.integer  "collaboration_run_id"
     t.text     "class_info_url"
+    t.string   "class_hash"
   end
 
   add_index "runs", ["activity_id"], :name => "index_runs_on_activity_id"
@@ -580,6 +581,8 @@ ActiveRecord::Schema.define(:version => 20190523183238) do
     t.datetime "created_at",      :null => false
     t.datetime "updated_at",      :null => false
     t.string   "key"
+    t.string   "class_hash"
+    t.string   "class_info_url"
   end
 
   add_index "sequence_runs", ["key"], :name => "sequence_runs_key_idx"

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -74,4 +74,78 @@ namespace :reporting do
   task :publish_runs => :environment do
     send_all_resources(Run, ReportService::RunSender)
   end
+
+  desc "import clazz info"
+  task :import_clazz_info => :environment do
+
+    def remote_endpoint_path(learner_key)
+      portal_url = ENV["IMPORT_PORTAL_URL"]
+      "#{portal_url}/dataservice/external_activity_data/#{learner_key}"
+    end
+
+    def class_info_url_path(class_id)
+      portal_url = ENV["IMPORT_PORTAL_URL"]
+      "#{portal_url}/api/v1/classes/#{class_id}"
+    end
+
+    def env_value(var_name, prompt, default)
+      cli = HighLine.new
+      ENV[var_name] ||= cli.ask("#{prompt}: ") { |q| q.default = default}
+    end
+
+    env_value "IMPORT_PORTAL_URL", "Portal URL", "http://app.portal.docker/"
+    import_filename = env_value "CLASS_IMPORT_FILENAME", "Import file", "clazz-learners.csv"
+
+    start_time = Time.now
+    line_count = 1
+    updated_srun_count = 0
+    updated_run_count = 0
+    num_lines = File.foreach(import_filename).inject(0) {|c, line| c+1}
+    line_interval = (num_lines / 100.0).ceil
+
+    import_file  = File.open(import_filename, 'r')
+    import_file.each_line do |import_line|
+      if line_count == 1 || line_count % line_interval == 0
+        puts "Processing line: #{line_count} of #{num_lines}"
+        puts "    Updated #{updated_srun_count} SequenceRuns"
+        puts "    Updated #{updated_run_count} Runs"
+      end
+      clazz_id, class_hash, learner_id, learner_key = import_line.strip.split(",")
+      remote_endpoint = remote_endpoint_path(learner_key)
+      info_url = class_info_url_path(clazz_id)
+      SequenceRun
+        .where(remote_endpoint: remote_endpoint)
+        .each do |srun|
+          srun.update_attributes({
+            class_info_url: info_url,
+            class_hash: class_hash
+          })
+          updated_srun_count = updated_srun_count + 1
+          # Child runs:
+          srun.runs.each do |run|
+            run.update_attributes({
+              class_info_url: info_url,
+              class_hash: class_hash
+            })
+            updated_run_count = updated_run_count + 1
+          end
+      end
+
+      Run
+        .where(remote_endpoint: remote_endpoint)
+        .each do |run|
+          run.update_attributes({
+            class_info_url: info_url,
+            class_hash: class_hash
+          })
+          updated_run_count = updated_run_count + 1
+        end
+      line_count = line_count + 1
+    end
+    elapsed = (Time.now - start_time).round(2)
+    puts "=============================================="
+    puts "Elapsed time: #{elapsed} seconds"
+    puts "Updated #{updated_srun_count} SequenceRuns"
+    puts "Updated #{updated_run_count} Runs"
+  end
 end


### PR DESCRIPTION
Part of the large bug / feature story about adding `class_info_url` and `class_hash`
to runs and sequence runs launched from the portal.

We need to update existing runs in the DB with this information.

[#165217423]
https://www.pivotaltracker.com/story/show/165217423

See also the [Portal PR #659](https://github.com/concord-consortium/rigse/pull/659) that exports the data that this Task imports from.