### PR TITLE
fix wrapping plugins

### DIFF
--- a/app/models/embeddable/embeddable_plugin.rb
+++ b/app/models/embeddable/embeddable_plugin.rb
@@ -10,7 +10,7 @@ module Embeddable
     attr_accessible :plugin, :approved_script_id, :description, :author_data,
     :is_full_width, :is_hidden, :component_label
 
-    has_one :plugin, as: :plugin_scope
+    has_one :plugin, as: :plugin_scope, autosave: true
 
     has_many :page_items, :as => :embeddable, :dependent => :destroy
     has_many :interactive_pages, :through => :page_items

--- a/spec/models/embeddable/embeddable_plugin_spec.rb
+++ b/spec/models/embeddable/embeddable_plugin_spec.rb
@@ -87,4 +87,14 @@ describe Embeddable::EmbeddablePlugin do
     end
 
   end
+
+  describe 'delegated to plugin methods' do
+    it 'should save value after a simple create, set, save, reload' do
+      embeddable = Embeddable::EmbeddablePlugin.create!
+      embeddable.approved_script_id = "123"
+      embeddable.save!
+      embeddable.reload
+      expect(embeddable.approved_script_id).to eq("123")
+    end
+  end
 end


### PR DESCRIPTION
previous change to replace belongs_to relationship with a has_one relationship did not include autosave
autosave causes the related object to be saved automatically when the main object is saved
this is necessary for our delegation code.