### PR TITLE
In `#import_clazz_info` of `reporting.rake` fall back to `learner_id`

### DIFF
--- a/lib/class_info_import_helper.rb
+++ b/lib/class_info_import_helper.rb
@@ -1,0 +1,50 @@
+
+module ClassInfoImportHelper
+
+  def self.remote_endpoint_path_for(import_line)
+    clazz_id, class_hash, l_id, l_key = import_line.strip.split(",")
+    learner_key = l_key.present? ? l_key : l_id
+    portal_url = ENV["IMPORT_PORTAL_URL"]
+    "#{portal_url}/dataservice/external_activity_data/#{learner_key.strip}"
+  end
+
+  def self.class_info_url_path(class_id)
+    portal_url = ENV["IMPORT_PORTAL_URL"]
+    "#{portal_url}/api/v1/classes/#{class_id}"
+  end
+
+  # Params:
+  # +import_line+: should look like this:
+  #     "<clazz_id>, <class_hash>, <learner_id>, <learner_secret_key>"
+  def self.update_runs_from_csv_line(import_line)
+    remote_endpoint = remote_endpoint_path_for(import_line)
+    clazz_id, class_hash, l_id, l_key = import_line.strip.split(",")
+    updated_run_count = 0
+    info_url = class_info_url_path(clazz_id)
+
+    SequenceRun.where(remote_endpoint: remote_endpoint).each do |srun|
+        srun.update_attributes({
+          class_info_url: info_url,
+          class_hash: class_hash
+        })
+        # Child runs:
+        srun.runs.each do |run|
+          run.update_attributes({
+            class_info_url: info_url,
+            class_hash: class_hash
+          })
+          updated_run_count = updated_run_count + 1
+        end
+    end
+
+    Run.where(remote_endpoint: remote_endpoint).each do |run|
+        run.update_attributes({
+          class_info_url: info_url,
+          class_hash: class_hash
+        })
+        updated_run_count = updated_run_count + 1
+      end
+    return updated_run_count
+  end
+
+end

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -113,6 +113,7 @@ namespace :reporting do
         puts "    Updated #{updated_run_count} Runs"
       end
       clazz_id, class_hash, learner_id, learner_key = import_line.strip.split(",")
+      learner_key = learner_key.present? ? learner_key : learner_id
       remote_endpoint = remote_endpoint_path(learner_key)
       info_url = class_info_url_path(clazz_id)
       SequenceRun

--- a/spec/libs/class_info_import_helper_spec.rb
+++ b/spec/libs/class_info_import_helper_spec.rb
@@ -1,0 +1,40 @@
+# spec/lib/class_info_import_helper_spec.rb
+require 'spec_helper'
+
+describe ClassInfoImportHelper do
+  let(:clazz_id)    { 123 }
+  let(:learner_id)  { 456 }
+  let(:class_hash)  { "C842239D-6447-4CED-89AD-44DD21A9012F" }
+  let(:learner_key) { "EDAC877F-209D-494D-B0CB-6F0CE3E577CD" }
+  before(:each) do
+    allow(ENV).to receive(:[])
+    .with("IMPORT_PORTAL_URL")
+    .and_return("http://app.portal.docker/")
+  end
+  let(:line_with_all_fields) do
+    "#{clazz_id}, #{class_hash}, #{learner_id}, #{learner_key}"
+  end
+  let(:line_missing_learner_key) do
+    "#{clazz_id}, #{class_hash}, #{learner_id}, "
+  end
+
+  describe "remote_endpoint_path" do
+    describe "with all fields" do
+      let(:line) { line_with_all_fields }
+      it "should use the learner_key for the remote endpoint url" do
+        remote_endpoint = ClassInfoImportHelper.remote_endpoint_path_for(line)
+        expected_enpoint = "http://app.portal.docker//dataservice/external_activity_data/EDAC877F-209D-494D-B0CB-6F0CE3E577CD"
+        expect(remote_endpoint).to eql expected_enpoint
+      end
+    end
+
+    describe "when missing the learner_key" do
+      let(:line) { line_missing_learner_key }
+      it "should use the learner_id for the remote endpoint url" do
+        remote_endpoint = ClassInfoImportHelper.remote_endpoint_path_for(line)
+        expected_enpoint = "http://app.portal.docker//dataservice/external_activity_data/456"
+        expect(remote_endpoint).to eql expected_enpoint
+      end
+    end
+  end
+end

--- a/spec/libs/tasks/reporting_rake_spec.rb
+++ b/spec/libs/tasks/reporting_rake_spec.rb
@@ -12,7 +12,7 @@ describe "reporting:publish_runs" do
   end
 
   before(:each) do
-    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("noah.lara.com")
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("app.lara.docker")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("http://foo.com")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return("report_service_token")
   end
@@ -21,6 +21,39 @@ describe "reporting:publish_runs" do
     expected_options = {:send_all_answers=>true}
     expect(ReportService::RunSender).to receive(:new).with(run, expected_options)
     subject.invoke
+  end
+
+end
+
+describe  "reporting:import_clazz_info" do
+  include_context "rake"
+  let(:clazz_id)    { 123 }
+  let(:learner_id)  { 456 }
+  let(:class_hash)  { "C842239D-6447-4CED-89AD-44DD21A9012F" }
+  let(:learner_key) { "EDAC877F-209D-494D-B0CB-6F0CE3E577CD" }
+
+  # Portal export file format:
+  let(:line_with_all_fields) do
+    "#{clazz_id}, #{class_hash}, #{learner_id}, #{learner_key}"
+  end
+
+  before(:each) do
+    file = Tempfile.new('foo')
+    file.write(line_with_all_fields)
+
+    allow(ENV).to receive(:[])
+      .with("IMPORT_PORTAL_URL")
+      .and_return("http://app.portal.docker/")
+
+    allow(ENV).to receive(:[])
+      .with("CLASS_IMPORT_FILENAME")
+      .and_return(file.path)
+
+  end
+
+  it "sends a run to the report service, specifying `send_all_answers`" do
+    # Just assert no exceptions for now...
+    expect { subject.invoke }.not_to raise_error
   end
 
 end


### PR DESCRIPTION
When `learner_key` isn't present, use `learner_id` to figure out `remote_endpoint`

When importing `class_hash` values from from portal CSV, if the learner secret key is missing, fall back to the `learner_id`.

[#166747707]

https://www.pivotaltracker.com/story/show/166747707