### PR TITLE
Updated authoring styles [#167292127]

### DIFF
--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -23,7 +23,7 @@
 
   &.allow-full-width {
     width: unset;
-    min-width: 450px;
+    min-width: 1000px;
   }
 
   & > .close {


### PR DESCRIPTION
Note: this only sets the gui authoring lightbox width.  Each plugin *may* need to update its styles to fill the lightbox.  For example this PR updates the teacher-tips-plugin: https://github.com/concord-consortium/teacher-edition-tips-plugin/pull/38