### PR TITLE
Use `answered?` method to check if answer should be sent to report

### DIFF
--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -33,10 +33,7 @@ module ReportService
     end
 
     def serlialized_answers(run)
-      age_threshold_seconds = 0.25
-      modified_answers = run.answers.select do |a|
-        a.updated_at - a.created_at > age_threshold_seconds
-      end
+      modified_answers = run.answers.select { |a| a.answered? }
       # Send only the dirty answers, onless forced to send them all.
       unless @send_all_answers
         modified_answers.select! do |a|

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
-def make_answer(index, dirty)
+def make_answer(index, dirty, answered=true)
   url = "#{self_host}activities/#{index}"
   report_service_hash = { question_id: index, type: "mock-answer", url: url }
   double("Answer", {
     report_service_hash: report_service_hash,
-    created_at: created_at,
-    updated_at: updated_at,
+    answered?: answered,
     dirty?: dirty
   })
 end
@@ -46,6 +45,7 @@ describe ReportService::RunSender do
       run_count: run_count,
       created_at: created_at,
       updated_at: updated_at,
+      answered?: true,
       activity_id: activity_id,
       remote_id: remote_id,
       page_id: page_id,
@@ -121,8 +121,7 @@ describe ReportService::RunSender do
           let(:unchanged_answer) do
             double("Answer", {
               report_service_hash: report_service_hash,
-              created_at: created_at,
-              updated_at: created_at, # Not changed since created
+              answered?: false,
               dirty?: true
             })
           end
@@ -160,8 +159,7 @@ describe ReportService::RunSender do
           let(:boom) { "boom" }
           let(:exploding_answer) do
             answer = double("Answer", {
-              created_at: created_at,
-              updated_at: updated_at,
+              answered?: true,
               dirty?: true
             })
             allow(answer).to receive(:report_service_hash).and_raise(boom)


### PR DESCRIPTION
When sending answers to the report service:

We don't want to send all answers. Just the answers that the students have actually worked on.

Our previous approach was to compare `updated_at` and `created_at timestamps`. That wasn't working though, in part because of how sequence runs work.

Instead we will use answers `answered?` method. It should work for most things, with the possible exception of labbook answers.

[#166769565]

https://www.pivotaltracker.com/story/show/166769565