### PR TITLE
Fix image question, move buttons out of `question-txt` class

### DIFF
--- a/app/views/embeddable/external_scripts/_lightweight.html.haml
+++ b/app/views/embeddable/external_scripts/_lightweight.html.haml
@@ -3,6 +3,8 @@
   %script{src:embeddable.url}
 .question-bd{style: "display:none;"}
   .question-txt
+    -# This class should contain ONLY text. It might be decorated by plugins, what means
+    -# that all the event handlers can be lost. So, buttons and forms shouldn't be placed there.
     != embeddable.url
   .output{id:runtimeDiv}
 

--- a/app/views/embeddable/image_question_answers/_lightweight.html.haml
+++ b/app/views/embeddable/image_question_answers/_lightweight.html.haml
@@ -1,46 +1,48 @@
 = render :partial => 'shared/question_header', :locals => { :embeddable => embeddable }
 .question-bd
   .question-txt
+    -# This class should contain ONLY text. It might be decorated by plugins, what means
+    -# that all the event handlers can be lost. So, buttons and forms shouldn't be placed there.
     != embeddable.drawing_prompt
-    %div.image-question{:id => "image_question_main_form_#{embeddable.id}"}
-      = form_for embeddable, :remote => true, :html => {:'data-type' => 'json', :class=> 'live_submit'} do |f|
-        -# The src of this thumbnail image will be rewritten by javascript
-        %img.snapshot_thumbnail{:src => embeddable.annotated_image_url, :width => '100%'}
-        %br
-        - if embeddable.prompt
-          .text_prompt
-            != embeddable.prompt
-          -# this 'formatting' is duplicated in image_question_answers_controller
-          .answer_text{ :data => { :raw => embeddable.answer_text } }
-            = simple_format h(truncate(embeddable.answer_text, length:140))
-        - if embeddable.is_shutterbug?
-          %button.image_question.button.image_snapshot_button.take_snapshot{:type => 'button'}
-            %i.fa.fa-camera
-            %span.take_snapshot_label
-              =t("TAKE_SNAPSHOT")
-          %button.image_question.button.image_snapshot_button.replace_snapshot{:type => 'button'}
-            %i.fa.fa-camera
-            %span.replace_snapshot_label
-              =t("REPLACE_SNAPSHOT")
-        - elsif embeddable.is_drawing?
-          %button.image_question.button.image_drawing_button.drawing_button{:type => 'button'}
-            %i.fa.fa-pencil
-            %span.make_drawing_label
-              =t("MAKE_DRAWING")
-        - elsif embeddable.is_upload?
-          %button.image_question.button.image_upload_button.upload_button{:type => 'button'}
-            %i.fa.fa-upload
-            %span.upload_label
-              =t("UPLOAD_IMAGE")
-        %button.image_question.button.image_snapshot_button.edit_answer{:type => 'button'}
-          =t("EDIT")
-        - if embeddable.require_image_url
-          = f.hidden_field 'image_url'
-        = f.hidden_field 'annotated_image_url'
-        = f.hidden_field 'annotation'
-        - unless embeddable.prompt.blank?
-          = f.hidden_field 'answer_text'
-        = prediction_button(embeddable, f)
+  %div.image-question{:id => "image_question_main_form_#{embeddable.id}"}
+    = form_for embeddable, :remote => true, :html => {:'data-type' => 'json', :class=> 'live_submit'} do |f|
+      -# The src of this thumbnail image will be rewritten by javascript
+      %img.snapshot_thumbnail{:src => embeddable.annotated_image_url, :width => '100%'}
+      %br
+      - if embeddable.prompt
+        .text_prompt
+          != embeddable.prompt
+        -# this 'formatting' is duplicated in image_question_answers_controller
+        .answer_text{ :data => { :raw => embeddable.answer_text } }
+          = simple_format h(truncate(embeddable.answer_text, length:140))
+      - if embeddable.is_shutterbug?
+        %button.image_question.button.image_snapshot_button.take_snapshot{:type => 'button'}
+          %i.fa.fa-camera
+          %span.take_snapshot_label
+            =t("TAKE_SNAPSHOT")
+        %button.image_question.button.image_snapshot_button.replace_snapshot{:type => 'button'}
+          %i.fa.fa-camera
+          %span.replace_snapshot_label
+            =t("REPLACE_SNAPSHOT")
+      - elsif embeddable.is_drawing?
+        %button.image_question.button.image_drawing_button.drawing_button{:type => 'button'}
+          %i.fa.fa-pencil
+          %span.make_drawing_label
+            =t("MAKE_DRAWING")
+      - elsif embeddable.is_upload?
+        %button.image_question.button.image_upload_button.upload_button{:type => 'button'}
+          %i.fa.fa-upload
+          %span.upload_label
+            =t("UPLOAD_IMAGE")
+      %button.image_question.button.image_snapshot_button.edit_answer{:type => 'button'}
+        =t("EDIT")
+      - if embeddable.require_image_url
+        = f.hidden_field 'image_url'
+      = f.hidden_field 'annotated_image_url'
+      = f.hidden_field 'annotation'
+      - unless embeddable.prompt.blank?
+        = f.hidden_field 'answer_text'
+      = prediction_button(embeddable, f)
 
 .image-question-dialog.content-mod{:id => "image_question_dialog_#{embeddable.id}", :style => "display: none"}
   .drawing-area

--- a/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
+++ b/app/views/embeddable/multiple_choice_answers/_lightweight.html.haml
@@ -2,6 +2,8 @@
 = render :partial => 'shared/question_header', :locals => { :embeddable => embeddable }
 .question-bd{ :id => embeddable.answer_id }
   .question-txt
+    -# This class should contain ONLY text. It might be decorated by plugins, what means
+    -# that all the event handlers can be lost. So, buttons and forms shouldn't be placed there.
     != embeddable.prompt
   = form_for embeddable,
     :remote => true,

--- a/app/views/embeddable/open_response_answers/_lightweight.html.haml
+++ b/app/views/embeddable/open_response_answers/_lightweight.html.haml
@@ -1,6 +1,8 @@
 = render :partial => 'shared/question_header', :locals => { :embeddable => embeddable }
 .question-bd{ :id => embeddable.answer_id }
   .question-txt
+    -# This class should contain ONLY text. It might be decorated by plugins, what means
+    -# that all the event handlers can be lost. So, buttons and forms shouldn't be placed there.
     != embeddable.prompt
   = form_for embeddable,
     :remote => true,


### PR DESCRIPTION
[#170211657]

This class should contain ONLY text. It might be decorated by plugins, which means
that all the event handlers can be lost. So, buttons and forms shouldn't be placed there.

That was the reason why snapshot buttons didn't work together with Glossary plugin.