### PR TITLE
Increase size of raw_data in interactive_run_state

### DIFF
--- a/db/migrate/20200427212533_increase_raw_data_limit_in_interactive_run_state.rb
+++ b/db/migrate/20200427212533_increase_raw_data_limit_in_interactive_run_state.rb
@@ -1,0 +1,8 @@
+class IncreaseRawDataLimitInInteractiveRunState < ActiveRecord::Migration
+  def up
+      change_column :interactive_run_states, :raw_data, :text, :limit => 16.megabytes - 1
+  end
+  def down
+      change_column :interactive_run_states, :raw_data, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200320002802) do
+ActiveRecord::Schema.define(:version => 20200427212533) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -368,9 +368,9 @@ ActiveRecord::Schema.define(:version => 20200320002802) do
     t.integer  "interactive_id"
     t.string   "interactive_type"
     t.integer  "run_id"
-    t.text     "raw_data"
     t.datetime "created_at",                          :null => false
     t.datetime "updated_at",                          :null => false
+    t.text     "raw_data",         :limit => 16777215
     t.text     "learner_url"
     t.boolean  "is_dirty",         :default => false
     t.string   "key"


### PR DESCRIPTION
This bumps the size of the `raw_data` column to 16mb to allow for interactives that save a lot of data, such as Sage in lara-serialization mode.

[#172545850]