### PR TITLE
Setup AWS CodePipeline and CodeBuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,10 @@ ENV RAILS_ENV=production
 # otherwise somewhere in the initializers it tries to connect to the database which will fail
 RUN bundle exec rake assets:precompile
 
+# pass in a version while building with --build-arg LARA_VERSION=x.y.z
+ARG LARA_VERSION
+ENV LARA_IMAGE_VERSION=$LARA_VERSION
+
 EXPOSE 80
 
 CMD ./docker/prod/run.sh

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,7 @@
       </p>
     <% end %>
     <p style="margin-top:10px">
-      Version: <%= ENV['LARA_VERSION'] %>
+      Version: <%= ENV['LARA_IMAGE_VERSION'].present? ? ENV['LARA_IMAGE_VERSION'] : ENV['LARA_VERSION'] %>
     </p>
   </div>
 </div>

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,13 +7,9 @@ phases:
       docker: 18
   pre_build:
     commands:
-      # - echo Logging in to Amazon ECR...
-      # - aws --version
-      # - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - echo Logging in to Docker Hub...
       - docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - REPOSITORY_URI=concord-consortium/lara-railslts
-      # need to login to docker hub
-      # and set the repository URI or get it from secrets
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
@@ -24,10 +20,11 @@ phases:
   post_build:
     commands:
       - echo Build completed on `date`
-      # - echo Pushing the Docker images...
-      # - docker push $REPOSITORY_URI:latest
-      # - docker push $REPOSITORY_URI:$IMAGE_TAG
-      # - echo Writing image definitions file...
-      # - printf '[{"name":"hello-world","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
-# artifacts:
-#     files: imagedefinitions.json
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo Writing image definitions file...
+      # TODO: This is only setup for the App task definition, we'll need to
+      #   figure how to also update the Worker task definition
+      - printf '[{"name":"App","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+artifacts:
+  files: imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,32 @@
+# Build configuration for CodeBuild
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      # - echo Logging in to Amazon ECR...
+      # - aws --version
+      # - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      # - REPOSITORY_URI=012345678910.dkr.ecr.us-west-2.amazonaws.com/hello-world
+      # need to login to docker hub
+      # and set the repository URI or get it from secrets
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -t $REPOSITORY_URI:$IMAGE_TAG .
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      # - echo Pushing the Docker images...
+      # - docker push $REPOSITORY_URI:latest
+      # - docker push $REPOSITORY_URI:$IMAGE_TAG
+      # - echo Writing image definitions file...
+      # - printf '[{"name":"hello-world","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+# artifacts:
+#     files: imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
       # - echo Logging in to Amazon ECR...
       # - aws --version
       # - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
-      # - REPOSITORY_URI=012345678910.dkr.ecr.us-west-2.amazonaws.com/hello-world
+      - REPOSITORY_URI=concord-consortium/lara-railslts
       # need to login to docker hub
       # and set the repository URI or get it from secrets
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,7 +12,12 @@ phases:
       - REPOSITORY_URI=concordconsortium/lara-railslts
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
-      - LARA_VERSION=${CODEBUILD_SOURCE_VERSION}-${COMMIT_HASH}
+      # The BRANCH_NAME is set in the build step of the CodePipline from the
+      # SourceVariables.BranchName
+      # If this build is run directly in CODEBUILD branch name will be empty
+      # but in that case the CODEBUILD_SOURCE_VERSION should point to the branch
+      # name
+      - LARA_VERSION=${BRANCH_NAME}-${COMMIT_HASH}
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,6 +10,7 @@ phases:
       # - echo Logging in to Amazon ECR...
       # - aws --version
       # - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
       - REPOSITORY_URI=concord-consortium/lara-railslts
       # need to login to docker hub
       # and set the repository URI or get it from secrets

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,7 +9,7 @@ phases:
     commands:
       - echo Logging in to Docker Hub...
       - docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-      - REPOSITORY_URI=concord-consortium/lara-railslts
+      - REPOSITORY_URI=concordconsortium/lara-railslts
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,11 +12,12 @@ phases:
       - REPOSITORY_URI=concordconsortium/lara-railslts
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
+      - LARA_VERSION=${CODEBUILD_SOURCE_VERSION}-${COMMIT_HASH}
   build:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build -t $REPOSITORY_URI:$IMAGE_TAG .
+      - docker build -t $REPOSITORY_URI:$IMAGE_TAG --build-arg LARA_VERSION=$LARA_VERSION .
   post_build:
     commands:
       - echo Build completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,6 +25,9 @@ phases:
       - echo Writing image definitions file...
       # TODO: This is only setup for the App task definition, we'll need to
       #   figure how to also update the Worker task definition
-      - printf '[{"name":"App","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+      - printf '[{"name":"App","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > app-imagedefinitions.json
+      - printf '[{"name":"Worker","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > worker-imagedefinitions.json
 artifacts:
-  files: imagedefinitions.json
+  files:
+    - app-imagedefinitions.json
+    - worker-imagedefinitions.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,11 +12,10 @@ phases:
       - REPOSITORY_URI=concordconsortium/lara-railslts
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
-      # The BRANCH_NAME is set in the build step of the CodePipline from the
+      # The BRANCH_NAME is set in the build step of the CodePipeline from the
       # SourceVariables.BranchName
-      # If this build is run directly in CODEBUILD branch name will be empty
-      # but in that case the CODEBUILD_SOURCE_VERSION should point to the branch
-      # name
+      # If this build is run directly in CodeBuild BRANCH_NAME will be empty.
+      # In CodeBuild the CODEBUILD_SOURCE_VERSION should point to the branch name
       - LARA_VERSION=${BRANCH_NAME}-${COMMIT_HASH}
   build:
     commands:
@@ -28,9 +27,7 @@ phases:
       - echo Build completed on `date`
       - echo Pushing the Docker images...
       - docker push $REPOSITORY_URI:$IMAGE_TAG
-      - echo Writing image definitions file...
-      # TODO: This is only setup for the App task definition, we'll need to
-      #   figure how to also update the Worker task definition
+      - echo Writing image definitions files...
       - printf '[{"name":"App","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > app-imagedefinitions.json
       - printf '[{"name":"Worker","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > worker-imagedefinitions.json
 artifacts:


### PR DESCRIPTION
These changes enable using CodePipeline to automatically build a docker image from a branch and then pushing the image to docker hub.
CodePipeline is configured to then take that image and update the ECS services with it.

Currently the branch of this PR is deployed here: https://lara-interactives-test.concordqa.org/
Which is run by the lara-int-test-App and lara-int-test-Worker services in concordqa ECS. Those services were initially setup by the standard lara-ecs Cloudformation template.

The pipeline for this demo is here: 
https://console.aws.amazon.com/codesuite/codepipeline/pipelines/lara-test/view?region=us-east-1
It seems it would be better to setup the pipeline using CloudFormation too. But for now the pipeline was setup using AWS Console. 