### PR TITLE
Fix show_index not handled correctly [#166640186]

### DIFF
--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -39,7 +39,7 @@ class SequencesController < ApplicationController
       format.html do
         raise_error_if_not_authorized_run(@sequence_run)
         if !params[:sequence_run_key]
-          redirect_to append_white_list_params sequence_with_sequence_run_key_path(@sequence, @sequence_run.key)
+          redirect_to append_white_list_params(sequence_with_sequence_run_key_path(@sequence, @sequence_run.key), sequence_param_whitelist)
           return
         end
         if @sequence_run.has_been_run

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -194,7 +194,12 @@ module ApplicationHelper
   # when the functionality is extended, the white-list could be located in
   # a more reasonable location in the code-base.
   def default_param_whitelist
-      ["mode"]
+    ["mode"]
+  end
+
+  # adds "show_index" to the default whitelisted parameters for sequences
+  def sequence_param_whitelist
+    default_param_whitelist << "show_index"
   end
 
   def teacher_content

--- a/spec/controllers/sequences_controller_spec.rb
+++ b/spec/controllers/sequences_controller_spec.rb
@@ -78,6 +78,10 @@ describe SequencesController do
         get :show, id: sequence.id, sequence_run_key: sequence_run.key
         expect(response).to redirect_to(sequence_activity_with_run_path(sequence.id, activity.id, run))
       end
+      it "does not redirect to the most recent activity if the show_index parameter is present" do
+        get :show, id: sequence.id, sequence_run_key: sequence_run.key, show_index: true
+        expect(response).not_to redirect_to(sequence_activity_with_run_path(sequence.id, activity.id, run))
+      end
     end
 
   end


### PR DESCRIPTION
Adds show_index to the list of whitelisted parameters when showing a sequence run.