### PR TITLE
Image link title fix

### DIFF
--- a/app/assets/stylesheets/components/authoring.scss
+++ b/app/assets/stylesheets/components/authoring.scss
@@ -93,3 +93,6 @@
     }
   }
 }
+.under-image .fullscreen a.colorbox {
+  display: none;
+}

--- a/app/views/image_interactives/_show.html.haml
+++ b/app/views/image_interactives/_show.html.haml
@@ -1,7 +1,8 @@
-- image_title = "#{interactive.caption} #{interactive.credit}"
+- if interactive.caption != ''
+  - image_title = "#{interactive.caption} #{interactive.credit}"
 - if interactive.show_lightbox
   %a{ :href => interactive.url,
-      :title => image_title,
+      :title => (image_title ? image_title : nil),
       :class => 'colorbox'}
     = render :partial => 'image_interactives/image', :locals => { :interactive => interactive }
 - else

--- a/app/views/image_interactives/_show.html.haml
+++ b/app/views/image_interactives/_show.html.haml
@@ -1,4 +1,4 @@
-- image_title = "#{interactive.caption} #{interactive.credit_with_link}"
+- image_title = "#{interactive.caption} #{interactive.credit}"
 - if interactive.show_lightbox
   %a{ :href => interactive.url,
       :title => image_title,


### PR DESCRIPTION
This fixes the issue where hovering over some images made a tooltip appear that could be empty or include HTML code. 

PT story: https://www.pivotaltracker.com/story/show/172487561

It also hides the big magnifying glass icon that appears below affected images in the authoring view. I'm pretty sure that icon isn't needed on the authoring side, but if it is, we could instead just make it much smaller.