### PR TITLE
Coder4math theme

### DIFF
--- a/app/assets/stylesheets/theme-rmath.scss
+++ b/app/assets/stylesheets/theme-rmath.scss
@@ -1,9 +1,13 @@
 @import "cc-runtime";
 
+$col-lightgray: #f1f1f1;
+$col-blue: #459ace;
+$col-orange: #ea6d2f;
+
 $theme-params: (
-  bgColorOrUrl: #f1f1f1,
-  theme-color-a: #459ace,
-  theme-color-b: #ea6d2f,
+  bgColorOrUrl: $col-lightgray,
+  theme-color-a: $col-blue,
+  theme-color-b: $col-orange,
   activity-menu-display: none
 );
 

--- a/app/assets/stylesheets/theme-rmath.scss
+++ b/app/assets/stylesheets/theme-rmath.scss
@@ -13,4 +13,5 @@ $theme-params: (
 
 @include theme($theme-params...);
 
+.interactive-container.full-window .full-window-overlay { background: $col-lightgray; }
 footer { color: #444; }


### PR DESCRIPTION
We want the full-window overlay color to match the theme. The default color doesn't work very well. It may be better to make that color one of the theme params, or based off the theme's bgColorOrUrl value, but I think doing that and making sure it looks good in all themes will involve more work than I have time for right now.