### PR TITLE
Updated plugin api documentation [#166851983]

### DIFF
--- a/docs/lara-plugin-api/README.md
+++ b/docs/lara-plugin-api/README.md
@@ -96,47 +96,29 @@ The `url` field can either be a fully qualified url or a relative one. Lara auto
 
 The LARA Plugin is divided into two regular JavaScript classes (or constructors), the runtime and authoring classes. There are no special requirements regarding their interfaces at the moment, but it's a subject to change. Always check the [IPlugin](interfaces/iplugin.md) interface first.
 
-##### Runtime implementation
-
-The first thing that should be done by the runtime class of the plugin script is call to [registerPlugin](#registerplugin).
-
-The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the runtime context object. The plugin constructor should expect [IPluginRuntimeContext](interfaces/ipluginruntimecontext.md) instance as the only argument.
+Once the two JavaScript classes are defined the plugin script should call [registerPlugin](#registerplugin) to register the classes with LARA. The plugin will be initialized by LARA automatically when needed once it is registered. LARA calls its constructor and provides the runtime context object. The plugin constructor should expect [IPluginRuntimeContext](interfaces/ipluginruntimecontext.md) instance as the only argument.
 
 Example:
 
 ```typescript
 class TestPlugin {
   constructor(context: IPluginRuntimeContext) {
-    console.log("Plugin initialized, id:", context.pluginId);
+    console.log("Test Runtime Plugin initialized, id:", context.pluginId);
   }
 }
 
-LARAPluginAPI.registerPlugin("testPlugin", TestPlugin);
+class TestAuthoringPlugin {
+  constructor(context: IPluginAuthoringContext) {
+    console.log("Test Authoring Plugin initialized, id:", context.pluginId);
+  }
+}
+
+LARAPluginAPI.registerPlugin({runtimeClass: TestPlugin, authoringClass: TestAuthoringPlugin});
 ```
 
 [registerPlugin](#registerplugin) should be called only once, but note that LARA might instantiate multiple instances of the same plugin (e.g. if the activity author adds multiple plugin instances to a page).
 
 Plugins can use all the functions documented below to modify LARA runtime or provide custom features. This documentation is generated automatically from TypeScript definitions and comments.
-
-##### Authoring implementation
-
-The first thing that should be done by the authoring class of the plugin script is call to [registerPlugin](#registerplugin).
-
-The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the authoring context object. The plugin constructor should expect [IPluginAuthoringContext](interfaces/ipluginruntimecontext.md) instance as the only argument.
-
-Example:
-
-```typescript
-class TestAuthoringPlugin {
-  constructor(context: IPluginAuthoringContext) {
-    console.log("Plugin initialized, id:", context.pluginId);
-  }
-}
-
-LARAPluginAPI.registerPlugin("testPlugin", TestAuthoringPlugin);
-```
-
-[registerPlugin](#registerplugin) should be called only once, but note that LARA might instantiate multiple instances of the same plugin (e.g. if the activity author adds multiple plugin instances to a page).
 
 #### Plugin styling
 

--- a/docs/lara-plugin-api/README.md
+++ b/docs/lara-plugin-api/README.md
@@ -22,7 +22,7 @@ Example of **webpack.config.js**:
   externals: {
     // LARA Plugin API implementation is exported to the window.LARA.PluginAPI_V3 namespace.
     '@concord-consortium/lara-plugin-api': 'LARA.PluginAPI_V3',
-    // Use React and ReactDOM provided by LARA, do not bundle an own copy.  
+    // Use React and ReactDOM provided by LARA, do not bundle an own copy.
     'react': 'React',
     'react-dom': 'ReactDOM',
   }
@@ -33,17 +33,72 @@ Finally, you can import LARA Plugin API anywhere in your code and benefit from a
 ```typescript
 import * as LARAPluginAPI from "@concord-consortium/lara-plugin-api";
 // (...)
-LARAPluginAPI.registerPlugin("test", Test);
+LARAPluginAPI.registerPlugin({ runtimeClass: TestPlugin, authoringClass: TestAuthoringPlugin });
 // (...)
 LARAPluginAPI.addSidebar({ content: "test sidebar" });
 // etc.
 ```
 
+If you do not wish to implement gui authoring mode you can omit the authoringClass in the `registerPlugin` call:
+
+```typescript
+LARAPluginAPI.registerPlugin({ runtimeClass: TestPlugin });
+```
+
+and then set `"guiAuthoring": false` in the manifest.json for each component of the plugin. Currently only the [model feedback](https://github.com/concord-consortium/model-feedback) plugin is the only V3 plugin that does not support gui authoring.
+
+#### Plugin manifests
+
+To limit the information need to install a plugin in LARA and to support a flexible and extensible plugin authoring system plugins use a file named `manifest.json` to expose their behavior and settings. The `manifest` part of the filename is a convention, but it must end in `.json`. The approved scripts CRUD interface in Lara reads these manifest files to automatically set the form fields and to store the `authoring_metadata` as a serialized json string. The `authoring_metadata` is then used at authoring time by Lara to determine where to place the plugin, either at the activity, embeddable or embeddable-decoration level.
+
+The `url` field can either be a fully qualified url or a relative one. Lara automatically converts relative urls to full qualified urls using the path to the manifest file as the start of the relative path.
+
+```json
+{
+  "name": "Test Plugin",
+  "label": "testPlugin",
+  "url": "plugin.js",
+  "version": 3,
+  "description": "This plugin provides an example manifest.json",
+  "authoring_metadata": {
+    "components": [
+      {
+        "label": "activity-component",
+        "name": "Activity Level",
+        "scope": "activity",
+        "guiAuthoring": true
+      },
+      {
+        "label": "embeddable-component",
+        "name": "Embeddable Level",
+        "scope": "embeddable",
+        "guiAuthoring": true
+      },
+      {
+        "label": "embeddable-decoration-component",
+        "name": "Embeddable Decoration Level",
+        "scope": "embeddable-decoration",
+        "decorates": [
+          "Embeddable::MultipleChoice",
+          "Embeddable::OpenResponse",
+          "MwInteractive",
+          "ImageInteractive",
+          "VideoInteractive"
+        ],
+        "guiAuthoring": true
+      }
+    ]
+  }
+}
+```
+
 #### Plugin implementation
 
-LARA Plugin is a regular JavaScript class (or constructor). There are no special requirements regarding its interface at the moment, but it's a subject to change. Always check [IPlugin](interfaces/iplugin.md) interface first.
+The LARA Plugin is divided into two regular JavaScript classes (or constructors), the runtime and authoring classes. There are no special requirements regarding their interfaces at the moment, but it's a subject to change. Always check the [IPlugin](interfaces/iplugin.md) interface first.
 
-The first thing that should be done by plugin script is call to [registerPlugin](#registerplugin).
+##### Runtime implementation
+
+The first thing that should be done by the runtime class of the plugin script is call to [registerPlugin](#registerplugin).
 
 The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the runtime context object. The plugin constructor should expect [IPluginRuntimeContext](interfaces/ipluginruntimecontext.md) instance as the only argument.
 
@@ -54,7 +109,7 @@ class TestPlugin {
   constructor(context: IPluginRuntimeContext) {
     console.log("Plugin initialized, id:", context.pluginId);
   }
-}  
+}
 
 LARAPluginAPI.registerPlugin("testPlugin", TestPlugin);
 ```
@@ -62,6 +117,26 @@ LARAPluginAPI.registerPlugin("testPlugin", TestPlugin);
 [registerPlugin](#registerplugin) should be called only once, but note that LARA might instantiate multiple instances of the same plugin (e.g. if the activity author adds multiple plugin instances to a page).
 
 Plugins can use all the functions documented below to modify LARA runtime or provide custom features. This documentation is generated automatically from TypeScript definitions and comments.
+
+##### Authoring implementation
+
+The first thing that should be done by the authoring class of the plugin script is call to [registerPlugin](#registerplugin).
+
+The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the authoring context object. The plugin constructor should expect [IPluginAuthoringContext](interfaces/ipluginruntimecontext.md) instance as the only argument.
+
+Example:
+
+```typescript
+class TestAuthoringPlugin {
+  constructor(context: IPluginAuthoringContext) {
+    console.log("Plugin initialized, id:", context.pluginId);
+  }
+}
+
+LARAPluginAPI.registerPlugin("testPlugin", TestAuthoringPlugin);
+```
+
+[registerPlugin](#registerplugin) should be called only once, but note that LARA might instantiate multiple instances of the same plugin (e.g. if the activity author adds multiple plugin instances to a page).
 
 #### Plugin styling
 
@@ -114,8 +189,6 @@ import "@concord-consortium/lara-plugin-api/normalize.css";
 * [IEventListeners](#ieventlisteners)
 * [IInteractiveAvailableEventHandler](#iinteractiveavailableeventhandler)
 * [ILogEventHandler](#ilogeventhandler)
-* [IPluginAuthoringConstructor](#ipluginauthoringconstructor)
-* [IPluginRuntimeConstructor](#ipluginruntimeconstructor)
 
 ### Functions
 
@@ -149,7 +222,7 @@ ___
 
 **Ƭ IInteractiveAvailableEventHandler**: *`function`*
 
-*Defined in [types.ts:219](../../lara-typescript/src/plugin-api/types.ts#L219)*
+*Defined in [types.ts:214](../../lara-typescript/src/plugin-api/types.ts#L214)*
 
 InteractiveAvailable event handler.
 
@@ -171,7 +244,7 @@ ___
 
 **Ƭ ILogEventHandler**: *`function`*
 
-*Defined in [types.ts:200](../../lara-typescript/src/plugin-api/types.ts#L200)*
+*Defined in [types.ts:195](../../lara-typescript/src/plugin-api/types.ts#L195)*
 
 Log event handler.
 
@@ -187,32 +260,6 @@ Log event handler.
 | event | [ILogData](interfaces/ilogdata.md) |
 
 **Returns:** `void`
-
-___
-<a id="ipluginauthoringconstructor"></a>
-
-###  IPluginAuthoringConstructor
-
-**Ƭ IPluginAuthoringConstructor**: *`object`*
-
-*Defined in [types.ts:13](../../lara-typescript/src/plugin-api/types.ts#L13)*
-
-Constructs a plugin given a IPluginAuthoringContext
-
-#### Type declaration
-
-___
-<a id="ipluginruntimeconstructor"></a>
-
-###  IPluginRuntimeConstructor
-
-**Ƭ IPluginRuntimeConstructor**: *`object`*
-
-*Defined in [types.ts:11](../../lara-typescript/src/plugin-api/types.ts#L11)*
-
-Constructs a plugin given a IPluginRuntimeContext
-
-#### Type declaration
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/iclassinfo.md
+++ b/docs/lara-plugin-api/interfaces/iclassinfo.md
@@ -27,7 +27,7 @@
 
 **● class_hash**: *`string`*
 
-*Defined in [types.ts:171](../../../lara-typescript/src/plugin-api/types.ts#L171)*
+*Defined in [types.ts:166](../../../lara-typescript/src/plugin-api/types.ts#L166)*
 
 ___
 <a id="id"></a>
@@ -36,7 +36,7 @@ ___
 
 **● id**: *`number`*
 
-*Defined in [types.ts:169](../../../lara-typescript/src/plugin-api/types.ts#L169)*
+*Defined in [types.ts:164](../../../lara-typescript/src/plugin-api/types.ts#L164)*
 
 ___
 <a id="offerings"></a>
@@ -45,7 +45,7 @@ ___
 
 **● offerings**: *[IOffering](ioffering.md)[]*
 
-*Defined in [types.ts:174](../../../lara-typescript/src/plugin-api/types.ts#L174)*
+*Defined in [types.ts:169](../../../lara-typescript/src/plugin-api/types.ts#L169)*
 
 ___
 <a id="students"></a>
@@ -54,7 +54,7 @@ ___
 
 **● students**: *[IUser](iuser.md)[]*
 
-*Defined in [types.ts:173](../../../lara-typescript/src/plugin-api/types.ts#L173)*
+*Defined in [types.ts:168](../../../lara-typescript/src/plugin-api/types.ts#L168)*
 
 ___
 <a id="teachers"></a>
@@ -63,7 +63,7 @@ ___
 
 **● teachers**: *[IUser](iuser.md)[]*
 
-*Defined in [types.ts:172](../../../lara-typescript/src/plugin-api/types.ts#L172)*
+*Defined in [types.ts:167](../../../lara-typescript/src/plugin-api/types.ts#L167)*
 
 ___
 <a id="uri"></a>
@@ -72,7 +72,7 @@ ___
 
 **● uri**: *`string`*
 
-*Defined in [types.ts:170](../../../lara-typescript/src/plugin-api/types.ts#L170)*
+*Defined in [types.ts:165](../../../lara-typescript/src/plugin-api/types.ts#L165)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
+++ b/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
@@ -27,7 +27,7 @@
 
 **● container**: *`HTMLElement`*
 
-*Defined in [types.ts:69](../../../lara-typescript/src/plugin-api/types.ts#L69)*
+*Defined in [types.ts:64](../../../lara-typescript/src/plugin-api/types.ts#L64)*
 
 Embeddable container.
 
@@ -38,7 +38,7 @@ ___
 
 **● getInteractiveState**: *`function`*
 
-*Defined in [types.ts:90](../../../lara-typescript/src/plugin-api/types.ts#L90)*
+*Defined in [types.ts:85](../../../lara-typescript/src/plugin-api/types.ts#L85)*
 
 Function that returns interactive state (Promise) or null if embeddable isn't interactive.
 
@@ -54,7 +54,7 @@ ___
 
 **● getReportingUrl**: *`function`*
 
-*Defined in [types.ts:100](../../../lara-typescript/src/plugin-api/types.ts#L100)*
+*Defined in [types.ts:95](../../../lara-typescript/src/plugin-api/types.ts#L95)*
 
 Function that returns reporting URL (Promise) or null if it's not an interactive or reporting URL is not defined. Note that reporting URL is defined in the interactive state (that can be obtained via #getInteractiveState method). If your code needs both interactive state and reporting URL, you can pass interactiveStatePromise as an argument to this method to limit number of network requests.
 
@@ -78,7 +78,7 @@ ___
 
 **● interactiveAvailable**: *`boolean`*
 
-*Defined in [types.ts:110](../../../lara-typescript/src/plugin-api/types.ts#L110)*
+*Defined in [types.ts:105](../../../lara-typescript/src/plugin-api/types.ts#L105)*
 
 True if the interactive is immediately available
 
@@ -89,7 +89,7 @@ ___
 
 **● laraJson**: *`any`*
 
-*Defined in [types.ts:88](../../../lara-typescript/src/plugin-api/types.ts#L88)*
+*Defined in [types.ts:83](../../../lara-typescript/src/plugin-api/types.ts#L83)*
 
 Serialized form of the embeddable. Defined by LARA export code, so it's format cannot be specified here. Example (interactive):
 
@@ -115,7 +115,7 @@ ___
 
 **● onInteractiveAvailable**: *`function`*
 
-*Defined in [types.ts:108](../../../lara-typescript/src/plugin-api/types.ts#L108)*
+*Defined in [types.ts:103](../../../lara-typescript/src/plugin-api/types.ts#L103)*
 
 Function that subscribes provided handler to event that gets called when the interactive's availablity changes. Normally an interactive starts as available unless click to play is enabled. When click to play is enabled the interactive starts as not available and this handler is called when the click to play overlay is hidden.
 

--- a/docs/lara-plugin-api/interfaces/iinteractiveavailableevent.md
+++ b/docs/lara-plugin-api/interfaces/iinteractiveavailableevent.md
@@ -25,7 +25,7 @@ Data passed to InteractiveAvailable event handlers.
 
 **● available**: *`boolean`*
 
-*Defined in [types.ts:213](../../../lara-typescript/src/plugin-api/types.ts#L213)*
+*Defined in [types.ts:208](../../../lara-typescript/src/plugin-api/types.ts#L208)*
 
 Availablility of interactive
 
@@ -36,7 +36,7 @@ ___
 
 **● container**: *`HTMLElement`*
 
-*Defined in [types.ts:209](../../../lara-typescript/src/plugin-api/types.ts#L209)*
+*Defined in [types.ts:204](../../../lara-typescript/src/plugin-api/types.ts#L204)*
 
 Interactive container of the interactive that was just started.
 

--- a/docs/lara-plugin-api/interfaces/iinteractivestate.md
+++ b/docs/lara-plugin-api/interfaces/iinteractivestate.md
@@ -27,7 +27,7 @@
 
 **● activity_name**: *`string`*
 
-*Defined in [types.ts:183](../../../lara-typescript/src/plugin-api/types.ts#L183)*
+*Defined in [types.ts:178](../../../lara-typescript/src/plugin-api/types.ts#L178)*
 
 ___
 <a id="id"></a>
@@ -36,7 +36,7 @@ ___
 
 **● id**: *`number`*
 
-*Defined in [types.ts:178](../../../lara-typescript/src/plugin-api/types.ts#L178)*
+*Defined in [types.ts:173](../../../lara-typescript/src/plugin-api/types.ts#L173)*
 
 ___
 <a id="interactive_name"></a>
@@ -45,7 +45,7 @@ ___
 
 **● interactive_name**: *`string`*
 
-*Defined in [types.ts:181](../../../lara-typescript/src/plugin-api/types.ts#L181)*
+*Defined in [types.ts:176](../../../lara-typescript/src/plugin-api/types.ts#L176)*
 
 ___
 <a id="interactive_state_url"></a>
@@ -54,7 +54,7 @@ ___
 
 **● interactive_state_url**: *`string`*
 
-*Defined in [types.ts:182](../../../lara-typescript/src/plugin-api/types.ts#L182)*
+*Defined in [types.ts:177](../../../lara-typescript/src/plugin-api/types.ts#L177)*
 
 ___
 <a id="key"></a>
@@ -63,7 +63,7 @@ ___
 
 **● key**: *`string`*
 
-*Defined in [types.ts:179](../../../lara-typescript/src/plugin-api/types.ts#L179)*
+*Defined in [types.ts:174](../../../lara-typescript/src/plugin-api/types.ts#L174)*
 
 ___
 <a id="raw_data"></a>
@@ -72,7 +72,7 @@ ___
 
 **● raw_data**: *`string`*
 
-*Defined in [types.ts:180](../../../lara-typescript/src/plugin-api/types.ts#L180)*
+*Defined in [types.ts:175](../../../lara-typescript/src/plugin-api/types.ts#L175)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ijwtclaims.md
+++ b/docs/lara-plugin-api/interfaces/ijwtclaims.md
@@ -26,7 +26,7 @@
 
 **● claims**: *[IPortalClaims](iportalclaims.md)*
 
-*Defined in [types.ts:148](../../../lara-typescript/src/plugin-api/types.ts#L148)*
+*Defined in [types.ts:143](../../../lara-typescript/src/plugin-api/types.ts#L143)*
 
 ___
 <a id="class_info_url"></a>
@@ -35,7 +35,7 @@ ___
 
 **● class_info_url**: *`string`*
 
-*Defined in [types.ts:147](../../../lara-typescript/src/plugin-api/types.ts#L147)*
+*Defined in [types.ts:142](../../../lara-typescript/src/plugin-api/types.ts#L142)*
 
 ___
 <a id="domain"></a>
@@ -44,7 +44,7 @@ ___
 
 **● domain**: *`string`*
 
-*Defined in [types.ts:144](../../../lara-typescript/src/plugin-api/types.ts#L144)*
+*Defined in [types.ts:139](../../../lara-typescript/src/plugin-api/types.ts#L139)*
 
 ___
 <a id="externalid"></a>
@@ -53,7 +53,7 @@ ___
 
 **● externalId**: *`number`*
 
-*Defined in [types.ts:146](../../../lara-typescript/src/plugin-api/types.ts#L146)*
+*Defined in [types.ts:141](../../../lara-typescript/src/plugin-api/types.ts#L141)*
 
 ___
 <a id="returnurl"></a>
@@ -62,7 +62,7 @@ ___
 
 **● returnUrl**: *`string`*
 
-*Defined in [types.ts:145](../../../lara-typescript/src/plugin-api/types.ts#L145)*
+*Defined in [types.ts:140](../../../lara-typescript/src/plugin-api/types.ts#L140)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ijwtresponse.md
+++ b/docs/lara-plugin-api/interfaces/ijwtresponse.md
@@ -23,7 +23,7 @@
 
 **● claims**: *[IJwtClaims](ijwtclaims.md) \| `__type`*
 
-*Defined in [types.ts:153](../../../lara-typescript/src/plugin-api/types.ts#L153)*
+*Defined in [types.ts:148](../../../lara-typescript/src/plugin-api/types.ts#L148)*
 
 ___
 <a id="token"></a>
@@ -32,7 +32,7 @@ ___
 
 **● token**: *`string`*
 
-*Defined in [types.ts:152](../../../lara-typescript/src/plugin-api/types.ts#L152)*
+*Defined in [types.ts:147](../../../lara-typescript/src/plugin-api/types.ts#L147)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ilogdata.md
+++ b/docs/lara-plugin-api/interfaces/ilogdata.md
@@ -26,7 +26,7 @@ That's the minimal set of properties that needs to be provided. All the other pr
 
 **● event**: *`string`*
 
-*Defined in [types.ts:191](../../../lara-typescript/src/plugin-api/types.ts#L191)*
+*Defined in [types.ts:186](../../../lara-typescript/src/plugin-api/types.ts#L186)*
 
 ___
 <a id="event_value"></a>
@@ -35,7 +35,7 @@ ___
 
 **● event_value**: *`any`*
 
-*Defined in [types.ts:192](../../../lara-typescript/src/plugin-api/types.ts#L192)*
+*Defined in [types.ts:187](../../../lara-typescript/src/plugin-api/types.ts#L187)*
 
 ___
 <a id="parameters"></a>
@@ -44,7 +44,7 @@ ___
 
 **● parameters**: *`any`*
 
-*Defined in [types.ts:193](../../../lara-typescript/src/plugin-api/types.ts#L193)*
+*Defined in [types.ts:188](../../../lara-typescript/src/plugin-api/types.ts#L188)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ioffering.md
+++ b/docs/lara-plugin-api/interfaces/ioffering.md
@@ -24,7 +24,7 @@
 
 **● id**: *`number`*
 
-*Defined in [types.ts:163](../../../lara-typescript/src/plugin-api/types.ts#L163)*
+*Defined in [types.ts:158](../../../lara-typescript/src/plugin-api/types.ts#L158)*
 
 ___
 <a id="name"></a>
@@ -33,7 +33,7 @@ ___
 
 **● name**: *`string`*
 
-*Defined in [types.ts:164](../../../lara-typescript/src/plugin-api/types.ts#L164)*
+*Defined in [types.ts:159](../../../lara-typescript/src/plugin-api/types.ts#L159)*
 
 ___
 <a id="url"></a>
@@ -42,7 +42,7 @@ ___
 
 **● url**: *`string`*
 
-*Defined in [types.ts:165](../../../lara-typescript/src/plugin-api/types.ts#L165)*
+*Defined in [types.ts:160](../../../lara-typescript/src/plugin-api/types.ts#L160)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ipluginauthoringcontext.md
+++ b/docs/lara-plugin-api/interfaces/ipluginauthoringcontext.md
@@ -28,7 +28,7 @@
 
 **● authoredState**: *`string` \| `null`*
 
-*Defined in [types.ts:121](../../../lara-typescript/src/plugin-api/types.ts#L121)*
+*Defined in [types.ts:116](../../../lara-typescript/src/plugin-api/types.ts#L116)*
 
 The authored configuration for this instance (if available).
 
@@ -39,7 +39,7 @@ ___
 
 **● componentLabel**: *`string`*
 
-*Defined in [types.ts:125](../../../lara-typescript/src/plugin-api/types.ts#L125)*
+*Defined in [types.ts:120](../../../lara-typescript/src/plugin-api/types.ts#L120)*
 
 The label of the plugin component.
 
@@ -50,7 +50,7 @@ ___
 
 **● container**: *`HTMLElement`*
 
-*Defined in [types.ts:123](../../../lara-typescript/src/plugin-api/types.ts#L123)*
+*Defined in [types.ts:118](../../../lara-typescript/src/plugin-api/types.ts#L118)*
 
 Reserved HTMLElement for the plugin output.
 
@@ -61,7 +61,7 @@ ___
 
 **● name**: *`string`*
 
-*Defined in [types.ts:115](../../../lara-typescript/src/plugin-api/types.ts#L115)*
+*Defined in [types.ts:110](../../../lara-typescript/src/plugin-api/types.ts#L110)*
 
 Name of the plugin
 
@@ -72,7 +72,7 @@ ___
 
 **● pluginId**: *`number`*
 
-*Defined in [types.ts:119](../../../lara-typescript/src/plugin-api/types.ts#L119)*
+*Defined in [types.ts:114](../../../lara-typescript/src/plugin-api/types.ts#L114)*
 
 Plugin instance ID.
 
@@ -83,7 +83,7 @@ ___
 
 **● saveAuthoredPluginState**: *`function`*
 
-*Defined in [types.ts:133](../../../lara-typescript/src/plugin-api/types.ts#L133)*
+*Defined in [types.ts:128](../../../lara-typescript/src/plugin-api/types.ts#L128)*
 
 Function that saves the authoring state for the plugin.
 
@@ -111,7 +111,7 @@ ___
 
 **● url**: *`string`*
 
-*Defined in [types.ts:117](../../../lara-typescript/src/plugin-api/types.ts#L117)*
+*Defined in [types.ts:112](../../../lara-typescript/src/plugin-api/types.ts#L112)*
 
 Url from which the plugin was loaded.
 

--- a/docs/lara-plugin-api/interfaces/ipluginruntimecontext.md
+++ b/docs/lara-plugin-api/interfaces/ipluginruntimecontext.md
@@ -35,7 +35,7 @@
 
 **● authoredState**: *`string` \| `null`*
 
-*Defined in [types.ts:23](../../../lara-typescript/src/plugin-api/types.ts#L23)*
+*Defined in [types.ts:18](../../../lara-typescript/src/plugin-api/types.ts#L18)*
 
 The authored configuration for this instance (if available).
 
@@ -46,9 +46,9 @@ ___
 
 **● container**: *`HTMLElement`*
 
-*Defined in [types.ts:27](../../../lara-typescript/src/plugin-api/types.ts#L27)*
+*Defined in [types.ts:22](../../../lara-typescript/src/plugin-api/types.ts#L22)*
 
-HTMLElement created by LARA for the plugin to render its output.
+HTMLElement created by LARA for the plugin to use to render both its runtime and authoring output.
 
 ___
 <a id="getclassinfo"></a>
@@ -57,7 +57,7 @@ ___
 
 **● getClassInfo**: *`function`*
 
-*Defined in [types.ts:46](../../../lara-typescript/src/plugin-api/types.ts#L46)*
+*Defined in [types.ts:41](../../../lara-typescript/src/plugin-api/types.ts#L41)*
 
 Function that returns class details (Promise) or null if class info is not available.
 
@@ -73,7 +73,7 @@ ___
 
 **● getFirebaseJwt**: *`function`*
 
-*Defined in [types.ts:48](../../../lara-typescript/src/plugin-api/types.ts#L48)*
+*Defined in [types.ts:43](../../../lara-typescript/src/plugin-api/types.ts#L43)*
 
 Function that returns JWT (Promise) for given app name.
 
@@ -95,7 +95,7 @@ ___
 
 **● learnerState**: *`string` \| `null`*
 
-*Defined in [types.ts:25](../../../lara-typescript/src/plugin-api/types.ts#L25)*
+*Defined in [types.ts:20](../../../lara-typescript/src/plugin-api/types.ts#L20)*
 
 The saved learner data for this instance (if available).
 
@@ -106,7 +106,7 @@ ___
 
 **● log**: *`function`*
 
-*Defined in [types.ts:64](../../../lara-typescript/src/plugin-api/types.ts#L64)*
+*Defined in [types.ts:59](../../../lara-typescript/src/plugin-api/types.ts#L59)*
 
 Logs event to the CC Log Server. Note that logging must be enabled for a given activity. Either by setting URL param logging=true or by enabling logging in Portal.
 
@@ -139,7 +139,7 @@ ___
 
 **● name**: *`string`*
 
-*Defined in [types.ts:17](../../../lara-typescript/src/plugin-api/types.ts#L17)*
+*Defined in [types.ts:12](../../../lara-typescript/src/plugin-api/types.ts#L12)*
 
 Name of the plugin
 
@@ -150,7 +150,7 @@ ___
 
 **● pluginId**: *`number`*
 
-*Defined in [types.ts:21](../../../lara-typescript/src/plugin-api/types.ts#L21)*
+*Defined in [types.ts:16](../../../lara-typescript/src/plugin-api/types.ts#L16)*
 
 Plugin instance ID.
 
@@ -161,7 +161,7 @@ ___
 
 **● remoteEndpoint**: *`string` \| `null`*
 
-*Defined in [types.ts:31](../../../lara-typescript/src/plugin-api/types.ts#L31)*
+*Defined in [types.ts:26](../../../lara-typescript/src/plugin-api/types.ts#L26)*
 
 The portal remote endpoint (if available).
 
@@ -172,7 +172,7 @@ ___
 
 **● runId**: *`number`*
 
-*Defined in [types.ts:29](../../../lara-typescript/src/plugin-api/types.ts#L29)*
+*Defined in [types.ts:24](../../../lara-typescript/src/plugin-api/types.ts#L24)*
 
 The run ID for the current LARA run.
 
@@ -183,7 +183,7 @@ ___
 
 **● saveLearnerPluginState**: *`function`*
 
-*Defined in [types.ts:44](../../../lara-typescript/src/plugin-api/types.ts#L44)*
+*Defined in [types.ts:39](../../../lara-typescript/src/plugin-api/types.ts#L39)*
 
 Function that saves the users state for the plugin. Note that plugins can have different scopes, e.g. activity or a single page. If the plugin instance is added to the activity, its state will be shared across all the pages. If multiple plugin instances are added to various pages, their state will be different on every page.
 
@@ -211,7 +211,7 @@ ___
 
 **● url**: *`string`*
 
-*Defined in [types.ts:19](../../../lara-typescript/src/plugin-api/types.ts#L19)*
+*Defined in [types.ts:14](../../../lara-typescript/src/plugin-api/types.ts#L14)*
 
 Url from which the plugin was loaded.
 
@@ -222,7 +222,7 @@ ___
 
 **● userEmail**: *`string` \| `null`*
 
-*Defined in [types.ts:33](../../../lara-typescript/src/plugin-api/types.ts#L33)*
+*Defined in [types.ts:28](../../../lara-typescript/src/plugin-api/types.ts#L28)*
 
 The current user email address (if available).
 
@@ -233,7 +233,7 @@ ___
 
 **● wrappedEmbeddable**: *[IEmbeddableRuntimeContext](iembeddableruntimecontext.md) \| `null`*
 
-*Defined in [types.ts:50](../../../lara-typescript/src/plugin-api/types.ts#L50)*
+*Defined in [types.ts:45](../../../lara-typescript/src/plugin-api/types.ts#L45)*
 
 Wrapped embeddable runtime context if plugin is wrapping some embeddable.
 

--- a/docs/lara-plugin-api/interfaces/iportalclaims.md
+++ b/docs/lara-plugin-api/interfaces/iportalclaims.md
@@ -25,7 +25,7 @@
 
 **● class_hash**: *`string`*
 
-*Defined in [types.ts:139](../../../lara-typescript/src/plugin-api/types.ts#L139)*
+*Defined in [types.ts:134](../../../lara-typescript/src/plugin-api/types.ts#L134)*
 
 ___
 <a id="offering_id"></a>
@@ -34,7 +34,7 @@ ___
 
 **● offering_id**: *`number`*
 
-*Defined in [types.ts:140](../../../lara-typescript/src/plugin-api/types.ts#L140)*
+*Defined in [types.ts:135](../../../lara-typescript/src/plugin-api/types.ts#L135)*
 
 ___
 <a id="user_id"></a>
@@ -43,7 +43,7 @@ ___
 
 **● user_id**: *`string`*
 
-*Defined in [types.ts:138](../../../lara-typescript/src/plugin-api/types.ts#L138)*
+*Defined in [types.ts:133](../../../lara-typescript/src/plugin-api/types.ts#L133)*
 
 ___
 <a id="user_type"></a>
@@ -52,7 +52,7 @@ ___
 
 **● user_type**: *"learner" \| "teacher"*
 
-*Defined in [types.ts:137](../../../lara-typescript/src/plugin-api/types.ts#L137)*
+*Defined in [types.ts:132](../../../lara-typescript/src/plugin-api/types.ts#L132)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/iregisterpluginoptions.md
+++ b/docs/lara-plugin-api/interfaces/iregisterpluginoptions.md
@@ -21,7 +21,7 @@
 
 ### `<Optional>` authoringClass
 
-**● authoringClass**: *[IPluginAuthoringConstructor](../#ipluginauthoringconstructor)*
+**● authoringClass**: *`undefined` \| `object`*
 
 *Defined in [types.ts:7](../../../lara-typescript/src/plugin-api/types.ts#L7)*
 
@@ -30,9 +30,11 @@ ___
 
 ###  runtimeClass
 
-**● runtimeClass**: *[IPluginRuntimeConstructor](../#ipluginruntimeconstructor)*
+**● runtimeClass**: *`object`*
 
 *Defined in [types.ts:6](../../../lara-typescript/src/plugin-api/types.ts#L6)*
+
+#### Type declaration
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/iuser.md
+++ b/docs/lara-plugin-api/interfaces/iuser.md
@@ -24,7 +24,7 @@
 
 **● first_name**: *`string`*
 
-*Defined in [types.ts:158](../../../lara-typescript/src/plugin-api/types.ts#L158)*
+*Defined in [types.ts:153](../../../lara-typescript/src/plugin-api/types.ts#L153)*
 
 ___
 <a id="id"></a>
@@ -33,7 +33,7 @@ ___
 
 **● id**: *`string`*
 
-*Defined in [types.ts:157](../../../lara-typescript/src/plugin-api/types.ts#L157)*
+*Defined in [types.ts:152](../../../lara-typescript/src/plugin-api/types.ts#L152)*
 
 ___
 <a id="last_name"></a>
@@ -42,7 +42,7 @@ ___
 
 **● last_name**: *`string`*
 
-*Defined in [types.ts:159](../../../lara-typescript/src/plugin-api/types.ts#L159)*
+*Defined in [types.ts:154](../../../lara-typescript/src/plugin-api/types.ts#L154)*
 
 ___
 

--- a/lara-typescript/src/lib/plugin-context.ts
+++ b/lara-typescript/src/lib/plugin-context.ts
@@ -15,7 +15,7 @@ interface IPluginCommonOptions {
   pluginId: number;
   /** The authored configuration for this instance (if available). */
   authoredState: string | null;
-  /** Reserved HTMLElement for the plugin output. */
+  /** HTMLElement created by LARA for the plugin to use to render both its runtime and authoring output. */
   container: HTMLElement;
   /** Name of plugin component */
   componentLabel: string;

--- a/lara-typescript/src/lib/plugins.ts
+++ b/lara-typescript/src/lib/plugins.ts
@@ -1,4 +1,4 @@
-import { IPluginRuntimeConstructor, IPluginAuthoringConstructor, IRegisterPluginOptions } from "../plugin-api";
+import { IRegisterPluginOptions } from "../plugin-api";
 import { IPluginContextOptions,
          IPluginRuntimeContextOptions,
          IPluginAuthoringContextOptions,
@@ -46,7 +46,7 @@ export const initPlugin = (label: string, options: IPluginContextOptions) => {
 };
 
 const initRuntimePlugin = (label: string, context: IPluginRuntimeContextOptions) => {
-  const Constructor: IPluginRuntimeConstructor = pluginClasses[label].runtimeClass;
+  const Constructor = pluginClasses[label].runtimeClass;
   if (typeof Constructor === "function") {
     try {
       const plugin = new Constructor(generateRuntimePluginContext(context));

--- a/lara-typescript/src/plugin-api/README.md
+++ b/lara-typescript/src/plugin-api/README.md
@@ -4,17 +4,17 @@
 
 #### Setup and webpack configuration
 
-LARA API will be available under `window.LARA.PluginAPI_V3` object / namespace once the plugin is initialized by LARA. 
+LARA API will be available under `window.LARA.PluginAPI_V3` object / namespace once the plugin is initialized by LARA.
 
-However, if the plugin is implemented using TypeScript, the best way to get type checking and hints in your IDE is to 
+However, if the plugin is implemented using TypeScript, the best way to get type checking and hints in your IDE is to
 install [LARA Plugin API NPM package](https://www.npmjs.com/package/@concord-consortium/lara-plugin-api):
 
 ```
 npm i --save-dev @concord-consortium/lara-plugin-api
 ```
 
-Then, you need to configure [webpack externals](https://webpack.js.org/configuration/externals/), so webpack does not 
-bundle Plugin API code but looks for global `window.LARA.PluginAPI_V3` object instead (and do the same for React if the 
+Then, you need to configure [webpack externals](https://webpack.js.org/configuration/externals/), so webpack does not
+bundle Plugin API code but looks for global `window.LARA.PluginAPI_V3` object instead (and do the same for React if the
 plugin uses it).
 
 Example of **webpack.config.js**:
@@ -22,7 +22,7 @@ Example of **webpack.config.js**:
   externals: {
     // LARA Plugin API implementation is exported to the window.LARA.PluginAPI_V3 namespace.
     '@concord-consortium/lara-plugin-api': 'LARA.PluginAPI_V3',
-    // Use React and ReactDOM provided by LARA, do not bundle an own copy.  
+    // Use React and ReactDOM provided by LARA, do not bundle an own copy.
     'react': 'React',
     'react-dom': 'ReactDOM',
   }
@@ -33,21 +33,75 @@ Finally, you can import LARA Plugin API anywhere in your code and benefit from a
 ```typescript
 import * as LARAPluginAPI from "@concord-consortium/lara-plugin-api";
 // (...)
-LARAPluginAPI.registerPlugin("test", Test);
+LARAPluginAPI.registerPlugin({ runtimeClass: TestPlugin, authoringClass: TestAuthoringPlugin });
 // (...)
 LARAPluginAPI.addSidebar({ content: "test sidebar" });
 // etc.
 ```
 
+If you do not wish to implement gui authoring mode you can omit the authoringClass in the `registerPlugin` call:
+
+```typescript
+LARAPluginAPI.registerPlugin({ runtimeClass: TestPlugin });
+```
+
+and then set `"guiAuthoring": false` in the manifest.json for each component of the plugin.  Currently only the [model feedback](https://github.com/concord-consortium/model-feedback) plugin is the only V3 plugin that does not support gui authoring.
+
+#### Plugin manifests
+
+To limit the information need to install a plugin in LARA and to support a flexible and extensible plugin authoring system plugins use a file named `manifest.json` to expose their behavior and settings.  The `manifest` part of the filename is a convention, but it must end in `.json`.  The approved scripts CRUD interface in Lara reads these manifest files to automatically set the form fields and to store the `authoring_metadata` as a serialized json string.  The `authoring_metadata` is then used at authoring time by Lara to determine where to place the plugin, either at the activity, embeddable or embeddable-decoration level.
+
+The `url` field can either be a fully qualified url or a relative one.  Lara automatically converts relative urls to full qualified urls using the path to the manifest file as the start of the relative path.
+
+```json
+{
+  "name": "Test Plugin",
+  "label": "testPlugin",
+  "url": "plugin.js",
+  "version": 3,
+  "description": "This plugin provides an example manifest.json",
+  "authoring_metadata": {
+    "components": [
+      {
+        "label": "activity-component",
+        "name": "Activity Level",
+        "scope": "activity",
+        "guiAuthoring": true
+      },
+      {
+        "label": "embeddable-component",
+        "name": "Embeddable Level",
+        "scope": "embeddable",
+        "guiAuthoring": true
+      },
+      {
+        "label": "embeddable-decoration-component",
+        "name": "Embeddable Decoration Level",
+        "scope": "embeddable-decoration",
+        "decorates": [
+          "Embeddable::MultipleChoice",
+          "Embeddable::OpenResponse",
+          "MwInteractive",
+          "ImageInteractive",
+          "VideoInteractive"
+        ],
+        "guiAuthoring": true
+      }
+    ]
+  }
+}
+```
+
 #### Plugin implementation
 
-LARA Plugin is a regular JavaScript class (or constructor). There are no special requirements regarding its interface 
-at the moment, but it's a subject to change. Always check [IPlugin](interfaces/iplugin.md) interface first.
+The LARA Plugin is divided into two regular JavaScript classes (or constructors), the runtime and authoring classes.  There are no special requirements regarding their interfaces at the moment, but it's a subject to change. Always check the [IPlugin](interfaces/iplugin.md) interface first.
 
-The first thing that should be done by plugin script is call to [registerPlugin](#registerplugin).
+##### Runtime implementation
 
-The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the runtime context 
-object. The plugin constructor should expect [IPluginRuntimeContext](interfaces/ipluginruntimecontext.md) instance as the only 
+The first thing that should be done by the runtime class of the plugin script is call to [registerPlugin](#registerplugin).
+
+The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the runtime context
+object. The plugin constructor should expect [IPluginRuntimeContext](interfaces/ipluginruntimecontext.md) instance as the only
 argument.
 
 Example:
@@ -56,7 +110,7 @@ class TestPlugin {
   constructor(context: IPluginRuntimeContext) {
     console.log("Plugin initialized, id:", context.pluginId);
   }
-}  
+}
 
 LARAPluginAPI.registerPlugin("testPlugin", TestPlugin);
 ```
@@ -67,17 +121,38 @@ of the same plugin (e.g. if the activity author adds multiple plugin instances t
 Plugins can use all the functions documented below to modify LARA runtime or provide custom features. This documentation
 is generated automatically from TypeScript definitions and comments.
 
+##### Authoring implementation
+
+The first thing that should be done by the authoring class of the plugin script is call to [registerPlugin](#registerplugin).
+
+The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the authoring context
+object. The plugin constructor should expect [IPluginAuthoringContext](interfaces/ipluginruntimecontext.md) instance as the only
+argument.
+
+Example:
+```typescript
+class TestAuthoringPlugin {
+  constructor(context: IPluginAuthoringContext) {
+    console.log("Plugin initialized, id:", context.pluginId);
+  }
+}
+
+LARAPluginAPI.registerPlugin("testPlugin", TestAuthoringPlugin);
+```
+
+[registerPlugin](#registerplugin) should be called only once, but note that LARA might instantiate multiple instances
+of the same plugin (e.g. if the activity author adds multiple plugin instances to a page).
 
 #### Plugin styling
 
 Note that LARA Plugins will be executed in LARA context which includes a lot of different CSS styles and rules.
-Sometimes it might be okay for plugin to inherit these styles and overwrite when necessary. In other cases, 
+Sometimes it might be okay for plugin to inherit these styles and overwrite when necessary. In other cases,
 it might be useful for plugin to reset and normalize its containers, so it's less dependant on LARA styles.
-Also, LARA styles obviously casue plugin content to be rendered differently in LARA and in some external 
+Also, LARA styles obviously casue plugin content to be rendered differently in LARA and in some external
 demo or authoring pages provided by plugin.
 
 To avoid these inconsistencies, plugins can use CSS reset/normalize helpers provided by LARA.
-Reset CSS rules are simply applied to all the containers with `normalized-container` class name. 
+Reset CSS rules are simply applied to all the containers with `normalized-container` class name.
 Plugins can use this case in its top-level container, e.g.:
 
 ```javascript
@@ -90,7 +165,7 @@ render() {
 }
 ```
 
-Also, these reset styles are part of the NPM package, so plugins can include them in demo and authoring pages 
+Also, these reset styles are part of the NPM package, so plugins can include them in demo and authoring pages
 to ensure that rendering is consistent:
 
 ```javascript

--- a/lara-typescript/src/plugin-api/README.md
+++ b/lara-typescript/src/plugin-api/README.md
@@ -96,11 +96,8 @@ The `url` field can either be a fully qualified url or a relative one.  Lara aut
 
 The LARA Plugin is divided into two regular JavaScript classes (or constructors), the runtime and authoring classes.  There are no special requirements regarding their interfaces at the moment, but it's a subject to change. Always check the [IPlugin](interfaces/iplugin.md) interface first.
 
-##### Runtime implementation
-
-The first thing that should be done by the runtime class of the plugin script is call to [registerPlugin](#registerplugin).
-
-The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the runtime context
+Once the two JavaScript classes are defined the plugin script should call [registerPlugin](#registerplugin) to register the classes with LARA.
+The plugin will be initialized by LARA automatically when needed once it is registered. LARA calls its constructor and provides the runtime context
 object. The plugin constructor should expect [IPluginRuntimeContext](interfaces/ipluginruntimecontext.md) instance as the only
 argument.
 
@@ -108,11 +105,17 @@ Example:
 ```typescript
 class TestPlugin {
   constructor(context: IPluginRuntimeContext) {
-    console.log("Plugin initialized, id:", context.pluginId);
+    console.log("Test Runtime Plugin initialized, id:", context.pluginId);
   }
 }
 
-LARAPluginAPI.registerPlugin("testPlugin", TestPlugin);
+class TestAuthoringPlugin {
+  constructor(context: IPluginAuthoringContext) {
+    console.log("Test Authoring Plugin initialized, id:", context.pluginId);
+  }
+}
+
+LARAPluginAPI.registerPlugin({runtimeClass: TestPlugin, authoringClass: TestAuthoringPlugin});
 ```
 
 [registerPlugin](#registerplugin) should be called only once, but note that LARA might instantiate multiple instances
@@ -121,27 +124,6 @@ of the same plugin (e.g. if the activity author adds multiple plugin instances t
 Plugins can use all the functions documented below to modify LARA runtime or provide custom features. This documentation
 is generated automatically from TypeScript definitions and comments.
 
-##### Authoring implementation
-
-The first thing that should be done by the authoring class of the plugin script is call to [registerPlugin](#registerplugin).
-
-The Plugin will be initialized by LARA automatically. LARA calls its constructor and provides the authoring context
-object. The plugin constructor should expect [IPluginAuthoringContext](interfaces/ipluginruntimecontext.md) instance as the only
-argument.
-
-Example:
-```typescript
-class TestAuthoringPlugin {
-  constructor(context: IPluginAuthoringContext) {
-    console.log("Plugin initialized, id:", context.pluginId);
-  }
-}
-
-LARAPluginAPI.registerPlugin("testPlugin", TestAuthoringPlugin);
-```
-
-[registerPlugin](#registerplugin) should be called only once, but note that LARA might instantiate multiple instances
-of the same plugin (e.g. if the activity author adds multiple plugin instances to a page).
 
 #### Plugin styling
 

--- a/lara-typescript/src/plugin-api/types.ts
+++ b/lara-typescript/src/plugin-api/types.ts
@@ -3,14 +3,9 @@ export interface IPlugin {
 }
 
 export interface IRegisterPluginOptions {
-  runtimeClass: IPluginRuntimeConstructor;
-  authoringClass?: IPluginAuthoringConstructor;
+  runtimeClass: new(runtimeContext: IPluginRuntimeContext) => IPlugin;
+  authoringClass?: new(authoringContext: IPluginAuthoringContext) => IPlugin;
 }
-
-/** Constructs a plugin given a IPluginRuntimeContext */
-export type IPluginRuntimeConstructor = new(runtimeContext: IPluginRuntimeContext) => IPlugin;
-/** Constructs a plugin given a IPluginAuthoringContext */
-export type IPluginAuthoringConstructor = new(authoringContext: IPluginAuthoringContext) => IPlugin;
 
 export interface IPluginRuntimeContext {
   /** Name of the plugin */
@@ -23,7 +18,7 @@ export interface IPluginRuntimeContext {
   authoredState: string | null;
   /** The saved learner data for this instance (if available). */
   learnerState: string | null;
-  /** HTMLElement created by LARA for the plugin to render its output. */
+  /** HTMLElement created by LARA for the plugin to use to render both its runtime and authoring output. */
   container: HTMLElement;
   /** The run ID for the current LARA run. */
   runId: number;


### PR DESCRIPTION
- converted registerPlugin to use new single object parameter signature
- added authoring information to plugin api readme, including which plugins don't support authoring
- added manifest section to plugin api readme
- removed unneeded constructor type aliases to reduce confusion in the generated docs