### PR TITLE
Added library interactives admin [#172126155]

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,3 +43,4 @@
 //= require idle
 //= require check-author-idle
 //= require application-init
+//= require interactive-form-helper

--- a/app/assets/javascripts/interactive-form-helper.js
+++ b/app/assets/javascripts/interactive-form-helper.js
@@ -1,0 +1,77 @@
+function interactive_form_helper(interactive) {
+
+  function el(prefix) {
+    var selector = "#" + prefix + "_" + (interactive.id ? interactive.id : "");
+    return $(selector);
+  }
+
+  function click_to_play(){
+    if (el("click_to_play").prop('checked')) {
+      el("image_url").attr("required", true);
+      el("full_window").removeAttr("disabled");
+      el('full_window_label').css("opacity", 1);
+      el("click_to_play_prompt").removeAttr("disabled");
+      el('click_to_play_prompt_label').css("opacity", 1);
+      el("image_url_warning").css("opacity", 1);
+      el("image_url").removeAttr("disabled");
+      el('image_url_label').css("opacity", 1);
+    } else {
+      $("#mw_interactive_image_url").removeAttr("required");
+      el("full_window").attr("disabled", true);
+      el('full_window_label').css("opacity", 0.3);
+      el("click_to_play_prompt").attr("disabled", true);
+      el('click_to_play_prompt_label').css("opacity", 0.3);
+      el("image_url_warning").css("opacity", 0.3);
+      el("image_url").attr("disabled", true);
+      el('image_url_label').css("opacity", 0.3);
+    }
+  }
+
+  click_to_play();
+
+  el('enable_learner_state').click(function() {
+    el('has_report_url').prop('checked', false);
+    if ($(this).prop('checked')) {
+      // ungrey
+      el('has_report_url').removeAttr("disabled");
+      el('show_delete_data_button').removeAttr("disabled");
+      el('parent_id').removeAttr("disabled");
+      el('enable_learner_state_indent').css("opacity", 1);
+    } else {
+      // grey
+      el('has_report_url').attr("disabled", true);
+      el('show_delete_data_button').attr("disabled", true);
+      el('parent_id').attr("disabled", true);
+      el('enable_learner_state_indent').css("opacity", 0.3);
+    }
+  });
+
+  if (!interactive.enable_learner_state) {
+    // uncheck and grey out the 'has report url' section
+    el('has_report_url').prop('checked', false);
+    el('has_report_url').attr("disabled", true);
+    el('show_delete_data_button').attr("disabled", true);
+    el('parent_id').attr("disabled", true);
+    el('enable_learner_state_indent').css("opacity", 0.3);
+  }
+
+  el("click_to_play").click(click_to_play);
+
+  var available_ratios = interactive.available_aspect_ratios;
+  var props = {
+    initialState: {
+      width: interactive.native_width,
+      height: interactive.native_height,
+      mode: interactive.aspect_ratio_method
+    },
+    availableAspectRatios: available_ratios,
+    updateValues: function(aspect_ratio_values) {
+      $('#width').val( aspect_ratio_values.width);
+      $('#height').val(aspect_ratio_values.height);
+      $('#method').val(aspect_ratio_values.mode);
+    }
+  };
+
+  Chooser = React.createElement(modulejs.require('components/common/aspect_ratio_chooser'), props);
+  ReactDOM.render(Chooser, $("#aspect_ratio")[0]);
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -31,4 +31,5 @@
  *= require question-tracker
  *= require common
  *= require lara-typescript
+ *= require styled-admin-forms
  */

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -114,6 +114,7 @@ button.disabled, .btn-primary.disabled, span.edit_trigger.disabled {
 .notice{
   height: 16px;
   padding:10px 0;
+  clear: both;
 }
 .content {
   height: auto;

--- a/app/assets/stylesheets/styled-admin-forms.scss
+++ b/app/assets/stylesheets/styled-admin-forms.scss
@@ -1,0 +1,36 @@
+.styled-admin-form {
+
+  fieldset {
+    margin-top: 20px;
+  }
+
+  legend {
+    margin-bottom: 5px;
+    font-weight: bold;
+  }
+
+  p {
+    margin: 20px 0;
+  }
+
+  input[type=text],
+  textarea,
+  select {
+    padding: 5px;
+    margin: 0;
+  }
+
+  input[type=text],
+  textarea {
+    width: 98%;
+  }
+
+  #aspect_ratio {
+    label {
+      margin: 8px 5px 0 10px;
+      font-weight: bold;
+      text-transform: capitalize;
+    }
+  }
+
+}

--- a/app/controllers/library_interactives_controller.rb
+++ b/app/controllers/library_interactives_controller.rb
@@ -1,0 +1,91 @@
+class LibraryInteractivesController < ApplicationController
+  before_filter :can_use_index, :only => :index
+  before_filter :can_manage, :except => :index
+
+  # GET /library_interactives
+  # GET /library_interactives.json
+  def index
+    @library_interactives = LibraryInteractive.all
+
+    respond_to do |format|
+      format.html # index.html.erb
+      format.json { render json: @library_interactives }
+    end
+  end
+
+  # GET /library_interactives/new
+  # GET /library_interactives/new.json
+  def new
+    @library_interactive = LibraryInteractive.new
+
+    respond_to do |format|
+      format.html # new.html.erb
+      format.json { render json: @library_interactive }
+    end
+  end
+
+  # GET /library_interactives/1/edit
+  def edit
+    @library_interactive = LibraryInteractive.find(params[:id])
+  end
+
+  # POST /library_interactives
+  # POST /library_interactives.json
+  def create
+    @library_interactive = LibraryInteractive.new(params[:library_interactive])
+
+    respond_to do |format|
+      if @library_interactive.save
+        format.html { redirect_to library_interactives_url, notice: 'Library interactive was successfully created.' }
+        format.json { render json: @library_interactive, status: :created }
+      else
+        format.html { render action: "new" }
+        format.json { render json: @library_interactive.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PUT /library_interactives/1
+  # PUT /library_interactives/1.json
+  def update
+    @library_interactive = LibraryInteractive.find(params[:id])
+
+    respond_to do |format|
+      if @library_interactive.update_attributes(params[:library_interactive])
+        format.html { redirect_to library_interactives_url, notice: 'Library interactive was successfully updated.' }
+        format.json { head :no_content }
+      else
+        format.html { render action: "edit" }
+        format.json { render json: @library_interactive.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /library_interactives/1
+  # DELETE /library_interactives/1.json
+  def destroy
+    @library_interactive = LibraryInteractive.find(params[:id])
+    @library_interactive.destroy
+
+    respond_to do |format|
+      format.html { redirect_to library_interactives_url }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def can_use_index
+    # allow json reads of index by authors
+    if request.format.json?
+      raise CanCan::AccessDenied unless current_user.author? or current_user.admin?
+    else
+      authorize! :manage, LibraryInteractive
+    end
+  end
+
+  def can_manage
+    authorize! :manage, LibraryInteractive
+  end
+
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,6 +15,7 @@ class Ability
       can :manage, QuestionTracker
       can :report, QuestionTracker
       can :manage, ApprovedScript
+      can :manage, LibraryInteractive
     elsif user.author?
       # Authors can create new items and manage those they created
       can :create, Sequence

--- a/app/models/has_aspect_ratio.rb
+++ b/app/models/has_aspect_ratio.rb
@@ -1,0 +1,41 @@
+module HasAspectRatio
+
+  ASPECT_RATIO_DEFAULT_WIDTH   = 576
+  ASPECT_RATIO_DEFAULT_HEIGHT  =  435
+  ASPECT_RATIO_DEFAULT_METHOD  = 'DEFAULT'
+  ASPECT_RATIO_MANUAL_METHOD   = 'MANUAL'
+  ASPECT_RATIO_MAX_METHOD      = 'MAX'
+
+  def available_aspect_ratios
+    [
+      HasAspectRatio::ASPECT_RATIO_DEFAULT_METHOD,
+      HasAspectRatio::ASPECT_RATIO_MANUAL_METHOD,
+      HasAspectRatio::ASPECT_RATIO_MAX_METHOD
+    ].map do |key|
+      { key: key, value: I18n.t("INTERACTIVE.ASPECT_RATIO.#{key}") }
+    end
+  end
+
+  # returns the aspect ratio of the interactive, dividing the width by the height.
+  # For an interactive with a native width of 400 and native height of 200,
+  # the aspect_ratio will be 2.
+  # If ASPECT_RATIO_MAX_METHOD is being used, it is expected that the available
+  # width and height are provided as arugments used to calculated an aspect_ratio
+  def aspect_ratio(avail_width=nil, avail_height=nil)
+    case self.aspect_ratio_method
+      when ASPECT_RATIO_DEFAULT_METHOD
+        return ASPECT_RATIO_DEFAULT_WIDTH / ASPECT_RATIO_DEFAULT_HEIGHT.to_f
+      when ASPECT_RATIO_MANUAL_METHOD
+        return self.native_width/self.native_height.to_f
+      when ASPECT_RATIO_MAX_METHOD
+        width  = avail_width  || ASPECT_RATIO_DEFAULT_WIDTH
+        height = avail_height || ASPECT_RATIO_DEFAULT_HEIGHT
+        return width / height.to_f
+    end
+  end
+
+  def height(avail_width, avail_height=nil)
+    return avail_width / self.aspect_ratio(avail_width, avail_height)
+  end
+
+end

--- a/app/models/library_interactive.rb
+++ b/app/models/library_interactive.rb
@@ -1,0 +1,28 @@
+class LibraryInteractive < ActiveRecord::Base
+  include HasAspectRatio
+
+  DEFAULT_CLICK_TO_PLAY_PROMPT = "Click here to start the interactive."
+
+  attr_accessible :aspect_ratio_method, :authoring_guidance, :base_url, :click_to_play, :click_to_play_prompt, :description,
+                  :enable_learner_state, :full_window, :has_report_url, :image_url, :name, :native_height, :native_width,
+                  :no_snapshots, :show_delete_data_button, :thumbnail_url
+
+  default_value_for :native_width, ASPECT_RATIO_DEFAULT_WIDTH
+  default_value_for :native_height, ASPECT_RATIO_DEFAULT_HEIGHT
+
+  validates :name, presence: true
+
+  url_format = {
+    with: /^https?:\/\//i,
+    message: "include protocol (http[s]://)"
+  }
+  optional_url_format = url_format.merge({allow_blank: true})
+
+  validates :base_url, format: url_format
+  validates :image_url, format: optional_url_format
+  validates :thumbnail_url, format: optional_url_format
+
+  validates_numericality_of :native_width
+  validates_numericality_of :native_height
+
+end

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -1,12 +1,8 @@
 class MwInteractive < ActiveRecord::Base
   include Embeddable
+  include HasAspectRatio
 
   DEFAULT_CLICK_TO_PLAY_PROMPT = "Click here to start the interactive."
-  ASPECT_RATIO_DEFAULT_WIDTH   = 576
-  ASPECT_RATIO_DEFAULT_HEIGHT  =  435
-  ASPECT_RATIO_DEFAULT_METHOD  = 'DEFAULT'
-  ASPECT_RATIO_MANUAL_METHOD   = 'MANUAL'
-  ASPECT_RATIO_MAX_METHOD      = 'MAX'
 
   attr_accessible :name, :url, :native_width, :native_height,
     :enable_learner_state, :has_report_url, :click_to_play,
@@ -38,37 +34,6 @@ class MwInteractive < ActiveRecord::Base
 
   def self.portal_type
     "iframe interactive"
-  end
-
-  def available_aspect_ratios
-    [
-      MwInteractive::ASPECT_RATIO_DEFAULT_METHOD,
-      MwInteractive::ASPECT_RATIO_MANUAL_METHOD,
-      MwInteractive::ASPECT_RATIO_MAX_METHOD
-    ].map do |key|
-      { key: key, value: I18n.t("INTERACTIVE.ASPECT_RATIO.#{key}") }
-    end
-  end
-  # returns the aspect ratio of the interactive, dividing the width by the height.
-  # For an interactive with a native width of 400 and native height of 200,
-  # the aspect_ratio will be 2.
-  # If ASPECT_RATIO_MAX_METHOD is being used, it is expected that the available
-  # width and height are provided as arugments used to calculated an aspect_ratio
-  def aspect_ratio(avail_width=nil, avail_height=nil)
-    case self.aspect_ratio_method
-      when ASPECT_RATIO_DEFAULT_METHOD
-        return ASPECT_RATIO_DEFAULT_WIDTH / ASPECT_RATIO_DEFAULT_HEIGHT.to_f
-      when ASPECT_RATIO_MANUAL_METHOD
-        return self.native_width/self.native_height.to_f
-      when ASPECT_RATIO_MAX_METHOD
-        width  = avail_width  || ASPECT_RATIO_DEFAULT_WIDTH
-        height = avail_height || ASPECT_RATIO_DEFAULT_HEIGHT
-        return width / height.to_f
-    end
-  end
-
-  def height(avail_width, avail_height=nil)
-    return avail_width / aspect_ratio(avail_width, avail_height)
   end
 
   def to_hash

--- a/app/views/library_interactives/_form.html.haml
+++ b/app/views/library_interactives/_form.html.haml
@@ -1,0 +1,68 @@
+= form_for @library_interactive, :html => {:class => "styled-admin-form"} do |f|
+  = f.error_messages
+  = field_set_tag 'Name' do
+    = f.text_field :name
+  = field_set_tag 'Description' do
+    = f.text_area :description, size: "100x4"
+  = field_set_tag 'Authoring Guidance' do
+    = f.text_area :authoring_guidance, :rows => 5, :class => 'wysiwyg-minimal'
+  = field_set_tag 'Base URL' do
+    = f.text_area :base_url, size: "100x2"
+  = field_set_tag 'Thumbnail URL' do
+    = f.text_area :thumbnail_url, size: "100x2"
+
+  = field_set_tag 'Aspect Ratio' do
+    %div{id:"aspect_ratio"}
+    = f.hidden_field :native_width,  :id => 'width'
+    = f.hidden_field :native_height, :id => 'height'
+    = f.hidden_field :aspect_ratio_method, :id => 'method'
+    .clear
+  = field_set_tag 'Click To Play Options' do
+    = f.check_box :click_to_play, :id => "click_to_play_#{@library_interactive.id}"
+    = f.label :click_to_play, 'Click to play'
+    %br
+    = f.check_box :full_window, :id => "full_window_#{@library_interactive.id}"
+    = f.label :full_window, :id => "full_window_label_#{@library_interactive.id}", :text => 'Full window mode'
+    %br
+    = f.label :click_to_play_prompt, :id => "click_to_play_prompt_label_#{@library_interactive.id}", :text => 'Click to play prompt'
+    = f.text_field :click_to_play_prompt, :id => "click_to_play_prompt_#{@library_interactive.id}", :placeholder => LibraryInteractive::DEFAULT_CLICK_TO_PLAY_PROMPT
+    %div{:style => "margin-bottom:5px;", :id => "image_url_warning_#{@library_interactive.id}"}
+      %em Warning:
+      Please provide an image URL to use click to play.
+    .image_url
+      = f.label :image_url, :id => "image_url_label_#{@library_interactive.id}", :text => 'Image URL'
+      = f.text_field :image_url, :id => "image_url_#{@library_interactive.id}"
+
+  %p
+  = field_set_tag 'Save Interactive State Options' do
+    = f.check_box :enable_learner_state, :id => "enable_learner_state_#{@library_interactive.id}"
+    = f.label :enable_learner_state, 'Save Interactive State'
+    .clear
+    %em Warning:
+    Please do not select this unless your interactive contains a serializable data set.
+    .clear
+    .indent{:id => "enable_learner_state_indent_#{@library_interactive.id}"}
+      = f.check_box :show_delete_data_button, :id => "show_delete_data_button_#{@library_interactive.id}"
+      = f.label :show_delete_data_button, 'Show "Undo all my work" button'
+      %br
+      = f.check_box :has_report_url, :id => "has_report_url_#{@library_interactive.id}"
+      = f.label :has_report_url, 'This interactive has a report URL'
+      .clear
+      %em Warning:
+      Please do not select this unless your interactive includes a report url in its saved state.
+
+  %p
+  = f.check_box :no_snapshots
+  = f.label :no_snapshots, 'Snapshots Not Supported'
+
+  %p
+    .actions
+      = f.submit
+
+:javascript
+  $(document).ready(function() {
+    initTinyMCE('.wysiwyg-minimal', window.TinyMCEConfigMinimal);
+    interactive_form_helper(#{ @library_interactive.to_json })
+  });
+
+

--- a/app/views/library_interactives/edit.html.haml
+++ b/app/views/library_interactives/edit.html.haml
@@ -1,0 +1,17 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :title do
+  = "Edit #{@library_interactive.name}"
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li
+        \/
+        = link_to 'All Library Iinteractives', library_interactives_path
+      %li= "/ Edit #{@library_interactive.name}"
+
+%h1.title= "Edit #{@library_interactive.name}"
+
+=render :partial => 'form'

--- a/app/views/library_interactives/index.html.haml
+++ b/app/views/library_interactives/index.html.haml
@@ -1,0 +1,33 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :title do
+  Library Interactives
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li / All Library Interactives
+
+.action_menu#activity-actions
+  .action_menu_header
+    .action_menu_header_left
+    .action_menu_header_right.index
+      %ul#new-menu
+        - if can? :create, LibraryInteractive
+          %li#add= link_to 'Create New Library Interactive', new_library_interactive_path
+
+#official_listing_heading
+  %h1 Library Interactives
+%ul.quiet_list.official_listing
+  - @library_interactives.each do |library_interactive|
+    %li{ :id => dom_id_for(library_interactive, :item), :class => 'item' }
+      %div.action_menu
+        %div.action_menu_header_left
+          = link_to library_interactive.name, edit_library_interactive_path(library_interactive), :class => 'container_link'
+        %div.action_menu_header_right.themes
+          %ul.menu
+            %li.edit= link_to "Edit", edit_library_interactive_path(library_interactive) if can? :update, library_interactive
+            %li.delete= link_to 'Delete', library_interactive_path(library_interactive), method: :delete, data: { confirm: 'Are you sure?' } if can? :update, library_interactive
+      %div.tiny
+        = library_interactive.description

--- a/app/views/library_interactives/new.html.haml
+++ b/app/views/library_interactives/new.html.haml
@@ -1,0 +1,17 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :title do
+  New Library Interactive
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li
+        \/
+        = link_to 'All Library Interactives', library_interactives_path
+      %li / New Library Interactive
+
+%h1.title New Library Interactive
+
+=render :partial => 'form'

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -25,12 +25,12 @@
   %br
   = f.label :click_to_play_prompt, :id => "click_to_play_prompt_label_#{@interactive.id}", :text => 'Click to play prompt'
   = f.text_field :click_to_play_prompt, :id => "click_to_play_prompt_#{@interactive.id}", :placeholder => MwInteractive::DEFAULT_CLICK_TO_PLAY_PROMPT
-  %div{:style => "margin-bottom:5px;"}
+  %div{:style => "margin-bottom:5px;", :id => "image_url_warning_#{@interactive.id}"}
     %em Warning:
     Please provide an image_url to use click to play.
   .image_url
-    = f.label :image_url, 'Image_url'
-    = f.text_field :image_url
+    = f.label :image_url, :id => "image_url_label_#{@interactive.id}", :text => 'Image URL'
+    = f.text_field :image_url, :id => "image_url_#{@interactive.id}"
   = f.label :is_full_width, t(:IS_FULL_WIDTH_ASSESMENT_ITEM)
   = f.check_box :is_full_width
   %br
@@ -64,68 +64,6 @@
   = f.submit "Save", :class => 'embeddable-save', :default => 'default'
 
 :javascript
-  function click_to_play(){
-    if ($("#click_to_play_#{@interactive.id}").prop('checked')) {
-        $("#mw_interactive_image_url").attr("required", true);
-        $("#full_window_#{@interactive.id}").removeAttr("disabled");
-        $('#full_window_label_#{@interactive.id}').css("opacity", 1);
-        $("#click_to_play_prompt_#{@interactive.id}").removeAttr("disabled");
-        $('#click_to_play_prompt_label_#{@interactive.id}').css("opacity", 1);
-      } else {
-        $("#mw_interactive_image_url").removeAttr("required");
-        $("#full_window_#{@interactive.id}").attr("disabled", true);
-        $('#full_window_label_#{@interactive.id}').css("opacity", 0.3);
-        $("#click_to_play_prompt_#{@interactive.id}").attr("disabled", true);
-        $('#click_to_play_prompt_label_#{@interactive.id}').css("opacity", 0.3);
-      }
-  }
-
   $(document).ready(function() {
-    click_to_play();
-    $('#enable_learner_state_#{@interactive.id}').click(function() {
-      $('#has_report_url_#{@interactive.id}').prop('checked', false);
-      if ($(this).prop('checked')) {
-        // ungrey
-        $('#has_report_url_#{@interactive.id}').removeAttr("disabled");
-        $('#show_delete_data_button_#{@interactive.id}').removeAttr("disabled");
-        $('#parent_id_#{@interactive.id}').removeAttr("disabled");
-        $('#enable_learner_state_indent_#{@interactive.id}').css("opacity", 1);
-      } else {
-        // grey
-        $('#has_report_url_#{@interactive.id}').attr("disabled", true);
-        $('#show_delete_data_button_#{@interactive.id}').attr("disabled", true);
-        $('#parent_id_#{@interactive.id}').attr("disabled", true);
-        $('#enable_learner_state_indent_#{@interactive.id}').css("opacity", 0.3);
-      }
-    });
-
-    if (! #{@interactive.enable_learner_state}) {
-          // uncheck and grey out the 'has report url' section
-          $('#has_report_url_#{@interactive.id}').prop('checked', false);
-          $('#has_report_url_#{@interactive.id}').attr("disabled", true);
-          $('#show_delete_data_button_#{@interactive.id}').attr("disabled", true);
-          $('#parent_id_#{@interactive.id}').attr("disabled", true);
-          $('#enable_learner_state_indent_#{@interactive.id}').css("opacity", 0.3);
-    }
-
-    $("#click_to_play_#{@interactive.id}").click(click_to_play);
-
-    var available_ratios = #{@interactive.available_aspect_ratios.to_json}
-    var props = {
-      initialState: {
-        width: "#{@interactive.native_width}",
-        height: "#{@interactive.native_height}",
-        mode: "#{@interactive.aspect_ratio_method}"
-      },
-      availableAspectRatios: available_ratios,
-      updateValues: function(aspect_ratio_values) {
-        $('#width').val( aspect_ratio_values.width);
-        $('#height').val(aspect_ratio_values.height);
-        $('#method').val(aspect_ratio_values.mode);
-      }
-    };
-
-    Chooser = React.createElement(modulejs.require('components/common/aspect_ratio_chooser'), props);
-    ReactDOM.render(Chooser, $("#aspect_ratio")[0]);
-
+    interactive_form_helper(#{ @interactive.to_json })
   });

--- a/app/views/shared/_session.html.haml
+++ b/app/views/shared/_session.html.haml
@@ -23,6 +23,9 @@
   -if can? :manage, CRater::ScoreMapping
     |
     = link_to "Score Mappings", c_rater_score_mappings_path
+  -if can? :manage, LibraryInteractive
+    |
+    = link_to "Library Interactives", library_interactives_path
 - else
   -#= link_to "Log In", user_omniauth_authorize_path(Concord::AuthPortal.default.strategy_name)
   - if Concord::AuthPortal.configured_portal_names.size > 1 # Note that this means no Twitter/GitHub/other at this point - easy to fix when needed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 LightweightStandalone::Application.routes.draw do
 
-  resources :approved_scripts
+  resources :library_interactives, :except => [:show]
 
+  resources :approved_scripts
 
   resources :projects do
     member do

--- a/db/migrate/20200430094758_create_library_interactives.rb
+++ b/db/migrate/20200430094758_create_library_interactives.rb
@@ -1,0 +1,24 @@
+class CreateLibraryInteractives < ActiveRecord::Migration
+  def change
+    create_table :library_interactives do |t|
+      t.string :name
+      t.text :description
+      t.text :authoring_guidance
+      t.text :base_url
+      t.string :thumbnail_url
+      t.string :image_url
+      t.string :click_to_play_prompt
+      t.boolean :click_to_play,                    :default => false
+      t.boolean :no_snapshots,                     :default => false
+      t.boolean :enable_learner_state,             :default => false
+      t.boolean :has_report_url,                   :default => false
+      t.boolean :show_delete_data_button,          :default => true
+      t.boolean :full_window,                      :default => false
+      t.string :aspect_ratio_method,               :default => "DEFAULT"
+      t.integer :native_width
+      t.integer :native_height
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20200427212533) do
+ActiveRecord::Schema.define(:version => 20200430094758) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -368,16 +368,37 @@ ActiveRecord::Schema.define(:version => 20200427212533) do
     t.integer  "interactive_id"
     t.string   "interactive_type"
     t.integer  "run_id"
-    t.datetime "created_at",                          :null => false
-    t.datetime "updated_at",                          :null => false
     t.text     "raw_data",         :limit => 16777215
+    t.datetime "created_at",                                              :null => false
+    t.datetime "updated_at",                                              :null => false
     t.text     "learner_url"
-    t.boolean  "is_dirty",         :default => false
+    t.boolean  "is_dirty",                             :default => false
     t.string   "key"
   end
 
   add_index "interactive_run_states", ["key"], :name => "interactive_run_states_key_idx"
   add_index "interactive_run_states", ["run_id"], :name => "interactive_run_states_run_id_idx"
+
+  create_table "library_interactives", :force => true do |t|
+    t.string   "name"
+    t.text     "description"
+    t.text     "authoring_guidance"
+    t.text     "base_url"
+    t.string   "thumbnail_url"
+    t.string   "image_url"
+    t.string   "click_to_play_prompt"
+    t.boolean  "click_to_play",           :default => false
+    t.boolean  "no_snapshots",            :default => false
+    t.boolean  "enable_learner_state",    :default => false
+    t.boolean  "has_report_url",          :default => false
+    t.boolean  "show_delete_data_button", :default => true
+    t.boolean  "full_window",             :default => false
+    t.string   "aspect_ratio_method",     :default => "DEFAULT"
+    t.integer  "native_width"
+    t.integer  "native_height"
+    t.datetime "created_at",                                     :null => false
+    t.datetime "updated_at",                                     :null => false
+  end
 
   create_table "lightweight_activities", :force => true do |t|
     t.string   "name"
@@ -622,8 +643,8 @@ ActiveRecord::Schema.define(:version => 20200427212533) do
   create_table "themes", :force => true do |t|
     t.string   "name"
     t.string   "css_file"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
     t.boolean  "footer_nav", :default => false
   end
 

--- a/spec/controllers/library_interactives_controller_spec.rb
+++ b/spec/controllers/library_interactives_controller_spec.rb
@@ -1,0 +1,230 @@
+require 'spec_helper'
+
+describe LibraryInteractivesController do
+
+  let(:valid_attributes) {
+    {
+      :aspect_ratio_method => "DEFAULT",
+      :authoring_guidance => "valid authoring_guidance",
+      :base_url => "http://example.com/",
+      :click_to_play => false,
+      :click_to_play_prompt => "valid click_to_play_prompt",
+      :description => "valid description",
+      :enable_learner_state => false,
+      :full_window => false,
+      :has_report_url => false,
+      :image_url => "http://example.com/image_url.jpg",
+      :name => "valid name",
+      :native_height => 100,
+      :native_width => 200,
+      :no_snapshots => false,
+      :show_delete_data_button => false,
+      :thumbnail_url => "http://example.com/thumbnail_url.jpg"
+    }
+  }
+
+  let(:invalid_attributes) {
+    {
+      :base_url => "does not start with protocol",
+      :native_height => "invalid",
+      :native_width => "invalid",
+    }
+  }
+
+  describe "as as admin" do
+    before(:each) do
+      @user = FactoryGirl.create(:admin)
+      sign_in @user
+    end
+
+    describe "GET #index" do
+      it "returns a success response" do
+        LibraryInteractive.create! valid_attributes
+        get :index, {}
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #new" do
+      it "returns a success response" do
+        get :new, {}
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #edit" do
+      it "returns a success response" do
+        library_interactive = LibraryInteractive.create! valid_attributes
+        get :edit, {:id => library_interactive.to_param}
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST #create" do
+      context "with valid params" do
+        it "creates a new LibraryInteractive" do
+          expect {
+            post :create, {:library_interactive => valid_attributes}
+          }.to change(LibraryInteractive, :count).by(1)
+        end
+
+        it "redirects to the library_interactive index" do
+          post :create, {:library_interactive => valid_attributes}
+          expect(response).to redirect_to(library_interactives_url)
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a success response (i.e. to display the 'new' template)" do
+          post :create, {:library_interactive => invalid_attributes}
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    describe "PUT #update" do
+      context "with valid params" do
+        let(:new_attributes) {
+          {:name => "new name"}
+        }
+
+        it "updates the requested library_interactive" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          put :update, {:id => library_interactive.to_param, :library_interactive => new_attributes}
+          library_interactive.reload
+          expect(library_interactive.name).to eq("new name")
+        end
+
+        it "redirects to the library_interactive index" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          put :update, {:id => library_interactive.to_param, :library_interactive => valid_attributes}
+          expect(response).to redirect_to(library_interactives_url)
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a success response (i.e. to display the 'edit' template)" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          put :update, {:id => library_interactive.to_param, :library_interactive => invalid_attributes}
+          expect(response).to be_successful
+        end
+      end
+    end
+
+    describe "DELETE #destroy" do
+      it "destroys the requested library_interactive" do
+        library_interactive = LibraryInteractive.create! valid_attributes
+        expect {
+          delete :destroy, {:id => library_interactive.to_param}
+        }.to change(LibraryInteractive, :count).by(-1)
+      end
+
+      it "redirects to the library_interactives list" do
+        library_interactive = LibraryInteractive.create! valid_attributes
+        delete :destroy, {:id => library_interactive.to_param}
+        expect(response).to redirect_to(library_interactives_url)
+      end
+    end
+  end
+
+  [:author, :user].each do |user_type|
+    describe "as a #{user_type}" do
+      before(:each) do
+        @user = FactoryGirl.create(user_type)
+        sign_in @user
+      end
+
+      describe "GET #index" do
+        it "returns a failure response for HTML requests" do
+          LibraryInteractive.create! valid_attributes
+          get :index, {}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      describe "GET #new" do
+        it "returns a failure response" do
+          get :new, {}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      describe "GET #edit" do
+        it "returns a failure response" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          get :edit, {:id => library_interactive.to_param}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      describe "POST #create" do
+        it "returns a failure response" do
+          post :create, {:library_interactive => valid_attributes}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      describe "PUT #update" do
+        it "returns a failure response" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          put :update, {:id => library_interactive.to_param, :library_interactive => {:name => "new name"}}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      describe "DELETE #destroy" do
+        it "returns a failure response" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          delete :destroy, {:id => library_interactive.to_param}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+  end
+
+  describe "for JSON requests" do
+    before(:each) do
+      request.env["HTTP_ACCEPT"] = 'application/json'
+    end
+
+    describe "as an author" do
+      before(:each) do
+        @user = FactoryGirl.create(:author)
+        sign_in @user
+      end
+
+      describe "GET #index" do
+        it "returns a success response" do
+          model = LibraryInteractive.create! valid_attributes
+          get :index, {}
+          expect(response.content_type).to eq("application/json")
+          expect(response).to be_successful
+          expect(response.body).to eq([model].to_json)
+        end
+      end
+    end
+
+    describe "as a non-admin/author user" do
+      before(:each) do
+        @user = FactoryGirl.create(:user)
+        sign_in @user
+      end
+
+      describe "GET #index" do
+        it "returns a failure response" do
+          LibraryInteractive.create! valid_attributes
+          get :index, {}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/factories/library_interactive.rb
+++ b/spec/factories/library_interactive.rb
@@ -1,0 +1,14 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  sequence (:li_url) { Faker::Internet.url() }
+
+  factory :library_interactive do
+    native_width { 100 }
+    native_height { 200 }
+    name { generate(:name) }
+    base_url  { generate(:li_url) }
+    image_url  { generate(:li_url) }
+    thumbnail_url  { generate(:li_url) }
+  end
+end

--- a/spec/models/library_interactive_spec.rb
+++ b/spec/models/library_interactive_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe LibraryInteractive do
+  let(:library_interactive) { FactoryGirl.create(:library_interactive) }
+
+  describe "validation" do
+
+    it "ensures name is present" do
+      library_interactive.name = "Name"
+      expect(library_interactive).to be_valid
+      library_interactive.name = ""
+      expect(library_interactive).not_to be_valid
+    end
+
+    it "ensures base_url is present and valid" do
+      library_interactive.base_url = "https://valid.url"
+      expect(library_interactive).to be_valid
+      library_interactive.base_url = ""
+      expect(library_interactive).not_to be_valid
+    end
+
+    it "ensures image_url is valid if present" do
+      library_interactive.image_url = "https://valid.url"
+      expect(library_interactive).to be_valid
+      library_interactive.image_url = ""
+      expect(library_interactive).to be_valid
+      library_interactive.image_url = "not an url"
+      expect(library_interactive).not_to be_valid
+    end
+
+    it "ensures thumbnail_url is valid if present" do
+      library_interactive.thumbnail_url = "https://valid.url"
+      expect(library_interactive).to be_valid
+      library_interactive.thumbnail_url = ""
+      expect(library_interactive).to be_valid
+      library_interactive.thumbnail_url = "not an url"
+      expect(library_interactive).not_to be_valid
+    end
+
+    it "ensures native_width is valid" do
+      library_interactive.native_width = 100
+      expect(library_interactive).to be_valid
+      library_interactive.native_width = "not an number"
+      expect(library_interactive).not_to be_valid
+    end
+
+    it "ensures native_height is valid" do
+      library_interactive.native_height = 100
+      expect(library_interactive).to be_valid
+      library_interactive.native_height = "not an number"
+      expect(library_interactive).not_to be_valid
+    end
+  end
+end

--- a/spec/routing/library_interactives_routing_spec.rb
+++ b/spec/routing/library_interactives_routing_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe LibraryInteractivesController do
+  describe "routing" do
+    it "routes to #index" do
+      expect(:get => "/library_interactives").to route_to("library_interactives#index")
+    end
+
+    it "routes to #new" do
+      expect(:get => "/library_interactives/new").to route_to("library_interactives#new")
+    end
+
+    it "routes to #edit" do
+      expect(:get => "/library_interactives/1/edit").to route_to("library_interactives#edit", :id => "1")
+    end
+
+    it "routes to #create" do
+      expect(:post => "/library_interactives").to route_to("library_interactives#create")
+    end
+
+    it "routes to #update via PUT" do
+      expect(:put => "/library_interactives/1").to route_to("library_interactives#update", :id => "1")
+    end
+
+    it "routes to #destroy" do
+      expect(:delete => "/library_interactives/1").to route_to("library_interactives#destroy", :id => "1")
+    end
+  end
+end

--- a/spec/views/library_interactives/edit.html.haml_spec.rb
+++ b/spec/views/library_interactives/edit.html.haml_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe "library_interactives/edit" do
+  before(:each) do
+    @library_interactive = assign(:library_interactive, LibraryInteractive.create!(
+      :name => "MyString",
+      :description => "MyText",
+      :base_url => "http://example.com",
+      :thumbnail_url => "http://example.com",
+      :authoring_guidance => "MyText",
+      :no_snapshots => false,
+      :enable_learner_state => false,
+      :has_report_url => false,
+      :show_delete_data_button => false,
+      :aspect_ratio_method => "MyString",
+      :native_width => 1,
+      :native_height => 1,
+      :click_to_play => false,
+      :full_window => false,
+      :click_to_play_prompt => "MyString",
+      :image_url => "http://example.com"
+    ))
+  end
+
+  it "renders the edit library_interactive form" do
+    render
+
+    assert_select "form[action=?][method=?]", library_interactive_path(@library_interactive), "post" do
+
+      assert_select "input[name=?]", "library_interactive[name]"
+
+      assert_select "textarea[name=?]", "library_interactive[description]"
+
+      assert_select "textarea[name=?]", "library_interactive[base_url]"
+
+      assert_select "textarea[name=?]", "library_interactive[thumbnail_url]"
+
+      assert_select "textarea[name=?]", "library_interactive[authoring_guidance]"
+
+      assert_select "input[name=?]", "library_interactive[no_snapshots]"
+
+      assert_select "input[name=?]", "library_interactive[enable_learner_state]"
+
+      assert_select "input[name=?]", "library_interactive[has_report_url]"
+
+      assert_select "input[name=?]", "library_interactive[show_delete_data_button]"
+
+      assert_select "input[name=?]", "library_interactive[aspect_ratio_method]"
+
+      assert_select "input[name=?]", "library_interactive[native_width]"
+
+      assert_select "input[name=?]", "library_interactive[native_height]"
+
+      assert_select "input[name=?]", "library_interactive[click_to_play]"
+
+      assert_select "input[name=?]", "library_interactive[full_window]"
+
+      assert_select "input[name=?]", "library_interactive[click_to_play_prompt]"
+
+      assert_select "input[name=?]", "library_interactive[image_url]"
+    end
+  end
+end

--- a/spec/views/library_interactives/index.html.haml_spec.rb
+++ b/spec/views/library_interactives/index.html.haml_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe "library_interactives/index", :type => :view do
+  before(:each) do
+    assign(:library_interactives, [
+      LibraryInteractive.create!(
+        :name => "Name",
+        :description => "MyText",
+        :base_url => "http://example.com/",
+        :thumbnail_url => "http://example.com/",
+        :authoring_guidance => "MyText",
+        :no_snapshots => false,
+        :enable_learner_state => false,
+        :has_report_url => false,
+        :show_delete_data_button => false,
+        :aspect_ratio_method => "Aspect Ratio Method",
+        :native_width => 2,
+        :native_height => 3,
+        :click_to_play => false,
+        :full_window => false,
+        :click_to_play_prompt => "Click To Play Prompt",
+        :image_url => "http://example.com/"
+      ),
+      LibraryInteractive.create!(
+        :name => "Name",
+        :description => "MyText",
+        :base_url => "http://example.com/",
+        :thumbnail_url => "http://example.com/",
+        :authoring_guidance => "MyText",
+        :no_snapshots => false,
+        :enable_learner_state => false,
+        :has_report_url => false,
+        :show_delete_data_button => false,
+        :aspect_ratio_method => "Aspect Ratio Method",
+        :native_width => 2,
+        :native_height => 3,
+        :click_to_play => false,
+        :full_window => false,
+        :click_to_play_prompt => "Click To Play Prompt",
+        :image_url => "http://example.com/"
+      )
+    ])
+  end
+
+  it "renders a list of library_interactives" do
+    render
+    assert_select "li.item", :count => 2
+  end
+end

--- a/spec/views/library_interactives/new.html.haml_spec.rb
+++ b/spec/views/library_interactives/new.html.haml_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe "library_interactives/new", :type => :view do
+  before(:each) do
+    assign(:library_interactive, LibraryInteractive.new(
+      :name => "MyString",
+      :description => "MyText",
+      :base_url => "http://example.com",
+      :thumbnail_url => "MyText",
+      :authoring_guidance => "MyText",
+      :no_snapshots => false,
+      :enable_learner_state => false,
+      :has_report_url => false,
+      :show_delete_data_button => false,
+      :aspect_ratio_method => "MyString",
+      :native_width => 1,
+      :native_height => 1,
+      :click_to_play => false,
+      :full_window => false,
+      :click_to_play_prompt => "MyString",
+      :image_url => "MyString"
+    ))
+  end
+
+  it "renders new library_interactive form" do
+    render
+
+    assert_select "form[action=?][method=?]", library_interactives_path, "post" do
+
+      assert_select "input[name=?]", "library_interactive[name]"
+
+      assert_select "textarea[name=?]", "library_interactive[description]"
+
+      assert_select "textarea[name=?]", "library_interactive[base_url]"
+
+      assert_select "textarea[name=?]", "library_interactive[thumbnail_url]"
+
+      assert_select "textarea[name=?]", "library_interactive[authoring_guidance]"
+
+      assert_select "input[name=?]", "library_interactive[no_snapshots]"
+
+      assert_select "input[name=?]", "library_interactive[enable_learner_state]"
+
+      assert_select "input[name=?]", "library_interactive[has_report_url]"
+
+      assert_select "input[name=?]", "library_interactive[show_delete_data_button]"
+
+      assert_select "input[name=?]", "library_interactive[aspect_ratio_method]"
+
+      assert_select "input[name=?]", "library_interactive[native_width]"
+
+      assert_select "input[name=?]", "library_interactive[native_height]"
+
+      assert_select "input[name=?]", "library_interactive[click_to_play]"
+
+      assert_select "input[name=?]", "library_interactive[full_window]"
+
+      assert_select "input[name=?]", "library_interactive[click_to_play_prompt]"
+
+      assert_select "input[name=?]", "library_interactive[image_url]"
+    end
+  end
+end


### PR DESCRIPTION
1. Adds the LibraryInteractives admin
2. Refactors the now common code between the existing `MWInteractives` and new `LibraryInteractives` in both the view and model code.
3. Introduces a new css class, `styled-admin-form`, that adjusts the style of admin forms.  This class is only used (for  now) in the new code.
4. Exposes a json endpoint for authors to use in the upcoming scaffolded question work.