### PR TITLE
Add resourceUrl to Plugin runtime context

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -16121,6 +16121,7 @@ exports.generateRuntimePluginContext = function (options) {
         runId: options.runId,
         remoteEndpoint: options.remoteEndpoint,
         userEmail: options.userEmail,
+        resourceUrl: options.resourceUrl,
         saveLearnerPluginState: function (state) { return exports.saveLearnerPluginState(options.learnerStateSaveUrl, state); },
         getClassInfo: function () { return getClassInfo(options.classInfoUrl); },
         getFirebaseJwt: function (appName) { return getFirebaseJwt(options.firebaseJwtUrl, appName); },

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -147,7 +147,8 @@
         userEmail: #{@run.user && @run.user.email ? "'#{escape_javascript(@run.user.email)}'" : 'null'},
         classInfoUrl: #{@run.class_info_url ? "'#{escape_javascript(@run.class_info_url)}'" : 'null'},
         firebaseJwtUrl: '#{escape_javascript(firebase_jwt_url)}',
-        wrappedEmbeddable: embeddableContext
+        wrappedEmbeddable: embeddableContext,
+        resourceUrl: '#{escape_javascript(@sequence_run ? sequence_url(@sequence_run.sequence) : activity_url(@run.activity))}'
       }
       console.log("Adding #{plugin.name} runtime plugin as #{v3_plugin_label} with V3 LARA Plugin API")
       LARA.InternalAPI.initPlugin('#{v3_plugin_label}', pluginContext);

--- a/docs/lara-plugin-api/README.md
+++ b/docs/lara-plugin-api/README.md
@@ -207,7 +207,7 @@ ___
 
 **Ƭ IInteractiveAvailableEventHandler**: *`function`*
 
-*Defined in [types.ts:233](../../lara-typescript/src/plugin-api/types.ts#L233)*
+*Defined in [types.ts:235](../../lara-typescript/src/plugin-api/types.ts#L235)*
 
 InteractiveAvailable event handler.
 
@@ -229,7 +229,7 @@ ___
 
 **Ƭ ILogEventHandler**: *`function`*
 
-*Defined in [types.ts:214](../../lara-typescript/src/plugin-api/types.ts#L214)*
+*Defined in [types.ts:216](../../lara-typescript/src/plugin-api/types.ts#L216)*
 
 Log event handler.
 

--- a/docs/lara-plugin-api/interfaces/iclassinfo.md
+++ b/docs/lara-plugin-api/interfaces/iclassinfo.md
@@ -27,7 +27,7 @@
 
 **● class_hash**: *`string`*
 
-*Defined in [types.ts:185](../../../lara-typescript/src/plugin-api/types.ts#L185)*
+*Defined in [types.ts:187](../../../lara-typescript/src/plugin-api/types.ts#L187)*
 
 ___
 <a id="id"></a>
@@ -36,7 +36,7 @@ ___
 
 **● id**: *`number`*
 
-*Defined in [types.ts:183](../../../lara-typescript/src/plugin-api/types.ts#L183)*
+*Defined in [types.ts:185](../../../lara-typescript/src/plugin-api/types.ts#L185)*
 
 ___
 <a id="offerings"></a>
@@ -45,7 +45,7 @@ ___
 
 **● offerings**: *[IOffering](ioffering.md)[]*
 
-*Defined in [types.ts:188](../../../lara-typescript/src/plugin-api/types.ts#L188)*
+*Defined in [types.ts:190](../../../lara-typescript/src/plugin-api/types.ts#L190)*
 
 ___
 <a id="students"></a>
@@ -54,7 +54,7 @@ ___
 
 **● students**: *[IUser](iuser.md)[]*
 
-*Defined in [types.ts:187](../../../lara-typescript/src/plugin-api/types.ts#L187)*
+*Defined in [types.ts:189](../../../lara-typescript/src/plugin-api/types.ts#L189)*
 
 ___
 <a id="teachers"></a>
@@ -63,7 +63,7 @@ ___
 
 **● teachers**: *[IUser](iuser.md)[]*
 
-*Defined in [types.ts:186](../../../lara-typescript/src/plugin-api/types.ts#L186)*
+*Defined in [types.ts:188](../../../lara-typescript/src/plugin-api/types.ts#L188)*
 
 ___
 <a id="uri"></a>
@@ -72,7 +72,7 @@ ___
 
 **● uri**: *`string`*
 
-*Defined in [types.ts:184](../../../lara-typescript/src/plugin-api/types.ts#L184)*
+*Defined in [types.ts:186](../../../lara-typescript/src/plugin-api/types.ts#L186)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
+++ b/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
@@ -27,7 +27,7 @@
 
 **● container**: *`HTMLElement`*
 
-*Defined in [types.ts:66](../../../lara-typescript/src/plugin-api/types.ts#L66)*
+*Defined in [types.ts:68](../../../lara-typescript/src/plugin-api/types.ts#L68)*
 
 Embeddable container.
 
@@ -38,7 +38,7 @@ ___
 
 **● getInteractiveState**: *`function`*
 
-*Defined in [types.ts:87](../../../lara-typescript/src/plugin-api/types.ts#L87)*
+*Defined in [types.ts:89](../../../lara-typescript/src/plugin-api/types.ts#L89)*
 
 Function that returns interactive state (Promise) or null if embeddable isn't interactive.
 
@@ -54,7 +54,7 @@ ___
 
 **● getReportingUrl**: *`function`*
 
-*Defined in [types.ts:97](../../../lara-typescript/src/plugin-api/types.ts#L97)*
+*Defined in [types.ts:99](../../../lara-typescript/src/plugin-api/types.ts#L99)*
 
 Function that returns reporting URL (Promise) or null if it's not an interactive or reporting URL is not defined. Note that reporting URL is defined in the interactive state (that can be obtained via #getInteractiveState method). If your code needs both interactive state and reporting URL, you can pass interactiveStatePromise as an argument to this method to limit number of network requests.
 
@@ -78,7 +78,7 @@ ___
 
 **● interactiveAvailable**: *`boolean`*
 
-*Defined in [types.ts:107](../../../lara-typescript/src/plugin-api/types.ts#L107)*
+*Defined in [types.ts:109](../../../lara-typescript/src/plugin-api/types.ts#L109)*
 
 True if the interactive is immediately available
 
@@ -89,7 +89,7 @@ ___
 
 **● laraJson**: *`any`*
 
-*Defined in [types.ts:85](../../../lara-typescript/src/plugin-api/types.ts#L85)*
+*Defined in [types.ts:87](../../../lara-typescript/src/plugin-api/types.ts#L87)*
 
 Serialized form of the embeddable. Defined by LARA export code, so it's format cannot be specified here. Example (interactive):
 
@@ -115,7 +115,7 @@ ___
 
 **● onInteractiveAvailable**: *`function`*
 
-*Defined in [types.ts:105](../../../lara-typescript/src/plugin-api/types.ts#L105)*
+*Defined in [types.ts:107](../../../lara-typescript/src/plugin-api/types.ts#L107)*
 
 Function that subscribes provided handler to event that gets called when the interactive's availablity changes. Normally an interactive starts as available unless click to play is enabled. When click to play is enabled the interactive starts as not available and this handler is called when the click to play overlay is hidden.
 

--- a/docs/lara-plugin-api/interfaces/iinteractiveavailableevent.md
+++ b/docs/lara-plugin-api/interfaces/iinteractiveavailableevent.md
@@ -25,7 +25,7 @@ Data passed to InteractiveAvailable event handlers.
 
 **● available**: *`boolean`*
 
-*Defined in [types.ts:227](../../../lara-typescript/src/plugin-api/types.ts#L227)*
+*Defined in [types.ts:229](../../../lara-typescript/src/plugin-api/types.ts#L229)*
 
 Availablility of interactive
 
@@ -36,7 +36,7 @@ ___
 
 **● container**: *`HTMLElement`*
 
-*Defined in [types.ts:223](../../../lara-typescript/src/plugin-api/types.ts#L223)*
+*Defined in [types.ts:225](../../../lara-typescript/src/plugin-api/types.ts#L225)*
 
 Interactive container of the interactive that was just started.
 

--- a/docs/lara-plugin-api/interfaces/iinteractivestate.md
+++ b/docs/lara-plugin-api/interfaces/iinteractivestate.md
@@ -27,7 +27,7 @@
 
 **● activity_name**: *`string`*
 
-*Defined in [types.ts:197](../../../lara-typescript/src/plugin-api/types.ts#L197)*
+*Defined in [types.ts:199](../../../lara-typescript/src/plugin-api/types.ts#L199)*
 
 ___
 <a id="id"></a>
@@ -36,7 +36,7 @@ ___
 
 **● id**: *`number`*
 
-*Defined in [types.ts:192](../../../lara-typescript/src/plugin-api/types.ts#L192)*
+*Defined in [types.ts:194](../../../lara-typescript/src/plugin-api/types.ts#L194)*
 
 ___
 <a id="interactive_name"></a>
@@ -45,7 +45,7 @@ ___
 
 **● interactive_name**: *`string`*
 
-*Defined in [types.ts:195](../../../lara-typescript/src/plugin-api/types.ts#L195)*
+*Defined in [types.ts:197](../../../lara-typescript/src/plugin-api/types.ts#L197)*
 
 ___
 <a id="interactive_state_url"></a>
@@ -54,7 +54,7 @@ ___
 
 **● interactive_state_url**: *`string`*
 
-*Defined in [types.ts:196](../../../lara-typescript/src/plugin-api/types.ts#L196)*
+*Defined in [types.ts:198](../../../lara-typescript/src/plugin-api/types.ts#L198)*
 
 ___
 <a id="key"></a>
@@ -63,7 +63,7 @@ ___
 
 **● key**: *`string`*
 
-*Defined in [types.ts:193](../../../lara-typescript/src/plugin-api/types.ts#L193)*
+*Defined in [types.ts:195](../../../lara-typescript/src/plugin-api/types.ts#L195)*
 
 ___
 <a id="raw_data"></a>
@@ -72,7 +72,7 @@ ___
 
 **● raw_data**: *`string`*
 
-*Defined in [types.ts:194](../../../lara-typescript/src/plugin-api/types.ts#L194)*
+*Defined in [types.ts:196](../../../lara-typescript/src/plugin-api/types.ts#L196)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ijwtclaims.md
+++ b/docs/lara-plugin-api/interfaces/ijwtclaims.md
@@ -35,7 +35,7 @@
 
 **● alg**: *`string`*
 
-*Defined in [types.ts:149](../../../lara-typescript/src/plugin-api/types.ts#L149)*
+*Defined in [types.ts:151](../../../lara-typescript/src/plugin-api/types.ts#L151)*
 
 ___
 <a id="aud"></a>
@@ -44,7 +44,7 @@ ___
 
 **● aud**: *`string`*
 
-*Defined in [types.ts:150](../../../lara-typescript/src/plugin-api/types.ts#L150)*
+*Defined in [types.ts:152](../../../lara-typescript/src/plugin-api/types.ts#L152)*
 
 ___
 <a id="claims"></a>
@@ -53,7 +53,7 @@ ___
 
 **● claims**: *[IPortalClaims](iportalclaims.md)*
 
-*Defined in [types.ts:162](../../../lara-typescript/src/plugin-api/types.ts#L162)*
+*Defined in [types.ts:164](../../../lara-typescript/src/plugin-api/types.ts#L164)*
 
 ___
 <a id="class_info_url"></a>
@@ -62,7 +62,7 @@ ___
 
 **● class_info_url**: *`string`*
 
-*Defined in [types.ts:151](../../../lara-typescript/src/plugin-api/types.ts#L151)*
+*Defined in [types.ts:153](../../../lara-typescript/src/plugin-api/types.ts#L153)*
 
 ___
 <a id="domain"></a>
@@ -71,7 +71,7 @@ ___
 
 **● domain**: *`string`*
 
-*Defined in [types.ts:152](../../../lara-typescript/src/plugin-api/types.ts#L152)*
+*Defined in [types.ts:154](../../../lara-typescript/src/plugin-api/types.ts#L154)*
 
 ___
 <a id="domain_uid"></a>
@@ -80,7 +80,7 @@ ___
 
 **● domain_uid**: *`number`*
 
-*Defined in [types.ts:153](../../../lara-typescript/src/plugin-api/types.ts#L153)*
+*Defined in [types.ts:155](../../../lara-typescript/src/plugin-api/types.ts#L155)*
 
 ___
 <a id="exp"></a>
@@ -89,7 +89,7 @@ ___
 
 **● exp**: *`number`*
 
-*Defined in [types.ts:154](../../../lara-typescript/src/plugin-api/types.ts#L154)*
+*Defined in [types.ts:156](../../../lara-typescript/src/plugin-api/types.ts#L156)*
 
 ___
 <a id="externalid"></a>
@@ -98,7 +98,7 @@ ___
 
 **● externalId**: *`number`*
 
-*Defined in [types.ts:155](../../../lara-typescript/src/plugin-api/types.ts#L155)*
+*Defined in [types.ts:157](../../../lara-typescript/src/plugin-api/types.ts#L157)*
 
 ___
 <a id="iat"></a>
@@ -107,7 +107,7 @@ ___
 
 **● iat**: *`number`*
 
-*Defined in [types.ts:156](../../../lara-typescript/src/plugin-api/types.ts#L156)*
+*Defined in [types.ts:158](../../../lara-typescript/src/plugin-api/types.ts#L158)*
 
 ___
 <a id="iss"></a>
@@ -116,7 +116,7 @@ ___
 
 **● iss**: *`string`*
 
-*Defined in [types.ts:157](../../../lara-typescript/src/plugin-api/types.ts#L157)*
+*Defined in [types.ts:159](../../../lara-typescript/src/plugin-api/types.ts#L159)*
 
 ___
 <a id="logging"></a>
@@ -125,7 +125,7 @@ ___
 
 **● logging**: *`boolean`*
 
-*Defined in [types.ts:158](../../../lara-typescript/src/plugin-api/types.ts#L158)*
+*Defined in [types.ts:160](../../../lara-typescript/src/plugin-api/types.ts#L160)*
 
 ___
 <a id="returnurl"></a>
@@ -134,7 +134,7 @@ ___
 
 **● returnUrl**: *`string`*
 
-*Defined in [types.ts:159](../../../lara-typescript/src/plugin-api/types.ts#L159)*
+*Defined in [types.ts:161](../../../lara-typescript/src/plugin-api/types.ts#L161)*
 
 ___
 <a id="sub"></a>
@@ -143,7 +143,7 @@ ___
 
 **● sub**: *`string`*
 
-*Defined in [types.ts:160](../../../lara-typescript/src/plugin-api/types.ts#L160)*
+*Defined in [types.ts:162](../../../lara-typescript/src/plugin-api/types.ts#L162)*
 
 ___
 <a id="uid"></a>
@@ -152,7 +152,7 @@ ___
 
 **● uid**: *`string`*
 
-*Defined in [types.ts:161](../../../lara-typescript/src/plugin-api/types.ts#L161)*
+*Defined in [types.ts:163](../../../lara-typescript/src/plugin-api/types.ts#L163)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ijwtresponse.md
+++ b/docs/lara-plugin-api/interfaces/ijwtresponse.md
@@ -23,7 +23,7 @@
 
 **● claims**: *[IJwtClaims](ijwtclaims.md)*
 
-*Defined in [types.ts:167](../../../lara-typescript/src/plugin-api/types.ts#L167)*
+*Defined in [types.ts:169](../../../lara-typescript/src/plugin-api/types.ts#L169)*
 
 ___
 <a id="token"></a>
@@ -32,7 +32,7 @@ ___
 
 **● token**: *`string`*
 
-*Defined in [types.ts:166](../../../lara-typescript/src/plugin-api/types.ts#L166)*
+*Defined in [types.ts:168](../../../lara-typescript/src/plugin-api/types.ts#L168)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ilogdata.md
+++ b/docs/lara-plugin-api/interfaces/ilogdata.md
@@ -26,7 +26,7 @@ That's the minimal set of properties that needs to be provided. All the other pr
 
 **● event**: *`string`*
 
-*Defined in [types.ts:205](../../../lara-typescript/src/plugin-api/types.ts#L205)*
+*Defined in [types.ts:207](../../../lara-typescript/src/plugin-api/types.ts#L207)*
 
 ___
 <a id="event_value"></a>
@@ -35,7 +35,7 @@ ___
 
 **● event_value**: *`any`*
 
-*Defined in [types.ts:206](../../../lara-typescript/src/plugin-api/types.ts#L206)*
+*Defined in [types.ts:208](../../../lara-typescript/src/plugin-api/types.ts#L208)*
 
 ___
 <a id="parameters"></a>
@@ -44,7 +44,7 @@ ___
 
 **● parameters**: *`any`*
 
-*Defined in [types.ts:207](../../../lara-typescript/src/plugin-api/types.ts#L207)*
+*Defined in [types.ts:209](../../../lara-typescript/src/plugin-api/types.ts#L209)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ioffering.md
+++ b/docs/lara-plugin-api/interfaces/ioffering.md
@@ -24,7 +24,7 @@
 
 **● id**: *`number`*
 
-*Defined in [types.ts:177](../../../lara-typescript/src/plugin-api/types.ts#L177)*
+*Defined in [types.ts:179](../../../lara-typescript/src/plugin-api/types.ts#L179)*
 
 ___
 <a id="name"></a>
@@ -33,7 +33,7 @@ ___
 
 **● name**: *`string`*
 
-*Defined in [types.ts:178](../../../lara-typescript/src/plugin-api/types.ts#L178)*
+*Defined in [types.ts:180](../../../lara-typescript/src/plugin-api/types.ts#L180)*
 
 ___
 <a id="url"></a>
@@ -42,7 +42,7 @@ ___
 
 **● url**: *`string`*
 
-*Defined in [types.ts:179](../../../lara-typescript/src/plugin-api/types.ts#L179)*
+*Defined in [types.ts:181](../../../lara-typescript/src/plugin-api/types.ts#L181)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/ipluginauthoringcontext.md
+++ b/docs/lara-plugin-api/interfaces/ipluginauthoringcontext.md
@@ -30,7 +30,7 @@
 
 **● authoredState**: *`string` \| `null`*
 
-*Defined in [types.ts:118](../../../lara-typescript/src/plugin-api/types.ts#L118)*
+*Defined in [types.ts:120](../../../lara-typescript/src/plugin-api/types.ts#L120)*
 
 The authored configuration for this instance (if available).
 
@@ -41,7 +41,7 @@ ___
 
 **● componentLabel**: *`string`*
 
-*Defined in [types.ts:122](../../../lara-typescript/src/plugin-api/types.ts#L122)*
+*Defined in [types.ts:124](../../../lara-typescript/src/plugin-api/types.ts#L124)*
 
 The label of the plugin component.
 
@@ -52,7 +52,7 @@ ___
 
 **● container**: *`HTMLElement`*
 
-*Defined in [types.ts:120](../../../lara-typescript/src/plugin-api/types.ts#L120)*
+*Defined in [types.ts:122](../../../lara-typescript/src/plugin-api/types.ts#L122)*
 
 Reserved HTMLElement for the plugin output.
 
@@ -63,7 +63,7 @@ ___
 
 **● getFirebaseJwt**: *`function`*
 
-*Defined in [types.ts:136](../../../lara-typescript/src/plugin-api/types.ts#L136)*
+*Defined in [types.ts:138](../../../lara-typescript/src/plugin-api/types.ts#L138)*
 
 Function that returns JWT (Promise) for given app name.
 
@@ -85,7 +85,7 @@ ___
 
 **● name**: *`string`*
 
-*Defined in [types.ts:112](../../../lara-typescript/src/plugin-api/types.ts#L112)*
+*Defined in [types.ts:114](../../../lara-typescript/src/plugin-api/types.ts#L114)*
 
 Name of the plugin
 
@@ -96,7 +96,7 @@ ___
 
 **● pluginId**: *`number`*
 
-*Defined in [types.ts:116](../../../lara-typescript/src/plugin-api/types.ts#L116)*
+*Defined in [types.ts:118](../../../lara-typescript/src/plugin-api/types.ts#L118)*
 
 Plugin instance ID.
 
@@ -107,7 +107,7 @@ ___
 
 **● saveAuthoredPluginState**: *`function`*
 
-*Defined in [types.ts:130](../../../lara-typescript/src/plugin-api/types.ts#L130)*
+*Defined in [types.ts:132](../../../lara-typescript/src/plugin-api/types.ts#L132)*
 
 Function that saves the authoring state for the plugin.
 
@@ -135,7 +135,7 @@ ___
 
 **● url**: *`string`*
 
-*Defined in [types.ts:114](../../../lara-typescript/src/plugin-api/types.ts#L114)*
+*Defined in [types.ts:116](../../../lara-typescript/src/plugin-api/types.ts#L116)*
 
 Url from which the plugin was loaded.
 
@@ -146,7 +146,7 @@ ___
 
 **● wrappedEmbeddable**: *[IEmbeddableRuntimeContext](iembeddableruntimecontext.md) \| `null`*
 
-*Defined in [types.ts:134](../../../lara-typescript/src/plugin-api/types.ts#L134)*
+*Defined in [types.ts:136](../../../lara-typescript/src/plugin-api/types.ts#L136)*
 
 Wrapped embeddable runtime context if plugin is wrapping some embeddable and the plugin has the guiPreview option set to true within its manifest.
 

--- a/docs/lara-plugin-api/interfaces/ipluginruntimecontext.md
+++ b/docs/lara-plugin-api/interfaces/ipluginruntimecontext.md
@@ -19,6 +19,7 @@
 * [name](ipluginruntimecontext.md#name)
 * [pluginId](ipluginruntimecontext.md#pluginid)
 * [remoteEndpoint](ipluginruntimecontext.md#remoteendpoint)
+* [resourceUrl](ipluginruntimecontext.md#resourceurl)
 * [runId](ipluginruntimecontext.md#runid)
 * [saveLearnerPluginState](ipluginruntimecontext.md#savelearnerpluginstate)
 * [url](ipluginruntimecontext.md#url)
@@ -57,7 +58,7 @@ ___
 
 **● getClassInfo**: *`function`*
 
-*Defined in [types.ts:41](../../../lara-typescript/src/plugin-api/types.ts#L41)*
+*Defined in [types.ts:43](../../../lara-typescript/src/plugin-api/types.ts#L43)*
 
 Function that returns class details (Promise) or null if class info is not available.
 
@@ -73,7 +74,7 @@ ___
 
 **● getFirebaseJwt**: *`function`*
 
-*Defined in [types.ts:43](../../../lara-typescript/src/plugin-api/types.ts#L43)*
+*Defined in [types.ts:45](../../../lara-typescript/src/plugin-api/types.ts#L45)*
 
 Function that returns JWT (Promise) for given app name.
 
@@ -106,7 +107,7 @@ ___
 
 **● log**: *`function`*
 
-*Defined in [types.ts:61](../../../lara-typescript/src/plugin-api/types.ts#L61)*
+*Defined in [types.ts:63](../../../lara-typescript/src/plugin-api/types.ts#L63)*
 
 Logs event to the CC Log Server. Note that logging must be enabled for a given activity. Either by setting URL param logging=true or by enabling logging in Portal.
 
@@ -166,6 +167,17 @@ ___
 The portal remote endpoint (if available).
 
 ___
+<a id="resourceurl"></a>
+
+###  resourceUrl
+
+**● resourceUrl**: *`string`*
+
+*Defined in [types.ts:30](../../../lara-typescript/src/plugin-api/types.ts#L30)*
+
+URL of the resource associated with the current run (sequence URL or activity URL)
+
+___
 <a id="runid"></a>
 
 ###  runId
@@ -183,7 +195,7 @@ ___
 
 **● saveLearnerPluginState**: *`function`*
 
-*Defined in [types.ts:39](../../../lara-typescript/src/plugin-api/types.ts#L39)*
+*Defined in [types.ts:41](../../../lara-typescript/src/plugin-api/types.ts#L41)*
 
 Function that saves the users state for the plugin. Note that plugins can have different scopes, e.g. activity or a single page. If the plugin instance is added to the activity, its state will be shared across all the pages. If multiple plugin instances are added to various pages, their state will be different on every page.
 
@@ -233,7 +245,7 @@ ___
 
 **● wrappedEmbeddable**: *[IEmbeddableRuntimeContext](iembeddableruntimecontext.md) \| `null`*
 
-*Defined in [types.ts:47](../../../lara-typescript/src/plugin-api/types.ts#L47)*
+*Defined in [types.ts:49](../../../lara-typescript/src/plugin-api/types.ts#L49)*
 
 Wrapped embeddable runtime context if plugin is wrapping some embeddable and the plugin has the guiPreview option set to true within its manifest.
 

--- a/docs/lara-plugin-api/interfaces/iportalclaims.md
+++ b/docs/lara-plugin-api/interfaces/iportalclaims.md
@@ -27,7 +27,7 @@
 
 **● class_hash**: *`string`*
 
-*Defined in [types.ts:140](../../../lara-typescript/src/plugin-api/types.ts#L140)*
+*Defined in [types.ts:142](../../../lara-typescript/src/plugin-api/types.ts#L142)*
 
 ___
 <a id="offering_id"></a>
@@ -36,7 +36,7 @@ ___
 
 **● offering_id**: *`number`*
 
-*Defined in [types.ts:141](../../../lara-typescript/src/plugin-api/types.ts#L141)*
+*Defined in [types.ts:143](../../../lara-typescript/src/plugin-api/types.ts#L143)*
 
 ___
 <a id="platform_id"></a>
@@ -45,7 +45,7 @@ ___
 
 **● platform_id**: *`string`*
 
-*Defined in [types.ts:142](../../../lara-typescript/src/plugin-api/types.ts#L142)*
+*Defined in [types.ts:144](../../../lara-typescript/src/plugin-api/types.ts#L144)*
 
 ___
 <a id="platform_user_id"></a>
@@ -54,7 +54,7 @@ ___
 
 **● platform_user_id**: *`number`*
 
-*Defined in [types.ts:143](../../../lara-typescript/src/plugin-api/types.ts#L143)*
+*Defined in [types.ts:145](../../../lara-typescript/src/plugin-api/types.ts#L145)*
 
 ___
 <a id="user_id"></a>
@@ -63,7 +63,7 @@ ___
 
 **● user_id**: *`string`*
 
-*Defined in [types.ts:144](../../../lara-typescript/src/plugin-api/types.ts#L144)*
+*Defined in [types.ts:146](../../../lara-typescript/src/plugin-api/types.ts#L146)*
 
 ___
 <a id="user_type"></a>
@@ -72,7 +72,7 @@ ___
 
 **● user_type**: *"learner" \| "teacher"*
 
-*Defined in [types.ts:145](../../../lara-typescript/src/plugin-api/types.ts#L145)*
+*Defined in [types.ts:147](../../../lara-typescript/src/plugin-api/types.ts#L147)*
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/iuser.md
+++ b/docs/lara-plugin-api/interfaces/iuser.md
@@ -24,7 +24,7 @@
 
 **● first_name**: *`string`*
 
-*Defined in [types.ts:172](../../../lara-typescript/src/plugin-api/types.ts#L172)*
+*Defined in [types.ts:174](../../../lara-typescript/src/plugin-api/types.ts#L174)*
 
 ___
 <a id="id"></a>
@@ -33,7 +33,7 @@ ___
 
 **● id**: *`string`*
 
-*Defined in [types.ts:171](../../../lara-typescript/src/plugin-api/types.ts#L171)*
+*Defined in [types.ts:173](../../../lara-typescript/src/plugin-api/types.ts#L173)*
 
 ___
 <a id="last_name"></a>
@@ -42,7 +42,7 @@ ___
 
 **● last_name**: *`string`*
 
-*Defined in [types.ts:173](../../../lara-typescript/src/plugin-api/types.ts#L173)*
+*Defined in [types.ts:175](../../../lara-typescript/src/plugin-api/types.ts#L175)*
 
 ___
 

--- a/lara-typescript/src/lib/plugin-context.spec.ts
+++ b/lara-typescript/src/lib/plugin-context.spec.ts
@@ -29,7 +29,8 @@ describe("Plugin runtime context helper", () => {
     classInfoUrl: "http://portal.class.info.url",
     firebaseJwtUrl: "http://firebase.jwt._FIREBASE_APP_.com",
     wrappedEmbeddable: null,
-    componentLabel: "test"
+    componentLabel: "test",
+    resourceUrl: "http://lara.activity.com/123"
   };
 
   it("should copy basic properties to runtime context", () => {
@@ -43,6 +44,7 @@ describe("Plugin runtime context helper", () => {
     expect(runtimeContext.runId).toEqual(pluginContext.runId);
     expect(runtimeContext.remoteEndpoint).toEqual(pluginContext.remoteEndpoint);
     expect(runtimeContext.userEmail).toEqual(pluginContext.userEmail);
+    expect(runtimeContext.resourceUrl).toEqual(pluginContext.resourceUrl);
   });
 
   describe("#saveLearnerPluginState", () => {

--- a/lara-typescript/src/lib/plugin-context.ts
+++ b/lara-typescript/src/lib/plugin-context.ts
@@ -45,6 +45,8 @@ export interface IPluginRuntimeContextOptions extends IPluginCommonOptions {
   classInfoUrl: string | null;
   /** The ID of the Embeddable that has been added to page, this embeddable refers to the plugin instance */
   embeddablePluginId: number | null;
+  /** URL of the resource associated with the current run (sequence URL or activity URL) */
+  resourceUrl: string;
 }
 
 export interface IPluginAuthoringContextOptions extends IPluginCommonOptions {
@@ -169,6 +171,7 @@ export const generateRuntimePluginContext = (options: IPluginRuntimeContextOptio
     runId: options.runId,
     remoteEndpoint: options.remoteEndpoint,
     userEmail: options.userEmail,
+    resourceUrl: options.resourceUrl,
     saveLearnerPluginState: (state: string) => saveLearnerPluginState(options.learnerStateSaveUrl, state),
     getClassInfo: () => getClassInfo(options.classInfoUrl),
     getFirebaseJwt: (appName: string) => getFirebaseJwt(options.firebaseJwtUrl, appName),

--- a/lara-typescript/src/lib/plugins.spec.ts
+++ b/lara-typescript/src/lib/plugins.spec.ts
@@ -65,7 +65,8 @@ describe("Plugins", () => {
       firebaseJwtUrl: "http://fake.jwt",
       embeddablePluginId: null,
       wrappedEmbeddable: null,
-      componentLabel: "test"
+      componentLabel: "test",
+      resourceUrl: "http://lara.activity.com/123"
     };
     const authoringContextOptions: IPluginAuthoringContextOptions = {
       type: "authoring",

--- a/lara-typescript/src/plugin-api/package.json
+++ b/lara-typescript/src/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-plugin-api",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "LARA Plugin API",
   "types": "./index.d.ts",
   "repository": {

--- a/lara-typescript/src/plugin-api/types.ts
+++ b/lara-typescript/src/plugin-api/types.ts
@@ -26,6 +26,8 @@ export interface IPluginRuntimeContext {
   remoteEndpoint: string | null;
   /** The current user email address (if available). */
   userEmail: string | null;
+  /** URL of the resource associated with the current run (sequence URL or activity URL) */
+  resourceUrl: string;
   /****************************************************************************
    Function that saves the users state for the plugin.
    Note that plugins can have different scopes, e.g. activity or a single page.

--- a/spec/views/plugins/_show.html.haml_spec.rb
+++ b/spec/views/plugins/_show.html.haml_spec.rb
@@ -30,7 +30,8 @@ describe "plugins/_show.html.haml" do
       user: user,
       id: run_id,
       class_info_url: class_info_url,
-      remote_endpoint: run_remote_endpoint
+      remote_endpoint: run_remote_endpoint,
+      activity: FactoryGirl.create(:activity)
     })
   end
   let(:plugin_local) do
@@ -92,7 +93,7 @@ describe "plugins/_show.html.haml" do
         common_plugin_code.each do |expected_string|
           expect(rendered).to match(expected_string)
         end
-      end 
+      end
     end
 
   end


### PR DESCRIPTION
[#166445035]

Add `resourceUrl` to Plugin runtime context, so LARA plugins don't have to construct that using URL (which quite often includes page and run key too).