### PR TITLE
Yet another fix of interactive sizing

### DIFF
--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -1,6 +1,22 @@
 /*global $ */
 
 function interactiveSizing () {
+  function setInteractiveWidth($iframe, width) {
+    $iframe.css('width', width);
+    var $header = $iframe.parents(".embeddable-container").find(".question-hdr")
+    if ($header.length > 0) {
+      $header.css('width', width);
+    }
+  }
+
+  function limitInteractiveHeight($iframe, maxHeight) {
+    if ($iframe.height() > maxHeight) {
+      var scale = (maxHeight / $iframe.height()) * 100 + '%';
+      setInteractiveWidth($iframe, scale);
+      $iframe.css('height', maxHeight);
+    }
+  }
+
   function setSize () {
     var $iframe = $(this);
     var aspectRatio = $iframe.data('aspect-ratio');
@@ -8,35 +24,43 @@ function interactiveSizing () {
     var maxHeight = window.innerHeight;
 
     var $pinned = $iframe.parents('.pinned');
-    if ($pinned.length > 0) {
-      // If interactive is pinned, make sure that maxHeight calculations don't cause interactive to become unpinned
-      // (as it gets too tall). Calculate the current difference between height of the interactive and its container.
-      // That will automatically handle question header (when interactive saves state) and all the possible margins
-      // and padding. Also, take into account a pinned interactive offset (space between the window top border and
-      // the interactive container top edge).
+    var isPinned = $pinned.length > 0;
+    var multipleInteractives = isPinned && $pinned.children().length > 1;
+
+    // Reset dimensions.
+    setInteractiveWidth($iframe, '100%');
+
+    if (isPinned && multipleInteractives) {
+      // This case is treated in a basic way for now. MAX setting doesn't make much sense.
+      // We just set aspect ratio (either provided by user or interactive) and we don't limit interactive height.
+      // So, interactives might get 'unpinned' as a result. It could have been treated better in the future,
+      // if there's a need for that.
+      $iframe.css('height', $iframe.width() / aspectRatio);
+      return;
+    }
+
+    if (isPinned) {
+      // If interactive is pinned (and there's only one interactive), make sure that maxHeight calculations don't
+      // cause interactive to become unpinned (as it gets too tall). Calculate the current difference between height
+      // of the interactive and its container. That will automatically handle question header (when interactive saves
+      // state) and all the possible margins and padding. Also, take into account a pinned interactive offset (space
+      // between the window top border and the interactive container top edge).
       var headersHeight = $pinned.height() - $iframe.height();
       maxHeight -= headersHeight + window.SCROLL_INTERACTIVE_MOD_OFFSET;
     }
-    $iframe.attr('width', '100%');
 
     if (resizeMethod === 'MAX') {
-      $iframe.height(maxHeight);
+      $iframe.css('height', maxHeight);
     }
     else if (resizeMethod === 'MANUAL') {
-      $iframe.height($iframe.width() / aspectRatio);
+      $iframe.css('height', $iframe.width() / aspectRatio);
     }
     else /* (resizeMethod === 'DEFAULT') */ {
-      $iframe.height($iframe.width() / aspectRatio);
-      if ($iframe.height() > maxHeight) {
-        var scale = (maxHeight / $iframe.height()) * 100 + '%';
-        $iframe.attr('width', scale);
-        $iframe.height(maxHeight);
-        // Rescale question header too (it's present when interactive saves state).
-        var $header = $iframe.parents(".embeddable-container").find(".question-hdr")
-        if ($header.length > 0) {
-          $header.css('width', scale);
-        }
-      }
+      $iframe.css('height', $iframe.width() / aspectRatio);
+      // PJ [7/16/2019]: Why is the height limited only in the DEFAULT mode, but not in MANUAL?
+      // I don't find this intuitive, but it has been implemented because of some issues described
+      // in this story: https://www.pivotaltracker.com/n/projects/736901/stories/161458506
+      limitInteractiveHeight($iframe, maxHeight);
     }
   }
 
@@ -45,8 +69,9 @@ function interactiveSizing () {
     $iframe.on('sizeUpdate', setSize);
     $iframe.trigger('sizeUpdate');
   });
-
 }
 
-$(document).ready(interactiveSizing);
-
+// Use 'load' event so all the images are loaded before we start calculating size.
+// Note that wrapping plugins can add images and other elements around interactive.
+// 'load' event should handle that (in contrast to 'ready').
+$(window).on('load', interactiveSizing);

--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -2,10 +2,9 @@
 
 function interactiveSizing () {
   function setInteractiveWidth($iframe, width) {
-    $iframe.css('width', width);
-    var $header = $iframe.parents(".embeddable-container").find(".question-hdr")
-    if ($header.length > 0) {
-      $header.css('width', width);
+    var $container = $iframe.parents(".embeddable-container")
+    if ($container.length > 0) {
+      $container.css('width', width);
     }
   }
 


### PR DESCRIPTION
This PR addresses a few separate issues (but all related to dynamic interactive sizing):

1. Size calculations were triggered too early, while some resources were still loading (e.g. images or stylesheets provided by plugins). It was causing issues with wrapping plugins described in this story: https://www.pivotaltracker.com/story/show/167044217. To fix that, it was enough to change `document.ready` event to `window.load`.

2. Sometimes interactive header width wasn't matching interactive size. That was caused by the fact that at the beginning of `setSize` execution, we're only resetting the size of the iframe and we were forgetting about the header. So, sometimes header was using previously calculated width (e.g. when interactive provides its own aspect ratio and calculations need to be triggered again). This has been fixed by enduring that we always change both the size of the interactive and its header.

3. To fix the problem described here: https://www.pivotaltracker.com/story/show/167317323, I changed DOM elements that have `width` updated. Instead of setting `width` separately for iframe and for its header, I just update the width of the whole `embeddable-container`. That will let plugins observe this value easily (see lara-sharing-plugin PR: https://github.com/concord-consortium/lara-sharing-plugin/pull/17) and adjust their own dimensions if necessary.