### PR TITLE
fix embeddable_plugin copying

### DIFF
--- a/app/models/embeddable/embeddable_plugin.rb
+++ b/app/models/embeddable/embeddable_plugin.rb
@@ -31,11 +31,16 @@ module Embeddable
     delegate :component_label=, to: :plugin
     delegate :component, to: :plugin, allow_nil: true
 
-    before_create do |embeddable|
+    # TODO: this approach isn't good, it is a circular reference in the database
+    # It'd be better if the embeddable.plugin method computed the plugin by finding
+    # plugin that referenced this embeddable with its plugin_scope
+    # this might work with a simple has_one :plugin, as: plugin_scope
+    after_create do |embeddable|
       unless(embeddable.plugin)
         embeddable.plugin = Plugin.create({})
       end
       embeddable.plugin.plugin_scope = embeddable
+      embeddable.plugin.save!
     end
 
     def self.name_as_param

--- a/db/migrate/20190806191648_remove_duplicate_plugin_id.rb
+++ b/db/migrate/20190806191648_remove_duplicate_plugin_id.rb
@@ -3,9 +3,10 @@ class RemoveDuplicatePluginId < ActiveRecord::Migration
   def up
     # need to go through all EmbeddablePlugins and make sure each of their
     # plugins correctly sets the plugin_scope field on the plugin
-    # we cannot easily use the polymorphic support of rails because we are also using
+    # we cannot easily use the polymorphic support of rails because we would also be using
     # temporary model classes, so plugin_scope_type added by the polymorphic code would
     # end up being:  RemoveDuplicatePluginId::Embeddable::EmbeddablePlugin
+    # plus the raw sql will run faster
     execute <<-SQL
       UPDATE plugins
       INNER JOIN embeddable_plugins
@@ -22,8 +23,7 @@ class RemoveDuplicatePluginId < ActiveRecord::Migration
     add_column :embeddable_plugins, :plugin_id, :integer
     add_index :embeddable_plugins, [:plugin_id], uniq: true
 
-    # go through all EmbeddablePlugins and make sure for each plugin that the plugin_id
-    # is set correctly on the EmbeddablePlugin
+    # go through all EmbeddablePlugins and set a plugin_id for each associated Plugin
     execute <<-SQL
       UPDATE embeddable_plugins
       INNER JOIN plugins

--- a/db/migrate/20190806191648_remove_duplicate_plugin_id.rb
+++ b/db/migrate/20190806191648_remove_duplicate_plugin_id.rb
@@ -1,0 +1,36 @@
+class RemoveDuplicatePluginId < ActiveRecord::Migration
+
+  def up
+    # need to go through all EmbeddablePlugins and make sure each of their
+    # plugins correctly sets the plugin_scope field on the plugin
+    # we cannot easily use the polymorphic support of rails because we are also using
+    # temporary model classes, so plugin_scope_type added by the polymorphic code would
+    # end up being:  RemoveDuplicatePluginId::Embeddable::EmbeddablePlugin
+    execute <<-SQL
+      UPDATE plugins
+      INNER JOIN embeddable_plugins
+      ON embeddable_plugins.plugin_id = plugins.id
+      SET plugins.plugin_scope_id = embeddable_plugins.id, plugins.plugin_scope_type = "Embeddable::EmbeddablePlugin"
+    SQL
+
+    remove_column :embeddable_plugins, :plugin_id
+
+    # the index should be removed automatically by the database
+  end
+
+  def down
+    add_column :embeddable_plugins, :plugin_id, :integer
+    add_index :embeddable_plugins, [:plugin_id], uniq: true
+
+    # go through all EmbeddablePlugins and make sure for each plugin that the plugin_id
+    # is set correctly on the EmbeddablePlugin
+    execute <<-SQL
+      UPDATE embeddable_plugins
+      INNER JOIN plugins
+      ON plugins.plugin_scope_id = embeddable_plugins.id
+      SET embeddable_plugins.plugin_id = plugins.id
+      WHERE plugins.plugin_scope_type = "Embeddable::EmbeddablePlugin"
+    SQL
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190724171834) do
+ActiveRecord::Schema.define(:version => 20190806191648) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -282,7 +282,6 @@ ActiveRecord::Schema.define(:version => 20190724171834) do
   end
 
   create_table "embeddable_plugins", :force => true do |t|
-    t.integer  "plugin_id"
     t.datetime "created_at",                         :null => false
     t.datetime "updated_at",                         :null => false
     t.integer  "embeddable_id"
@@ -290,8 +289,6 @@ ActiveRecord::Schema.define(:version => 20190724171834) do
     t.boolean  "is_hidden",       :default => false
     t.boolean  "is_full_width",   :default => false
   end
-
-  add_index "embeddable_plugins", ["plugin_id"], :name => "index_embeddable_plugins_on_plugin_id"
 
   create_table "embeddable_xhtmls", :force => true do |t|
     t.string   "name"

--- a/spec/models/embeddable/embeddable_plugin_spec.rb
+++ b/spec/models/embeddable/embeddable_plugin_spec.rb
@@ -56,6 +56,35 @@ describe Embeddable::EmbeddablePlugin do
         is_hidden: is_hidden
       })
     end
+    it "the new instance's plugin is setup correctly" do
+      duplicate = embeddable_plugin.duplicate
+
+      # this the page level duplicate fuction calls save like this
+      duplicate.save!(validate: false)
+      duplicate.reload
+      expect(duplicate.plugin.plugin_scope).to eq(duplicate)
+    end
+
   end
 
+  describe '#import' do
+    let(:example_json_file) { 'activity_with_arg_block_section' }
+    let(:activity_json) do
+      JSON.parse(File.read(
+        Rails.root +
+        "spec/import_examples/#{example_json_file}.json"),
+        :symbolize_names => true)
+    end
+
+    let(:test_page_index) { 0 }
+    let(:page_json) { activity_json[:pages][test_page_index] }
+    let(:page) { InteractivePage.import(page_json)}
+
+    it 'sets the plugin_scope of the associated plugin' do
+      embeddable = page.embeddables.find{|e| e.is_a? Embeddable::EmbeddablePlugin}
+      expect(embeddable).to_not be_nil
+      expect(embeddable.plugin.plugin_scope).to eq(embeddable)
+    end
+
+  end
 end


### PR DESCRIPTION
In the previous code, without an id, then the setup of the embeddable.plugin.plugin_scope was failing. This only happened during duplicate. I didn't track down exactly why, but I'd guess
in other cases the embeddable was being saved first so it actually had an id.
Perhaps this happens on the `embeddable.plugin = Plugin.create({})` call.

I initially switch to after_create to make sure the embeddable had an id. However
as the comment said in that commit it was better to remove the duplicate plugin_id here. 

So the final change is to remove the plugin_id from EmbeddablePlugin, and switch to an after_initialize callback.  This also includes a migration that serves two purposes: 
1. clean up any EmbeddablePlugins that that pointed at plugins with a nil plugin_scope_id
2. remove the plugin_id from EmbeddablePlugin