### PR TITLE
Added plugin authoring metadata and wrapper UI [#166193534] [#166194332]

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -633,6 +633,39 @@ form.new_lightweight_activity {
     }
   }
 }
+.available_plugins {
+  .embeddable-plugin-form {
+    margin: 1em 0.5em 0.5em 0.5em;
+  }
+  input[type=submit] {
+    float: right;
+  }
+}
+.wrapped_plugins {
+  .plugin_list {
+    grid-template-columns: 3fr 1fr 1fr;
+    display: grid;
+    div {
+      margin: 0.5em;
+    }
+    .edit a {
+      background: transparent url(/assets/icons/edit.png) 0 0 no-repeat;
+      background-size: 14px;
+      color: #333;
+      height: 14px;
+      padding-left: 18px;
+      text-decoration: none;
+    }
+    .delete a {
+      background: transparent url(/assets/icons/delete.png) 0 0 no-repeat;
+      background-size: 14px;
+      color: #333;
+      height: 14px;
+      padding-left: 18px;
+      text-decoration: none;
+    }
+  }
+}
 ul#new {
    margin-top: 1em;
   li#add a {
@@ -1067,3 +1100,22 @@ form {
   }
 }
 
+.edit_approved_script {
+  input[type=text] {
+    width: 60%;
+  }
+  th {
+    font-weight: bold;
+    text-align: left;
+    padding: 5px;
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+  td {
+    padding: 5px;
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+}

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -113,6 +113,11 @@ class InteractivePagesController < ApplicationController
     authorize! :update, @page
     update_activity_changed_by
     e = Embeddable.create_for_string(params[:embeddable_type])
+    if (params[:embeddable_type] == Embeddable::EmbeddablePlugin.to_s)
+      e.approved_script_id = params[:approved_script_id] if !params[:approved_script_id].empty?
+      e.component_label = params[:component_label] if !params[:component_label].empty?
+      e.save!
+    end
     @page.add_embeddable(e, nil, params[:section])
     # The call below supposed to open edit dialog, but it doesn't seem to work anymore.
     edit_embeddable_redirect(e)

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -114,8 +114,9 @@ class InteractivePagesController < ApplicationController
     update_activity_changed_by
     e = Embeddable.create_for_string(params[:embeddable_type])
     if (params[:embeddable_type] == Embeddable::EmbeddablePlugin.to_s)
-      e.approved_script_id = params[:approved_script_id] if !params[:approved_script_id].empty?
-      e.component_label = params[:component_label] if !params[:component_label].empty?
+      e.approved_script_id = params[:approved_script_id] if !params[:approved_script_id].blank?
+      e.component_label = params[:component_label] if !params[:component_label].blank?
+      e.embeddable_select_value = params[:embeddable_select_value] if !params[:embeddable_select_value].blank?
       e.save!
     end
     @page.add_embeddable(e, nil, params[:section])

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -305,6 +305,19 @@ class LightweightActivitiesController < ApplicationController
     redirect_to :back
   end
 
+  def add_plugin
+    authorize! :update, @activity
+    @activity.plugins.create({
+      approved_script_id: params[:approved_script_id],
+      component_label: params[:component_label]
+    })
+    if request.xhr?
+      respond_with_nothing
+    else
+      redirect_to edit_activity_path(@activity)
+    end
+  end
+
   private
   def set_activity
     if params[:activity_id]

--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -6,8 +6,8 @@ class PluginsController < ApplicationController
     render_to_string('_list_plugins', layout: false, locals: {plugins: all_plugins})
   end
 
-  def _form(plugin)
-    render_to_string('_form', layout: false, locals: { plugin: @plugin })
+  def _form(plugin, edit)
+    render_to_string('_form', layout: false, locals: { plugin: @plugin, edit: edit })
   end
 
   public
@@ -17,7 +17,7 @@ class PluginsController < ApplicationController
     respond_to do |format|
       format.js {
         render :json => {
-          html: _form(@plugin)
+          html: _form(@plugin, true)
         }
       }
     end
@@ -30,7 +30,7 @@ class PluginsController < ApplicationController
     respond_to do |format|
       format.js {
         render :json => {
-          html: _form(@plugin)
+          html: _form(@plugin, false)
         }
       }
     end

--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -1,11 +1,6 @@
 class PluginsController < ApplicationController
 
   private
-  def _list_plugins(plugin)
-    all_plugins = plugin.plugin_scope.reload.plugins
-    render_to_string('_list_plugins', layout: false, locals: {plugins: all_plugins})
-  end
-
   def _form(plugin, edit)
     render_to_string('_form', layout: false, locals: { plugin: @plugin, edit: edit })
   end
@@ -18,7 +13,7 @@ class PluginsController < ApplicationController
       format.js {
         render :json => {
           html: _form(@plugin, true)
-        }
+        }, :content_type => 'text/json'
       }
     end
   end
@@ -47,7 +42,6 @@ class PluginsController < ApplicationController
       @plugin.reload
     end
 
-    @plugin_list = _list_plugins(@plugin)
     respond_to do |format|
       format.js do
         # will render update.js.erb
@@ -60,7 +54,6 @@ class PluginsController < ApplicationController
     @plugin = Plugin.find(params[:id])
     authorize! :manage, @plugin
     @plugin.destroy
-    @plugin_list = _list_plugins(@plugin)
     respond_to do |format|
       format.js do
         # will render destroy.js.erb

--- a/app/helpers/embeddable_helper.rb
+++ b/app/helpers/embeddable_helper.rb
@@ -2,12 +2,28 @@ module EmbeddableHelper
 
   def embeddable_selector
     embeddable_types = Embeddable::Types.map { |k,v| [v, k.to_s] }
-    plugins_items = ApprovedScript.authoring_menu_items("embeddable").map { |ami| [ami.component_name, Embeddable::EmbeddablePlugin.to_s, {"data-approved-script-id" => ami.approved_script_id, "data-component-label" => ami.component_label}] }
-    select_tag :embeddable_type, options_for_select(embeddable_types + plugins_items)
+    plugin_items = ApprovedScript.authoring_menu_items("embeddable").map { |ami| [ami.name, Embeddable::EmbeddablePlugin.to_s, {"data-approved-script-id" => ami.approved_script_id, "data-component-label" => ami.component_label}] }
+    select_tag :embeddable_type, options_for_select(embeddable_types + plugin_items)
   end
 
   def embeddable_interactives_selector
     select_tag :embeddable_type, options_for_select(Embeddable::InteractiveTypes.map { |k,v| [v, k.to_s] })
   end
 
+  def available_wrapped_embeddable_plugins(embeddable)
+    ApprovedScript.authoring_menu_items("embeddable-decoration", embeddable)
+  end
+
+  def wrapped_embeddable_selector(embeddable)
+    plugin_items = available_wrapped_embeddable_plugins(embeddable).map { |ami| [ami.name, Embeddable::EmbeddablePlugin.to_s, {"data-approved-script-id" => ami.approved_script_id, "data-component-label" => ami.component_label}] }
+    if plugin_items.length > 0
+      select_tag :embeddable_type, options_for_select(plugin_items), {id: "embeddable_type_#{embeddable.embeddable_dom_id}", class: "wrapped-embeddable-type"}
+    else
+      nil
+    end
+  end
+
+  def wrapped_embeddable_plugins(embeddable)
+    Embeddable::EmbeddablePlugin.where({embeddable_id: embeddable.id, embeddable_type: embeddable.class.name})
+  end
 end

--- a/app/helpers/embeddable_helper.rb
+++ b/app/helpers/embeddable_helper.rb
@@ -1,7 +1,9 @@
 module EmbeddableHelper
 
   def embeddable_selector
-    select_tag :embeddable_type, options_for_select(Embeddable::Types.map { |k,v| [v, k.to_s] })
+    embeddable_types = Embeddable::Types.map { |k,v| [v, k.to_s] }
+    plugins_items = ApprovedScript.authoring_menu_items("embeddable").map { |ami| [ami.component_name, Embeddable::EmbeddablePlugin.to_s, {"data-approved-script-id" => ami.approved_script_id, "data-component-label" => ami.component_label}] }
+    select_tag :embeddable_type, options_for_select(embeddable_types + plugins_items)
   end
 
   def embeddable_interactives_selector

--- a/app/helpers/plugin_helper.rb
+++ b/app/helpers/plugin_helper.rb
@@ -7,4 +7,9 @@ module PluginHelper
     false
   end
 
+  def plugin_options(scope)
+    plugins_items = ApprovedScript.authoring_menu_items(scope).map { |ami| [ami.component_name, ami.approved_script_id, {"data-component-label" => ami.component_label}] }
+    options_for_select(plugins_items)
+  end
+
 end

--- a/app/helpers/plugin_helper.rb
+++ b/app/helpers/plugin_helper.rb
@@ -8,7 +8,7 @@ module PluginHelper
   end
 
   def plugin_options(scope)
-    plugins_items = ApprovedScript.authoring_menu_items(scope).map { |ami| [ami.component_name, ami.approved_script_id, {"data-component-label" => ami.component_label}] }
+    plugins_items = ApprovedScript.authoring_menu_items(scope).map { |ami| [ami.name, ami.approved_script_id, {"data-component-label" => ami.component_label}] }
     options_for_select(plugins_items)
   end
 

--- a/app/models/approved_script.rb
+++ b/app/models/approved_script.rb
@@ -1,5 +1,5 @@
 class ApprovedScript < ActiveRecord::Base
-  attr_accessible :name, :url, :label, :description, :version, :json_url
+  attr_accessible :name, :url, :label, :description, :version, :json_url, :authoring_metadata
   validates :name, presence: true
   validates :label, format: {
     with: /^([A-Za-z0-9]+)$/,
@@ -10,4 +10,39 @@ class ApprovedScript < ActiveRecord::Base
     message: "include protocol (https://)"
   }
   belongs_to :appoved_script
+
+  def self.authoring_menu_items(scope)
+    menu_items = []
+    ApprovedScript.all.each do |as|
+      as.components_for_authoring_scope(scope).each do |c|
+        menu_items.push(OpenStruct.new({
+          approved_script_id: as[:id],
+          component_label: c[:label],
+          component_name: c[:name]
+        }))
+      end
+    end
+    menu_items
+  end
+
+  def components
+    parsed_authoring_metadata[:components] || []
+  end
+
+  def component(label)
+    c = components.find {|c| c[:label] == label}
+    c && OpenStruct.new(c)
+  end
+
+  def components_for_authoring_scope(scope)
+    components.select {|c| c[:scope] == scope}
+  end
+
+  def parsed_authoring_metadata
+    begin
+      JSON.parse authoring_metadata, :symbolize_names => true
+    rescue
+      {}
+    end
+  end
 end

--- a/app/models/approved_script.rb
+++ b/app/models/approved_script.rb
@@ -11,18 +11,25 @@ class ApprovedScript < ActiveRecord::Base
   }
   belongs_to :appoved_script
 
-  def self.authoring_menu_items(scope)
+  def self.authoring_menu_items(scope, embeddable=nil)
+    embeddable_class = embeddable ? embeddable.class.name : nil
     menu_items = []
     ApprovedScript.all.each do |as|
       as.components_for_authoring_scope(scope).each do |c|
-        menu_items.push(OpenStruct.new({
-          approved_script_id: as[:id],
-          component_label: c[:label],
-          component_name: c[:name]
-        }))
+        if !embeddable_class || (c.has_key?(:decorates) && c[:decorates].include?(embeddable_class))
+          menu_items.push(OpenStruct.new({
+            approved_script_id: as[:id],
+            component_label: c[:label],
+            component_name: c[:name],
+            name: "#{as[:name]}: #{c[:name]}"
+          }))
+        end
       end
     end
     menu_items
+  end
+
+  def self.available_plugins_for_embeddable(embeddable)
   end
 
   def components

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -7,7 +7,6 @@ module Embeddable
     Embeddable::Labbook        => "Labbook",
     QuestionTracker            => "Tracked Question",
     Embeddable::ExternalScript => "External Script",
-    Embeddable::EmbeddablePlugin => "Plugin"
   }
 
   InteractiveTypes = {
@@ -34,7 +33,7 @@ module Embeddable
   end
 
   def self.valid_type(class_string)
-    return Types.detect{|k,v| k.to_s == class_string }
+    return class_string == Embeddable::EmbeddablePlugin.to_s || Types.detect{|k,v| k.to_s == class_string }
   end
 
   def self.create_for_string(class_string)

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -75,6 +75,10 @@ module Embeddable
     true
   end
 
+  def show_in_edit?
+    true
+  end
+
   # This should not take into account the hidden attribute. The caller should combine
   # is_hidden with reportable? to know what to show in a report
   def reportable?

--- a/app/models/embeddable/embeddable_plugin.rb
+++ b/app/models/embeddable/embeddable_plugin.rb
@@ -95,5 +95,9 @@ module Embeddable
       # It is if it's attached to some other embeddable.
       attached_to_embeddable
     end
+
+    def show_in_edit?
+      !component || component[:scope] != "embeddable-decoration"
+    end
   end
 end

--- a/app/models/embeddable/embeddable_plugin.rb
+++ b/app/models/embeddable/embeddable_plugin.rb
@@ -8,7 +8,7 @@ module Embeddable
     end
 
     attr_accessible :plugin, :approved_script_id, :description, :author_data,
-    :is_full_width, :is_hidden
+    :is_full_width, :is_hidden, :component_label
 
     belongs_to :plugin, autosave: true
 
@@ -27,6 +27,9 @@ module Embeddable
     delegate :name,  to: :plugin, allow_nil: true
     delegate :label, to: :plugin, allow_nil: true
     delegate :url, to: :plugin, allow_nil: true
+    delegate :component_label, to: :plugin
+    delegate :component_label=, to: :plugin
+    delegate :component, to: :plugin, allow_nil: true
 
     before_create do |embeddable|
       unless(embeddable.plugin)

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -20,7 +20,8 @@ class Plugin < ActiveRecord::Base
     {
       description: description,
       author_data: author_data,
-      approved_script_label: approved_script && approved_script.label
+      approved_script_label: approved_script && approved_script.label,
+      component_label: component_label
     }
   end
 
@@ -50,6 +51,14 @@ class Plugin < ActiveRecord::Base
   end
 
   def name
-    (component && component.name) || (approved_script && approved_script.name) || nil
+    if approved_script && component
+      "#{approved_script.name}: #{component.name}"
+    elsif approved_script
+      approved_script.name
+    elsif component
+      component.name
+    else
+      nil
+    end
   end
 end

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -1,12 +1,11 @@
 
 class Plugin < ActiveRecord::Base
 
-  attr_accessible :description, :author_data, :approved_script_id, :approved_script, :shared_learner_state_key
+  attr_accessible :description, :author_data, :approved_script_id, :approved_script, :shared_learner_state_key, :component_label
 
   belongs_to :approved_script
   belongs_to :plugin_scope, polymorphic: true
 
-  delegate :name,  to: :approved_script, allow_nil: true
   delegate :label, to: :approved_script, allow_nil: true
   delegate :url,   to: :approved_script, allow_nil: true
   delegate :version, to: :approved_script, allow_nil: true
@@ -46,4 +45,11 @@ class Plugin < ActiveRecord::Base
     Plugin.import(serialized)
   end
 
+  def component
+    approved_script.component(component_label) if component_label && approved_script
+  end
+
+  def name
+    (component && component.name) || (approved_script && approved_script.name) || nil
+  end
 end

--- a/app/views/approved_scripts/_form.html.haml
+++ b/app/views/approved_scripts/_form.html.haml
@@ -34,6 +34,7 @@
       = f.label :description
       %br
       = f.text_area :description
+    = f.hidden_field :authoring_metadata
     .actions{style: "margin: 1em 0px;"}
       = f.submit
 
@@ -58,12 +59,15 @@
         return resp.json();
       })
       .then(function(json) {
-        ["name", "label", "url", "version", "description"].forEach(function (field) {
+        ["name", "label", "url", "version", "description", "authoring_metadata"].forEach(function (field) {
           var value = json[field];
           if (value) {
             // allow urls to be relative to the json base url
             if ((field === "url") && value && !/https?:/.test(value)) {
               value = baseUrl + value;
+            }
+            if (field === "authoring_metadata") {
+              value = JSON.stringify(value);
             }
             document.getElementById("approved_script_" + field).value = value;
           }

--- a/app/views/approved_scripts/_form.html.haml
+++ b/app/views/approved_scripts/_form.html.haml
@@ -1,5 +1,5 @@
 = form_for(@approved_script) do |f|
-  %div{style: "margin: 0em 5em; display: flex; flex-direction: column; width: 300px;"}
+  %div{style: "margin: 0em 5em; display: flex; flex-direction: column;"}
     - if @approved_script.errors.any?
       #error_explanation
         %h2
@@ -34,11 +34,28 @@
       = f.label :description
       %br
       = f.text_area :description
+    #component_display.field{style: "margin: 1em 0px;"}
     = f.hidden_field :authoring_metadata
     .actions{style: "margin: 1em 0px;"}
       = f.submit
 
 :javascript
+  function showAuthoringMetadata() {
+    var metadata = JSON.parse(document.getElementById("approved_script_authoring_metadata").value || "{}");
+    var rows = [];
+    (metadata.components || []).forEach(function (component) {
+      var decorates = component.decorates ? component.decorates.map(function (d) { return d.replace("Embeddable::", "")}).join(", ") : "<i>n/a</i>";
+      rows.push("<tr><td>" + component.name + "</td><td>" + component.scope + "<td>" + decorates + "</td></tr>")
+    });
+    var el = document.getElementById("component_display");
+    if (rows.length > 0) {
+      el.innerHTML = "<table><thead><tr><th>Component</th><th>Scope</th><th>Decorates</th></thead><tbody>" + rows.join("") + "</tbody></table>";
+    }
+    else {
+      el.innerHTML = "No authoring metadata found.";
+    }
+  }
+
   function loadPluginJSON() {
     var baseUrl;
     Promise.resolve(document.getElementById("approved_script_json_url"))
@@ -59,6 +76,7 @@
         return resp.json();
       })
       .then(function(json) {
+        // document.getElementById("json").innerHTML = JSON.stringify(json.authoring_metadata || {});
         ["name", "label", "url", "version", "description", "authoring_metadata"].forEach(function (field) {
           var value = json[field];
           if (value) {
@@ -70,6 +88,7 @@
               value = JSON.stringify(value);
             }
             document.getElementById("approved_script_" + field).value = value;
+            showAuthoringMetadata();
           }
         })
       })
@@ -77,3 +96,5 @@
         alert("Unable to load JSON: " + e.toString());
       });
   }
+
+  showAuthoringMetadata();

--- a/app/views/embeddable/embeddable_plugins/_form.html.haml
+++ b/app/views/embeddable/embeddable_plugins/_form.html.haml
@@ -5,10 +5,6 @@
   = f.error_messages
   %div{style: "display: grid; grid-template-columns: 100px auto;grid-row-gap: 2em;"}
     %div
-      = f.label "Wrapped Embeddable:"
-    %div
-      = f.select :embeddable_select_value, @embeddable.embeddables_for_select, {}, class: :select_embeddable
-    %div
       = f.label "Author Data:"
     %div
       = f.text_area :author_data, {id:'jsonConfigText'}

--- a/app/views/embeddable/embeddable_plugins/_form.html.haml
+++ b/app/views/embeddable/embeddable_plugins/_form.html.haml
@@ -1,17 +1,9 @@
 %h1{style: "font-size: 1.5em; font-weight: bold; margin-bottom: 1em;"}
-  Embeddable Plugin
+  = @embeddable.name
 
 = form_for @embeddable do |f|
   = f.error_messages
   %div{style: "display: grid; grid-template-columns: 100px auto;grid-row-gap: 2em;"}
-    %div
-      = f.label "Plugin:"
-    %div
-      = f.collection_select(:approved_script_id, ApprovedScript.all, :id, :name)
-    %div
-      = f.label "Description:"
-    %div
-      = f.text_field :description
     %div
       = f.label "Wrapped Embeddable:"
     %div

--- a/app/views/embeddable/external_scripts/_author.html.haml
+++ b/app/views/embeddable/external_scripts/_author.html.haml
@@ -8,3 +8,4 @@
     Name: #{embeddable.name.html_safe unless embeddable.name.blank?}
   .url{name: "questions[embeddable__#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}]"}
     URL: #{(embeddable.url or "")}
+= render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }

--- a/app/views/embeddable/image_questions/_author.html.haml
+++ b/app/views/embeddable/image_questions/_author.html.haml
@@ -21,3 +21,4 @@
     %button.image_question.button{:type => 'submit', :id => 'image_upload_button'}
       %i.fa.fa-upload
       Upload image
+= render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }

--- a/app/views/embeddable/labbooks/_author.html.haml
+++ b/app/views/embeddable/labbooks/_author.html.haml
@@ -16,3 +16,4 @@
   - if params[:edit_embed_lb].to_i == embeddable.id
     :javascript
       $("a[id^=edit-embed-lb-#{embeddable.id}]").click()
+= render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }

--- a/app/views/embeddable/multiple_choices/_author.html.haml
+++ b/app/views/embeddable/multiple_choices/_author.html.haml
@@ -1,7 +1,7 @@
 .embeddable_tools
   .drag_handle
   = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'mc', :allow_hide => allow_hide }
-.embeddable_options  
+.embeddable_options
   .prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
   - if embeddable.show_as_menu
     = select embeddable, :answers, options_from_collection_for_select(embeddable.choices, 'id', 'choice', embeddable.answers.last), { :include_blank => "Pick one" }
@@ -17,3 +17,4 @@
         = choice.choice
   - if embeddable.enable_check_answer
     %button= "Check answer"
+= render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }

--- a/app/views/embeddable/open_responses/_author.html.haml
+++ b/app/views/embeddable/open_responses/_author.html.haml
@@ -4,3 +4,4 @@
 .embeddable_options
   .prompt= embeddable.prompt.html_safe unless embeddable.prompt.blank?
   %textarea{:name => "questions[embeddable__#{embeddable.class.to_s.demodulize.underscore}_#{embeddable.id}]"}=(embeddable.default_text or "").html_safe
+= render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }

--- a/app/views/embeddable/xhtmls/_author.html.haml
+++ b/app/views/embeddable/xhtmls/_author.html.haml
@@ -1,9 +1,10 @@
 .embeddable_tools
   .drag_handle
   = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'xhtml', :allow_hide => allow_hide }
-.embeddable_options  
+.embeddable_options
   - if embeddable.content.blank?
     .xhtml
       Embeddable text will go here.
   - else
     .xhtml= embeddable.content.html_safe
+= render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -93,10 +93,11 @@
             = submit_tag 'Add Embeddable', {id: 'add_embeddable_button'}
           .embeddables_list.sortable_embeddables
             - @page.section_embeddables(nil).each do |e|
-              - tracked = e.respond_to?(:tracked_question) && e.tracked_question
-              - tracked_class = tracked ? 'tracked' : ''
-              .authorable{:id => "embeddable_#{e.id}.#{e.class.to_s}", :class => tracked_class}
-                = render :partial => "#{e.class.name.underscore.pluralize}/author", :locals => { :embeddable => e, :page => @page, :allow_hide => true }
+              - if e.show_in_edit?
+                - tracked = e.respond_to?(:tracked_question) && e.tracked_question
+                - tracked_class = tracked ? 'tracked' : ''
+                .authorable{:id => "embeddable_#{e.id}.#{e.class.to_s}", :class => tracked_class}
+                  = render :partial => "#{e.class.name.underscore.pluralize}/author", :locals => { :embeddable => e, :page => @page, :allow_hide => true }
       -# Additional sections are dynamically loaded, based on .visible_sections value:
       - @page.visible_sections.each do |s|
         = render :partial => "#{s[:dir]}/author", :locals => { :page => @page, :section_name => s[:name], :section_label => s[:label], :allow_hide => false }
@@ -142,5 +143,14 @@
       var selected = $(this).find(':selected');
       $('#approved_script_id').val(selected.data('approved-script-id') || "")
       $('#component_label').val(selected.data('component-label') || "")
+    })
+
+    // set the hidden plugin fields when wrapped embeddable plugins are selected
+    $('.wrapped-embeddable-type').on('change', function() {
+      var $this = $(this);
+      var selected = $this.find(':selected');
+      var form = $this.closest("form");
+      form.find('[name=approved_script_id]').val(selected.data('approved-script-id') || "")
+      form.find('[name=component_label]').val(selected.data('component-label') || "")
     })
   });

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -88,6 +88,8 @@
           %h2 Info/Assess
           = form_tag add_embeddable_activity_page_path(@activity, @page), :class => 'embeddables-form' do
             = embeddable_selector
+            = hidden_field_tag :approved_script_id
+            = hidden_field_tag :component_label
             = submit_tag 'Add Embeddable', {id: 'add_embeddable_button'}
           .embeddables_list.sortable_embeddables
             - @page.section_embeddables(nil).each do |e|
@@ -134,4 +136,11 @@
         this.form.submit();
       }
     });
+
+    // set the hidden plugin fields when embeddable plugins are selected
+    $('#embeddable_type').on('change', function() {
+      var selected = $(this).find(':selected');
+      $('#approved_script_id').val(selected.data('approved-script-id') || "")
+      $('#component_label').val(selected.data('component-label') || "")
+    })
   });

--- a/app/views/plugins/_form.html.haml
+++ b/app/views/plugins/_form.html.haml
@@ -4,9 +4,10 @@
   = form_for plugin, remote: true do |f|
     = f.error_messages
     %div{style: "display: flex; flex-direction: column;"}
-      %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
-        = f.label t("PLUGIN.APPROVED_SCRIPT")
-        = f.collection_select(:approved_script_id, ApprovedScript.all, :id, :name)
+      - if !edit
+        %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
+          = f.label t("PLUGIN.APPROVED_SCRIPT")
+          = f.select :approved_script_id, plugin_options("activity")
       %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
         = f.label t("PLUGIN.GLOBAL_ID")
         = f.text_field :shared_learner_state_key
@@ -16,5 +17,14 @@
       %div{style: "margin-top: 0.5em; flex-direction: column; align-items: stretch;"}
         = f.label t("PLUGIN.AUTHORING_DATA")
         = f.text_area :author_data
+    = f.hidden_field :component_label
     = f.submit t("CANCEL"), :class => 'close'
     = f.submit t("SAVE"), :class => 'embeddable-save'
+
+:javascript
+  $(function() {
+    $('#plugin_approved_script_id').on('change', function() {
+      var selected = $(this).find(':selected');
+      $('#plugin_component_label').val(selected.data('component-label') || "")
+    })
+  });

--- a/app/views/plugins/_form.html.haml
+++ b/app/views/plugins/_form.html.haml
@@ -1,19 +1,9 @@
-%div{style: "margin-top: 0.5em; padding: 0.5em; background: white;" }
-
-  %h3 #{t("PLUGIN.ACTIVITY_PLUGIN")} <em>#{plugin.name}</em>
+%div
+  %h1{style: "font-size: 1.5em; font-weight: bold; margin-bottom: 1em;"}
+    = plugin.name
   = form_for plugin, remote: true do |f|
     = f.error_messages
     %div{style: "display: flex; flex-direction: column;"}
-      - if !edit
-        %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
-          = f.label t("PLUGIN.APPROVED_SCRIPT")
-          = f.select :approved_script_id, plugin_options("activity")
-      %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
-        = f.label t("PLUGIN.GLOBAL_ID")
-        = f.text_field :shared_learner_state_key
-      %div{style: "margin-top: 0.5em; display: flex; justify-content: space-between;"}
-        = f.label t("PLUGIN.DESCRIPTION")
-        = f.text_field :description
       %div{style: "margin-top: 0.5em; flex-direction: column; align-items: stretch;"}
         = f.label t("PLUGIN.AUTHORING_DATA")
         = f.text_area :author_data

--- a/app/views/plugins/_list.html.haml
+++ b/app/views/plugins/_list.html.haml
@@ -1,7 +1,27 @@
 %h2=t("PLUGIN.ACTIVITY_LIST_TITLE")
 
-#plugin_list
-  =render partial: 'plugins/list_plugins', locals: {plugins: activity.plugins}
+- available_plugins = ApprovedScript.authoring_menu_items("activity")
+- if available_plugins.length > 0
+  .available_plugins
+    - first_plugin = available_plugins[0]
+    = form_tag add_plugin_activity_path(@activity), :class => 'plugin-form' do
+      = select_tag :approved_script_id, plugin_options("activity")
+      = hidden_field_tag :component_label, first_plugin.component_label, {id: "component_label"}
+      = submit_tag 'Add', {id: 'add_plugin_button'}
 
-#add_plugin= link_to t("PLUGIN.ADD"), new_plugin_path(params: {activity_id: activity.id}), remote: true, :"data-replace" => '#plugin_form'
-#plugin_form
+- if activity.plugins.length > 0
+  .wrapped_plugins
+    .plugin_list
+      - activity.plugins.each do |plugin|
+        .item
+          #{plugin.name}
+        .edit= link_to t("PLUGIN.EDIT"), edit_plugin_path(plugin), remote: true
+        .delete= link_to t("PLUGIN.DELETE"), plugin_path(plugin), remote: true, method: :delete, data: { confirm: t("PLUGIN.DELETE_WARNING") }
+
+:javascript
+  $(function() {
+    $('#approved_script_id').on('change', function() {
+      var selected = $(this).find(':selected');
+      $('#component_label').val(selected.data('component-label') || "")
+    })
+  })

--- a/app/views/plugins/_list_plugins.html.haml
+++ b/app/views/plugins/_list_plugins.html.haml
@@ -1,5 +1,0 @@
-- plugins.each do |plugin|
-  .item
-    #{plugin.name} –
-  .edit= link_to t("PLUGIN.EDIT"), edit_plugin_path(plugin), remote: true, :"data-replace" => '#plugin_form'
-  .delete= link_to t("PLUGIN.DELETE"), plugin_path(plugin), remote: true,  method: :delete, data: { confirm: t("PLUGIN.DELETE_WARNING") }

--- a/app/views/plugins/destroy.js.erb
+++ b/app/views/plugins/destroy.js.erb
@@ -1,8 +1,2 @@
-
-$('#plugin_list').html('<%= j @plugin_list.html_safe %>')
-$('#plugin_list [data-remote][data-replace]')
-  .data('type', 'html')
-  .on('ajax:success', function (event, data) {
-      var $this = $(this);
-      $($this.data('replace')).html(JSON.parse(data).html);
-  });
+// reload the activity edit page
+window.location.reload();

--- a/app/views/plugins/update.js.erb
+++ b/app/views/plugins/update.js.erb
@@ -1,10 +1,2 @@
-
-$('#plugin_list').html('<%= j @plugin_list.html_safe %>')
-
-$('#plugin_list [data-remote][data-replace]')
-  .data('type', 'html')
-  .on('ajax:success', function (event, data) {
-      var $this = $(this);
-      $($this.data('replace')).html(JSON.parse(data).html);
-  });
-$('#plugin_form').html('')
+// reload the activity edit page
+window.location.reload();

--- a/app/views/shared/_embedded_editor_wrapper_plugins.html.haml
+++ b/app/views/shared/_embedded_editor_wrapper_plugins.html.haml
@@ -1,0 +1,21 @@
+- available_plugins = available_wrapped_embeddable_plugins(embeddable)
+- if available_plugins.length > 0
+  .available_plugins
+    - first_plugin = available_plugins[0]
+    - dom_id = embeddable.embeddable_dom_id
+    = form_tag add_embeddable_activity_page_path(@activity, @page), :class => 'embeddable-plugin-form' do
+      = wrapped_embeddable_selector(embeddable)
+      = hidden_field_tag :approved_script_id, first_plugin.approved_script_id, {id: "approved_script_id_#{dom_id}"}
+      = hidden_field_tag :component_label, first_plugin.component_label, {id: "component_label_#{dom_id}"}
+      = hidden_field_tag :embeddable_select_value, "#{embeddable.id}-#{embeddable.class.name}", {id: "embeddable_select_value_#{dom_id}"}
+      = submit_tag 'Add', {id: 'add_embeddable_plugin_button'}
+
+- defined_plugins = wrapped_embeddable_plugins(embeddable)
+- if defined_plugins.length > 0
+  .wrapped_plugins
+    .plugin_list
+      - defined_plugins.each do |plugin|
+        .item
+          #{plugin.name}
+        .edit= link_to t("PLUGIN.EDIT"), edit_embeddable_embeddable_plugin_path(plugin), :remote => true
+        .delete= link_to t("PLUGIN.DELETE"), page_remove_embeddable_path(@page, plugin), method: :post, data: { confirm: t("PLUGIN.DELETE_WARNING") }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ LightweightStandalone::Application.routes.draw do
       get 'export'
       get 'export_for_portal'
       get 'show_status'
+      post 'add_plugin'
       # TODO: dpeprecate this Dashboard route
       get :dashboard_toc, to: redirect(path: "/api/v1/dashboard_toc/activities/%{id}")
     end

--- a/cypress/cypress/integration/approved_scripts/load_json_manifest_spec.js
+++ b/cypress/cypress/integration/approved_scripts/load_json_manifest_spec.js
@@ -35,8 +35,42 @@ context('New approved scripts', function () {
       "name": "Test LARA Sharing Plugin",
       "label": "TestLARASharingPlugin",
       "url": fullUrl,
-      "version": "2",
-      "description": "Test Description"
+      "version": "3",
+      "description": "Test Description",
+      "authoring_metadata": {
+        "components": [
+          {
+            "label": "test-plugin:activity1",
+            "name": "Test: Activity Plugin 1",
+            "scope": "activity"
+          },
+          {
+            "label": "test-plugin:activity2",
+            "name": "Test: Activity Plugin 2",
+            "scope": "activity"
+          },
+          {
+            "label": "test-plugin:embeddable1",
+            "name": "Test: Embeddable Plugin 1",
+            "scope": "embeddable"
+          },
+          {
+            "label": "test-plugin:embeddable2",
+            "name": "Test: Embeddable Plugin 2",
+            "scope": "embeddable"
+          },
+          {
+            "label": "test-plugin:embeddable-decoration1",
+            "name": "Test: Embeddable Decoration Plugin 1",
+            "scope": "embeddable-decoration"
+          },
+          {
+            "label": "test-plugin:embeddable-decoration2",
+            "name": "Test: Embeddable Decoration Plugin 2",
+            "scope": "embeddable-decoration"
+          }
+        ]
+      }
     }
 
     beforeEach(() => {
@@ -67,6 +101,7 @@ context('New approved scripts', function () {
         shouldHaveValue("url", pluginManifest.url)
         shouldHaveValue("version", pluginManifest.version)
         shouldHaveValue("description", pluginManifest.description)
+        shouldHaveValue("authoring_metadata", JSON.stringify(pluginManifest.authoring_metadata))
       })
     })
 

--- a/db/migrate/20190528183514_add_approved_script_authoring_metadata.rb
+++ b/db/migrate/20190528183514_add_approved_script_authoring_metadata.rb
@@ -1,0 +1,5 @@
+class AddApprovedScriptAuthoringMetadata < ActiveRecord::Migration
+  def change
+    add_column :approved_scripts, :authoring_metadata, :text
+  end
+end

--- a/db/migrate/20190530130347_add_component_label_to_plugins.rb
+++ b/db/migrate/20190530130347_add_component_label_to_plugins.rb
@@ -1,0 +1,5 @@
+class AddComponentLabelToPlugins < ActiveRecord::Migration
+  def change
+    add_column :plugins, :component_label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190528192812) do
+ActiveRecord::Schema.define(:version => 20190530130347) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -24,11 +24,12 @@ ActiveRecord::Schema.define(:version => 20190528192812) do
     t.string   "name"
     t.string   "url"
     t.text     "description"
-    t.datetime "created_at",                                                :null => false
-    t.datetime "updated_at",                                                :null => false
+    t.datetime "created_at",                                                       :null => false
+    t.datetime "updated_at",                                                       :null => false
     t.string   "label"
-    t.decimal  "version",     :precision => 10, :scale => 0, :default => 1
+    t.decimal  "version",            :precision => 10, :scale => 0, :default => 1
     t.string   "json_url"
+    t.text     "authoring_metadata"
   end
 
   create_table "authentications", :force => true do |t|
@@ -504,6 +505,7 @@ ActiveRecord::Schema.define(:version => 20190528192812) do
     t.datetime "created_at",               :null => false
     t.datetime "updated_at",               :null => false
     t.string   "shared_learner_state_key"
+    t.string   "component_label"
   end
 
   add_index "plugins", ["plugin_scope_id", "plugin_scope_type"], :name => "plugin_scopes"

--- a/lara-typescript/src/plugin-api/json/glossary-plugin-manifest.json
+++ b/lara-typescript/src/plugin-api/json/glossary-plugin-manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Glossary",
+  "label": "glossary",
+  "url": "https://glossary-plugin.concord.org/version/3.0.1/plugin.js",
+  "version": 3,
+  "description": "This plugin provides the glossary activity plugin",
+  "authoring_metadata": {
+    "components": [
+      {
+        "label": "glossary",
+        "name": "Activity",
+        "scope": "activity"
+      }
+    ]
+  }
+}

--- a/lara-typescript/src/plugin-api/json/sample-plugin-manifest.json
+++ b/lara-typescript/src/plugin-api/json/sample-plugin-manifest.json
@@ -2,6 +2,40 @@
   "name": "Test LARA Sharing Plugin",
   "label": "TestLARASharingPlugin",
   "url": "test-plugin.js",
-  "version": 2,
-  "description": "Test Description"
+  "version": 3,
+  "description": "Test Description",
+  "authoring_metadata": {
+    "components": [
+      {
+        "label": "test-plugin:activity1",
+        "name": "Test: Activity Plugin 1",
+        "scope": "activity"
+      },
+      {
+        "label": "test-plugin:activity2",
+        "name": "Test: Activity Plugin 2",
+        "scope": "activity"
+      },
+      {
+        "label": "test-plugin:embeddable1",
+        "name": "Test: Embeddable Plugin 1",
+        "scope": "embeddable"
+      },
+      {
+        "label": "test-plugin:embeddable2",
+        "name": "Test: Embeddable Plugin 2",
+        "scope": "embeddable"
+      },
+      {
+        "label": "test-plugin:embeddable-decoration1",
+        "name": "Test: Embeddable Decoration Plugin 1",
+        "scope": "embeddable-decoration"
+      },
+      {
+        "label": "test-plugin:embeddable-decoration2",
+        "name": "Test: Embeddable Decoration Plugin 2",
+        "scope": "embeddable-decoration"
+      }
+    ]
+  }
 }

--- a/lara-typescript/src/plugin-api/json/sample-plugin-manifest.json
+++ b/lara-typescript/src/plugin-api/json/sample-plugin-manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Test LARA Sharing Plugin",
-  "label": "TestLARASharingPlugin",
+  "name": "Test Plugin",
+  "label": "TestPlugin",
   "url": "test-plugin.js",
   "version": 3,
   "description": "Test Description",
@@ -8,33 +8,41 @@
     "components": [
       {
         "label": "test-plugin:activity1",
-        "name": "Test: Activity Plugin 1",
+        "name": "Activity Plugin 1",
         "scope": "activity"
       },
       {
         "label": "test-plugin:activity2",
-        "name": "Test: Activity Plugin 2",
+        "name": "Activity Plugin 2",
         "scope": "activity"
       },
       {
         "label": "test-plugin:embeddable1",
-        "name": "Test: Embeddable Plugin 1",
+        "name": "Embeddable Plugin 1",
         "scope": "embeddable"
       },
       {
         "label": "test-plugin:embeddable2",
-        "name": "Test: Embeddable Plugin 2",
+        "name": "Embeddable Plugin 2",
         "scope": "embeddable"
       },
       {
         "label": "test-plugin:embeddable-decoration1",
-        "name": "Test: Embeddable Decoration Plugin 1",
-        "scope": "embeddable-decoration"
+        "name": "Decoration Plugin 1",
+        "scope": "embeddable-decoration",
+        "decorates": [
+          "Embeddable::ImageQuestion",
+          "Embeddable::MultipleChoice"
+        ]
       },
       {
         "label": "test-plugin:embeddable-decoration2",
-        "name": "Test: Embeddable Decoration Plugin 2",
-        "scope": "embeddable-decoration"
+        "name": "Decoration Plugin 2",
+        "scope": "embeddable-decoration",
+        "decorates": [
+          "Embeddable::ImageQuestion",
+          "Embeddable::OpenResponse"
+        ]
       }
     ]
   }

--- a/lara-typescript/src/plugin-api/json/sharing-plugin-manifest.json
+++ b/lara-typescript/src/plugin-api/json/sharing-plugin-manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Sharing",
+  "label": "laraSharing",
+  "url": "http://lara-sharing-plugin.concord.org/version/v3.0.0/plugin.js",
+  "version": 3,
+  "description": "This plugin provides the sharing component",
+  "authoring_metadata": {
+    "components": [
+      {
+        "label": "interactives",
+        "name": "Interactives",
+        "scope": "embeddable-decoration",
+        "decorates": [
+          "MwInteractive"
+        ]
+      }
+    ]
+  }
+}

--- a/lara-typescript/src/plugin-api/json/teacher-tips-plugin-manifest.json
+++ b/lara-typescript/src/plugin-api/json/teacher-tips-plugin-manifest.json
@@ -7,17 +7,17 @@
   "authoring_metadata": {
     "components": [
       {
-        "label": "window-shades",
+        "label": "windowShade",
         "name": "Window Shades",
         "scope": "embeddable"
       },
       {
-        "label": "side-tips",
+        "label": "sideTip",
         "name": "Side Tips",
         "scope": "embeddable"
       },
       {
-        "label": "question-wrapper",
+        "label": "questionWrapper",
         "name": "Question Wrapper",
         "scope": "embeddable-decoration",
         "decorates": [

--- a/lara-typescript/src/plugin-api/json/teacher-tips-plugin-manifest.json
+++ b/lara-typescript/src/plugin-api/json/teacher-tips-plugin-manifest.json
@@ -1,0 +1,29 @@
+{
+  "name": "Teacher Edition",
+  "label": "teacherEditionTips",
+  "url": "http://teacher-edition-tips-plugin.concord.org/version/v3.1.1/plugin.js",
+  "version": 3,
+  "description": "This plugin provides Teacher Edition components",
+  "authoring_metadata": {
+    "components": [
+      {
+        "label": "window-shades",
+        "name": "Window Shades",
+        "scope": "embeddable"
+      },
+      {
+        "label": "side-tips",
+        "name": "Side Tips",
+        "scope": "embeddable"
+      },
+      {
+        "label": "question-wrapper",
+        "name": "Question Wrapper",
+        "scope": "embeddable-decoration",
+        "decorates": [
+          "Embeddable::MultipleChoice"
+        ]
+      }
+    ]
+  }
+}

--- a/script/add_components_to_plugins.rb
+++ b/script/add_components_to_plugins.rb
@@ -1,0 +1,28 @@
+# to be run in rails console to add component labels to version 3 plugins
+
+ApprovedScript.where({version: 3}).each do |as|
+  if as.url =~ /teacher-edition-tips-plugin/
+    Plugin.where({approved_script_id: as.id}).each do |p|
+      begin
+        author_data = JSON.parse(p.author_data, :symbolize_names => true)
+        if author_data && author_data[:tipType] && p.component_label.blank?
+          # the component label is the same as the tip type in the teacher tips manifest
+          p.component_label = author_data[:tipType]
+          p.save!
+        end
+      rescue
+        nil
+      end
+    end
+  elsif (as.url =~ /lara-sharing-plugin/) || (as.url =~ /glossary-plugin/)
+    metadata = JSON.parse(as.authoring_metadata, :symbolize_names => true)
+    # lara sharing and glossary only have 1 component
+    component_label = metadata[:components][0][:label]
+    Plugin.where({approved_script_id: as.id}).each do |p|
+      if p.component_label.blank?
+        p.component_label = component_label
+        p.save!
+      end
+    end
+  end
+end

--- a/spec/models/embeddable/embeddable_embeddable_plugin_spec.rb
+++ b/spec/models/embeddable/embeddable_embeddable_plugin_spec.rb
@@ -25,7 +25,8 @@ describe Embeddable::EmbeddablePlugin do
         plugin: {
           description: plugin.description,
           author_data: plugin.author_data,
-          approved_script_label: plugin.approved_script.label
+          approved_script_label: plugin.approved_script.label,
+          component_label: plugin.component_label
         },
         is_hidden: true,
         is_full_width: true

--- a/spec/models/plugin_spec.rb
+++ b/spec/models/plugin_spec.rb
@@ -14,12 +14,14 @@ describe Plugin do
   let(:approved_script) { FactoryGirl.create(:approved_script, approved_script_opts) }
   let(:description)     { "description" }
   let(:author_data)     { "authored_data" }
+  let(:component_label) { "component_label" }
   let(:plugin_opts) do
     {
       shared_learner_state_key: shared_learner_state_key,
       description: description,
       author_data: author_data,
-      approved_script: approved_script
+      approved_script: approved_script,
+      component_label: component_label
     }
   end
 
@@ -45,7 +47,8 @@ describe Plugin do
         {
           description: description,
           author_data: author_data,
-          approved_script_label: approved_script.label
+          approved_script_label: approved_script.label,
+          component_label: component_label
         }
       )
     end

--- a/spec/support/shared_examples/attached_to_embeddable_form.rb
+++ b/spec/support/shared_examples/attached_to_embeddable_form.rb
@@ -1,38 +1,18 @@
 shared_examples "attached to embeddable form" do
-  def embeddable_choice_select_css
-    "select.select_embeddable option"
-  end
 
-  def no_embeddable_text
-    AttachedToEmbeddable::NO_EMBEDDABLE_LABEL
-  end
-
-  let(:embeddable_a)  { FactoryGirl.create(:open_response) }
-  let(:embeddable_b)  { FactoryGirl.create(:open_response) }
-  let(:embeddables)   { [] }
-  let(:page)           { FactoryGirl.create(:page, embeddables: embeddables) }
-  let(:args)           { {} }
+  let(:page) { FactoryGirl.create(:page) }
+  let(:args) { {} }
 
   before :each do
     page.add_embeddable(test_embeddable)
   end
 
-  describe "without any embeddables on the page" do
-    it "includes one choice for 'no embeddable'" do
+  describe "edit form" do
+    it "includes author data and full width checkbox" do
       assign(:embeddable, test_embeddable)
       render
-      expect(rendered).to have_css(
-        embeddable_choice_select_css,
-        text: no_embeddable_text)
-    end
-  end
-
-  describe "with two embeddables on the page" do
-    let(:embeddables)  {[embeddable_a,embeddable_b]}
-    it "includes four choices (no interactive, next interactive, and two embeddables)" do
-      assign(:embeddable, test_embeddable)
-      render
-      expect(rendered).to have_css embeddable_choice_select_css, count: 4
+      expect(rendered).to have_field("embeddable_embeddable_plugin[author_data]")
+      expect(rendered).to have_field("embeddable_embeddable_plugin[is_full_width]")
     end
   end
 end


### PR DESCRIPTION
Adds authoring_metadata to approved scripts which currently has list of components scoped to activity, embeddable and embeddable-decoration.  The authoring_metadata field is a stringified JSON blob to allow for change during the remaining plugin authoring stories.  Once the json is finalized a schema validator should be added as part of the code that loads the authoring metadata from the external json manifest.

The activity forms that deal with plugins now select plugins appropriate to the scope and then saves the component label to the plugin so that the component name can be used and displayed instead of the generic plugin name.  This allows for plugins to expose multiple components at different scopes.

One final change is that once a component is added at either the activity or embeddable level there is no way to change the type of component in the edit form.