### PR TITLE
fix default text in prompts, fix bullets in image question dialog

### DIFF
--- a/app/views/embeddable/image_question_answers/_lightweight.html.haml
+++ b/app/views/embeddable/image_question_answers/_lightweight.html.haml
@@ -42,7 +42,7 @@
           = f.hidden_field 'answer_text'
         = prediction_button(embeddable, f)
 
-.image-question-dialog{:id => "image_question_dialog_#{embeddable.id}", :style => "display: none"}
+.image-question-dialog.content-mod{:id => "image_question_dialog_#{embeddable.id}", :style => "display: none"}
   .drawing-area
     %div{:id => "drawing-tool-container_for_#{embeddable.id}"}
   .question-area

--- a/app/views/embeddable/open_responses/_form.html.haml
+++ b/app/views/embeddable/open_responses/_form.html.haml
@@ -5,7 +5,7 @@
   = field_set_tag 'Prompt' do
     = f.text_area :prompt, :rows => 5, :class => "wysiwyg-minimal"
   = field_set_tag 'Default Text' do
-    = f.text_area :default_text, :rows => 5, :class => "wysiwyg-minimal"
+    = f.text_area :default_text, :rows => 5
   = field_set_tag 'Hint' do
     .help
       If this is provided, the user will be able to see expandable hint next to the question title.


### PR DESCRIPTION
This removes the rich text editor from default text in open response prompts. The text box for students doesn't allow rich text.
[#98887694]

This also fixes bullets and numbers that were rendered behind the drawing tool. As part of this it also updates the font of the button text.
 [#169986185]