### PR TITLE
Add report tool id config

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -47,6 +47,18 @@ module ReportService
       ENV['REPORT_SERVICE_TOKEN']
     end
 
+    def tool_id
+      if ENV['REPORT_SERVICE_TOOL_ID'].present?
+        ENV['REPORT_SERVICE_TOOL_ID']
+      else
+        self_url
+      end
+    end
+
+    def source_key
+      ReportService::make_source_key(tool_id)
+    end
+
     def api_endpoint
       "#{report_service_url}/#{api_method}"
     end

--- a/app/services/report_service/resource_sender.rb
+++ b/app/services/report_service/resource_sender.rb
@@ -18,8 +18,8 @@ module ReportService
       id = @payload[:id]
       @payload[:created] = created
       @payload[:version] = version
-      @payload[:source_key] = ReportService::make_source_key(self_url)
-      @payload[:tool_id] = self_url
+      @payload[:source_key] = source_key
+      @payload[:tool_id] = tool_id
       @payload[:id] = ReportService::make_key(type, id)
     end
 

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -17,8 +17,8 @@ module ReportService
     def add_meta_data(run, record)
       record[:version] = RunSender::Version
       record[:created] = Time.now.utc.to_s
-      record[:source_key] = ReportService::make_source_key(self_url)
-      record[:tool_id] = self_url
+      record[:source_key] = source_key
+      record[:tool_id] = tool_id
       record[:tool_user_id] = run.user_id.to_s
       record[:platform_id] = run.platform_id
       record[:platform_user_id] = run.platform_user_id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       REPORT_SERVICE_TOKEN:
       REPORT_SERVICE_URL:
       REPORT_SERVICE_SELF_URL:
+      REPORT_SERVICE_TOOL_ID:
     # no ports are published, see below for details
     depends_on:
       - db

--- a/spec/services/report_service/resource_sender_spec.rb
+++ b/spec/services/report_service/resource_sender_spec.rb
@@ -58,7 +58,7 @@ describe ReportService::ResourceSender do
         end
 
         it "The resourceUrl should still start with the self_url" do
-          expect(json['resource_url']).to start_with(self_host)
+          expect(json['url']).to start_with(self_host)
         end
       end
     end

--- a/spec/services/report_service/resource_sender_spec.rb
+++ b/spec/services/report_service/resource_sender_spec.rb
@@ -13,6 +13,7 @@ describe ReportService::ResourceSender do
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(self_host)
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return(report_service_url)
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return(report_service_token)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return(nil)
   end
 
   describe "to_json" do
@@ -32,18 +33,33 @@ describe ReportService::ResourceSender do
       end
 
       it "The source key should contain host name info" do
-        expect(json['source_key']).to match('app')
-        expect(json['source_key']).to match('lara')
-        expect(json['source_key']).to match('docker')
-        expect(json['tool_id']).to match('app')
-        expect(json['tool_id']).to match('lara')
-        expect(json['tool_id']).to match('docker')
+        expect(json['source_key']).to match('app.lara.docker')
+        expect(json['tool_id']).to match('app.lara.docker')
         expect(json['id']).to match('activity')
         expect(json['id']).to match("#{resource.id}")
       end
 
       it "Should have a children[] array" do
         expect(json['children']).not_to be_nil
+      end
+
+      context "when a developer overrides the tool id" do
+        before(:each) do
+          allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return("http://local.dev.test")
+        end
+
+        it "The tool id should match what the developer set" do
+          expect(json['tool_id']).to match('http://local.dev.test')
+        end
+
+        it "The source key should contain host name info from the tool_id" do
+          expect(json['source_key']).to match('local.dev.test')
+          # should check the resourceId continues to match the self_url
+        end
+
+        it "The resourceUrl should still start with the self_url" do
+          expect(json['resource_url']).to start_with(self_host)
+        end
       end
     end
 
@@ -53,6 +69,7 @@ describe ReportService::ResourceSender do
         expect {sender}.to raise_error(ReportService::NotConfigured)
       end
     end
+
   end
 
 end

--- a/spec/services/report_service/run_sender_spec.rb
+++ b/spec/services/report_service/run_sender_spec.rb
@@ -75,6 +75,7 @@ describe ReportService::RunSender do
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(self_host)
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return(report_service_url)
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return(report_service_token)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return(nil)
     Timecop.freeze(Time.new(2016))
   end
 
@@ -118,6 +119,7 @@ describe ReportService::RunSender do
             expect(a).to include("version")
           end
         end
+
 
         describe "One answer that has never been started" do
           let(:report_service_hash) do
@@ -189,6 +191,25 @@ describe ReportService::RunSender do
           let(:sequence_id) { nil }
           it "the resource_url should be activity url" do
             expect(json["resource_url"]).to match("#{self_host}/activities/#{sequence_id}")
+          end
+        end
+
+        context "when a developer overrides the tool id" do
+          before(:each) do
+            allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return("http://local.dev.test")
+          end
+
+          it "The tool id should match what the developer set" do
+            expect(json['tool_id']).to match('http://local.dev.test')
+          end
+
+          it "The source key should contain host name info from the tool_id" do
+            expect(json['source_key']).to match('local.dev.test')
+            # should check the resourceId continues to match the self_url
+          end
+
+          it "The resourceUrl should still start with the self_url" do
+            expect(json['resource_url']).to start_with(self_host)
           end
         end
 

--- a/spec/services/submit_dirty_answers_job_spec.rb
+++ b/spec/services/submit_dirty_answers_job_spec.rb
@@ -32,6 +32,7 @@ describe SubmitDirtyAnswersJob do
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return(self_host)
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return(report_service_url)
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return(report_service_token)
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return(nil)
   end
 
   describe "#perform" do


### PR DESCRIPTION
This is the LARA side of this PR: 
https://github.com/concord-consortium/portal-report/pull/130

The tool id is configured in LARA using the optional REPORT_SERVICE_TOOL_ID environment variable.

If I have time I'd like to remove the need for the REPORT_SERVICE_SELF_URL. It really is only needed during rake task runs when it isn't clear what the host url is. In other case we can figure out the host url from the request and save it in the delayed jobs which is how the portal publishing works. But that work is separate from this work, so it'll be in a separate PR.