### PR TITLE
Added https proxy docker compose overlay

### DIFF
--- a/docker/dev/docker-compose-portal-https-proxy.yml
+++ b/docker/dev/docker-compose-portal-https-proxy.yml
@@ -1,0 +1,12 @@
+#
+# add this after docker-compose-portal-proxy.yml to switch to https.
+#
+# Example in .env:
+#
+# COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-portal-proxy.yml:docker/dev/docker-compose-portal-https-proxy.yml:...
+#
+version: '3'
+services:
+  app:
+    environment:
+      CONCORD_LOCALHOST_URL: https://${PORTAL_HOST}/


### PR DESCRIPTION
I keep stashing this file so I thought I'd add it as an overlay.  It allows local docker https lara to login with https local rigse.