### PR TITLE
Simplify LARA's internal interactive handling code

### DIFF
--- a/app/models/embeddable/answer_finder.rb
+++ b/app/models/embeddable/answer_finder.rb
@@ -23,17 +23,9 @@ module Embeddable
       when Embeddable::Labbook
         return "lb_#{question.id}"
       when MwInteractive
-        return "if_#{question.id}"
+        return "mw_#{question.id}"
       when ManagedInteractive
-        return "if_#{question.id}"
-      when InteractiveRunState::QuestionStandin
-        # It is not clear but I beleive this bit of hackyness is here for this reason:
-        # When a InteractiveRunState is asked for its
-        # question, it returns an InteractiveRunState::QuestionStandin instead of MwInteractive
-        # (I'm not sure why). And then that question is sometimes used later in the process
-        # to try to find the answer again. So that is why it is OK for the same key to be used
-        # in that case. I haven't found where this happens.
-        return question.interactive ? "if_#{question.interactive.id}" : nil
+        return "mi_#{question.id}"
       end
       return nil
     end

--- a/app/models/embeddable/answer_finder.rb
+++ b/app/models/embeddable/answer_finder.rb
@@ -24,6 +24,8 @@ module Embeddable
         return "lb_#{question.id}"
       when MwInteractive
         return "if_#{question.id}"
+      when ManagedInteractive
+        return "if_#{question.id}"
       when InteractiveRunState::QuestionStandin
         # It is not clear but I beleive this bit of hackyness is here for this reason:
         # When a InteractiveRunState is asked for its
@@ -55,14 +57,14 @@ module Embeddable
     def find_answer(question)
       type = answer_type(question)
       return question if type.nil?
-      answer =  self.answer_map[self.question_key(question)] 
+      answer =  self.answer_map[self.question_key(question)]
       if answer.nil?
         conditions = { :run => self.run, :question => question }
         # If this is an ImageQuestion with an author-defined background image, we want to copy that into the answer.
         if type == Embeddable::ImageQuestionAnswer and !question.is_shutterbug? and !question.bg_url.blank?
           conditions[:image_url] = question.bg_url
         end
-        answer = type.default_answer(conditions) 
+        answer = type.default_answer(conditions)
         self.add_answer(answer)
       end
       return answer
@@ -80,6 +82,8 @@ module Embeddable
       when Embeddable::Labbook
         return Embeddable::LabbookAnswer
       when MwInteractive
+        return InteractiveRunState
+      when ManagedInteractive
         return InteractiveRunState
       end
       return nil

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -32,26 +32,8 @@ class InteractiveRunState < ActiveRecord::Base
     return results
   end
 
-  # Make Embeddable::Answer assumptions work
-  class QuestionStandin
-    attr_accessor :interactive
-    def name
-      interactive.name.present? ? interactive.name : "Interactive"
-    end
-    def prompt; nil; end
-    def is_prediction; false; end
-    def give_prediction_feedback; false; end
-    def prediction_feedback; nil; end
-    def reportable?
-      interactive.reportable?
-    end
-  end
-
   def question
-    return @question if @question
-    @question = QuestionStandin.new
-    @question.interactive = interactive
-    @question
+    interactive
   end
 
   def page
@@ -228,26 +210,6 @@ class InteractiveRunState < ActiveRecord::Base
     else
       raw_data.present?
     end
-  end
-
-  class AnswerStandin
-    def initialize(opts={})
-      q = question
-      q.interactive = opts[:question] if opts[:question]
-    end
-    def question
-      @question ||= QuestionStandin.new
-    end
-    def prompt
-      question.prompt
-    end
-    def name
-      question.name
-    end
-  end
-
-  def self.default_answer(conditions)
-    return AnswerStandin.new(conditions)
   end
 
   def add_key_if_nil

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -217,4 +217,8 @@ class ManagedInteractive < ActiveRecord::Base
   def reportable_in_iframe?
     !has_report_url
   end
+
+  def prompt
+    name
+  end
 end

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -140,4 +140,8 @@ class MwInteractive < ActiveRecord::Base
       end
     end
   end
+
+  def prompt
+    name
+  end
 end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -335,12 +335,8 @@ class Run < ActiveRecord::Base
     # it, then there will still be an answer this hidden item.
     # But the hidden item won't be in the reportable_items list
 
-    # FIXME it would be much easier if interactive_run_states just returned the iteractive as
-    # the answer, to change this we need to track down all the places where answer.question is
-    # called to see what expectations the code has about the result.
     answered_items = q_answers.select do |a|
       question = a.question
-      question = question.interactive if question.is_a? InteractiveRunState::QuestionStandin
       reportable_items.include?(question)
     end
     answered_items.size

--- a/app/views/interactive_run_state/answer_standins/_summary.html.haml
+++ b/app/views/interactive_run_state/answer_standins/_summary.html.haml
@@ -1,2 +1,0 @@
-.answer
-  %p No work to show.


### PR DESCRIPTION
This should fix LARA summary page with Managed Interactives.

I've removed Question and Answer Standins and did a bit of smoke testing:
- LARA page rendered correctly
- student state was saved
- summary page worked
- sequence complete ribbon was working correctly
- Portal progress bar was correct
- Portal Report was correct (showing answers only when they're provided)

The only "breaking" change is that the previous LARA summary page was showing "Interactive" as prompt if interactive itself didn't specify its name (probably most authors don't do it). Now, it'll be blank - only question number visible. But given that we're going to use interactives as questions, I think it might be even better, as "interactive" there could be confusing.