### PR TITLE
multiple plugins of the same type on the same page were broken

### DIFF
--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -1,4 +1,4 @@
-- v3_plugin_label = "plugin#{plugin.id}"
+- v3_plugin_label = "plugin#{plugin.approved_script.id}"
 - unless plugin_loaded(plugin.url)
   = content_for :external_scripts do
     :javascript

--- a/spec/views/plugins/_show.html.haml_spec.rb
+++ b/spec/views/plugins/_show.html.haml_spec.rb
@@ -8,6 +8,7 @@ describe "plugins/_show.html.haml" do
   let(:user_id)  { 123 }
   let(:run_id)   { 123 }
   let(:run_remote_endpoint) { nil }
+  let(:approved_script_id){ 447 }
   let(:plugin_id){ 123 }
   let(:plugin_name){ 'plugin-name' }
   let(:plugin_label) {'plugin-label'}
@@ -37,7 +38,10 @@ describe "plugins/_show.html.haml" do
         url: plugin_url,
         version: version,
         author_data: plugin_author_data,
-        shared_learner_state_key: shared_learner_state_key
+        shared_learner_state_key: shared_learner_state_key,
+        approved_script: double({
+          id: approved_script_id
+        })
       })
     }
   end
@@ -58,7 +62,7 @@ describe "plugins/_show.html.haml" do
       /remoteEndpoint: null/,
       /container:/,
       /wrappedEmbeddable:/,
-      /LARA\.InternalAPI\.initPlugin\('plugin123', pluginContext\)/,
+      /LARA\.InternalAPI\.initPlugin\('plugin#{approved_script_id}', pluginContext\)/,
     ].each do |expected_string|
       expect(rendered).to match(expected_string)
     end


### PR DESCRIPTION
the plugin.id is different for each place the plugin is used.
instead we want an id that is constant for each javascript file that is loaded

[#166627102]