### PR TITLE
Add API Key to LARA Users

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -34,6 +34,10 @@ class Ability
       cannot :export, LightweightActivity
       cannot :export, Sequence
     end
+    if user.can_export?
+      can :export, LightweightActivity
+      can :export, Sequence
+    end
     # Everyone (author and regular user) can read public, hidden and archived sequences or activities.
     ['public', 'hidden', 'archive'].each do |allowed_status|
       can :read, Sequence, :publication_status => allowed_status

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,8 @@ class User < ActiveRecord::Base
   has_many :imports
 
   # Setup accessible (or protected) attributes for your model
-  attr_accessible :email, :password, :password_confirmation, :remember_me, :is_admin, :is_author,
+  attr_accessible :email, :password, :password_confirmation, :remember_me,
+    :is_admin, :is_author, :can_export,
     :provider, :uid, :authentication_token, :api_key, :has_api_key
   # attr_accessible :title, :body
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,8 @@ class User < ActiveRecord::Base
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :timeoutable
+         :recoverable, :rememberable, :trackable, :validatable, :timeoutable,
+         :token_authenticatable, :bearer_token_authenticatable
   devise :omniauthable, :omniauth_providers => Concord::AuthPortal.all_strategy_names
 
   has_many :activities, :class_name => LightweightActivity
@@ -13,10 +14,17 @@ class User < ActiveRecord::Base
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :password, :password_confirmation, :remember_me, :is_admin, :is_author,
-    :provider, :uid, :authentication_token
+    :provider, :uid, :authentication_token, :api_key, :has_api_key
   # attr_accessible :title, :body
 
   has_many :authentications, :dependent => :delete_all
+
+  self.token_authentication_key = "api_key"
+
+  def self.find_for_token_authentication(condition)
+    self.where(condition).first
+  end
+
 
   # access cancan outside of current_user
   # see https://github.com/ryanb/cancan/wiki/ability-for-other-users
@@ -115,4 +123,19 @@ class User < ActiveRecord::Base
    rack_session.delete "portal_domain"
    rack_session.delete "user_return_to"
   end
+
+  def has_api_key
+    return api_key.present?
+  end
+
+  def has_api_key=(newvalue)
+    if newvalue == "1"
+      if api_key.blank?
+        update_attribute(:api_key, UUIDTools::UUID.random_create.to_s)
+      end
+    else
+      update_attribute(:api_key, nil)
+    end
+  end
+
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -32,7 +32,7 @@
   </p>
   <p>
     <label for="has_api_key">
-      Allow API access?
+      Allow API access (for GET requests)?
       <%= f.check_box :has_api_key %>
       <% if @user.has_api_key%>
         <p>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -25,6 +25,12 @@
     </label>
   </p>
   <p>
+    <label for="can_export">
+      Allowed to export activities and sequences?
+      <%= f.check_box :can_export %>
+    </label>
+  </p>
+  <p>
     <label for="has_api_key">
       Allow API access?
       <%= f.check_box :has_api_key %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -24,6 +24,19 @@
       <%= f.check_box :is_author %>
     </label>
   </p>
+  <p>
+    <label for="has_api_key">
+      Allow API access?
+      <%= f.check_box :has_api_key %>
+      <% if @user.has_api_key%>
+        <p>
+          API KEY: <input type="text" size="64" readonly value="<%= @user.api_key %>">
+        </p>
+      <% end %>
+    </label>
+  </p>
+
+
 </fieldset>
 
 <div class="actions">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -259,3 +259,5 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = "/my_engine/users/auth"
 end
+
+require "bearer_token_authenticatable/bearer_token"

--- a/db/migrate/20190621151921_add_api_key_to_user.rb
+++ b/db/migrate/20190621151921_add_api_key_to_user.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :api_key, :text
+  end
+end

--- a/db/migrate/20190621195718_add_can_export_to_user.rb
+++ b/db/migrate/20190621195718_add_can_export_to_user.rb
@@ -1,0 +1,5 @@
+class AddCanExportToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :can_export, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190621151921) do
+ActiveRecord::Schema.define(:version => 20190621195718) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -653,6 +653,7 @@ ActiveRecord::Schema.define(:version => 20190621151921) do
     t.boolean  "is_admin",               :default => false
     t.boolean  "is_author",              :default => false
     t.text     "api_key"
+    t.boolean  "can_export",             :default => false
   end
 
   add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190614110454) do
+ActiveRecord::Schema.define(:version => 20190621151921) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -652,6 +652,7 @@ ActiveRecord::Schema.define(:version => 20190614110454) do
     t.datetime "updated_at",                                :null => false
     t.boolean  "is_admin",               :default => false
     t.boolean  "is_author",              :default => false
+    t.text     "api_key"
   end
 
   add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true

--- a/lib/bearer_token_authenticatable/bearer_token.rb
+++ b/lib/bearer_token_authenticatable/bearer_token.rb
@@ -1,0 +1,42 @@
+module BearerTokenAuthenticatable
+  class BearerToken < Devise::Strategies::Authenticatable
+
+    def valid?
+      token_valid?()
+    end
+
+    def authenticate!
+      return fail(:invalid_token) unless token_valid?
+      resource = User.find_for_token_authentication(User.token_authentication_key => token_value)
+      return fail(:invalid_token) unless resource
+      success!(resource)
+    end
+
+    private
+    def validate(resource)
+      ! resource.nil?
+    end
+
+    def token_valid?
+      return false unless token_value
+      return true  # TODO: Validate the string length?
+    end
+
+    def referer
+      return request.env["HTTP_REFERER"]
+    end
+
+    def token_value
+      header = request.headers["Authorization"]
+      if header && header =~ /^Bearer (.*)$/
+        $1
+      else
+        nil
+      end
+    end
+
+  end
+end
+
+Warden::Strategies.add(:bearer_token_authenticatable, BearerTokenAuthenticatable::BearerToken)
+Devise.add_module :bearer_token_authenticatable, :strategy => true

--- a/spec/controllers/api/v1/plugin_learner_states_controller_spec.rb
+++ b/spec/controllers/api/v1/plugin_learner_states_controller_spec.rb
@@ -13,7 +13,8 @@ describe Api::V1::PluginLearnerStatesController do
       id: 42,
       email: "student@school.edu",
       admin?: false,
-      author?: false
+      author?: false,
+      can_export?: false
     }
   end
 
@@ -22,7 +23,8 @@ describe Api::V1::PluginLearnerStatesController do
       id: 44,
       email: "student@school.edu",
       admin?: false,
-      author?: false
+      author?: false,
+      can_export?: false
     }
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,5 +31,15 @@ FactoryGirl.define do
     password_confirmation 'author..'
     is_admin false
     is_author true
+    can_export false
+  end
+
+  factory :can_export, :class => User do
+    email { generate(:email) }
+    password 'exporter..'
+    password_confirmation 'exporter..'
+    is_admin false
+    is_author false
+    can_export true
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -185,4 +185,59 @@ describe User do
     end
   end
 
+  describe "#has_api_key" do
+    let(:existing_api_key) { nil }
+    let(:opts) { { api_key: existing_api_key } }
+    let(:user) { FactoryGirl.build(:user, opts) }
+
+    it "by default users do not have an api_key" do
+      expect(user.api_key).to be_nil
+      expect(user.has_api_key).to be false
+    end
+
+    describe "Enabling the API key for the user" do
+
+      describe "when the user doesn't already have an api_key" do
+        let(:existing_api_key) { nil }
+        it "should give them a new api_key" do
+          expect(user.api_key).to be_nil
+          user.has_api_key = "1"
+          expect(user.api_key).not_to be_nil
+        end
+      end
+
+      describe "when the user already has an api_key" do
+        let(:existing_api_key) { "fake_key"}
+        it "the api_key for the user should not be changed" do
+          expect(user.api_key).to eql "fake_key"
+          user.has_api_key = "1"
+          expect(user.api_key).to eql "fake_key"
+        end
+      end
+
+      describe "Disabling the API key for the user" do
+
+        describe "when the user doesn't have an api_key" do
+          let(:existing_api_key) { nil }
+          it "none should be generated" do
+            expect(user.api_key).to be_nil
+            user.has_api_key = "0"
+            expect(user.api_key).to be_nil
+          end
+        end
+  
+        describe "when the user has an api_key" do
+          let(:existing_api_key) { "fake_key"}
+          it "the api_key should be deleted" do
+            expect(user.api_key).to eql "fake_key"
+            user.has_api_key = "0"
+            expect(user.api_key).to be_nil
+          end
+        end
+      end
+
+    end
+
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,6 +64,13 @@ describe User do
       it { is_expected.not_to be_able_to(:duplicate, locked_activity) }
     end
 
+    context 'when the user can export activities' do
+      let(:user) { FactoryGirl.build(:can_export) }
+      let(:self_activity) { stub_model(LightweightActivity, :user_id => user.id) }
+      it { is_expected.to be_able_to(:export, Sequence) }
+      it { is_expected.to be_able_to(:export, LightweightActivity) }
+    end
+
     context 'when is a user' do
       # pending 'currently same as anonymous'
     end

--- a/spec/support/shared_examples/remote_duplicate_support.rb
+++ b/spec/support/shared_examples/remote_duplicate_support.rb
@@ -9,6 +9,17 @@ shared_examples "remote duplicate support" do
         post :remote_duplicate, { :id => resource.id }
         expect(response.status).to be(403)
       end
+      describe "Even when the admin has an API token (also uses `Bearer` auth headers)" do
+        let(:api_key) { "D7EF1172-2172-47B1-9F50-6C2ED1430DBD"}
+        let(:headers) { { 'Authorization' => "Bearer #{api_key}" } }
+        before(:each) do
+          user.update_attribute(:api_key, api_key)
+        end
+        it "should return 403 unauthorized" do
+          post :remote_duplicate, { :id => resource.id }, headers
+          expect(response.status).to be(403)
+        end
+      end
     end
 
     describe "when request is coming from peer (trusted Portal)" do


### PR DESCRIPTION
[NP/DL]

Addresses the PT story [#166795180] Add API Key to Users

https://www.pivotaltracker.com/n/projects/736901/stories/166795180

Follows the pattern in Portal to implement an API key for LARA users. The UI is implement as an additional check-box in the users-admin screen. When clicked, a UUID style API key is generated and stored in the user's record. If so enabled, the API key is displayed adjacent to the check-box where it can be easily copied.

Un-clicking the checkbox removes the API key from the user (and the database).

REQUIRES MIGRATION, as a column was added to the users table in the schema.

Spec tests have been added.

