### PR TITLE
Define explicit `report_service_hash` methods for questions and answers

### DIFF
--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -83,7 +83,11 @@ module Embeddable
   end
 
   def index_in_activity(act = nil)
-    (act ? act : self.activity).reportable_items.index(self) + 1
+    if !act && !self.activity
+      nil
+    else
+      (act ? act : self.activity).reportable_items.index(self) + 1
+    end
   end
 
   # ID which is unique among all the embeddable types.
@@ -91,14 +95,8 @@ module Embeddable
     "embeddable-#{self.class.to_s.demodulize.underscore}_#{self.id}"
   end
 
-  def report_service_hash
-    # Once LARA doesn't publish to portal, we can just rename portal_hash to report_service_hash
-    return nill unless respond_to?(:portal_hash)
-    result = portal_hash
-    result[:key] = ReportService::make_key(result[:type], result[:id])
-    if activity
-      result[:question_number] = index_in_activity(activity)
-    end
-    result
+  # ID which is unique among all the embeddable types.
+  def embeddable_id
+    "#{self.class.to_s.demodulize.underscore}_#{self.id}"
   end
 end

--- a/app/models/embeddable/image_question.rb
+++ b/app/models/embeddable/image_question.rb
@@ -48,6 +48,17 @@ class Embeddable::ImageQuestion < ActiveRecord::Base
     }
   end
 
+  def report_service_hash
+    {
+      type: 'image_question',
+      id: embeddable_id,
+      prompt: prompt,
+      drawing_prompt: drawing_prompt,
+      show_in_featured_question_report: show_in_featured_question_report,
+      question_number: index_in_activity
+    }
+  end
+
   def duplicate
     return Embeddable::ImageQuestion.new(self.to_hash)
   end

--- a/app/models/embeddable/image_question_answer.rb
+++ b/app/models/embeddable/image_question_answer.rb
@@ -53,6 +53,19 @@ module Embeddable
       }
     end
 
+    def report_service_hash
+      {
+        id: answer_id,
+        type: 'image_question_answer',
+        question_id: question.embeddable_id,
+        question_type: 'image_question',
+        answer: {
+          image_url: annotated_image_url,
+          text: answer_text
+        }
+      }
+    end
+
     def answered?
       annotated_image_url.present?
     end

--- a/app/models/embeddable/labbook.rb
+++ b/app/models/embeddable/labbook.rb
@@ -63,6 +63,19 @@ module Embeddable
       }
     end
 
+    def report_service_hash
+      {
+        type: 'iframe_interactive',
+        id: embeddable_id,
+        name: name,
+        show_in_featured_question_report: show_in_featured_question_report,
+        display_in_iframe: true,
+        width: 600,
+        height: 500,
+        question_number: index_in_activity
+      }
+    end
+
     def to_hash
       {
         action_type: action_type,

--- a/app/models/embeddable/labbook_answer.rb
+++ b/app/models/embeddable/labbook_answer.rb
@@ -79,6 +79,16 @@ module Embeddable
       }
     end
 
+    def report_service_hash
+      {
+        id: answer_id,
+        type: 'external_link',
+        question_id: question.embeddable_id,
+        question_type: 'iframe_interactive',
+        answer: report_url
+      }
+    end
+
     def answered?
       # Labbook is an external service, we don't really know its content. However, there is an assumption that once
       # Labbook is opened, `update_at` timestamp is updated and the album link is sent to Portal. So, if `created_at`

--- a/app/models/embeddable/multiple_choice.rb
+++ b/app/models/embeddable/multiple_choice.rb
@@ -7,7 +7,7 @@ module Embeddable
     LAYOUT_VERTICAL = "vertical"
     LAYOUT_HORIZONTAL = "horizontal"
     LAYOUT_LIKERT = "likert"
-    
+
 
     has_many :choices,
       :class_name => 'Embeddable::MultipleChoiceChoice',
@@ -118,6 +118,21 @@ module Embeddable
       }
     end
 
+    def report_service_hash
+      {
+        type: 'multiple_choice',
+        id: embeddable_id,
+        prompt: prompt,
+        choices: choices.map { |choice| {
+          id: choice.id,
+          content: choice.choice,
+          correct: choice.is_correct
+        }},
+        show_in_featured_question_report: show_in_featured_question_report,
+        question_number: index_in_activity
+      }
+    end
+
     def duplicate
       mc = Embeddable::MultipleChoice.new(self.to_hash)
       self.choices.each do |choice|
@@ -125,7 +140,7 @@ module Embeddable
       end
       return mc
     end
-    
+
     def export
       mc_export = as_json(only:[:name,
                                 :prompt,
@@ -143,15 +158,15 @@ module Embeddable
                                 :hint])
 
       mc_export[:choices] = []
-      
+
       self.choices.each do |choice|
         mc_export[:choices] << choice.export
       end
-      
-      return mc_export                          
-                  
+
+      return mc_export
+
     end
-    
+
     def is_likert
       layout == "likert"
     end

--- a/app/models/embeddable/multiple_choice_answer.rb
+++ b/app/models/embeddable/multiple_choice_answer.rb
@@ -78,6 +78,18 @@ module Embeddable
       }
     end
 
+    def report_service_hash
+      {
+        id: answer_id,
+        type: 'multiple_choice_answer',
+        question_id: question.embeddable_id,
+        question_type: 'multiple_choice',
+        answer: {
+          choice_ids: answers.map { |a| a.id }
+        }
+      }
+    end
+
     # Expects a parameters hash. Normalizes to allow update_attributes.
     def update_from_form_params(params)
       if params && params[:answers].kind_of?(Array)

--- a/app/models/embeddable/open_response.rb
+++ b/app/models/embeddable/open_response.rb
@@ -45,6 +45,16 @@ module Embeddable
       }
     end
 
+    def report_service_hash
+      {
+        type: 'open_response',
+        id: embeddable_id,
+        prompt: prompt,
+        show_in_featured_question_report: show_in_featured_question_report,
+        question_number: index_in_activity
+      }
+    end
+
     def duplicate
       return Embeddable::OpenResponse.new(self.to_hash)
     end

--- a/app/models/embeddable/open_response_answer.rb
+++ b/app/models/embeddable/open_response_answer.rb
@@ -35,6 +35,16 @@ module Embeddable
       }
     end
 
+    def report_service_hash
+      {
+        id: answer_id,
+        type: 'open_response_answer',
+        question_id: question.embeddable_id,
+        question_type: 'open_response',
+        answer: answer_text
+      }
+    end
+
     def answered?
       self.answer_text.present?
     end

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -90,6 +90,27 @@ class InteractiveRunState < ActiveRecord::Base
     end
   end
 
+  def report_service_hash
+    result = {
+      id: answer_id,
+      question_type: "iframe_interactive",
+      question_id: interactive.embeddable_id
+    }
+    # There are two options how interactive can be saved in report service:
+    # - When reporting url is provided, it means that the interactive is supposed to be saved as an URL.
+    #   It's useful if state can be saved in the URL or is kept by the interactive itself (e.g. CODAP / docstore)
+    # - Otherwise, interactive state JSON is sent to the Portal. Later, the same state will be provided to teacher report
+    #   and sent to the interactive using LARA Interactive API.
+    if interactive.has_report_url
+      result[:type] = "external_link"
+      result[:answer] = reporting_url
+    else
+      result[:type] = "interactive_state"
+      result[:answer] = report_state.to_json
+    end
+    result
+  end
+
   def maybe_send_to_portal
     if interactive.has_report_url
       send_to_portal if reporting_url.present?

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -257,7 +257,7 @@ class LightweightActivity < ActiveRecord::Base
   def serialize_for_report_service(host)
     activity_url = "#{host}#{Rails.application.routes.url_helpers.activity_path(self)}"
     data = {
-      id: self.id,
+      id: "activity_" + self.id.to_s,
       type: "activity",
       name: self.name,
       url: activity_url
@@ -271,7 +271,7 @@ class LightweightActivity < ActiveRecord::Base
         # Otherwise we don't support this embeddable type right now.
       end
       pages.push({
-        id: page.id,
+        id: "page_" + page.id.to_s,
         type: "page",
         name: page.name,
         url: "#{host}#{Rails.application.routes.url_helpers.page_path(page)}",
@@ -282,7 +282,7 @@ class LightweightActivity < ActiveRecord::Base
     # Fake section to satisfy current report service requirement. Hopefully, it won't be necessary soon.
     section = {
       # There's only one, artificial section per activity, so it's fine to reuse activity ID.
-      id: self.id,
+      id: "section_" + self.id.to_s,
       type: "section",
       name: "#{self.name} Section",
       url: activity_url,

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -102,6 +102,20 @@ class MwInteractive < ActiveRecord::Base
     iframe_data
   end
 
+  def report_service_hash
+    {
+      type: 'iframe_interactive',
+      id: embeddable_id,
+      name: name,
+      url: url,
+      show_in_featured_question_report: show_in_featured_question_report,
+      display_in_iframe: reportable_in_iframe?,
+      width: native_width,
+      height: native_height,
+      question_number: index_in_activity
+    }
+  end
+
   def duplicate
     # Generate a new object with those values
     MwInteractive.new(self.to_hash)
@@ -184,7 +198,7 @@ class MwInteractive < ActiveRecord::Base
   end
 
   def question_index
-    if respond_to? :index_in_activity 
+    if respond_to? :index_in_activity
       begin
         return self.index_in_activity()
       rescue StandardError => e
@@ -192,5 +206,5 @@ class MwInteractive < ActiveRecord::Base
       end
     end
     return nil
-  end  
+  end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -143,7 +143,7 @@ class Sequence < ActiveRecord::Base
   def serialize_for_report_service(host)
     local_url = "#{host}#{Rails.application.routes.url_helpers.sequence_path(self)}"
     data = {
-      id: self.id,
+      id: 'sequence_' + self.id.to_s,
       type: 'sequence',
       name: self.title,
       url: local_url

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -4,12 +4,6 @@ module ReportService
     DefaultClassHash = "anonymous-run"
     DefaultUserEmail = "anonymous"
 
-    def question_key(answer_hash)
-      question_type = answer_hash[:type] || answer_hash['type']
-      question_id = answer_hash[:question_id] || answer_hash['question_id']
-      ReportService::make_key(question_type, question_id)
-    end
-
     def get_class_hash(run)
       # TODO: Maybe we look this up?
       run.class_info_url || DefaultClassHash
@@ -36,14 +30,8 @@ module ReportService
     end
 
     def serialized_answer(ans, run, host)
-      answer_hash = ans.portal_hash
-      answer_hash[:id] = ans.answer_id
-      answer_hash[:question_key] = question_key(answer_hash)
+      answer_hash = ans.report_service_hash
       add_meta_data(run, answer_hash, host)
-      if answer_hash[:url].blank?
-        answer_hash[:url] = ""
-        answer_hash[:has_url] = false
-      end
       answer_hash
     end
 

--- a/spec/models/embeddable/image_question_spec.rb
+++ b/spec/models/embeddable/image_question_spec.rb
@@ -56,12 +56,11 @@ describe Embeddable::ImageQuestion do
     it 'returns properties supported by the report service' do
       expect(image_question.report_service_hash).to eq(
         type: "image_question",
-        id: image_question.id,
-        key: "image_question-" + image_question.id.to_s,
+        id: "image_question_" + image_question.id.to_s,
         prompt: image_question.prompt,
         drawing_prompt: image_question.drawing_prompt,
-        is_required: image_question.is_prediction,
-        show_in_featured_question_report: image_question.show_in_featured_question_report
+        show_in_featured_question_report: image_question.show_in_featured_question_report,
+        question_number: nil
       )
     end
   end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -476,13 +476,13 @@ describe LightweightActivity do
     it 'returns a simple hash that can be consumed by the report service' do
       url = "http://test.host/activities/#{activity.id}"
       report_service_hash = {
-        id: activity.id,
+        id: "activity_#{activity.id}",
         type: "activity",
         name: activity.name,
         url: url,
         children: [
           {
-            id: activity.id,
+            id: "section_#{activity.id}",
             type: "section",
             name: "#{activity.name} Section",
             url: url,

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -172,7 +172,7 @@ describe Sequence do
 
     let(:simple_report_service_hash) do
       {
-        id: sequence.id,
+        id: "sequence_#{sequence.id}",
         type: "sequence",
         name: sequence.title,
         url: "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence)}",
@@ -182,7 +182,7 @@ describe Sequence do
 
     let(:complex_report_service_hash) do
       {
-        id: sequence_with_activities.id,
+        id: "sequence_#{sequence_with_activities.id}",
         type: "sequence",
         name: sequence_with_activities.title,
         url: "http://test.host#{Rails.application.routes.url_helpers.sequence_path(sequence_with_activities)}",

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -23,10 +23,9 @@ describe ReportService::RunSender do
   let(:answers) do
     1.upto(5).map do |index|
       url = "#{host}activities/#{index}"
-      portal_hash = {question_id: index, type: "mock-answer", url: url }
+      report_service_hash = { question_id: index, type: "mock-answer", url: url }
       double("Answer", {
-        portal_hash: portal_hash,
-        answer_id: "mock_question_answer_#{index}"
+        report_service_hash: report_service_hash
       })
     end
   end
@@ -75,25 +74,13 @@ describe ReportService::RunSender do
       end
 
       describe "the encoded answers" do
-        it "should also include the run_key, user_email, class_hash " do
+        it "should also include metadata" do
           answers = json["answers"]
-          answers.each_with_index do |a,index|
-            expect(a).to include("question_key")
+          answers.each_with_index do |a|
             expect(a["source_key"]).to match("app_lara_docker")
             expect(a["source_key"]).not_to match("/")
             expect(a["source_key"]).not_to match(/\./)
-
-            expect(a["id"]).to match("mock_question_answer")
-            expect(a["id"]).not_to match("/")
-            expect(a["id"]).not_to match(/\./)
-
-            expect(a["question_key"]).to match("mock-answer")
-            expect(a["question_key"]).to match("#{index+1}")
-            expect(a["question_key"]).not_to match("/")
-            expect(a["question_key"]).not_to match(/\./)
-
             expect(a["resource_url"]).to match("#{host}/sequences/#{sequence_id}")
-
             expect(a).to include("created")
             expect(a).to include("url")
             expect(a).to include("run_key")
@@ -110,7 +97,7 @@ describe ReportService::RunSender do
           let(:not_an_answer) { "not even an answer" }
           let(:exploding_answer) do
             answer = double("Answer")
-            allow(answer).to receive(:portal_hash).and_raise(boom)
+            allow(answer).to receive(:report_service_hash).and_raise(boom)
             answer
           end
           it "The JSON should include the good answers, and log bad ones" do


### PR DESCRIPTION
We won't heave to deal with inconsistencies present in portal_hash.
Also, I've removed `key` and `question_key` props. Now, I'm assuming that all the `id` should be unique among questions and answers. It could make sense for other types (activities, pages, sequences) if we think about providing a fully flexible activity structure in the future.