### PR TITLE
add number and bulleted lists to toolbar

### DIFF
--- a/app/assets/javascripts/tinymce-config.js.erb
+++ b/app/assets/javascripts/tinymce-config.js.erb
@@ -2,10 +2,10 @@ window.TinyMCEConfig = {
   menubar: false,
   statusbar: false,
   toolbar_items_size: 'small',
-  toolbar: "undo redo | bold italic strikethrough underline | " +
-           "aligncenter alignjustify alignleft alignright indent outdent | " +
+  toolbar: "undo redo | bold italic underline | " +
+           "aligncenter alignleft alignright indent outdent | " +
            "subscript superscript | numlist bullist | link unlink | hr image | code",
-  plugins: 'paste link hr image autoresize code',
+  plugins: 'paste link hr image autoresize code lists',
   paste_as_text: true,
   image_class_list: [
     {title: 'None', value: ''},
@@ -17,7 +17,7 @@ window.TinyMCEConfig = {
 };
 
 window.TinyMCEConfigMinimal = $.extend({}, window.TinyMCEConfig, {
-  toolbar: "bold italic strikethrough underline indent outdent " +
+  toolbar: "bold italic underline aligncenter indent outdent " +
            "subscript superscript numlist bullist link unlink hr image code"
 });
 

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -18,7 +18,7 @@
 .modal {
   display: none;
   position: absolute;
-  width: 450px;
+  width: 500px;
   left: 50%;
   transform: translate(-50%, 0);
   padding: 20px;


### PR DESCRIPTION
This also adds aligncenter to the small editor toolbar.

The lists plugin was not added to tinymce, so the items weren't showing up,
even though they were configured.

In the fullsize editor this change caused the toolbar to have two lines, so I
removed strikethrough which isn't used much and alignjustify which wasn't
working anyway.

In the small editor I removed strikethrough. The small editor overflowed
the multiple choice edit dialog by a few pixels so I increased modal dialog width globally by 50 pixels. This dialog has been unnecessarily narrow for a while, so this seems like a safe change.