### PR TITLE
Publish Activity changes to reporting service

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,7 +81,7 @@ class ApplicationController < ActionController::Base
     rescue
       # We don't want to return a server error if this update fails; it's not important
       # enough to derail the user.
-      logger.debug "changed_by update for Activity #{@activity.id} failed."
+      logger.debug "changed_by update for Activity #{activity.id} failed."
     end
   end
 

--- a/app/models/send_to_report_service_job.rb
+++ b/app/models/send_to_report_service_job.rb
@@ -1,0 +1,53 @@
+class SendToReportServiceJob < Struct.new(:publishable_type, :publishable_id, :queuetime)
+  class FailedToSendToReportService < StandardError
+  end
+
+  def get_publishable()
+    begin
+      publishable_class = publishable_type.camelcase.constantize
+      return publishable_class.find(publishable_id)
+    rescue
+      failmsg = "No publishable: #{publishable_type} #{publishable_id}"
+      Rails.logger.error(failmsg)
+      return false
+    end
+  end
+
+  # If this function `perform` completes without error, our job will be removed
+  # from the delayed Job queue. ( https://github.com/collectiveidea/delayed_job )
+  # On error, the job is rescheduled in 5 seconds + N ** 4; N == number of tries
+  def perform
+    # Skip if the report service isn't configured. Removes from queue.
+    return unless ReportService.configured?
+
+    # Skip if we can't find the publishable. Removes from queue.
+    publishable = get_publishable()
+    return unless publishable
+
+    # Skip if the publishable has changed since enqueuing. Removes from queue.
+    # A new job will be scheduled. The new job should be run instead of this one.
+    return if publishable.updated_at > queuetime
+    resource_sender = ReportService::ResourceSender.new(publishable)
+
+    # Skip it if nothing interesting changed. Removes from queue.
+    return if resource_sender.payload_hash == publishable.last_report_service_hash
+
+    result = resource_sender.send()
+    unless (result && result["success"])
+      # Delayed job automatically retries failed `perform`s.
+      # rescheduled in 5 seconds + N ** 4
+      raise FailedToSendToReportService.new("Failed to send")
+    end
+
+    # Record the last payload_hash to the publishable.
+    publishable.update_column(:last_report_service_hash, resource_sender.payload_hash)
+
+    # Success: If we made it to the end of our fuction this job will
+    # be removed from delayed job queue.
+  end
+
+  def max_attempts
+    5
+  end
+
+end

--- a/app/models/send_to_report_service_job.rb
+++ b/app/models/send_to_report_service_job.rb
@@ -26,24 +26,24 @@ class SendToReportServiceJob < Struct.new(:publishable_type, :publishable_id, :q
 
     # Skip if the publishable has changed since enqueuing. Removes from queue.
     # A new job will be scheduled. The new job should be run instead of this one.
-    return if publishable.updated_at > queuetime
+    return if (publishable.updated_at > queuetime)
     resource_sender = ReportService::ResourceSender.new(publishable)
 
     # Skip it if nothing interesting changed. Removes from queue.
-    return if resource_sender.payload_hash == publishable.last_report_service_hash
+    return if (resource_sender.payload_hash == publishable.last_report_service_hash)
 
     result = resource_sender.send()
-    unless (result && result["success"])
+    
+    if result["success"]
+      # Record the last payload_hash to the publishable.
+      publishable.update_column(:last_report_service_hash, resource_sender.payload_hash)
+      # Success: If we made it to the end of our fuction this job will
+      # be removed from delayed job queue.
+    else
       # Delayed job automatically retries failed `perform`s.
       # rescheduled in 5 seconds + N ** 4
       raise FailedToSendToReportService.new("Failed to send")
     end
-
-    # Record the last payload_hash to the publishable.
-    publishable.update_column(:last_report_service_hash, resource_sender.payload_hash)
-
-    # Success: If we made it to the end of our fuction this job will
-    # be removed from delayed job queue.
   end
 
   def max_attempts

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -62,6 +62,10 @@ module ReportService
       )
     end
 
+    def payload_hash
+      Digest::SHA1.hexdigest(to_json)
+    end
+
   end
 
 end

--- a/db/migrate/20190619221556_add_last_report_service_hash_to_sequences.rb
+++ b/db/migrate/20190619221556_add_last_report_service_hash_to_sequences.rb
@@ -1,0 +1,6 @@
+class AddLastReportServiceHashToSequences < ActiveRecord::Migration
+  def change
+    add_column :sequences, :last_report_service_hash, :text
+    add_column :lightweight_activities, :last_report_service_hash, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -385,28 +385,29 @@ ActiveRecord::Schema.define(:version => 20190621195718) do
   create_table "lightweight_activities", :force => true do |t|
     t.string   "name"
     t.integer  "user_id"
-    t.string   "publication_status",                   :default => "private"
-    t.datetime "created_at",                                                  :null => false
-    t.datetime "updated_at",                                                  :null => false
+    t.string   "publication_status",                     :default => "private"
+    t.datetime "created_at",                                                    :null => false
+    t.datetime "updated_at",                                                    :null => false
     t.integer  "offerings_count"
     t.text     "related"
     t.text     "description"
     t.integer  "changed_by_id"
-    t.boolean  "is_official",                          :default => false
+    t.boolean  "is_official",                            :default => false
     t.integer  "time_to_complete"
-    t.boolean  "is_locked",                            :default => false
+    t.boolean  "is_locked",                              :default => false
     t.text     "notes"
     t.string   "thumbnail_url"
     t.integer  "theme_id"
     t.integer  "project_id"
-    t.integer  "portal_run_count",                     :default => 0
-    t.integer  "layout",                               :default => 0
-    t.integer  "editor_mode",                          :default => 0
-    t.string   "publication_hash",       :limit => 40
+    t.integer  "portal_run_count",                       :default => 0
+    t.integer  "layout",                                 :default => 0
+    t.integer  "editor_mode",                            :default => 0
+    t.string   "publication_hash",         :limit => 40
     t.string   "imported_activity_url"
     t.integer  "copied_from_id"
     t.text     "external_report_url"
-    t.boolean  "student_report_enabled",               :default => true
+    t.boolean  "student_report_enabled",                 :default => true
+    t.text     "last_report_service_hash"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -600,20 +601,21 @@ ActiveRecord::Schema.define(:version => 20190621195718) do
   create_table "sequences", :force => true do |t|
     t.string   "title"
     t.text     "description"
-    t.datetime "created_at",                                                 :null => false
-    t.datetime "updated_at",                                                 :null => false
+    t.datetime "created_at",                                                    :null => false
+    t.datetime "updated_at",                                                    :null => false
     t.integer  "user_id"
     t.integer  "theme_id"
     t.integer  "project_id"
     t.text     "logo"
-    t.string   "publication_status",                  :default => "private"
-    t.boolean  "is_official",                         :default => false
+    t.string   "publication_status",                     :default => "private"
+    t.boolean  "is_official",                            :default => false
     t.string   "display_title"
     t.string   "thumbnail_url"
     t.text     "abstract"
-    t.string   "publication_hash",      :limit => 40
+    t.string   "publication_hash",         :limit => 40
     t.string   "imported_activity_url"
     t.text     "external_report_url"
+    t.text     "last_report_service_hash"
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"

--- a/spec/models/send_to_report_service_job_spec.rb
+++ b/spec/models/send_to_report_service_job_spec.rb
@@ -56,18 +56,7 @@ describe "SendToReportServiceJob" do
       end
     end
 
-    describe "when the published item has been modified afeter enqueing" do
-      let(:queuetime) { 1.hour.ago }
-      it "the job should not throw an exception" do
-        expect { job.perform }.not_to raise_error
-      end
-      it "the job should not make a requst to the report server" do
-        expect(sender).not_to receive(:send)
-        job.perform
-      end
-    end
-
-    describe "when the published item has been modified afeter enqueing" do
+    describe "when the published item has been modified afrer enqueuing" do
       let(:queuetime) { 1.hour.ago }
       it "the job should not throw an exception" do
         expect { job.perform }.not_to raise_error
@@ -83,7 +72,7 @@ describe "SendToReportServiceJob" do
       it "the job should not throw an exception" do
         expect { job.perform }.not_to raise_error
       end
-      it "the job should not make a requst to the report server" do
+      it "the job should not make a request to the report server" do
         expect(sender).not_to receive(:send)
         job.perform
       end

--- a/spec/models/send_to_report_service_job_spec.rb
+++ b/spec/models/send_to_report_service_job_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe "SendToReportServiceJob" do
+  before(:each) do
+    allow(Sequence).to receive(:find).and_return(sequence)
+    allow(ReportService::ResourceSender).to receive(:new).and_return(sender)
+    allow(ReportService).to receive(:configured?).and_return(report_service_configured)
+  end
+
+  let(:report_service_configured) { true }
+  let(:report_service_response) { { "status" => 200, "success" => true } }
+
+  let(:payload_hash) { "FACF4D8E-7AD9-489C-8CEC-58D004500795" }
+  let(:senderOpts) do
+    {
+      payload_hash: payload_hash,
+      send: report_service_response
+    }
+  end
+
+  let(:sender) { double("Sender", senderOpts) }
+
+  let(:sequence_update_time) {  1.minute.ago }
+  let(:last_report_service_hash) { "" }
+  let(:sequence) do
+    double("Sequence", {
+      type: 'Sequence',
+      id: 12,
+      updated_at: sequence_update_time,
+      last_report_service_hash: last_report_service_hash,
+      update_column: true
+    })
+  end
+
+  let(:queuetime) { Time.now }
+  let(:job) do
+    publishable_id = sequence.id
+    publishable_type = sequence.type
+    SendToReportServiceJob.new(publishable_type, publishable_id, queuetime)
+  end
+
+  it "the job should exist" do
+    expect(job).not_to be_nil
+  end
+
+  describe "#perform" do
+
+    describe "when the report service is not configured" do
+      let(:report_service_configured) { false }
+      it "should not raise an excpetion" do
+        expect {  job.perform }.not_to raise_error
+      end
+      it "should not send a request to the report server" do
+        expect(sender).not_to receive(:send)
+        job.perform
+      end
+    end
+
+    describe "when the published item has been modified afeter enqueing" do
+      let(:queuetime) { 1.hour.ago }
+      it "the job should not throw an exception" do
+        expect { job.perform }.not_to raise_error
+      end
+      it "the job should not make a requst to the report server" do
+        expect(sender).not_to receive(:send)
+        job.perform
+      end
+    end
+
+    describe "when the published item has been modified afeter enqueing" do
+      let(:queuetime) { 1.hour.ago }
+      it "the job should not throw an exception" do
+        expect { job.perform }.not_to raise_error
+      end
+      it "the job should not make a requst to the report server" do
+        expect(sender).not_to receive(:send)
+        job.perform
+      end
+    end
+
+    describe "when the published item has the same payload_hash" do
+      let(:last_report_service_hash) { payload_hash }
+      it "the job should not throw an exception" do
+        expect { job.perform }.not_to raise_error
+      end
+      it "the job should not make a requst to the report server" do
+        expect(sender).not_to receive(:send)
+        job.perform
+      end
+    end
+
+    describe "when the server returns an error"  do
+      let(:report_service_response) { { "status" => 400, "success" => false } }
+      it "the job should throw an exception to retry the job" do
+        expect(sender).not_to receive(:update_column)
+        expect { job.perform }.to raise_exception
+      end
+    end
+
+    describe "when everything goes just right" do
+      it "should send the new structure to the report service" do
+        expect(sender).to receive(:send)
+        job.perform
+      end
+      it "should update the report_service_hash column" do
+        expect(sequence).to receive(:update_column)
+          .with(:last_report_service_hash, payload_hash)
+        job.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the structure of an Activity or Sequence changes, enqueue an update the FireStore reporting service if one is configured.

This implements the same basic pattern as is used to update the Portal.  Some minor differences:

* If there is no reporting service configured, we don't send anything (duh).
* If the Activity updated time is newer than the enqueue time, then we don't send it. We wait for the newly queued job to send it.
* We save a hash of the last serialized json hash.
* We don't send anything if the serialzed json hasn't changed from last update.  

[#165204332]

https://www.pivotaltracker.com/story/show/165204332