### PR TITLE
Don't send non-changed answers to the report service in `reporting.rake`

### DIFF
--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -31,9 +31,9 @@ module ReportService
     end
 
     def serlialized_answers(run, host)
-      age_threashold_seconds = 0.25
+      age_threshold_seconds = 0.25
       modified_answers = run.answers.select do
-        |a| a.updated_at - a.created_at > age_threashold_seconds
+        |a| a.updated_at - a.created_at > age_threshold_seconds
       end
       modified_answers.map do |ans|
         begin

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -36,8 +36,11 @@ module ReportService
     end
 
     def serlialized_answers(run, host)
-      run.answers
-      .map do |ans|
+      age_threashold_seconds = 0.25
+      modified_answers = run.answers.select do
+        |a| a.updated_at - a.created_at > age_threashold_seconds
+      end
+      modified_answers.map do |ans|
         begin
           serialized_answer(ans, run, host)
         rescue => e

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -4,11 +4,6 @@ module ReportService
     DefaultClassHash = "anonymous-run"
     DefaultUserEmail = "anonymous"
 
-    def get_class_hash(run)
-      # TODO: Maybe we look this up?
-      run.class_info_url || DefaultClassHash
-    end
-
     def get_resource_url(run, host)
       if run.sequence_id
         "#{host}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
@@ -22,7 +17,7 @@ module ReportService
       record[:created] = Time.now.utc.to_s
       record[:source_key] = ReportService::make_source_key(host)
       record[:resource_url] = get_resource_url(run, host)
-      record[:class_hash] = get_class_hash(run)
+      record[:class_hash] = run.class_hash
       record[:class_info_url] = run.class_info_url
       record[:user_email] = run.user ? run.user.email : DefaultUserEmail
       record[:remote_endpoint] = run.remote_endpoint

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -89,8 +89,8 @@ describe ReportService::RunSender do
             expect(a).to include("url")
             expect(a).to include("run_key")
             expect(a).to include("user_email")
-            expect(a).to include("class_hash")
-            expect(a).to include("class_info_url")
+            expect(a).to include("class_hash" => class_hash)
+            expect(a).to include("class_info_url" => class_info_url)
             expect(a).to include("version")
           end
         end

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -19,6 +19,7 @@ describe ReportService::RunSender do
   let(:remote_id)            { 'remote-id' }
   let(:remote_endpoint)      { "https://mock.data.com/spec/offering/1" }
   let(:class_info_url)       { "https://mock.data.com/spec/class/2" }
+  let(:class_hash)           { "15291405-6B03-4E50-B49F-ACBC99D6255F" }
   let(:answers) do
     1.upto(5).map do |index|
       url = "#{host}activities/#{index}"
@@ -47,6 +48,7 @@ describe ReportService::RunSender do
       sequence_run_id: sequence_run_id,
       collaboration_run_id: collaboration_run_id,
       class_info_url: class_info_url,
+      class_hash: class_hash,
       answers: answers
     })
   end


### PR DESCRIPTION
As per @pjanik 's suggestion, we only send answers who's `updated_at` is newer than `created_at`.

[#166524647]
https://www.pivotaltracker.com/story/show/166524647