### PR TITLE
Set portal info in a newly created activity run when a sequence is launched

### DIFF
--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -204,6 +204,8 @@ class SequencesController < ApplicationController
   def find_or_create_sequence_run
     if sequence_run_key = params['sequence_run_key']
       @sequence_run = SequenceRun.where(key: sequence_run_key).first!
+      @sequence_run.make_or_update_runs
+      @sequence_run.update_platform_info(params)
       return @sequence_run
     end
 
@@ -220,6 +222,8 @@ class SequencesController < ApplicationController
         @sequence_run.disable_collaboration
       end
     end
+    # Update platform info in case sequence run has been just created or new activities have been added.
+    @sequence_run.update_platform_info(params)
   end
 
 end

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -213,7 +213,7 @@ class SequencesController < ApplicationController
       @sequence_run = cc.call
     else
       portal = RemotePortal.new(params)
-      @sequence_run = SequenceRun.lookup_or_create(@sequence, current_user, portal, params)
+      @sequence_run = SequenceRun.lookup_or_create(@sequence, current_user, portal)
       # If sequence is ran with "portal" params, it means that user wants to run it individually.
       # Note that "portal" refers to individual student data endpoint, this name should be updated.
       if portal.valid?

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -204,6 +204,8 @@ class SequencesController < ApplicationController
   def find_or_create_sequence_run
     if sequence_run_key = params['sequence_run_key']
       @sequence_run = SequenceRun.where(key: sequence_run_key).first!
+      # FIXME: If a new activity has been added to the sequence then this new activity won't
+      # get its platform info added like what happens at the end of this function
       return @sequence_run
     end
 

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -204,8 +204,6 @@ class SequencesController < ApplicationController
   def find_or_create_sequence_run
     if sequence_run_key = params['sequence_run_key']
       @sequence_run = SequenceRun.where(key: sequence_run_key).first!
-      @sequence_run.make_or_update_runs
-      @sequence_run.update_platform_info(params)
       return @sequence_run
     end
 
@@ -215,15 +213,13 @@ class SequencesController < ApplicationController
       @sequence_run = cc.call
     else
       portal = RemotePortal.new(params)
-      @sequence_run = SequenceRun.lookup_or_create(@sequence, current_user, portal)
+      @sequence_run = SequenceRun.lookup_or_create(@sequence, current_user, portal, params)
       # If sequence is ran with "portal" params, it means that user wants to run it individually.
       # Note that "portal" refers to individual student data endpoint, this name should be updated.
       if portal.valid?
         @sequence_run.disable_collaboration
       end
     end
-    # Update platform info in case sequence run has been just created or new activities have been added.
-    @sequence_run.update_platform_info(params)
   end
 
 end

--- a/app/controllers/sequences_controller.rb
+++ b/app/controllers/sequences_controller.rb
@@ -204,8 +204,6 @@ class SequencesController < ApplicationController
   def find_or_create_sequence_run
     if sequence_run_key = params['sequence_run_key']
       @sequence_run = SequenceRun.where(key: sequence_run_key).first!
-      # FIXME: If a new activity has been added to the sequence then this new activity won't
-      # get its platform info added like what happens at the end of this function
       return @sequence_run
     end
 
@@ -222,8 +220,6 @@ class SequencesController < ApplicationController
         @sequence_run.disable_collaboration
       end
     end
-    # If we have new class_info_url or class_hash update it
-    @sequence_run.update_platform_info(params)
   end
 
 end

--- a/app/models/remote_portal.rb
+++ b/app/models/remote_portal.rb
@@ -1,11 +1,12 @@
 class RemotePortal
 
-  attr_accessor :remote_endpoint, :domain, :remote_id
+  attr_accessor :remote_endpoint, :domain, :remote_id, :platform_info
 
   def initialize(params)
     self.remote_endpoint    = params[:returnUrl]
     self.domain             = params[:domain]
     self.remote_id          = params[:externalId]
+    self.platform_info = params.slice(:platform_id, :platform_user_id, :resource_link_id, :context_id, :class_info_url)
   end
 
   def valid?

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -77,11 +77,12 @@ class Run < ActiveRecord::Base
       #TODO: add domain
     }
     conditions[:activity_id]     = activity.id if activity
-    found = self.where(conditions).first
-    if found
-      return found
+    run = self.where(conditions).first
+    unless run
+      run = self.create!(conditions)
     end
-    return self.create!(conditions)
+    run.update_platform_info(portal.platform_info)
+    run
   end
 
   def self.for_user_activity_and_sequence(user,activity,seq_id)
@@ -107,7 +108,7 @@ class Run < ActiveRecord::Base
 
     # if no run has been found and there is a seq_id, create a sequence run too
     if seq_id
-      seq_run = SequenceRun.lookup_or_create(Sequence.find(seq_id), user, RemotePortal.new({}), {})
+      seq_run = SequenceRun.lookup_or_create(Sequence.find(seq_id), user, RemotePortal.new({}))
       return seq_run.run_for_activity(activity)
     else
       return self.create!(conditions)

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -107,7 +107,7 @@ class Run < ActiveRecord::Base
 
     # if no run has been found and there is a seq_id, create a sequence run too
     if seq_id
-      seq_run = SequenceRun.lookup_or_create(Sequence.find(seq_id), user, RemotePortal.new({}))
+      seq_run = SequenceRun.lookup_or_create(Sequence.find(seq_id), user, RemotePortal.new({}), {})
       return seq_run.run_for_activity(activity)
     else
       return self.create!(conditions)

--- a/app/models/sequence_run.rb
+++ b/app/models/sequence_run.rb
@@ -56,14 +56,6 @@ class SequenceRun < ActiveRecord::Base
         raise Exception.new("Activity is not part of this sequence")
       end
 
-      # FIXME: If an activity is added to a sequence after the student has already started
-      # the sequence, this code path will be triggered. If the sequence run has
-      # platform info then this new activity run should be setup with the same
-      # platform info. This will probably overlap with what is already happen through
-      # SequenceController#update_platform_info that is called by SequenceController#find_or_create_sequence_run
-      # Before SequenceController#find_or_create_sequence_run calls update_platform_info,
-      # it calls SequenceController.lookup_or_create which calls
-      # SequenceController#make_or_update_runs which calls this method (run_for_activity).
       #
       # So if this method (run_for_activity) sets the platform_info for the activity
       # run, then SequenceController#update_platform_info should not need to do it too.
@@ -78,8 +70,13 @@ class SequenceRun < ActiveRecord::Base
         remote_id:       remote_id,
         user_id:         user ? user.id : nil,
         activity_id:     activity.id,
-        sequence_id:     sequence.id
+        sequence_id:     sequence.id,
       })
+      # If an activity is added to a sequence after the student has already started
+      # the sequence, this code path will be triggered. If the sequence run has
+      # platform info then this new activity run should be setup with the same
+      # platform info.
+      run.update_platform_info(self.attributes)
       runs << run
     end
     run

--- a/app/models/sequence_run.rb
+++ b/app/models/sequence_run.rb
@@ -15,7 +15,7 @@ class SequenceRun < ActiveRecord::Base
     SecureRandom.hex(20)
   end
 
-  def self.lookup_or_create(sequence, user, portal, platform_info = nil)
+  def self.lookup_or_create(sequence, user, portal)
     if portal.valid? && user.nil?
       raise ActiveRecord::RecordNotFound.new(
         "user must be logged in to access a SequenceRun via portal parameters"
@@ -42,9 +42,7 @@ class SequenceRun < ActiveRecord::Base
       seq_run = self.create!(conditions)
     end
 
-    if platform_info
-      seq_run.update_platform_info(platform_info)
-    end
+    seq_run.update_platform_info(portal.platform_info)
     seq_run.make_or_update_runs
     seq_run
   end

--- a/app/models/sequence_run.rb
+++ b/app/models/sequence_run.rb
@@ -55,14 +55,6 @@ class SequenceRun < ActiveRecord::Base
         # request an activity that is no longer part of the sequence
         raise Exception.new("Activity is not part of this sequence")
       end
-
-      #
-      # So if this method (run_for_activity) sets the platform_info for the activity
-      # run, then SequenceController#update_platform_info should not need to do it too.
-      # I think there are tests that newly created sequence runs have the the platform info
-      # set on their child runs, but if not that test should be added before changing the
-      # the code.
-
       # create the run, we use this form instead of runs.create to make testing
       # easier
       run = Run.create!({
@@ -72,11 +64,6 @@ class SequenceRun < ActiveRecord::Base
         activity_id:     activity.id,
         sequence_id:     sequence.id,
       })
-      # If an activity is added to a sequence after the student has already started
-      # the sequence, this code path will be triggered. If the sequence run has
-      # platform info then this new activity run should be setup with the same
-      # platform info.
-      run.update_platform_info(self.attributes)
       runs << run
     end
     run
@@ -123,9 +110,7 @@ class SequenceRun < ActiveRecord::Base
 
   # see /app/models/with_class_info.rb#update_platform_info
   def update_platform_info(url_params)
-    updates = super(url_params)
-    if (updates)
-      self.runs.each { |r| r.update_platform_info(url_params) }
-    end
+    super(url_params)
+    runs.each { |r| r.update_platform_info(url_params) }
   end
 end

--- a/app/models/sequence_run.rb
+++ b/app/models/sequence_run.rb
@@ -56,6 +56,21 @@ class SequenceRun < ActiveRecord::Base
         raise Exception.new("Activity is not part of this sequence")
       end
 
+      # FIXME: If an activity is added to a sequence after the student has already started
+      # the sequence, this code path will be triggered. If the sequence run has
+      # platform info then this new activity run should be setup with the same
+      # platform info. This will probably overlap with what is already happen through
+      # SequenceController#update_platform_info that is called by SequenceController#find_or_create_sequence_run
+      # Before SequenceController#find_or_create_sequence_run calls update_platform_info,
+      # it calls SequenceController.lookup_or_create which calls
+      # SequenceController#make_or_update_runs which calls this method (run_for_activity).
+      #
+      # So if this method (run_for_activity) sets the platform_info for the activity
+      # run, then SequenceController#update_platform_info should not need to do it too.
+      # I think there are tests that newly created sequence runs have the the platform info
+      # set on their child runs, but if not that test should be added before changing the
+      # the code.
+
       # create the run, we use this form instead of runs.create to make testing
       # easier
       run = Run.create!({

--- a/app/services/create_collaboration.rb
+++ b/app/services/create_collaboration.rb
@@ -77,8 +77,7 @@ class CreateCollaboration
   end
 
   def add_sequence_runs(user, portal_endpoint, collaborator_data)
-    sequence_run = SequenceRun.lookup_or_create(@sequence, user, portal_endpoint)
-    sequence_run.update_platform_info(collaborator_data)
+    sequence_run = SequenceRun.lookup_or_create(@sequence, user, portal_endpoint, collaborator_data)
     @collaboration_run.runs.push(*sequence_run.runs)
     # Save sequence run that belongs to the collaboration owner.
     @owners_sequence_run = sequence_run if user == @owner

--- a/app/services/create_collaboration.rb
+++ b/app/services/create_collaboration.rb
@@ -60,24 +60,29 @@ class CreateCollaboration
       # Well, RemotePortal is a single endpoint in fact. Naming isn't consistent at all.
       portal_endpoint = RemotePortal.new(
         returnUrl: c['endpoint_url'],
-        externalId: c['learner_id']
+        externalId: c['learner_id'],
+        # Platform info
+        platform_id: c['platform_id'],
+        platform_user_id: c['platform_user_id'],
+        resource_link_id: c['resource_link_id'],
+        context_id: c['context_id'],
+        class_info_url: c['class_info_url']
       )
-      add_activity_run(user, portal_endpoint, c) if @activity
-      add_sequence_runs(user, portal_endpoint, c) if @sequence
+      add_activity_run(user, portal_endpoint) if @activity
+      add_sequence_runs(user, portal_endpoint) if @sequence
     end
   end
 
-  def add_activity_run(user, portal_endpoint, collaborator_data)
+  def add_activity_run(user, portal_endpoint)
     # for_user_and_portal is in fact lookup_or_create
     run = Run.for_user_and_portal(user, @activity, portal_endpoint)
-    run.update_platform_info(collaborator_data)
     @collaboration_run.runs.push(run)
     # Save run that belongs to the collaboration owner.
     @owners_run = run if user == @owner
   end
 
-  def add_sequence_runs(user, portal_endpoint, collaborator_data)
-    sequence_run = SequenceRun.lookup_or_create(@sequence, user, portal_endpoint, collaborator_data)
+  def add_sequence_runs(user, portal_endpoint)
+    sequence_run = SequenceRun.lookup_or_create(@sequence, user, portal_endpoint)
     @collaboration_run.runs.push(*sequence_run.runs)
     # Save sequence run that belongs to the collaboration owner.
     @owners_sequence_run = sequence_run if user == @owner

--- a/db/migrate/20200114203042_add_missing_platform_info.rb
+++ b/db/migrate/20200114203042_add_missing_platform_info.rb
@@ -1,0 +1,13 @@
+class AddMissingPlatformInfo < ActiveRecord::Migration
+  def up
+    runs = Run.joins(:sequence_run).where('runs.platform_id IS NULL AND sequence_runs.platform_id IS NOT NULL').pluck(:id)
+    puts "Found #{runs.count} runs with missing platform info"
+    runs.each do |run_id|
+      run = Run.find(run_id)
+      run.update_platform_info(run.sequence_run.attributes)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20200114203042_add_missing_platform_info.rb
+++ b/db/migrate/20200114203042_add_missing_platform_info.rb
@@ -13,7 +13,7 @@ class AddMissingPlatformInfo < ActiveRecord::Migration
       sender = ReportService::RunSender.new(run, { send_all_answers: true })
       result = sender.send
       if !result || !result["success"]
-        puts "Failed to send Sequence Run: #{run.id}"
+        puts "Failed to send Run: #{run.id}"
       end
     end
   end

--- a/db/migrate/20200114203042_add_missing_platform_info.rb
+++ b/db/migrate/20200114203042_add_missing_platform_info.rb
@@ -5,6 +5,16 @@ class AddMissingPlatformInfo < ActiveRecord::Migration
     runs.each do |run_id|
       run = Run.find(run_id)
       run.update_platform_info(run.sequence_run.attributes)
+      # Sending run to firestore
+      # check that the local environment has
+      # ENV["REPORT_SERVICE_SELF_URL"]
+      # ENV["REPORT_SERVICE_URL"]
+      # ENV["REPORT_SERVICE_TOKEN"]
+      sender = ReportService::RunSender.new(run, { send_all_answers: true })
+      result = sender.send
+      if !result || !result["success"]
+        puts "Failed to send Sequence Run: #{run.id}"
+      end
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20190904182947) do
+ActiveRecord::Schema.define(:version => 20200114203042) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"

--- a/spec/controllers/sequences_controller_spec.rb
+++ b/spec/controllers/sequences_controller_spec.rb
@@ -63,8 +63,43 @@ describe SequencesController do
       let(:run_variable_name) { :sequence_run }
     end
 
+    describe "when sequence has some activities" do
+      before :each do
+        sequence.activities << activity
+        sequence.save!
+      end
+
+      describe "when platform info is provided and sequence run doesn't exist" do
+        it "creates sequence and activity runs with platform info" do
+          expect(SequenceRun.count).to eq(0)
+          expect(Run.count).to eq(0)
+          get :show, {:id => sequence.id, platform_id: "test_platform"}
+          expect(SequenceRun.count).to eq(1)
+          expect(Run.count).to eq(1)
+          expect(SequenceRun.last.platform_id).to eq("test_platform")
+          expect(Run.last.platform_id).to eq("test_platform")
+        end
+      end
+
+      describe "when platform info is provided and sequence run exists" do
+        let(:sequence_run) { FactoryGirl.create(:sequence_run, user_id: nil, sequence: sequence) }
+        before :each do
+          sequence_run
+        end
+        it "creates activity runs with platform info" do
+          expect(SequenceRun.count).to eq(1)
+          expect(Run.count).to eq(0)
+          get :show, id: sequence.id, sequence_run_key: sequence_run.key, platform_id: "test_platform"
+          expect(SequenceRun.count).to eq(1)
+          expect(Run.count).to eq(1)
+          expect(SequenceRun.last.platform_id).to eq("test_platform")
+          expect(Run.last.platform_id).to eq("test_platform")
+        end
+      end
+    end
+
     describe "when there is a sequence run that has been run before" do
-      let(:sequence_run) { FactoryGirl.create(:sequence_run, user_id: nil) }
+      let(:sequence_run) { FactoryGirl.create(:sequence_run, user_id: nil, sequence: sequence) }
       let(:run) { FactoryGirl.create(:run,
         sequence: sequence,
         sequence_run: sequence_run,
@@ -83,7 +118,6 @@ describe SequencesController do
         expect(response).not_to redirect_to(sequence_activity_with_run_path(sequence.id, activity.id, run))
       end
     end
-
   end
 
 

--- a/spec/controllers/sequences_controller_spec.rb
+++ b/spec/controllers/sequences_controller_spec.rb
@@ -82,14 +82,15 @@ describe SequencesController do
       end
 
       describe "when platform info is provided and sequence run exists" do
-        let(:sequence_run) { FactoryGirl.create(:sequence_run, user_id: nil, sequence: sequence) }
+        let(:sequence_run) { FactoryGirl.create(:sequence_run, user_id: user.id, sequence: sequence) }
         before :each do
           sequence_run
+          sign_in user
         end
         it "creates activity runs with platform info" do
           expect(SequenceRun.count).to eq(1)
           expect(Run.count).to eq(0)
-          get :show, id: sequence.id, sequence_run_key: sequence_run.key, platform_id: "test_platform"
+          get :show, id: sequence.id, platform_id: "test_platform"
           expect(SequenceRun.count).to eq(1)
           expect(Run.count).to eq(1)
           expect(SequenceRun.last.platform_id).to eq("test_platform")

--- a/spec/features/author_edits_sequence.rb
+++ b/spec/features/author_edits_sequence.rb
@@ -18,6 +18,9 @@ feature "Author edits a sequence while it is being used" do
   let(:activity2)    { FactoryGirl.create(:activity, pages: [page3, page4]) }
   let(:activity3)    { FactoryGirl.create(:activity, pages: [page5, page6]) }
   let(:sequence)     { FactoryGirl.create(:sequence, :title => 'teacher-edition mode test Sequence', :user_id => author.id, :lightweight_activities => [activity1, activity2], :publication_status => 'public')}
+  # Note that platform_id is a "platform_info" that we care about. externalId and returnUrl are necessary for
+  # sequence run lookup.
+  let(:portal_params) { "?platform_id=test_platform&externalId=123&returnUrl=http://return.url" }
 
   def current_sequence_run
     # find the SequenceRun from the current url
@@ -25,35 +28,8 @@ feature "Author edits a sequence while it is being used" do
     SequenceRun.find_by_key(sequence_run_key)
   end
 
-  scenario "student runs sequence, then author adds a new activity, student continues running sequence" do
-    visit sequence_path(sequence)
-
-    # binding.pry
-    first_sequence_run = current_sequence_run
-    expect(first_sequence_run.runs.count).to be 2
-
-    sequence.lightweight_activities << activity3
-
-    expect(first_sequence_run.runs.count).to be 2
-
-    visit current_url
-
-    # make sure the revisiting the url doesn't cause some kind of strange re-creation of
-    # the sequence run key
-    expect(current_sequence_run).to eq(first_sequence_run)
-
-    # might need to reload this object here
-    first_sequence_run.reload
-    expect(first_sequence_run.runs.count).to be 3
-  end
-
-  scenario "student runs sequence from Portal, then author adds a new activity, student continues running sequence" do
+  def execute_test_for_reload_url
     # Ensure that a new activity run is created and platform info is passed down to the new run.
-
-    # Note that platform_id is a "platform_info" that we care about. externalId and returnUrl are necessary for
-    # sequence run lookup.
-    portal_params = "?platform_id=test_platform&externalId=123&returnUrl=http://return.url"
-
     login_as user, :scope => :user
 
     expect(SequenceRun.count).to eq 0
@@ -68,9 +44,10 @@ feature "Author edits a sequence while it is being used" do
 
     sequence.lightweight_activities << activity3
 
-    expect(first_sequence_run.runs.count).to eq 2
+    expect(first_sequence_run.runs.count).to be 2
 
-    visit sequence_path(sequence) + portal_params
+    visit yield
+
     expect(SequenceRun.count).to eq 1
 
     # make sure the revisiting the url doesn't cause some kind of strange re-creation of
@@ -83,5 +60,13 @@ feature "Author edits a sequence while it is being used" do
     expect(first_sequence_run.runs[0].platform_id).to eq "test_platform"
     expect(first_sequence_run.runs[1].platform_id).to eq "test_platform"
     expect(first_sequence_run.runs[2].platform_id).to eq "test_platform"
+  end
+
+  scenario "student runs sequence, then author adds a new activity, student reloads sequence" do
+    execute_test_for_reload_url { current_url }
+  end
+
+  scenario "student runs sequence from Portal, then author adds a new activity, student starts sequence from Portal again" do
+    execute_test_for_reload_url { sequence_path(sequence) + portal_params }
   end
 end

--- a/spec/features/author_edits_sequence.rb
+++ b/spec/features/author_edits_sequence.rb
@@ -45,4 +45,11 @@ feature "Author edits a sequence while it is being used" do
     first_sequence_run.reload
     expect(first_sequence_run.runs.count).to be 3
   end
+
+  # TODO add an additional scenario to confirm that the platform params are correctly
+  # copied to the new activity run when it is created when revisiting the page after
+  # the activity was added.
+  # it might be necessary to browse to an activity in the sequence first before adding
+  # the new activity. I suspect the code which redirects to the current activity doesn't
+  # trigger the setting of the platform info
 end

--- a/spec/models/remote_portal_spec.rb
+++ b/spec/models/remote_portal_spec.rb
@@ -4,7 +4,12 @@ describe RemotePortal do
   let(:params) do
     { :domain => "concord.org",
       :externalId => "23",
-      :returnUrl => "http://concord.org/foo"
+      :returnUrl => "http://concord.org/foo",
+      :platform_id => "platform",
+      :platform_user_id => "123",
+      :resource_link_id => "link_1",
+      :context_id => "context_1",
+      :class_info_url => "http://class.url"
     }
   end
 
@@ -14,6 +19,13 @@ describe RemotePortal do
       expect(portal.domain).to eq(params[:domain])
       expect(portal.remote_id).to eq(params[:externalId])
       expect(portal.remote_endpoint).to eq(params[:returnUrl])
+      expect(portal.platform_info).to eq({
+        :platform_id => "platform",
+        :platform_user_id => "123",
+        :resource_link_id => "link_1",
+        :context_id => "context_1",
+        :class_info_url => "http://class.url"
+      })
     end
 
     it "should be valid with valid params" do

--- a/spec/models/sequence_run_spec.rb
+++ b/spec/models/sequence_run_spec.rb
@@ -13,6 +13,7 @@ describe SequenceRun do
     double("portal",
       :remote_endpoint => remote_endpoint,
       :remote_id       => remote_id,
+      :platform_info   => {},
       :valid?          => true)
   end
 
@@ -57,6 +58,7 @@ describe SequenceRun do
           double("portal",
             :remote_id       => "something_else",
             :remote_endpoint => remote_endpoint,
+            :platform_info   => {},
             :valid?          => true) }
         it "should make a new run" do
           expect(subject.lookup_or_create(sequence, user, other_portal)).not_to eq(existing_seq_run)
@@ -64,11 +66,16 @@ describe SequenceRun do
       end
 
       describe "when platform info is provided" do
+        let(:portal) {
+          double("portal",
+            :remote_endpoint => remote_endpoint,
+            :remote_id       => remote_id,
+            :platform_info => { platform_id: "test_platform" },
+            :valid?        => true
+          )
+        }
         it "should save it" do
-          portal_info = {
-            platform_id: "test_platform"
-          }
-          expect(subject.lookup_or_create(sequence, user, portal, portal_info).platform_id).to eq("test_platform")
+          expect(subject.lookup_or_create(sequence, user, portal).platform_id).to eq("test_platform")
         end
       end
     end

--- a/spec/models/sequence_run_spec.rb
+++ b/spec/models/sequence_run_spec.rb
@@ -62,6 +62,15 @@ describe SequenceRun do
           expect(subject.lookup_or_create(sequence, user, other_portal)).not_to eq(existing_seq_run)
         end
       end
+
+      describe "when platform info is provided" do
+        it "should save it" do
+          portal_info = {
+            platform_id: "test_platform"
+          }
+          expect(subject.lookup_or_create(sequence, user, portal, portal_info).platform_id).to eq("test_platform")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
@scytacki, I had a few iterations on this, even though the fix is tiny.

Actually, the old code:
```
def update_platform_info(url_params)
    updates = super(url_params)
    if (updates)
      self.runs.each { |r| r.update_platform_info(url_params) }
    end
end
```
 would work perfectly fine if it was without this `if` statement. And my final fix is pretty much based on that. The problem was that when sequence run already had platform info, `updates` was equal to false, and we're skipping activity run updates. The other issue with this is that `update_platform_info` function defined in mixin isn't really prepared to return information whether there were any updates or not (it worked by accident, as the last statement is one of the updates).

Your suggestion to update `SequenceRun#run_for_activity` would work fine too and it was my first approach. But I'd also need to update `SequenceRun#lookup_or_create` to save platform info (before activity runs are created). Or still keep using `SequenceRun#update_platform_info`. Generally, we'd start adding this code to various lookup_or_create functions. And I'd be totally lost when platform info is set or when it can be set.

I thought that it's better to call `update_platform_info` in controllers explicitly as we used to do before. At least it's visible, more explicit and it's a bit easier to follow. But it's easy to change if you think the other way is better.

