### PR TITLE
166241318 submit answers to report service

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -3,6 +3,16 @@ module ReportService
   UrlRegex = /https?:\/\/([^\/]+)/
   KeyReplacement = "_"
   KeyJoiner = "-"
+  ErrorMessage = <<-EOF
+    Configure with REPORT_SERVICE_TOKEN, REPORT_SERVICE_URL,
+    and REPORT_SERVICE_SELF_URL
+  EOF
+
+  class NotConfigured < StandardError
+    def initialize(msg=ErrorMessage)
+      super(msg)
+    end
+  end
 
   def self.make_key(*values)
     key = values.join(KeyJoiner)
@@ -17,6 +27,31 @@ module ReportService
     ENV['REPORT_SERVICE_TOKEN'].present? &&
     ENV['REPORT_SERVICE_URL'].present? &&
     ENV['REPORT_SERVICE_SELF_URL'].present?
+  end
+
+
+  module Sender
+    def to_json()
+      @payload.to_json
+    end
+
+    def send(endpoint)
+      HTTParty.post(
+        "#{@report_service_url}/#{endpoint}",
+        :body => self.to_json,
+        :headers => {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{@report_service_token}"
+        }
+      )
+    end
+
+    def getParamsFromEnv
+      raise ReportService::NotConfigured.new unless ReportService::configured?
+      @self_url = ENV['REPORT_SERVICE_SELF_URL']
+      @report_service_url = ENV['REPORT_SERVICE_URL']
+      @report_service_token = ENV['REPORT_SERVICE_TOKEN']
+    end
   end
 
 end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -31,27 +31,37 @@ module ReportService
 
 
   module Sender
-    def to_json()
-      @payload.to_json
+
+    def self_url
+      raise ReportService::NotConfigured.new unless ReportService::configured?
+      ENV['REPORT_SERVICE_SELF_URL']
     end
 
-    def send(endpoint)
+    def report_service_url
+      raise ReportService::NotConfigured.new unless ReportService::configured?
+      ENV['REPORT_SERVICE_URL']
+    end
+
+    def report_service_token
+      raise ReportService::NotConfigured.new unless ReportService::configured?
+      ENV['REPORT_SERVICE_TOKEN']
+    end
+
+    def api_endpoint
+      "#{report_service_url}/#{api_method}"
+    end
+
+    def send()
       HTTParty.post(
-        "#{@report_service_url}/#{endpoint}",
-        :body => self.to_json,
+        api_endpoint,
+        :body => to_json,
         :headers => {
           'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{@report_service_token}"
+          'Authorization' => "Bearer #{report_service_token}"
         }
       )
     end
 
-    def getParamsFromEnv
-      raise ReportService::NotConfigured.new unless ReportService::configured?
-      @self_url = ENV['REPORT_SERVICE_SELF_URL']
-      @report_service_url = ENV['REPORT_SERVICE_URL']
-      @report_service_token = ENV['REPORT_SERVICE_TOKEN']
-    end
   end
 
 end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -12,4 +12,11 @@ module ReportService
   def self.make_source_key(url)
     make_key(url.gsub(UrlRegex, '\1'))
   end
+
+  def self.configured?()
+    ENV['REPORT_SERVICE_TOKEN'].present? &&
+    ENV['REPORT_SERVICE_URL'].present? &&
+    ENV['REPORT_SERVICE_SELF_URL'].present?
+  end
+
 end

--- a/app/services/report_service/resource_sender.rb
+++ b/app/services/report_service/resource_sender.rb
@@ -2,15 +2,16 @@ module ReportService
   class ResourceSender
     Version = "1"
 
-    def initialize(resource, host)
+    def initialize(resource)
+      @self_url = ENV['REPORT_SERVICE_SELF_URL']
       version = ResourceSender::Version
       created = Time.now.utc.to_s
-      @resource_payload = resource.serialize_for_report_service(host)
+      @resource_payload = resource.serialize_for_report_service(@self_url)
       type = @resource_payload[:type]
       id = @resource_payload[:id]
       @resource_payload[:created] = created
       @resource_payload[:version] = version
-      @resource_payload[:source_key] = ReportService::make_source_key(host)
+      @resource_payload[:source_key] = ReportService::make_source_key(@self_url)
       @resource_payload[:id] = ReportService::make_key(type, id)
     end
 
@@ -18,7 +19,9 @@ module ReportService
       @resource_payload.to_json
     end
 
-    def send(url, token)
+    def send()
+      url = ENV['REPORT_SERVICE_URL']
+      token = ENV['REPORT_SERVICE_TOKEN']
       puts "posting resource: #{@resource_payload[:type]} #{@resource_payload[:name]}"
       return HTTParty.post(
         "#{url}/import_structure",

--- a/app/services/report_service/resource_sender.rb
+++ b/app/services/report_service/resource_sender.rb
@@ -1,10 +1,11 @@
 module ReportService
   class ResourceSender
+    include Sender
     Version = "1"
 
     def initialize(resource)
-      @self_url = ENV['REPORT_SERVICE_SELF_URL']
-      version = ResourceSender::Version
+      getParamsFromEnv
+      version = Version
       created = Time.now.utc.to_s
       @resource_payload = resource.serialize_for_report_service(@self_url)
       type = @resource_payload[:type]
@@ -20,16 +21,7 @@ module ReportService
     end
 
     def send()
-      url = ENV['REPORT_SERVICE_URL']
-      token = ENV['REPORT_SERVICE_TOKEN']
-      puts "posting resource: #{@resource_payload[:type]} #{@resource_payload[:name]}"
-      return HTTParty.post(
-        "#{url}/import_structure",
-        :body => self.to_json,
-        :headers => {
-          'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{token}"
-        })
+      super.send('import_structure')
     end
   end
 end

--- a/app/services/report_service/resource_sender.rb
+++ b/app/services/report_service/resource_sender.rb
@@ -3,25 +3,25 @@ module ReportService
     include Sender
     Version = "1"
 
+    def api_method
+      "import_structure"
+    end
+
     def initialize(resource)
-      getParamsFromEnv
       version = Version
       created = Time.now.utc.to_s
-      @resource_payload = resource.serialize_for_report_service(@self_url)
-      type = @resource_payload[:type]
-      id = @resource_payload[:id]
-      @resource_payload[:created] = created
-      @resource_payload[:version] = version
-      @resource_payload[:source_key] = ReportService::make_source_key(@self_url)
-      @resource_payload[:id] = ReportService::make_key(type, id)
+      @payload = resource.serialize_for_report_service(self_url)
+      type = @payload[:type]
+      id = @payload[:id]
+      @payload[:created] = created
+      @payload[:version] = version
+      @payload[:source_key] = ReportService::make_source_key(self_url)
+      @payload[:id] = ReportService::make_key(type, id)
     end
 
-    def to_json()
-      @resource_payload.to_json
+    def to_json
+      @payload.to_json
     end
 
-    def send()
-      super.send('import_structure')
-    end
   end
 end

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -1,22 +1,23 @@
 module ReportService
+
   class RunSender
     Version = "1"
     DefaultClassHash = "anonymous-run"
     DefaultUserEmail = "anonymous"
 
-    def get_resource_url(run, host)
+    def get_resource_url(run)
       if run.sequence_id
-        "#{host}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
+        "#{@self_url}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
       else
-        "#{host}#{Rails.application.routes.url_helpers.activity_path(run.activity_id)}"
+        "#{@self_url}#{Rails.application.routes.url_helpers.activity_path(run.activity_id)}"
       end
     end
 
-    def add_meta_data(run, record, host)
+    def add_meta_data(run, record)
       record[:version] = RunSender::Version
       record[:created] = Time.now.utc.to_s
-      record[:source_key] = ReportService::make_source_key(host)
-      record[:resource_url] = get_resource_url(run, host)
+      record[:source_key] = ReportService::make_source_key(@self_url)
+      record[:resource_url] = get_resource_url(run)
       record[:class_hash] = run.class_hash
       record[:class_info_url] = run.class_info_url
       record[:user_email] = run.user ? run.user.email : DefaultUserEmail
@@ -24,20 +25,26 @@ module ReportService
       record[:run_key] = run.key
     end
 
-    def serialized_answer(ans, run, host)
+    def serialized_answer(ans, run)
       answer_hash = ans.report_service_hash
-      add_meta_data(run, answer_hash, host)
+      add_meta_data(run, answer_hash)
       answer_hash
     end
 
-    def serlialized_answers(run, host)
+    def serlialized_answers(run)
       age_threshold_seconds = 0.25
-      modified_answers = run.answers.select do
-        |a| a.updated_at - a.created_at > age_threshold_seconds
+      modified_answers = run.answers.select do |a|
+        a.updated_at - a.created_at > age_threshold_seconds
+      end
+      # Send only the dirty answers, onless forced to send them all.
+      unless @send_all_answers
+        modified_answers.select! do |a|
+          a.dirty?
+        end
       end
       modified_answers.map do |ans|
         begin
-          serialized_answer(ans, run, host)
+          serialized_answer(ans, run)
         rescue => e
           Rails.logger.error "Failed to serialize answer: #{e}"
           nil
@@ -46,8 +53,10 @@ module ReportService
       .compact
     end
 
-    def initialize(run, host)
-      url = "#{host}#{Rails.application.routes.url_helpers.run_path(run)}"
+    def initialize(run, send_all_answers=false)
+      @self_url = ENV['REPORT_SERVICE_SELF_URL']
+      @send_all_answers = send_all_answers
+      url = "#{@self_url}#{Rails.application.routes.url_helpers.run_path(run)}"
       @run_payload = {
         id: run.key,
         url: url,
@@ -60,16 +69,18 @@ module ReportService
         sequence_id: run.sequence_id,
         sequence_run_id: run.sequence_run_id,
         collaboration_run_id: run.collaboration_run_id,
-        answers: serlialized_answers(run, host)
+        answers: serlialized_answers(run)
       }
-      add_meta_data(run, @run_payload, host)
+      add_meta_data(run, @run_payload)
     end
 
     def to_json()
       @run_payload.to_json
     end
 
-    def send(url, token)
+    def send()
+      url = ENV['REPORT_SERVICE_URL']
+      token = ENV['REPORT_SERVICE_TOKEN']
       HTTParty.post(
         "#{url}/import_run",
         :body => self.to_json,

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -8,16 +8,16 @@ module ReportService
 
     def get_resource_url(run)
       if run.sequence_id
-        "#{@self_url}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
+        "#{self_url}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
       else
-        "#{@self_url}#{Rails.application.routes.url_helpers.activity_path(run.activity_id)}"
+        "#{self_url}#{Rails.application.routes.url_helpers.activity_path(run.activity_id)}"
       end
     end
 
     def add_meta_data(run, record)
       record[:version] = RunSender::Version
       record[:created] = Time.now.utc.to_s
-      record[:source_key] = ReportService::make_source_key(@self_url)
+      record[:source_key] = ReportService::make_source_key(self_url)
       record[:resource_url] = get_resource_url(run)
       record[:class_hash] = run.class_hash
       record[:class_info_url] = run.class_info_url
@@ -54,10 +54,13 @@ module ReportService
       .compact
     end
 
+    def api_method
+      "import_run"
+    end
+
     def initialize(run, send_all_answers=false)
-      self.getParamsFromEnv
       @send_all_answers = send_all_answers
-      url = "#{@self_url}#{Rails.application.routes.url_helpers.run_path(run)}"
+      url = "#{self_url}#{Rails.application.routes.url_helpers.run_path(run)}"
       @payload = {
         id: run.key,
         url: url,
@@ -75,8 +78,9 @@ module ReportService
       add_meta_data(run, @payload)
     end
 
-    def send()
-      super.send("/import_run")
+    def to_json
+      @payload.to_json
     end
+
   end
 end

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -1,8 +1,9 @@
 module ReportService
 
   class RunSender
+    include Sender
+
     Version = "1"
-    DefaultClassHash = "anonymous-run"
     DefaultUserEmail = "anonymous"
 
     def get_resource_url(run)
@@ -54,10 +55,10 @@ module ReportService
     end
 
     def initialize(run, send_all_answers=false)
-      @self_url = ENV['REPORT_SERVICE_SELF_URL']
+      self.getParamsFromEnv
       @send_all_answers = send_all_answers
       url = "#{@self_url}#{Rails.application.routes.url_helpers.run_path(run)}"
-      @run_payload = {
+      @payload = {
         id: run.key,
         url: url,
         run_count: run.run_count,
@@ -71,24 +72,11 @@ module ReportService
         collaboration_run_id: run.collaboration_run_id,
         answers: serlialized_answers(run)
       }
-      add_meta_data(run, @run_payload)
-    end
-
-    def to_json()
-      @run_payload.to_json
+      add_meta_data(run, @payload)
     end
 
     def send()
-      url = ENV['REPORT_SERVICE_URL']
-      token = ENV['REPORT_SERVICE_TOKEN']
-      HTTParty.post(
-        "#{url}/import_run",
-        :body => self.to_json,
-        :headers => {
-          'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{token}"
-        }
-      )
+      super.send("/import_run")
     end
   end
 end

--- a/app/services/submit_dirty_answers_job.rb
+++ b/app/services/submit_dirty_answers_job.rb
@@ -3,23 +3,26 @@ class SubmitDirtyAnswersJob < Struct.new(:run_id, :start_time)
     job.run_at = 30.seconds.from_now
   end
 
+  def send_to_report_service(run)
+    begin
+      # only send answers which are 'dirty':
+      force = false
+      sender = ReportService::RunSender.new(run, force)
+      sender.send()
+    rescue => e
+      Rails.logger.error("Couldn't send run #{run.key} to report service:")
+      Rails.logger.error(e)
+    end
+  end
+
   def perform
     run = Run.find(run_id)
     # Find array of dirty answers and send them to the portal
     da = run.dirty_answers
     return if da.empty?
     if run.send_to_portal(da, start_time)
-      # if there is a report service configured send run data there too:
-      if ReportService::configured?
-        begin
-          force = false
-          sender = ReportService::RunSender.new(run, force)
-          sender.send()
-        rescue => e
-          Rail.logger.error("Couldn't send run to report service:")
-          Rail.logger.error(e)
-        end
-      end
+      # if there is a report service configured send run data there
+      send_to_report_service(run) if ReportService::configured?
       run.set_answers_clean(da) # We're only cleaning the same set we sent to the portal
       run.reload
       if run.dirty_answers.empty?

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -19,8 +19,8 @@ namespace :reporting do
     service_url = ENV["REPORT_SERVICE_URL"]
     service_token = ENV["REPORT_SERVICE_TOKEN"]
     begin
-      payload = sender_class.new(resource, self_host)
-      result = payload.send(service_url, service_token)
+      payload = sender_class.new(resource)
+      result = payload.send()
       if (result && result["success"])
         return true
       end

--- a/spec/services/report_service/resource_sender_spec.rb
+++ b/spec/services/report_service/resource_sender_spec.rb
@@ -1,14 +1,18 @@
 require 'spec_helper'
 
 describe ReportService::ResourceSender do
-  let(:host)      { "app.lara.docker" }
+  let(:self_host)            { "app.lara.docker" }
+  let(:report_service_url)   { "fake-report-service.foo" }
+  let(:report_service_token) { "secret-token-ssh" }
   let(:id)        { "resource-id"}
 
   let(:resource) { FactoryGirl.create(:activity_with_page_and_or) }
   let(:sender)   { ReportService::ResourceSender.new(resource) }
 
   before(:each) do
-    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(host)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(self_host)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return(report_service_url)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return(report_service_token)
   end
 
   describe "to_json" do
@@ -37,6 +41,13 @@ describe ReportService::ResourceSender do
 
       it "Should have a children[] array" do
         expect(json['children']).not_to be_nil
+      end
+    end
+
+    describe "when the service is not configured"  do
+      let(:report_service_token) { nil }
+      it "should raise an excpeption" do
+        expect {sender}.to raise_error(ReportService::NotConfigured)
       end
     end
   end

--- a/spec/services/report_service/resource_sender_spec.rb
+++ b/spec/services/report_service/resource_sender_spec.rb
@@ -5,12 +5,17 @@ describe ReportService::ResourceSender do
   let(:id)        { "resource-id"}
 
   let(:resource) { FactoryGirl.create(:activity_with_page_and_or) }
-  let(:sender)   { ReportService::ResourceSender.new(resource, host) }
+  let(:sender)   { ReportService::ResourceSender.new(resource) }
+
+  before(:each) do
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(host)
+  end
 
   describe "to_json" do
     it "should be a string with a length" do
       expect(sender.to_json().length).to be > 1
     end
+
     it "should parse" do
       expect { JSON.parse(sender.to_json()) }.not_to raise_error
     end

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -52,10 +52,12 @@ describe ReportService::RunSender do
       answers: answers
     })
   end
-  let(:sender) { ReportService::RunSender.new(run, host)     }
+  let(:send_all_answers) { true }
+  let(:sender) { ReportService::RunSender.new(run, send_all_answers)     }
 
   before(:each) do
     allow(Rails.application.routes.url_helpers).to receive(:run_path).and_return("runs/12345")
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(host)
     Timecop.freeze(Time.new(2016))
   end
 

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 describe ReportService::RunSender do
-  let(:host)      { "app.lara.docker" }
+  let(:report_service_url)   { 'http://fake-report-service.fake' }
+  let(:report_service_token) { 'very-secret-token' }
+  let(:self_host)            { 'app.lara.docker' }
+
   let(:key)       { "run-key "}
 
   let(:user)      { double("User", {email: "anon@concord.org", id: 34}) }
@@ -22,7 +25,7 @@ describe ReportService::RunSender do
   let(:class_hash)           { "15291405-6B03-4E50-B49F-ACBC99D6255F" }
   let(:answers) do
     1.upto(5).map do |index|
-      url = "#{host}activities/#{index}"
+      url = "#{self_host}activities/#{index}"
       report_service_hash = { question_id: index, type: "mock-answer", url: url }
       double("Answer", {
         report_service_hash: report_service_hash,
@@ -52,16 +55,26 @@ describe ReportService::RunSender do
       answers: answers
     })
   end
+
   let(:send_all_answers) { true }
   let(:sender) { ReportService::RunSender.new(run, send_all_answers)     }
 
   before(:each) do
     allow(Rails.application.routes.url_helpers).to receive(:run_path).and_return("runs/12345")
-    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(host)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(self_host)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return(report_service_url)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return(report_service_token)
     Timecop.freeze(Time.new(2016))
   end
 
   describe "to_json" do
+    describe "when the service is not configured"  do
+      let(:report_service_token) { nil }
+      it "should raise an excpeption" do
+        expect {sender}.to raise_error(ReportService::NotConfigured)
+      end
+    end
+
     it "should be a string with a length" do
       expect(sender.to_json().length).to be > 1
     end
@@ -86,7 +99,7 @@ describe ReportService::RunSender do
             expect(a["source_key"]).to match("app_lara_docker")
             expect(a["source_key"]).not_to match("/")
             expect(a["source_key"]).not_to match(/\./)
-            expect(a["resource_url"]).to match("#{host}/sequences/#{sequence_id}")
+            expect(a["resource_url"]).to match("#{self_host}/sequences/#{sequence_id}")
             expect(a).to include("created")
             expect(a).to include("url")
             expect(a).to include("run_key")
@@ -137,14 +150,14 @@ describe ReportService::RunSender do
 
         describe "when run is part of the sequence" do
           it "the resource_url should be sequence url" do
-            expect(json["resource_url"]).to match("#{host}/sequences/#{sequence_id}")
+            expect(json["resource_url"]).to match("#{self_host}/sequences/#{sequence_id}")
           end
         end
 
         describe "when run isn't part of the sequence" do
           let(:sequence_id) { nil }
           it "the resource_url should be activity url" do
-            expect(json["resource_url"]).to match("#{host}/activities/#{sequence_id}")
+            expect(json["resource_url"]).to match("#{self_host}/activities/#{sequence_id}")
           end
         end
 

--- a/spec/services/submit_dirty_answers_job_spec.rb
+++ b/spec/services/submit_dirty_answers_job_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+
+describe SubmitDirtyAnswersJob do
+
+  let(:answers) do
+    5.times.map { |i| double("Asnwer", {}) }
+  end
+
+  let(:run_stubs) do
+    {
+      key: "run-key",
+      dirty_answers: answers,
+      id: run_id,
+      send_to_portal: true,
+      set_answers_clean: true,
+      reload: true,
+      abort_job_and_requeue: true
+    }
+  end
+
+  let(:run_id) { 7 }
+
+  let(:run) { double("Run", run_stubs) }
+  let(:report_service_configured) { false}
+  let(:submit_time) { Time.now }
+  let(:job) { SubmitDirtyAnswersJob.new(run_id, submit_time) }
+
+  before(:each) do
+    allow(ReportService)
+      .to receive(:configured?)
+      .and_return report_service_configured
+
+    allow(Run).to receive(:find).with(run_id).and_return(run)
+  end
+
+  describe "#send_to_report_service" do
+    describe "when the report service is not configured" do
+      let(:report_service_configured) { false }
+      it "we shouldn't send data to the report service" do
+        expect(job).not_to receive(:send_to_report_service)
+        expect { job.perform }.not_to raise_error
+      end
+    end
+
+    describe "When the report service is configured" do
+      let(:report_service_configured) { true }
+      it "should send data to the report service" do
+        expect(job).to receive(:send_to_report_service).with(run)
+        expect { job.perform }.not_to raise_error
+      end
+      describe "When something goes wrong while sending" do
+        before(:each) do
+          allow_any_instance_of(ReportService::RunSender)
+            .to receive(:send)
+            .and_raise("bang")
+        end
+        it "should report an error without halting" do
+          expect(Rails.logger).to receive(:error).at_least(:once)
+          expect { job.perform }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,6 +114,7 @@ RSpec.configure do |config|
   end
   config.before(:each) do
     stub_temporary_protocol_routes
+    clean_env_vars
   end
 
   # include the Haml helper module
@@ -147,4 +148,12 @@ def stub_temporary_protocol_routes
   # This code will be removed when versioned learner data is widely deployed to portals.
   stub_request(:any, /.*\/#{PortalSender::Protocol::VersionRoutePrefix}\/.*/)
   .to_return(:status => [500, "Internal Server Error"])
+end
+
+# some ENV vars set on dev machines should be ignored for tests:
+def  clean_env_vars
+  envs = %w(
+    REPORT_SERVICE_SELF_URL REPORT_SERVICE_URL REPORT_SERVICE_TOKEN
+  )
+  envs.each { |e| ENV.delete(e) }
 end


### PR DESCRIPTION
This PR will send updated student answers to a report service if one is configured.

It reuses the existing `submit_dirty_answers_job` background job.  

In the future we might imagine sending this  directly from the client.

PT: https://www.pivotaltracker.com/story/show/166241318

Story: "Student Answer Submission" 
When a student answers a question in an assignment, the new reporting data must reflect the most recent answer.


