### PR TITLE
Add resource_url to answers exported to Firestore, change user_id => user_email

### DIFF
--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -2,7 +2,7 @@ module ReportService
   class RunSender
     Version = "1"
     DefaultClassHash = "anonymous-run"
-    DefaultUserName = "anonymous"
+    DefaultUserEmail = "anonymous"
 
     def question_key(answer_hash)
       question_type = answer_hash[:type] || answer_hash['type']
@@ -15,17 +15,22 @@ module ReportService
       run.class_info_url || DefaultClassHash
     end
 
-    def username_for_run(run)
-      run.user ? run.user.email : DefaultUserName
+    def get_resource_url(run, host)
+      if run.sequence
+        "#{host}#{Rails.application.routes.url_helpers.sequence_path(run.sequence)}"
+      else
+        "#{host}#{Rails.application.routes.url_helpers.activity_path(run.activity)}"
+      end
     end
 
     def add_meta_data(run, record, host)
       record[:version] = RunSender::Version
       record[:created] = Time.now.utc.to_s
       record[:source_key] = ReportService::make_source_key(host)
+      record[:resource_url] = get_resource_url(run, host)
       record[:class_hash] = get_class_hash(run)
       record[:class_info_url] = run.class_info_url
-      record[:user_id] = username_for_run(run)
+      record[:user_email] = run.user ? run.user.email : DefaultUserEmail
       record[:remote_endpoint] = run.remote_endpoint
       record[:run_key] = run.key
     end

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -16,10 +16,10 @@ module ReportService
     end
 
     def get_resource_url(run, host)
-      if run.sequence
-        "#{host}#{Rails.application.routes.url_helpers.sequence_path(run.sequence)}"
+      if run.sequence_id
+        "#{host}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
       else
-        "#{host}#{Rails.application.routes.url_helpers.activity_path(run.activity)}"
+        "#{host}#{Rails.application.routes.url_helpers.activity_path(run.activity_id)}"
       end
     end
 

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -69,13 +69,13 @@ describe ReportService::RunSender do
       let(:json) { JSON.parse(sender.to_json())}
       it "should have a key fields" do
         expect(json).to include(
-          "version", "created", "user_id",
+          "version", "created", "user_email",
           "answers", "class_hash", "run_key"
         )
       end
 
       describe "the encoded answers" do
-        it "should also include the run_key, user_id, class_hash " do
+        it "should also include the run_key, user_email, class_hash " do
           answers = json["answers"]
           answers.each_with_index do |a,index|
             expect(a).to include("question_key")
@@ -92,10 +92,12 @@ describe ReportService::RunSender do
             expect(a["question_key"]).not_to match("/")
             expect(a["question_key"]).not_to match(/\./)
 
+            expect(a["resource_url"]).to match("#{host}/sequences/#{sequence_id}")
+
             expect(a).to include("created")
             expect(a).to include("url")
             expect(a).to include("run_key")
-            expect(a).to include("user_id")
+            expect(a).to include("user_email")
             expect(a).to include("class_hash")
             expect(a).to include("class_info_url")
             expect(a).to include("version")
@@ -118,6 +120,19 @@ describe ReportService::RunSender do
             accepted_answers = json["answers"]
             # bad answers wont appear in the JSON
             expect(answers.length).to be > accepted_answers.length
+          end
+        end
+
+        describe "when run is part of the sequence" do
+          it "the resource_url should be sequence url" do
+            expect(json["resource_url"]).to match("#{host}/sequences/#{sequence_id}")
+          end
+        end
+
+        describe "when run isn't part of the sequence" do
+          let(:sequence_id) { nil }
+          it "the resource_url should be activity url" do
+            expect(json["resource_url"]).to match("#{host}/activities/#{sequence_id}")
           end
         end
 


### PR DESCRIPTION
[#166187624]

We need to query answers for a given activity or sequence in the Portal Report app. Current data format was missing a simple way to do it. We could theoretically query for every single question_key, but it doesn't seem too reasonable (we'd have dozens of Firestore observers and queries running in one report).  Also, `resource_url` seems better than `activity_id` or `sequence_id` as we're independent of the resource type and naming.

I've also changed "user_id" to "user_email" as that's what it actually is.

BTW, most of this data that we export for answers and runs won't be useful in reports. Not saying it's a problem, but I'm wondering if we should try to export everything that we can or things that we need.