### PR TITLE
Set Run info from portal launch parameters

### DIFF
--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -28,13 +28,11 @@ class LightweightActivitiesController < ApplicationController
   end
 
   # These are the runtime (student-facing) actions, show and summary
-
   def show # show index
-    if params[:class_info_url]
-      @run.class_info_url = params[:class_info_url]
-      @run.save!
-    end
 
+    # If there are launch parameters, set class info on run,
+    # See /app/models/with_class_info.rb #update_class_info
+    @run.update_class_info(params)
     authorize! :read, @activity
 
     setup_show

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -219,6 +219,8 @@ class SequencesController < ApplicationController
       if portal.valid?
         @sequence_run.disable_collaboration
       end
+      # If we have new class_info_url or class_hash update it
+      @sequence_run.update_class_info(params)
     end
   end
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -55,6 +55,9 @@ class Run < ActiveRecord::Base
     :format => { :with => /\A[a-zA-Z0-9\-]*\z/ },
     :length => { :is => 36 }
 
+  # /app/models/with_class_info.rb for #update_class_info
+  include WithClassInfo
+  
   def check_key
     unless key.present?
       self.key = session_guid

--- a/app/models/sequence_run.rb
+++ b/app/models/sequence_run.rb
@@ -8,6 +8,9 @@ class SequenceRun < ActiveRecord::Base
 
   before_save :add_key_if_nil
 
+  # /app/models/with_class_info.rb for #update_class_info
+  include WithClassInfo
+
   def self.generate_key
     SecureRandom.hex(20)
   end
@@ -104,5 +107,13 @@ class SequenceRun < ActiveRecord::Base
 
   def add_key_if_nil
     self.key = SequenceRun.generate_key if self.key.nil?
+  end
+
+  # see /app/models/with_class_info.rb#update_class_info
+  def update_class_info(url_params)
+    updates = super(url_params)
+    if (updates)
+      self.runs.each { |r| r.update_class_info(url_params) }
+    end
   end
 end

--- a/app/models/with_class_info.rb
+++ b/app/models/with_class_info.rb
@@ -1,0 +1,28 @@
+module WithClassInfo
+
+  # If we have new class_info_url or class_hash in our query params
+  # set our class_hash and class_info URLs to that (if they are blank)
+  # Discussion: Not setting these values if they are already set seems safest.
+  # Returns changed attributes, or false if nothing was changed.
+  def update_class_info(raw_params)
+    params = raw_params.stringify_keys
+    new_class_info_url = params['class_info_url']
+    new_class_hash = params['class_hash']
+    update_attributes = {}
+    changed = false
+    if new_class_info_url && (self.class_info_url.blank?)
+      update_attributes[:class_info_url] = new_class_info_url
+      changed = true
+    end
+    if new_class_hash && (self.class_hash.blank?)
+      update_attributes[:class_hash] = new_class_hash
+      changed = true
+    end
+    if (changed)
+      self.update_attributes(update_attributes)
+      return update_attributes
+    end
+    return false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -284,10 +284,10 @@ ActiveRecord::Schema.define(:version => 20190528192812) do
     t.integer  "plugin_id"
     t.datetime "created_at",                         :null => false
     t.datetime "updated_at",                         :null => false
-    t.integer  "embeddable_id"
-    t.string   "embeddable_type"
     t.boolean  "is_hidden",       :default => false
     t.boolean  "is_full_width",   :default => false
+    t.integer  "embeddable_id"
+    t.string   "embeddable_type"
   end
 
   add_index "embeddable_plugins", ["plugin_id"], :name => "index_embeddable_plugins_on_plugin_id"

--- a/spec/models/with_class_info_spec.rb
+++ b/spec/models/with_class_info_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe "WithClassInfo" do
+
+  class HasClassInfo
+    include WithClassInfo
+    attr_accessor :class_info_url
+    attr_accessor :class_hash
+
+    def initialize(props)
+      update_attributes(props)
+    end
+    def update_attributes(new_attrs)
+      self.class_info_url = new_attrs[:class_info_url]
+      self.class_hash     = new_attrs[:class_hash]
+    end
+  end
+
+  describe HasClassInfo do
+    let(:params){ {'class_info_url' => "class_info_url", 'class_hash' => "class_hash"} }
+    let(:props) { {} }
+    let(:my_run) { HasClassInfo.new(props) }
+    describe "with no existing class info" do
+      it 'has nil attributes' do
+        expect(my_run.class_info_url).to be_nil
+        expect(my_run.class_hash).to be_nil
+      end
+      it "can be updated with it has no existing attributes" do
+        my_run.update_class_info(params)
+        expect(my_run.class_info_url).to eql "class_info_url"
+        expect(my_run.class_hash).to eql "class_hash"
+      end
+    end
+    describe "with existing class info" do
+      let(:props){ {class_info_url: "old_class_info", class_hash: "old_class_hash"} }
+      it 'has the attributes' do
+        expect(my_run.class_info_url).to eql("old_class_info")
+        expect(my_run.class_hash).to eql("old_class_hash")
+      end
+      it "wont be updated with new values" do
+        my_run.update_class_info(params)
+        expect(my_run.class_info_url).to eql "old_class_info"
+        expect(my_run.class_hash).to eql "old_class_hash"
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
When launched from the portal, the `class_info_url` `class_hash` will be set on Runs and Sequence runs.

This addresses a bug where `class_info_url` was not being set for sequence runs.
Also adds a `class_hash` property to the runs & sequence runs if provided in launch params.

Will not update existing run parameters if they already exist on runs.

This PR is based off of #424 and should be reviewed after it.

See also portal pull request: 
[#165217423]
https://www.pivotaltracker.com/story/show/165217423