### PR TITLE
fix passing of shutterbug uri

### DIFF
--- a/app/assets/javascripts/api-urls.js.erb
+++ b/app/assets/javascripts/api-urls.js.erb
@@ -1,1 +1,0 @@
-var SHUTTERBUG_URI = "<%= ENV['SHUTTERBUG_URI'] %>";

--- a/app/assets/javascripts/image_question_drawing_tool.js.coffee
+++ b/app/assets/javascripts/image_question_drawing_tool.js.coffee
@@ -169,7 +169,7 @@ class ImageQuestionDrawingTool
 
     Shutterbug.snapshot
       selector: @interactive_sel
-      server: SHUTTERBUG_URI # defined in api-urls.js.erb
+      server: gon.shutterbugURI
       done: (image_src) =>
         @set_image_source(image_src)
         stopWaiting()
@@ -183,7 +183,7 @@ class ImageQuestionDrawingTool
   take_drawing_tool_snapshot: ->
     Shutterbug.snapshot
       selector: "#{@drawing_tool_sel} canvas.lower-canvas"
-      server: SHUTTERBUG_URI # defined in api-urls.js.erb
+      server: gon.shutterbugURI
       done: (image_src) =>
         @copy_to_form_and_save(image_src)
         stopWaiting()

--- a/app/assets/javascripts/labbook.coffee
+++ b/app/assets/javascripts/labbook.coffee
@@ -96,7 +96,7 @@ class LabbookController
     @showDialog()
     Shutterbug.snapshot({
       selector: @interactiveSel,
-      server: SHUTTERBUG_URI # defined in api-urls.js.erb
+      server: gon.shutterbugURI
       done: (imgSrc) =>
         @stopWaiting()
         @setIframeUrl("#{@baseUrl}/albums?#{@albumId}&todo=create&source_url=#{imgSrc}")

--- a/app/assets/javascripts/runtime.js
+++ b/app/assets/javascripts/runtime.js
@@ -22,7 +22,6 @@
 //= require eventemitter2
 //= require iframe-phone-manager
 //= require drawing-tool
-//= require api-urls
 //= require jquery_ujs
 //= require jquery.placeholder
 //= require jquery.jcarousel

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,7 @@ class ApplicationController < ActionController::Base
   before_filter :reject_old_browsers, :except => [:bad_browser]
   before_filter :set_locale
   before_filter :store_auto_publish_url # to enable auto publishing to build an url from the request object
+  before_filter :set_api_urls
   after_filter :log_session_after
 
   # Try to set local from the request headers
@@ -337,6 +338,10 @@ class ApplicationController < ActionController::Base
 
   def store_auto_publish_url
     Thread.current[:auto_publish_url] = "#{request.protocol}#{request.host_with_port}"
+  end
+
+  def set_api_urls
+    gon.shutterbugURI = ENV['SHUTTERBUG_URI']
   end
 
   def unauthorized_response_data(action, resource)


### PR DESCRIPTION
In production the javascript files are pre-complied. And the SHUTTERBUG_URI is not defined during this stage.
In other parts of LARA we use the 'gon' library to pass variables between ruby and javascript.
So this change switches to that approach.