### PR TITLE
ReportService Run sending rake should send old runs too.

### DIFF
--- a/app/services/report_service/resource_sender.rb
+++ b/app/services/report_service/resource_sender.rb
@@ -7,7 +7,10 @@ module ReportService
       "import_structure"
     end
 
-    def initialize(resource)
+    # Params:
+    # +resource+:: Sequence LightweightActivity to send structure of
+    # +opts+:: _ignored at the moment_
+    def initialize(resource, opts={})
       version = Version
       created = Time.now.utc.to_s
       @payload = resource.serialize_for_report_service(self_url)

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -58,8 +58,11 @@ module ReportService
       "import_run"
     end
 
-    def initialize(run, send_all_answers=false)
-      @send_all_answers = send_all_answers
+    # Params:
+    # +run+:: run to send to report service
+    # +opts+:: _send_all_answers_ by default only send changed answers.
+    def initialize(run, opts={ send_all_answers: false} )
+      @send_all_answers = opts[:send_all_answers]
       url = "#{self_url}#{Rails.application.routes.url_helpers.run_path(run)}"
       @payload = {
         id: run.key,

--- a/app/services/submit_dirty_answers_job.rb
+++ b/app/services/submit_dirty_answers_job.rb
@@ -6,8 +6,7 @@ class SubmitDirtyAnswersJob < Struct.new(:run_id, :start_time)
   def send_to_report_service(run)
     begin
       # only send answers which are 'dirty':
-      force = false
-      sender = ReportService::RunSender.new(run, force)
+      sender = ReportService::RunSender.new(run, {send_all_answers: false})
       sender.send()
     rescue => e
       Rails.logger.error("Couldn't send run #{run.key} to report service:")

--- a/spec/libs/tasks/reporting_rake_spec.rb
+++ b/spec/libs/tasks/reporting_rake_spec.rb
@@ -1,0 +1,26 @@
+# spec/lib/tasks/reporting_rake_spec.rb
+require 'spec_helper'
+
+describe "reporting:publish_runs" do
+  include_context "rake"
+  let(:run) do
+    Run.create( {
+      user_id: 1,
+      activity_id: 1,
+      remote_endpoint: "http://fake.portal.com/1"
+    })
+  end
+
+  before(:each) do
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("noah.lara.com")
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("http://foo.com")
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return("report_service_token")
+  end
+
+  it "sends a run to the report service, specifying `send_all_answers`" do
+    expected_options = {:send_all_answers=>true}
+    expect(ReportService::RunSender).to receive(:new).with(run, expected_options)
+    subject.invoke
+  end
+
+end

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -1,5 +1,16 @@
 require 'spec_helper'
 
+def make_answer(index, dirty)
+  url = "#{self_host}activities/#{index}"
+  report_service_hash = { question_id: index, type: "mock-answer", url: url }
+  double("Answer", {
+    report_service_hash: report_service_hash,
+    created_at: created_at,
+    updated_at: updated_at,
+    dirty?: dirty
+  })
+end
+
 describe ReportService::RunSender do
   let(:report_service_url)   { 'http://fake-report-service.fake' }
   let(:report_service_token) { 'very-secret-token' }
@@ -24,15 +35,7 @@ describe ReportService::RunSender do
   let(:class_info_url)       { "https://mock.data.com/spec/class/2" }
   let(:class_hash)           { "15291405-6B03-4E50-B49F-ACBC99D6255F" }
   let(:answers) do
-    1.upto(5).map do |index|
-      url = "#{self_host}activities/#{index}"
-      report_service_hash = { question_id: index, type: "mock-answer", url: url }
-      double("Answer", {
-        report_service_hash: report_service_hash,
-        created_at: created_at,
-        updated_at: updated_at
-      })
-    end
+    1.upto(5).map { |index| make_answer(index, true) }
   end
 
   let(:run) do
@@ -56,8 +59,9 @@ describe ReportService::RunSender do
     })
   end
 
-  let(:send_all_answers) { true }
-  let(:sender) { ReportService::RunSender.new(run, send_all_answers)     }
+  let(:send_all_answers) { false }
+  let(:send_opts) { {send_all_answers: send_all_answers} }
+  let(:sender)    { ReportService::RunSender.new(run, send_opts) }
 
   before(:each) do
     allow(Rails.application.routes.url_helpers).to receive(:run_path).and_return("runs/12345")
@@ -110,7 +114,7 @@ describe ReportService::RunSender do
           end
         end
 
-        describe "with one answer that hasn't changed" do
+        describe "One answer that has never been started" do
           let(:report_service_hash) do
             { question_id: "fake_answer_1", type: "mock-answer", url: "url" }
           end
@@ -118,13 +122,36 @@ describe ReportService::RunSender do
             double("Answer", {
               report_service_hash: report_service_hash,
               created_at: created_at,
-              updated_at: created_at # Not changed since created
+              updated_at: created_at, # Not changed since created
+              dirty?: true
             })
           end
-          it "The answers json should not include the unchanged answer" do
+          it "The answers json should not include the unanswered answer" do
             answers << unchanged_answer
-            expect(answers.length).to be  6
-            expect(json["answers"].length).to be 5
+            expect(answers.length).to eql 6
+            expect(json["answers"].length).to eql 5
+          end
+        end
+
+        describe "When some answers aren't dirty" do
+          before(:each) do
+            5.times do |count|
+              answers << make_answer(count, false)
+            end
+          end
+
+          describe "When configured to force_send all answers" do
+            let(:send_all_answers) { true }
+            it "should send all 10 answers" do
+              expect(json["answers"].length).to eql 10
+            end
+          end
+
+          describe "When configured not to force_send all answers" do
+            let(:send_all_answers) { false }
+            it "should send ony first five dirty answers" do
+              expect(json["answers"].length).to eql 5
+            end
           end
         end
 
@@ -134,7 +161,8 @@ describe ReportService::RunSender do
           let(:exploding_answer) do
             answer = double("Answer", {
               created_at: created_at,
-              updated_at: updated_at
+              updated_at: updated_at,
+              dirty?: true
             })
             allow(answer).to receive(:report_service_hash).and_raise(boom)
             answer

--- a/spec/support/shared_context/rake.rb
+++ b/spec/support/shared_context/rake.rb
@@ -1,0 +1,22 @@
+# spec/support/shared_contexts/rake.rb
+# See: https://thoughtbot.com/blog/test-rake-tasks-like-a-boss
+
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
By default `run_sender.rb` only sends for `dirty` answers.

But when we run the rake task we need to send all answers.

The edge case which is important to remember is that we *dont* send answers that were created with the run, but were never actually seen by the student.  For that compare we compare `created_at` and `update_at`. 

This PR enhances the testing around that logic, and also changes the Rake task to explicitly ignore the `dirty?`  flag on answers.

#166735324

https://www.pivotaltracker.com/story/show/166735324