### PR TITLE
Moved logger init to before plugin init [#166135835]

### DIFF
--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -31,6 +31,7 @@
 //= require page-unload-warning
 //= require modals
 //= require modal-dialog
+//= require logger
 //= require lara-plugin-api-V2
 //= require lara-typescript
 //= require common
@@ -50,7 +51,6 @@
 //= require activity-box-click
 //= require wait-message
 //= require external-scripts
-//= require logger
 //= require labbook
 //= require c_rater
 //= require global-iframe-saver


### PR DESCRIPTION
Moved the logger.js initialization to before the plugin initialization so that the plugins can use the logger.

Added an event queue to the logger so that events generated before the plugin pub/sub system is setup are not lost.

Note: before the logger was waiting for document.ready to initialize itself to ensure the window.gon variable existed.  Since the logger is only used in runtime.js and the runtime.js file is loaded after window.gon is set there is no need to wait for document.ready.