### PR TITLE
only send Portal Runs to the report service

### DIFF
--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -72,7 +72,8 @@ namespace :reporting do
 
   desc "publish runs to report service"
   task :publish_runs => :environment do
-    send_all_resources(Run, ReportService::RunSender)
+    # limit this to portal runs for now
+    send_all_resources(Run.where('remote_endpoint is not null'), ReportService::RunSender)
   end
 
   desc "import clazz info"


### PR DESCRIPTION
this is is much fewer runs at the time of the commit this was 3,000 runs instead 800,000 runs.

We can currently only use the report with portal runs, so this isn't breaking anything.
When we support report service reports on teacher previews and anonymous runs, then we'll need to change this. 