### PR TITLE
fix authorization error with embeddable level plugins

### DIFF
--- a/app/models/embeddable/embeddable_plugin.rb
+++ b/app/models/embeddable/embeddable_plugin.rb
@@ -99,5 +99,11 @@ module Embeddable
     def show_in_edit?
       !component || component[:scope] != "embeddable-decoration"
     end
+
+    # embeddable_plugins are one type of plugin_scope used by plugins
+    # the authorization expects the plugin_scope to have a user_id
+    def user_id
+      activity && activity.user_id
+    end
   end
 end

--- a/spec/controllers/api/v1/plugins_controller_spec.rb
+++ b/spec/controllers/api/v1/plugins_controller_spec.rb
@@ -8,6 +8,15 @@ describe Api::V1::PluginsController do
   let(:plugin_id)    { 400 }
   let(:author_data)  { 'author_data' }
   let(:plugin_scope) { nil }
+  let(:author)       { nil }
+  let(:activity) { FactoryGirl.create(:activity, user: author) }
+  let(:embeddable_plugin) {
+    page = FactoryGirl.create(:page)
+    activity.pages << page
+    embeddable_plugin = FactoryGirl.create(:embeddable_plugin)
+    page.add_embeddable(embeddable_plugin)
+    embeddable_plugin
+  }
 
   let(:plugin) { FactoryGirl.create(:plugin, id: plugin_id, author_data: author_data, plugin_scope: plugin_scope) }
 
@@ -36,41 +45,88 @@ describe Api::V1::PluginsController do
 
   describe "When an author of an activity they didn't create uses a plugin" do
     let(:user) { FactoryGirl.create(:author)}
-    let(:other_author) { FactoryGirl.create(:author)}
-    let(:plugin_scope) { FactoryGirl.create(:activity, user: other_author) }
+    let(:author) { FactoryGirl.create(:author)}
 
-    describe 'to load author data' do
-      it "they should get a not authorized error" do
-        post :load_author_data, plugin_id: plugin_id
-        expect(response.status).to eq(403)
+    context 'at the activity level' do
+      let(:plugin_scope) { activity }
+
+      describe 'to load author data' do
+        it "they should get a not authorized error" do
+          post :load_author_data, plugin_id: plugin_id
+          expect(response.status).to eq(403)
+        end
+      end
+
+      describe 'to save author data' do
+        it "they should get a not authorized error" do
+          post :save_author_data, plugin_id: plugin_id, author_data: "new_author_data"
+          expect(response.status).to eq(403)
+        end
       end
     end
 
-    describe 'to save author data' do
-      it "they should get a not authorized error" do
-        post :save_author_data, plugin_id: plugin_id, author_data: "new_author_data"
-        expect(response.status).to eq(403)
+    context 'at the embeddable level' do
+      let(:plugin_scope) { embeddable_plugin }
+
+      describe 'to load author data' do
+        it "they should get a not authorized error" do
+          post :load_author_data, plugin_id: plugin_id
+          expect(response.status).to eq(403)
+        end
       end
+
+      describe 'to save author data' do
+        it "they should get a not authorized error" do
+          post :save_author_data, plugin_id: plugin_id, author_data: "new_author_data"
+          expect(response.status).to eq(403)
+        end
+      end
+
     end
+
   end
 
   describe "When an author of an activity uses a plugin in that activity" do
     let(:user) { FactoryGirl.create(:author)}
-    let(:plugin_scope) { FactoryGirl.create(:activity, user: user) }
+    let(:author) { user }
 
-    describe 'to load author data' do
-      it "they should get the author data" do
-        post :load_author_data, plugin_id: plugin_id
-        expect(response.status).to eq(200)
-        expect(json_response_body['author_data']).to eq(author_data)
+    context 'at the activity level' do
+      let(:plugin_scope) { activity }
+
+      describe 'to load author data' do
+        it "they should get the author data" do
+          post :load_author_data, plugin_id: plugin_id
+          expect(response.status).to eq(200)
+          expect(json_response_body['author_data']).to eq(author_data)
+        end
+      end
+
+      describe 'to save author data' do
+        it "they should save the author data" do
+          post :save_author_data, plugin_id: plugin_id, author_data: "new_author_data"
+          expect(response.status).to eq(200)
+          expect(json_response_body['author_data']).to eq("new_author_data")
+        end
       end
     end
 
-    describe 'to save author data' do
-      it "they should save the author data" do
-        post :save_author_data, plugin_id: plugin_id, author_data: "new_author_data"
-        expect(response.status).to eq(200)
-        expect(json_response_body['author_data']).to eq("new_author_data")
+    context 'at the embeddable level' do
+      let(:plugin_scope) { embeddable_plugin }
+
+      describe 'to load author data' do
+        it "they should get the author data" do
+          post :load_author_data, plugin_id: plugin_id
+          expect(response.status).to eq(200)
+          expect(json_response_body['author_data']).to eq(author_data)
+        end
+      end
+
+      describe 'to save author data' do
+        it "they should save the author data" do
+          post :save_author_data, plugin_id: plugin_id, author_data: "new_author_data"
+          expect(response.status).to eq(200)
+          expect(json_response_body['author_data']).to eq("new_author_data")
+        end
       end
     end
   end


### PR DESCRIPTION
ability.rb assumes a plugin has a plugin_scope with a user_id, it checks this user_id
against the current user. So to keep this level of security the embeddable needs to
provide a user_id.