### PR TITLE
Fix plugin wrapping of interactives when no info/assessment block is defined  [#166724753]

### DIFF
--- a/app/helpers/interactive_page_helper.rb
+++ b/app/helpers/interactive_page_helper.rb
@@ -26,6 +26,14 @@ module InteractivePageHelper
     return link_to name, runnable_activity_page_path(activity,page), opts
   end
 
+  def is_wrapping_plugin?(e)
+    e.respond_to?(:wrapping_plugin?) && e.wrapping_plugin?
+  end
+
+  def main_section_wrapping_plugins(page, run)
+    page.main_visible_embeddables.select { |e| is_wrapping_plugin?(e) }
+  end
+
   def main_section_visible_embeddables(page, run)
     finder = Embeddable::AnswerFinder.new(run)
     # Limit visible embeddables to ones that do not belong to any section.

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -7,7 +7,7 @@
         - is_likert = e.is_a?(Embeddable::MultipleChoiceAnswer) && e.is_likert
         - css_class = e.is_a?(Embeddable::Xhtml) ? 'challenge' : is_likert ? "likert" : ""
         - css_class += e.respond_to?(:is_full_width) && e.is_full_width ? " full-width-item" : ""
-        - css_class += e.respond_to?(:wrapping_plugin?) && e.wrapping_plugin? ? " hidden" : ""
+        - css_class += is_wrapping_plugin?(e) ? " hidden" : ""
         - if e.show_in_runtime?
           -# e variable is actually either embeddable (for interactives, plugins, etc.) or embeddable answer
           -# (open response, multiple choice and all the question types). If the latter, get a real question object.

--- a/app/views/interactive_pages/_list_wrapping_plugins.html.haml
+++ b/app/views/interactive_pages/_list_wrapping_plugins.html.haml
@@ -1,0 +1,7 @@
+- wrapping_plugins.each do |e|
+  - css_class = "hidden"
+  - css_class += e.respond_to?(:is_full_width) && e.is_full_width ? " full-width-item" : ""
+  .question{ class: css_class, id: e.embeddable_dom_id }
+    .embeddable-container
+      - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
+      = render(partial: partial_name, locals: { embeddable: e })

--- a/app/views/interactive_pages/_show.html.haml
+++ b/app/views/interactive_pages/_show.html.haml
@@ -12,6 +12,7 @@
       = render partial: 'interactive_pages/interactive', locals: {page: page, layout: layout}
 
   .questions-mod.ui-block-2{ :class => page.embeddable_display_mode == 'carousel' ? 'jcarousel' : '' }
+    -# Wrapping plugins don't necessarily wrap items in the assessment block, so they need to be rendered separately.
     = render partial: 'interactive_pages/list_wrapping_plugins', locals: {wrapping_plugins: main_section_wrapping_plugins(page, @run)}
     - if page.show_info_assessment
       = render partial: 'interactive_pages/list_embeddables', locals: {embeddables: main_section_visible_embeddables(page, @run).select {|e| !is_wrapping_plugin?(e) }}

--- a/app/views/interactive_pages/_show.html.haml
+++ b/app/views/interactive_pages/_show.html.haml
@@ -12,8 +12,9 @@
       = render partial: 'interactive_pages/interactive', locals: {page: page, layout: layout}
 
   .questions-mod.ui-block-2{ :class => page.embeddable_display_mode == 'carousel' ? 'jcarousel' : '' }
+    = render partial: 'interactive_pages/list_wrapping_plugins', locals: {wrapping_plugins: main_section_wrapping_plugins(page, @run)}
     - if page.show_info_assessment
-      = render partial: 'interactive_pages/list_embeddables', locals: {embeddables: main_section_visible_embeddables(page, @run)}
+      = render partial: 'interactive_pages/list_embeddables', locals: {embeddables: main_section_visible_embeddables(page, @run).select {|e| !is_wrapping_plugin?(e) }}
 
     .buttons
       - if page.embeddable_display_mode == 'carousel' && page.visible_embeddables.length > 1


### PR DESCRIPTION
Update:
Instead of removing check for page.show_info_assessment I instead created a new view that outputs all wrapper plugins before the if check.  The view that lists embeddables under the if is now provided an array without the wrapper plugins.

Originally:
Removes check for page.show_info_assessment before listing embeddables.  Since plugins are treated as hidden embeddables the plugin show code was being skipped if no info or assessment blocks were added to the page.