### PR TITLE
167209213 remove `external_report_url` from Activities / Sequences

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -18,7 +18,7 @@ class LightweightActivity < ActiveRecord::Base
   attr_accessible :name, :user_id, :pages, :related, :description,
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :theme_id, :project_id,
                   :portal_run_count, :layout, :editor_mode, :publication_hash, :copied_from_id,
-                  :external_report_url, :student_report_enabled
+                  :student_report_enabled
 
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
@@ -97,7 +97,6 @@ class LightweightActivity < ActiveRecord::Base
       notes: notes,
       layout: layout,
       editor_mode: editor_mode,
-      external_report_url: external_report_url,
       student_report_enabled: student_report_enabled
     }
   end
@@ -135,7 +134,6 @@ class LightweightActivity < ActiveRecord::Base
                                         :notes,
                                         :layout,
                                         :editor_mode,
-                                        :external_report_url,
                                         :student_report_enabled
     ])
     activity_json[:version] = 1
@@ -162,7 +160,6 @@ class LightweightActivity < ActiveRecord::Base
       related: activity_json_object[:related],
       theme_id: activity_json_object[:theme_id],
       thumbnail_url: activity_json_object[:thumbnail_url],
-      external_report_url: activity_json_object[:external_report_url],
       student_report_enabled: activity_json_object[:student_report_enabled],
       time_to_complete: activity_json_object[:time_to_complete],
       layout: activity_json_object[:layout],
@@ -221,7 +218,6 @@ class LightweightActivity < ActiveRecord::Base
       "create_url" => local_url,
       "author_url" => author_url,
       "print_url"  => print_url,
-      "external_report_url"  => external_report_url,
       "student_report_enabled"  => student_report_enabled,
       "thumbnail_url" => thumbnail_url,
       "author_email" => self.user.email,

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,7 +1,7 @@
 class Sequence < ActiveRecord::Base
   attr_accessible :description, :title, :theme_id, :project_id,
-    :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash,
-    :external_report_url
+    :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash
+
   include Publishable # defines methods to publish to portals
   include PublicationStatus # defines publication status scopes and helpers
   has_many :lightweight_activities_sequences, :order => :position, :dependent => :destroy
@@ -52,8 +52,7 @@ class Sequence < ActiveRecord::Base
       project_id: project_id,
       logo: logo,
       display_title: display_title,
-      thumbnail_url: thumbnail_url,
-      external_report_url: external_report_url
+      thumbnail_url: thumbnail_url
     }
   end
 
@@ -97,8 +96,7 @@ class Sequence < ActiveRecord::Base
                                         :project_id,
                                         :logo,
                                         :display_title,
-                                        :thumbnail_url,
-                                        :external_report_url
+                                        :thumbnail_url
     ])
     sequence_json[:activities] = []
     self.lightweight_activities.each_with_index do |a,i|
@@ -132,7 +130,6 @@ class Sequence < ActiveRecord::Base
       "create_url" => local_url,
       "author_url" => author_url,
       "print_url"  => print_url,
-      "external_report_url" => external_report_url,
       "thumbnail_url" => thumbnail_url,
       "author_email" => self.user.email
     }
@@ -161,8 +158,7 @@ class Sequence < ActiveRecord::Base
       project_id: sequence_json_object[:project_id],
       theme_id: sequence_json_object[:theme_id],
       thumbnail_url: sequence_json_object[:thumbnail_url],
-      title: sequence_json_object[:title],
-      external_report_url: sequence_json_object[:external_report_url]
+      title: sequence_json_object[:title]
     }
 
   end

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -60,11 +60,6 @@
           .activity_thumbnail#thumbnail_preview
             %img
       .field
-        = f.label :external_report_url, t("EXTERNAL_REPORT_URL")
-        = f.text_field :external_report_url
-        %br
-        .hint=t("EXTERNAL_REPORT_WARNING")
-      .field
         = f.label :student_report_enabled, t("STUDENT_REPORT_ENABLED")
         = f.check_box :student_report_enabled
         %br

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -30,11 +30,6 @@
         .activity_thumbnail#thumbnail_preview
           %img
     .field
-      = f.label :external_report_url, t("EXTERNAL_REPORT_URL")
-      = f.text_field :external_report_url
-      %br
-      .hint=t("EXTERNAL_REPORT_WARNING")
-    .field
       = f.label :theme_id, "Theme"
       = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @sequence.theme_id), { :include_blank => "None (inherit from project, or site default)" }
     .field

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,6 @@ en:
   EDIT: "Edit"
   EXTERNAL_REPORT_URL: "Custom Reporting URL"
   STUDENT_REPORT_ENABLED: "Student Report Enabled"
-  EXTERNAL_REPORT_WARNING: "(Don't change, unless you know what you are doing!)"
   DATA_WILL_NOT_BE_SAVED:  "Data will not be saved"
   TIME_TO_COMPLETE: "Estimated Time to Complete This Module:"
   MINUTES: "minutes"

--- a/cypress/cypress/fixtures/activities/activity_with_arg_block_section.json
+++ b/cypress/cypress/fixtures/activities/activity_with_arg_block_section.json
@@ -1,7 +1,6 @@
 {
     "description": "",
     "editor_mode": 0,
-    "external_report_url": null,
     "layout": 0,
     "name": "[Cypress] Arg Block Test",
     "notes": "",

--- a/cypress/cypress/fixtures/activities/activity_with_empty_plugin.json
+++ b/cypress/cypress/fixtures/activities/activity_with_empty_plugin.json
@@ -1,7 +1,6 @@
 {
   "description": "",
   "editor_mode": 0,
-  "external_report_url": null,
   "layout": 0,
   "name": "[Cypress] Empty Plugin Test",
   "notes": "",

--- a/cypress/cypress/fixtures/activities/hints.json
+++ b/cypress/cypress/fixtures/activities/hints.json
@@ -1,7 +1,6 @@
 {
   "description": "",
   "editor_mode": 0,
-  "external_report_url": null,
   "layout": 0,
   "name": "[Cypress] Hints",
   "notes": "",

--- a/cypress/cypress/fixtures/activities/interactive-questions.json
+++ b/cypress/cypress/fixtures/activities/interactive-questions.json
@@ -3,7 +3,6 @@
 {
     "description": "",
     "editor_mode": 0,
-    "external_report_url": null,
     "layout": 0,
     "name": "[Cypress] Test Interactive Header",
     "notes": "",

--- a/cypress/cypress/fixtures/activities/multiple-choice-simple.json
+++ b/cypress/cypress/fixtures/activities/multiple-choice-simple.json
@@ -1,7 +1,6 @@
 {
   "description": "",
   "editor_mode": 0,
-  "external_report_url": null,
   "layout": 0,
   "name": "[Cypress] Multiple Choice Simple",
   "notes": "",

--- a/cypress/cypress/fixtures/activities/open-response-simple.json
+++ b/cypress/cypress/fixtures/activities/open-response-simple.json
@@ -1,7 +1,6 @@
 {
   "description": "",
   "editor_mode": 0,
-  "external_report_url": null,
   "layout": 0,
   "name": "[Cypress] Open Response Simple",
   "notes": "",

--- a/cypress/cypress/fixtures/sequences/simple-sequence.json
+++ b/cypress/cypress/fixtures/sequences/simple-sequence.json
@@ -2,7 +2,6 @@
   "abstract": "",
   "description": "",
   "display_title": "",
-  "external_report_url": "",
   "logo": "",
   "project_id": null,
   "theme_id": null,
@@ -12,7 +11,6 @@
     {
       "description": "",
       "editor_mode": 0,
-      "external_report_url": null,
       "layout": 0,
       "name": "[Cypress] Open Response Simple",
       "notes": "",
@@ -66,7 +64,6 @@
     {
       "description": "",
       "editor_mode": 0,
-      "external_report_url": null,
       "layout": 0,
       "name": "[Cypress] Multiple Choice Simple",
       "notes": "",

--- a/db/migrate/20190724171834_remove_external_report_url_from_light_weight_activity.rb
+++ b/db/migrate/20190724171834_remove_external_report_url_from_light_weight_activity.rb
@@ -1,0 +1,14 @@
+class RemoveExternalReportUrlFromLightWeightActivity < ActiveRecord::Migration
+  # Removes columns added in AddExternalReportUrlToLightweightActivity
+  # 20160722195644_add_external_report_url_to_lightweight_activity.rb
+
+  def up
+    remove_column :lightweight_activities, :external_report_url
+    remove_column :sequences, :external_report_url
+  end
+
+  def down
+    add_column :lightweight_activities, :external_report_url, :text
+    add_column :sequences, :external_report_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190621195718) do
+ActiveRecord::Schema.define(:version => 20190724171834) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -405,7 +405,6 @@ ActiveRecord::Schema.define(:version => 20190621195718) do
     t.string   "publication_hash",         :limit => 40
     t.string   "imported_activity_url"
     t.integer  "copied_from_id"
-    t.text     "external_report_url"
     t.boolean  "student_report_enabled",                 :default => true
     t.text     "last_report_service_hash"
   end
@@ -614,7 +613,6 @@ ActiveRecord::Schema.define(:version => 20190621195718) do
     t.text     "abstract"
     t.string   "publication_hash",         :limit => 40
     t.string   "imported_activity_url"
-    t.text     "external_report_url"
     t.text     "last_report_service_hash"
   end
 

--- a/script/generate-print-test-activty.js
+++ b/script/generate-print-test-activty.js
@@ -5,7 +5,6 @@
 var activity = {
   "description": "An activity to test printing interactives in various ways.",
   "editor_mode": 0,
-  "external_report_url": null,
   "layout": 0,
   "name": "Interactive Print Test",
   "notes": "",

--- a/spec/controllers/publication_controller_spec.rb
+++ b/spec/controllers/publication_controller_spec.rb
@@ -52,7 +52,6 @@ describe PublicationsController do
         "create_url"    =>"http://test.host/activities/#{act_one.id}",
         "author_url"    =>"http://test.host/activities/#{act_one.id}/edit",
         "print_url"     =>"http://test.host/activities/#{act_one.id}/print_blank",
-        "external_report_url"  => act_one.external_report_url,
         "student_report_enabled" => act_one.student_report_enabled,
         "thumbnail_url" =>"thumbnail",
         "author_email"  => @user.email,

--- a/spec/import_examples/activity_with_arg_block_section.json
+++ b/spec/import_examples/activity_with_arg_block_section.json
@@ -1,7 +1,6 @@
 {
     "description": "",
     "editor_mode": 0,
-    "external_report_url": null,
     "layout": 0,
     "name": "Sharing test",
     "notes": "",

--- a/spec/import_examples/valid_lightweight_activity_import.json
+++ b/spec/import_examples/valid_lightweight_activity_import.json
@@ -6,7 +6,6 @@
   "related": "Contains all interactivities and embeddables.",
   "theme_id": null,
   "thumbnail_url": "",
-  "external_report_url": "https://reports.concord.org/",
   "time_to_complete": null,
   "pages": [{
     "layout": "l-6040",

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -73,8 +73,6 @@ describe Sequence do
 
   describe '#serialize_for_portal' do
     let(:user) { FactoryGirl.create(:user) }
-    let(:report_url)    { "https://foo.bar.report/" }
-    let(:sequence_opts) { {external_report_url: report_url } }
     let(:act1) {
       activity = FactoryGirl.build(:activity_with_page)
       activity.user = user
@@ -114,8 +112,7 @@ describe Sequence do
         "print_url"     => print_url,
         "thumbnail_url" => nil, # our simple sequence doesn't have one
         "author_email" => sequence.user.email,
-        "activities"=>[],
-        "external_report_url" => report_url
+        "activities"=>[]
       }
     end
 
@@ -137,8 +134,7 @@ describe Sequence do
           # Note that we reordered activities!
           act2.serialize_for_portal("http://test.host"),
           act1.serialize_for_portal("http://test.host")
-        ],
-        "external_report_url" => report_url
+        ]
       }
     end
 
@@ -204,8 +200,7 @@ describe Sequence do
   end
 
   describe '#to_hash' do
-    let(:report_url)    { "https://foo.bar.report/" }
-    let(:sequence_opts) { {external_report_url: report_url } }
+    let(:sequence_opts) { {} }
     it 'returns a hash with relevant values for sequence duplication' do
       expected = {
         title: sequence.title,
@@ -216,42 +211,36 @@ describe Sequence do
         project_id: sequence.project_id,
         logo: sequence.logo,
         display_title: sequence.display_title,
-        thumbnail_url: sequence.thumbnail_url,
-        external_report_url: report_url
+        thumbnail_url: sequence.thumbnail_url
       }
       expect(sequence.to_hash).to eq(expected)
     end
   end
 
   describe '#export' do
-    let(:report_url) { "https://reports.concord.org/" }
-    let(:sequence_opts) { {external_report_url: report_url} }
+    let(:sequence_opts) { {} }
     it 'returns json of a sequence' do
       sequence_json = JSON.parse(sequence.export)
       expect(sequence_json['activities'].length).to eq(sequence.activities.count)
-      expect(sequence_json['external_report_url']).to eq(report_url)
     end
   end
 
   describe '#import' do
-    let(:report_url)    { "https://reports.concord.org/" }
     let(:logo)          { "https://concord.org/logo.jpg" }
     let(:thumbnail_url) { "https://concord.org/sunflower.jpg" }
     let(:title)         { "title" }
-    let(:sequence_opts) { {external_report_url: report_url, logo: logo, thumbnail_url: thumbnail_url, title: title} }
+    let(:sequence_opts) { {logo: logo, thumbnail_url: thumbnail_url, title: title} }
     let(:owner)         { FactoryGirl.create(:user) }
 
     it 'returns json of a sequence' do
       data = JSON.parse(sequence.export, :symbolize_names => true)
       imported = Sequence.import(data, owner)
-      expect(imported.external_report_url).to eq(report_url)
       expect(imported.thumbnail_url).to eq(thumbnail_url)
       expect(imported.logo).to eq(logo)
     end
   end
   describe '#duplicate' do
-    let(:report_url)    { "https://reports.concord.org/" }
-    let(:sequence_opts) { { external_report_url: report_url} }
+    let(:sequence_opts) { {} }
     let(:owner)         { FactoryGirl.create(:user) }
     let(:act1) {
       activity = FactoryGirl.build(:activity_with_page)
@@ -295,7 +284,6 @@ describe Sequence do
       expect(dup.display_title).to eq(sequence.display_title)
       expect(dup.thumbnail_url).to eq(sequence.thumbnail_url)
       expect(dup.activities.length).to eq(sequence.activities.length)
-      expect(dup.external_report_url).to eq(report_url)
     end
 
     it 'performs deep copy of all activities included in a given sequence' do

--- a/spec/views/lightweight_activities/edit.html.haml_spec.rb
+++ b/spec/views/lightweight_activities/edit.html.haml_spec.rb
@@ -8,8 +8,7 @@ end
 
 describe "lightweight_activities/edit" do
 
-  let(:external_report_url) { "http://reporting.concord.org/" }
-  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name', :external_report_url => external_report_url) }
+  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name') }
   let(:user)      { stub_model(User, :is_admin => false)      }
 
   before(:each) do
@@ -47,12 +46,6 @@ describe "lightweight_activities/edit" do
       render
       expect(rendered).to match /<textarea[^>]+name="lightweight_activity\[description\]"[^<]*>/
     end
-
-    it 'should show the custom reporting URL' do
-      render
-      expect(rendered).to have_css("input#lightweight_activity_external_report_url[value=\"#{external_report_url}\"]")
-    end
-
 
     it 'should show related text' do
       render

--- a/spec/views/sequences/edit.html.haml_spec.rb
+++ b/spec/views/sequences/edit.html.haml_spec.rb
@@ -1,15 +1,13 @@
 require 'spec_helper'
 
 describe "sequences/edit" do
-  let(:report_url) { "https://reporting.concord.org/" }
   before(:each) do
     @user ||= FactoryGirl.create(:admin)
     sign_in @user
 
     @sequence = assign(:sequence, stub_model(Sequence,
       :title => "MyString",
-      :description => "MyText",
-      :external_report_url => report_url
+      :description => "MyText"
     ))
   end
 
@@ -23,7 +21,6 @@ describe "sequences/edit" do
       assert_select "select#sequence_theme_id", :name => "sequence[theme_id]" do
         assert_select 'option'
       end
-      assert_select "input#sequence_external_report_url", :value => report_url
     end
   end
 end


### PR DESCRIPTION
We will be managing `external_reports` exclusively from the portal side.

This PR removes all `external_report_url` references from Activities and Sequences.

See: https://www.pivotaltracker.com/story/show/167209213