### PR TITLE
sequences should be republished to report service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
     volumes:
       - .:/lara
       - "bundle:/bundle"
+    # open standard in and turn on tty so we can attach to the container and debug it
+    stdin_open: true
+    tty: true
+
   db:
     image: mysql:5.6
     environment:

--- a/docker/dev/attach-console.sh
+++ b/docker/dev/attach-console.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# this is a simple script to attach a console to the running app container
+# it is useful for debugging the app. Another requirement for debugging is to enable
+# stdin and tty. This is already done in docker-compose.yml
+docker attach $(docker-compose ps -q app)

--- a/spec/controllers/embeddable/image_questions_controller_spec.rb
+++ b/spec/controllers/embeddable/image_questions_controller_spec.rb
@@ -2,4 +2,6 @@ require 'spec_helper'
 
 describe Embeddable::ImageQuestionsController do
 
+  it_should_behave_like 'an embeddable controller', :image_question
+
 end

--- a/spec/controllers/embeddable/multiple_choices_controller_spec.rb
+++ b/spec/controllers/embeddable/multiple_choices_controller_spec.rb
@@ -2,7 +2,8 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Embeddable::MultipleChoicesController do
 
-  # it_should_behave_like 'an embeddable controller'
+  it_should_behave_like 'an embeddable controller', :mc_embeddable
+  
   describe '#check' do
     let (:multiple) { FactoryGirl.create(:mc_embeddable, :custom => true ) }
     let (:correct) { FactoryGirl.create(:mcc_embeddable, :choice => 'This is correct', :is_correct => true, :multiple_choice => multiple) }
@@ -18,7 +19,7 @@ describe Embeddable::MultipleChoicesController do
         expect(response).to redirect_to(interactive_page_path(page))
       end
     end
-    
+
     context 'the choice has no owning page' do
       it 'generates a 500 error for HTML requests' do
         correct

--- a/spec/controllers/embeddable/open_responses_controller_spec.rb
+++ b/spec/controllers/embeddable/open_responses_controller_spec.rb
@@ -2,6 +2,6 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Embeddable::OpenResponsesController do
 
-  # it_should_behave_like 'an embeddable controller'
+  it_should_behave_like 'an embeddable controller', :open_response
 
 end

--- a/spec/controllers/embeddable/xhtmls_controller_spec.rb
+++ b/spec/controllers/embeddable/xhtmls_controller_spec.rb
@@ -2,6 +2,6 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Embeddable::XhtmlsController do
 
-  # it_should_behave_like 'an embeddable controller'
+  it_should_behave_like 'an embeddable controller', :xhtml
 
 end


### PR DESCRIPTION
this also adds support to debug the app when running in docker
this also replaces some unused shared example code in the embeddable_controller_helper

https://www.pivotaltracker.com/story/show/169066612
