### PR TITLE
Interactive API: support "hint" message

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -16734,6 +16734,17 @@ var IFrameSaver = /** @class */ (function () {
             _this.$iframe.data("height", height);
             _this.$iframe.trigger("sizeUpdate");
         });
+        this.addListener("hint", function (hint) {
+            var $container = _this.$iframe.closest(".embeddable-container");
+            var $helpIcon = $container.find(".help-icon");
+            if (hint) {
+                $helpIcon.removeClass("hidden");
+            }
+            else {
+                $container.find(".help-icon").addClass("hidden");
+            }
+            $container.find(".help-content .text").text(hint || "");
+        });
         this.addListener("supportedFeatures", function (info) {
             if (info.features && info.features.aspectRatio) {
                 // If the author specifies the aspect-ratio-method as "DEFAULT"

--- a/app/assets/stylesheets/partials/_runtime-question-hints.scss
+++ b/app/assets/stylesheets/partials/_runtime-question-hints.scss
@@ -12,6 +12,10 @@
   top: .5em;
   width: 1.25em;
   float: right;
+
+  &.hidden {
+    display: none;
+  }
 }
 
 .help-content {

--- a/app/views/shared/_question_header.html.haml
+++ b/app/views/shared/_question_header.html.haml
@@ -13,13 +13,13 @@
 .question-hdr
   %h5.h5
     = header_text
-  - if has_hint
-    .help-icon.screen-only{id: icon_id} ?
+  .help-icon.screen-only{id: icon_id, class: has_hint ? "" : "hidden"} ?
 
-- if has_hint
-  .help-content.screen-only{id: content_id}
-    = embeddable.hint.html_safe
-    .close{id: close_id} hide this
+.help-content.screen-only{id: content_id}
+  .text
+    - if has_hint
+      = embeddable.hint.html_safe
+  .close{id: close_id} hide this
 
   :javascript
     jQuery("##{icon_id}").on("click", function () {

--- a/docs/interactive-api-client/README.md
+++ b/docs/interactive-api-client/README.md
@@ -186,7 +186,7 @@ Calling the `setAuthoredState`, `setInteractiveState` and `setGlobalInteractiveS
 
 **Ƭ ClientMessage**: *[DeprecatedIFrameSaverClientMessage](#deprecatediframesaverclientmessage) \| [IFrameSaverClientMessage](#iframesaverclientmessage) \| [GlobalIFrameSaverClientMessage](#globaliframesaverclientmessage)*
 
-*Defined in [types.ts:100](../../lara-typescript/src/interactive-api-client/types.ts#L100)*
+*Defined in [types.ts:101](../../lara-typescript/src/interactive-api-client/types.ts#L101)*
 
 ___
 <a id="deprecatediframesaverclientmessage"></a>
@@ -195,7 +195,7 @@ ___
 
 **Ƭ DeprecatedIFrameSaverClientMessage**: *"setLearnerUrl"*
 
-*Defined in [types.ts:97](../../lara-typescript/src/interactive-api-client/types.ts#L97)*
+*Defined in [types.ts:98](../../lara-typescript/src/interactive-api-client/types.ts#L98)*
 
 ___
 <a id="deprecatediframesaverservermessage"></a>
@@ -204,7 +204,7 @@ ___
 
 **Ƭ DeprecatedIFrameSaverServerMessage**: *"getLearnerUrl" \| "loadInteractive"*
 
-*Defined in [types.ts:98](../../lara-typescript/src/interactive-api-client/types.ts#L98)*
+*Defined in [types.ts:99](../../lara-typescript/src/interactive-api-client/types.ts#L99)*
 
 ___
 <a id="globaliframesaverclientmessage"></a>
@@ -213,7 +213,7 @@ ___
 
 **Ƭ GlobalIFrameSaverClientMessage**: *"interactiveStateGlobal"*
 
-*Defined in [types.ts:92](../../lara-typescript/src/interactive-api-client/types.ts#L92)*
+*Defined in [types.ts:93](../../lara-typescript/src/interactive-api-client/types.ts#L93)*
 
 ___
 <a id="globaliframesaverservermessage"></a>
@@ -222,14 +222,14 @@ ___
 
 **Ƭ GlobalIFrameSaverServerMessage**: *"loadInteractiveGlobal"*
 
-*Defined in [types.ts:93](../../lara-typescript/src/interactive-api-client/types.ts#L93)*
+*Defined in [types.ts:94](../../lara-typescript/src/interactive-api-client/types.ts#L94)*
 
 ___
 <a id="iframesaverclientmessage"></a>
 
 ###  IFrameSaverClientMessage
 
-**Ƭ IFrameSaverClientMessage**: *"interactiveState" \| "height" \| "getAuthInfo" \| "supportedFeatures" \| "navigation" \| "getFirebaseJWT" \| "authoredState"*
+**Ƭ IFrameSaverClientMessage**: *"interactiveState" \| "height" \| "hint" \| "getAuthInfo" \| "supportedFeatures" \| "navigation" \| "getFirebaseJWT" \| "authoredState"*
 
 *Defined in [types.ts:79](../../lara-typescript/src/interactive-api-client/types.ts#L79)*
 
@@ -249,7 +249,7 @@ ___
 
 **Ƭ IframePhoneServerMessage**: *"hello"*
 
-*Defined in [types.ts:95](../../lara-typescript/src/interactive-api-client/types.ts#L95)*
+*Defined in [types.ts:96](../../lara-typescript/src/interactive-api-client/types.ts#L96)*
 
 ___
 <a id="iframesaverservermessage"></a>
@@ -258,7 +258,7 @@ ___
 
 **Ƭ IframeSaverServerMessage**: *"authInfo" \| "getInteractiveState" \| "initInteractive" \| "firebaseJWT"*
 
-*Defined in [types.ts:87](../../lara-typescript/src/interactive-api-client/types.ts#L87)*
+*Defined in [types.ts:88](../../lara-typescript/src/interactive-api-client/types.ts#L88)*
 
 ___
 <a id="initinteractivemode"></a>
@@ -276,7 +276,7 @@ ___
 
 **Ƭ ServerMessage**: *[IframePhoneServerMessage](#iframephoneservermessage) \| [DeprecatedIFrameSaverServerMessage](#deprecatediframesaverservermessage) \| [IframeSaverServerMessage](#iframesaverservermessage) \| [GlobalIFrameSaverServerMessage](#globaliframesaverservermessage)*
 
-*Defined in [types.ts:104](../../lara-typescript/src/interactive-api-client/types.ts#L104)*
+*Defined in [types.ts:105](../../lara-typescript/src/interactive-api-client/types.ts#L105)*
 
 ___
 

--- a/docs/interactive-api-client/classes/client.md
+++ b/docs/interactive-api-client/classes/client.md
@@ -30,6 +30,7 @@
 * [setAuthoredState](client.md#setauthoredstate)
 * [setGlobalInteractiveState](client.md#setglobalinteractivestate)
 * [setHeight](client.md#setheight)
+* [setHint](client.md#sethint)
 * [setInteractiveState](client.md#setinteractivestate)
 * [setNavigation](client.md#setnavigation)
 * [setSupportedFeatures](client.md#setsupportedfeatures)
@@ -111,7 +112,7 @@ ___
 
 ▸ **getAuthInfo**(): `Promise`<[IAuthInfo](../interfaces/iauthinfo.md)>
 
-*Defined in [client.ts:136](../../../lara-typescript/src/interactive-api-client/client.ts#L136)*
+*Defined in [client.ts:140](../../../lara-typescript/src/interactive-api-client/client.ts#L140)*
 
 **Returns:** `Promise`<[IAuthInfo](../interfaces/iauthinfo.md)>
 
@@ -122,7 +123,7 @@ ___
 
 ▸ **getFirebaseJWT**(options: *[IGetFirebaseJwtOptions](../interfaces/igetfirebasejwtoptions.md)*): `Promise`<`string`>
 
-*Defined in [client.ts:153](../../../lara-typescript/src/interactive-api-client/client.ts#L153)*
+*Defined in [client.ts:157](../../../lara-typescript/src/interactive-api-client/client.ts#L157)*
 
 **Parameters:**
 
@@ -139,7 +140,7 @@ ___
 
 ▸ **setAuthoredState**(authoredState: *`AuthoredState`*): `boolean`
 
-*Defined in [client.ts:128](../../../lara-typescript/src/interactive-api-client/client.ts#L128)*
+*Defined in [client.ts:132](../../../lara-typescript/src/interactive-api-client/client.ts#L132)*
 
 **Parameters:**
 
@@ -156,7 +157,7 @@ ___
 
 ▸ **setGlobalInteractiveState**(globalState: *`GlobalInteractiveState`*): `boolean`
 
-*Defined in [client.ts:132](../../../lara-typescript/src/interactive-api-client/client.ts#L132)*
+*Defined in [client.ts:136](../../../lara-typescript/src/interactive-api-client/client.ts#L136)*
 
 **Parameters:**
 
@@ -184,6 +185,23 @@ ___
 **Returns:** `boolean`
 
 ___
+<a id="sethint"></a>
+
+###  setHint
+
+▸ **setHint**(hint: *`string`*): `boolean`
+
+*Defined in [client.ts:116](../../../lara-typescript/src/interactive-api-client/client.ts#L116)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| hint | `string` |
+
+**Returns:** `boolean`
+
+___
 <a id="setinteractivestate"></a>
 
 ###  setInteractiveState
@@ -207,7 +225,7 @@ ___
 
 ▸ **setNavigation**(options: *[INavigationOptions](../interfaces/inavigationoptions.md)*): `boolean`
 
-*Defined in [client.ts:124](../../../lara-typescript/src/interactive-api-client/client.ts#L124)*
+*Defined in [client.ts:128](../../../lara-typescript/src/interactive-api-client/client.ts#L128)*
 
 **Parameters:**
 
@@ -224,7 +242,7 @@ ___
 
 ▸ **setSupportedFeatures**(features: *[ISupportedFeatures](../interfaces/isupportedfeatures.md)*): `boolean`
 
-*Defined in [client.ts:116](../../../lara-typescript/src/interactive-api-client/client.ts#L116)*
+*Defined in [client.ts:120](../../../lara-typescript/src/interactive-api-client/client.ts#L120)*
 
 **Parameters:**
 

--- a/docs/interactive-api-client/classes/client.md
+++ b/docs/interactive-api-client/classes/client.md
@@ -44,7 +44,7 @@
 
 ⊕ **new Client**(options: *[IClientOptions](../interfaces/iclientoptions.md)<`InteractiveState`, `AuthoredState`, `GlobalInteractiveState`>*): [Client](client.md)
 
-*Defined in [client.ts:27](../../../lara-typescript/src/interactive-api-client/client.ts#L27)*
+*Defined in [client.ts:25](../../../lara-typescript/src/interactive-api-client/client.ts#L25)*
 
 **Parameters:**
 
@@ -64,7 +64,7 @@ ___
 
 **get InIFrame**(): `boolean`
 
-*Defined in [client.ts:106](../../../lara-typescript/src/interactive-api-client/client.ts#L106)*
+*Defined in [client.ts:104](../../../lara-typescript/src/interactive-api-client/client.ts#L104)*
 
 **Returns:** `boolean`
 
@@ -75,7 +75,7 @@ ___
 
 **get iframePhone**(): `undefined` \| `IFrameEndpoint`
 
-*Defined in [client.ts:40](../../../lara-typescript/src/interactive-api-client/client.ts#L40)*
+*Defined in [client.ts:38](../../../lara-typescript/src/interactive-api-client/client.ts#L38)*
 
 **Returns:** `undefined` \| `IFrameEndpoint`
 
@@ -89,7 +89,7 @@ ___
 
 ▸ **connect**(): `boolean`
 
-*Defined in [client.ts:44](../../../lara-typescript/src/interactive-api-client/client.ts#L44)*
+*Defined in [client.ts:42](../../../lara-typescript/src/interactive-api-client/client.ts#L42)*
 
 **Returns:** `boolean`
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **disconnect**(): `boolean`
 
-*Defined in [client.ts:90](../../../lara-typescript/src/interactive-api-client/client.ts#L90)*
+*Defined in [client.ts:88](../../../lara-typescript/src/interactive-api-client/client.ts#L88)*
 
 **Returns:** `boolean`
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **getAuthInfo**(): `Promise`<[IAuthInfo](../interfaces/iauthinfo.md)>
 
-*Defined in [client.ts:138](../../../lara-typescript/src/interactive-api-client/client.ts#L138)*
+*Defined in [client.ts:136](../../../lara-typescript/src/interactive-api-client/client.ts#L136)*
 
 **Returns:** `Promise`<[IAuthInfo](../interfaces/iauthinfo.md)>
 
@@ -122,7 +122,7 @@ ___
 
 ▸ **getFirebaseJWT**(options: *[IGetFirebaseJwtOptions](../interfaces/igetfirebasejwtoptions.md)*): `Promise`<`string`>
 
-*Defined in [client.ts:155](../../../lara-typescript/src/interactive-api-client/client.ts#L155)*
+*Defined in [client.ts:153](../../../lara-typescript/src/interactive-api-client/client.ts#L153)*
 
 **Parameters:**
 
@@ -139,7 +139,7 @@ ___
 
 ▸ **setAuthoredState**(authoredState: *`AuthoredState`*): `boolean`
 
-*Defined in [client.ts:130](../../../lara-typescript/src/interactive-api-client/client.ts#L130)*
+*Defined in [client.ts:128](../../../lara-typescript/src/interactive-api-client/client.ts#L128)*
 
 **Parameters:**
 
@@ -156,7 +156,7 @@ ___
 
 ▸ **setGlobalInteractiveState**(globalState: *`GlobalInteractiveState`*): `boolean`
 
-*Defined in [client.ts:134](../../../lara-typescript/src/interactive-api-client/client.ts#L134)*
+*Defined in [client.ts:132](../../../lara-typescript/src/interactive-api-client/client.ts#L132)*
 
 **Parameters:**
 
@@ -173,7 +173,7 @@ ___
 
 ▸ **setHeight**(height: *`number` \| `string`*): `boolean`
 
-*Defined in [client.ts:114](../../../lara-typescript/src/interactive-api-client/client.ts#L114)*
+*Defined in [client.ts:112](../../../lara-typescript/src/interactive-api-client/client.ts#L112)*
 
 **Parameters:**
 
@@ -190,7 +190,7 @@ ___
 
 ▸ **setInteractiveState**(interactiveState: *`InteractiveState` \| `string` \| `null`*): `boolean`
 
-*Defined in [client.ts:110](../../../lara-typescript/src/interactive-api-client/client.ts#L110)*
+*Defined in [client.ts:108](../../../lara-typescript/src/interactive-api-client/client.ts#L108)*
 
 **Parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **setNavigation**(options: *[INavigationOptions](../interfaces/inavigationoptions.md)*): `boolean`
 
-*Defined in [client.ts:126](../../../lara-typescript/src/interactive-api-client/client.ts#L126)*
+*Defined in [client.ts:124](../../../lara-typescript/src/interactive-api-client/client.ts#L124)*
 
 **Parameters:**
 
@@ -224,7 +224,7 @@ ___
 
 ▸ **setSupportedFeatures**(features: *[ISupportedFeatures](../interfaces/isupportedfeatures.md)*): `boolean`
 
-*Defined in [client.ts:118](../../../lara-typescript/src/interactive-api-client/client.ts#L118)*
+*Defined in [client.ts:116](../../../lara-typescript/src/interactive-api-client/client.ts#L116)*
 
 **Parameters:**
 

--- a/docs/interactive-api-client/interfaces/iauthinfo.md
+++ b/docs/interactive-api-client/interfaces/iauthinfo.md
@@ -26,7 +26,7 @@
 
 **● email**: *`undefined` \| `string`*
 
-*Defined in [types.ts:140](../../../lara-typescript/src/interactive-api-client/types.ts#L140)*
+*Defined in [types.ts:141](../../../lara-typescript/src/interactive-api-client/types.ts#L141)*
 
 ___
 <a id="loggedin"></a>
@@ -35,7 +35,7 @@ ___
 
 **● loggedIn**: *`boolean`*
 
-*Defined in [types.ts:139](../../../lara-typescript/src/interactive-api-client/types.ts#L139)*
+*Defined in [types.ts:140](../../../lara-typescript/src/interactive-api-client/types.ts#L140)*
 
 ___
 <a id="provider"></a>
@@ -44,7 +44,7 @@ ___
 
 **● provider**: *`string`*
 
-*Defined in [types.ts:138](../../../lara-typescript/src/interactive-api-client/types.ts#L138)*
+*Defined in [types.ts:139](../../../lara-typescript/src/interactive-api-client/types.ts#L139)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/igetauthinforequest.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforequest.md
@@ -26,7 +26,7 @@
 
 *Inherited from IBaseRequestResponse.requestId*
 
-*Defined in [types.ts:134](../../../lara-typescript/src/interactive-api-client/types.ts#L134)*
+*Defined in [types.ts:135](../../../lara-typescript/src/interactive-api-client/types.ts#L135)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/igetauthinforesponse.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforesponse.md
@@ -31,7 +31,7 @@
 
 *Inherited from [IAuthInfo](iauthinfo.md).[email](iauthinfo.md#email)*
 
-*Defined in [types.ts:140](../../../lara-typescript/src/interactive-api-client/types.ts#L140)*
+*Defined in [types.ts:141](../../../lara-typescript/src/interactive-api-client/types.ts#L141)*
 
 ___
 <a id="loggedin"></a>
@@ -42,7 +42,7 @@ ___
 
 *Inherited from [IAuthInfo](iauthinfo.md).[loggedIn](iauthinfo.md#loggedin)*
 
-*Defined in [types.ts:139](../../../lara-typescript/src/interactive-api-client/types.ts#L139)*
+*Defined in [types.ts:140](../../../lara-typescript/src/interactive-api-client/types.ts#L140)*
 
 ___
 <a id="provider"></a>
@@ -53,7 +53,7 @@ ___
 
 *Inherited from [IAuthInfo](iauthinfo.md).[provider](iauthinfo.md#provider)*
 
-*Defined in [types.ts:138](../../../lara-typescript/src/interactive-api-client/types.ts#L138)*
+*Defined in [types.ts:139](../../../lara-typescript/src/interactive-api-client/types.ts#L139)*
 
 ___
 <a id="requestid"></a>
@@ -64,7 +64,7 @@ ___
 
 *Inherited from IBaseRequestResponse.requestId*
 
-*Defined in [types.ts:134](../../../lara-typescript/src/interactive-api-client/types.ts#L134)*
+*Defined in [types.ts:135](../../../lara-typescript/src/interactive-api-client/types.ts#L135)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtoptions.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtoptions.md
@@ -24,7 +24,7 @@
 
 **● firebase_app**: *`undefined` \| `string`*
 
-*Defined in [types.ts:151](../../../lara-typescript/src/interactive-api-client/types.ts#L151)*
+*Defined in [types.ts:152](../../../lara-typescript/src/interactive-api-client/types.ts#L152)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
@@ -29,7 +29,7 @@
 
 *Inherited from [IGetFirebaseJwtOptions](igetfirebasejwtoptions.md).[firebase_app](igetfirebasejwtoptions.md#firebase_app)*
 
-*Defined in [types.ts:151](../../../lara-typescript/src/interactive-api-client/types.ts#L151)*
+*Defined in [types.ts:152](../../../lara-typescript/src/interactive-api-client/types.ts#L152)*
 
 ___
 <a id="requestid"></a>
@@ -40,7 +40,7 @@ ___
 
 *Inherited from IBaseRequestResponse.requestId*
 
-*Defined in [types.ts:134](../../../lara-typescript/src/interactive-api-client/types.ts#L134)*
+*Defined in [types.ts:135](../../../lara-typescript/src/interactive-api-client/types.ts#L135)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
@@ -27,7 +27,7 @@
 
 **● message**: *`undefined` \| `string`*
 
-*Defined in [types.ts:160](../../../lara-typescript/src/interactive-api-client/types.ts#L160)*
+*Defined in [types.ts:161](../../../lara-typescript/src/interactive-api-client/types.ts#L161)*
 
 ___
 <a id="requestid"></a>
@@ -38,7 +38,7 @@ ___
 
 *Inherited from IBaseRequestResponse.requestId*
 
-*Defined in [types.ts:134](../../../lara-typescript/src/interactive-api-client/types.ts#L134)*
+*Defined in [types.ts:135](../../../lara-typescript/src/interactive-api-client/types.ts#L135)*
 
 ___
 <a id="response_type"></a>
@@ -47,7 +47,7 @@ ___
 
 **● response_type**: *`undefined` \| "ERROR"*
 
-*Defined in [types.ts:159](../../../lara-typescript/src/interactive-api-client/types.ts#L159)*
+*Defined in [types.ts:160](../../../lara-typescript/src/interactive-api-client/types.ts#L160)*
 
 ___
 <a id="token"></a>
@@ -56,7 +56,7 @@ ___
 
 **● token**: *`undefined` \| `string`*
 
-*Defined in [types.ts:161](../../../lara-typescript/src/interactive-api-client/types.ts#L161)*
+*Defined in [types.ts:162](../../../lara-typescript/src/interactive-api-client/types.ts#L162)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/inavigationoptions.md
+++ b/docs/interactive-api-client/interfaces/inavigationoptions.md
@@ -23,7 +23,7 @@
 
 **● enableForwardNav**: *`undefined` \| `false` \| `true`*
 
-*Defined in [types.ts:125](../../../lara-typescript/src/interactive-api-client/types.ts#L125)*
+*Defined in [types.ts:126](../../../lara-typescript/src/interactive-api-client/types.ts#L126)*
 
 ___
 <a id="message"></a>
@@ -32,7 +32,7 @@ ___
 
 **● message**: *`undefined` \| `string`*
 
-*Defined in [types.ts:126](../../../lara-typescript/src/interactive-api-client/types.ts#L126)*
+*Defined in [types.ts:127](../../../lara-typescript/src/interactive-api-client/types.ts#L127)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/isupportedfeatures.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeatures.md
@@ -24,7 +24,7 @@
 
 **● aspectRatio**: *`undefined` \| `number`*
 
-*Defined in [types.ts:114](../../../lara-typescript/src/interactive-api-client/types.ts#L114)*
+*Defined in [types.ts:115](../../../lara-typescript/src/interactive-api-client/types.ts#L115)*
 
 ___
 <a id="authoredstate"></a>
@@ -33,7 +33,7 @@ ___
 
 **● authoredState**: *`undefined` \| `false` \| `true`*
 
-*Defined in [types.ts:115](../../../lara-typescript/src/interactive-api-client/types.ts#L115)*
+*Defined in [types.ts:116](../../../lara-typescript/src/interactive-api-client/types.ts#L116)*
 
 ___
 <a id="interactivestate"></a>
@@ -42,7 +42,7 @@ ___
 
 **● interactiveState**: *`undefined` \| `false` \| `true`*
 
-*Defined in [types.ts:116](../../../lara-typescript/src/interactive-api-client/types.ts#L116)*
+*Defined in [types.ts:117](../../../lara-typescript/src/interactive-api-client/types.ts#L117)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
@@ -23,7 +23,7 @@
 
 **● apiVersion**: *`1`*
 
-*Defined in [types.ts:120](../../../lara-typescript/src/interactive-api-client/types.ts#L120)*
+*Defined in [types.ts:121](../../../lara-typescript/src/interactive-api-client/types.ts#L121)*
 
 ___
 <a id="features"></a>
@@ -32,7 +32,7 @@ ___
 
 **● features**: *[ISupportedFeatures](isupportedfeatures.md)*
 
-*Defined in [types.ts:121](../../../lara-typescript/src/interactive-api-client/types.ts#L121)*
+*Defined in [types.ts:122](../../../lara-typescript/src/interactive-api-client/types.ts#L122)*
 
 ___
 

--- a/lara-typescript/src/interactive-api-client/client.spec.ts
+++ b/lara-typescript/src/interactive-api-client/client.spec.ts
@@ -190,6 +190,11 @@ describe("Client", () => {
         expect(mockedPhone().messages).toEqual([{type: "height", content: 100}]);
       });
 
+      it("supports setHint", () => {
+        expect(client.setHint("test hint")).toBe(true);
+        expect(mockedPhone().messages).toEqual([{type: "hint", content: "test hint"}]);
+      });
+
       it("supports setSupportedFeatures", () => {
         expect(client.setSupportedFeatures({interactiveState: true, authoredState: true, aspectRatio: 1})).toBe(true);
         expect(mockedPhone().messages).toEqual([{type: "supportedFeatures", content: {

--- a/lara-typescript/src/interactive-api-client/client.ts
+++ b/lara-typescript/src/interactive-api-client/client.ts
@@ -113,6 +113,10 @@ export class Client<InteractiveState = {}, AuthoredState = {}, GlobalInteractive
     return this.post("height", height);
   }
 
+  public setHint(hint: string) {
+    return this.post("hint", hint);
+  }
+
   public setSupportedFeatures(features: ISupportedFeatures) {
     const request: ISupportedFeaturesRequest = {
       apiVersion: 1,

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/lara-typescript/src/interactive-api-client/types.ts
+++ b/lara-typescript/src/interactive-api-client/types.ts
@@ -78,6 +78,7 @@ export interface IHookOptions {
 // the iframesaver messages are 1 per line to reduce merge conflicts as new ones are added
 export type IFrameSaverClientMessage = "interactiveState" |
                                 "height" |
+                                "hint" |
                                 "getAuthInfo" |
                                 "supportedFeatures" |
                                 "navigation" |

--- a/lara-typescript/src/interactive-api-client/use-api-hook.ts
+++ b/lara-typescript/src/interactive-api-client/use-api-hook.ts
@@ -66,6 +66,12 @@ export function useLaraInteractiveApi<InteractiveState = {}, AuthoredState = {},
     }
   };
 
+  const handleSetHint = (hint: string) => {
+    if (client.current) {
+      client.current.setHint(hint);
+    }
+  };
+
   const handleSetAspectRatio = (aspectRatio: number) => {
     if (client.current) {
       const existingFeatures = hookOptions.supportedFeatures || {};
@@ -111,6 +117,7 @@ export function useLaraInteractiveApi<InteractiveState = {}, AuthoredState = {},
     setGlobalInteractiveState: handleSetGlobalInteractiveState,
     setHeight: handleSetHeight,
     setAspectRatio: handleSetAspectRatio,
+    setHint: handleSetHint,
     setNavigation: handleSetNavigation,
     getAuthInfo: handleGetAuthInfo,
     getFirebaseJWT: handleGetFirebaseJWT

--- a/lara-typescript/src/interactive-api/iframe-saver.spec.ts
+++ b/lara-typescript/src/interactive-api/iframe-saver.spec.ts
@@ -33,21 +33,26 @@ describe("IFrameSaver", () => {
     MockedIframePhoneManager.install();
     setAutoConnect(false);
     $(document.body).html(`
-      <iframe src="" id="interactive" frameborder="0"></iframe>
-      <div id="under_iframe">
-        <div id="interactive_data_div"
-            data-enable-learner-state="true"
-            data-interactive-run-state-url="foo/42"
-            data-authored-state='{"test": 123}'
-            data-class-info-url=null
-            data-interactive-id=1
-            data-interactive-name="test"
-            data-authprovider="fakeprovider"
-            data-user-email="user@example.com"
-            data-loggedin="true"
-        >
+      <div class="embeddable-container">
+        <div class="help-icon hidden"/>
+        <div class="help-content"><div class="text">Test hint</div></div>
+
+        <iframe src="" id="interactive" frameborder="0"></iframe>
+        <div id="under_iframe">
+          <div id="interactive_data_div"
+              data-enable-learner-state="true"
+              data-interactive-run-state-url="foo/42"
+              data-authored-state='{"test": 123}'
+              data-class-info-url=null
+              data-interactive-id=1
+              data-interactive-name="test"
+              data-authprovider="fakeprovider"
+              data-user-email="user@example.com"
+              data-loggedin="true"
+          >
+          </div>
+          <button class="delete_interactive_data">Undo all my work</button>
         </div>
-        <button class="delete_interactive_data">Undo all my work</button>
       </div>
 
       <!-- save indicator -->
@@ -185,6 +190,25 @@ describe("IFrameSaver", () => {
           authInfo: {provider: "fakeprovider", loggedIn: true, email: "user@example.com"}
         });
       });
+    });
+  });
+
+  describe("hint iframe-phone message", () => {
+    beforeEach(() => {
+      saver = getSaver();
+      MockedIframePhoneManager.connect();
+    });
+
+    it("should enable hint", () => {
+      const $helpIcon = $(".help-icon");
+      expect($helpIcon.hasClass("hidden")).toEqual(true);
+      MockedIframePhoneManager.postMessageFrom($("#interactive")[0], { type: "hint", content: "new hint" });
+      expect($helpIcon.hasClass("hidden")).toEqual(false);
+      expect($(".help-content .text").text()).toEqual("new hint");
+
+      MockedIframePhoneManager.postMessageFrom($("#interactive")[0], { type: "hint", content: "" });
+      expect($helpIcon.hasClass("hidden")).toEqual(true);
+      expect($(".help-content .text").text()).toEqual("");
     });
   });
 });

--- a/lara-typescript/src/interactive-api/iframe-saver.ts
+++ b/lara-typescript/src/interactive-api/iframe-saver.ts
@@ -1,4 +1,3 @@
-
 import { ParentEndpoint } from "iframe-phone";
 import * as LaraInteractiveApi from "../interactive-api-client";
 import { IframePhoneManager } from "./iframe-phone-manager";
@@ -218,6 +217,17 @@ export class IFrameSaver {
     this.addListener("height", (height: number | string) => {
       this.$iframe.data("height", height);
       this.$iframe.trigger("sizeUpdate");
+    });
+
+    this.addListener("hint", (hint: string | null) => {
+      const $container = this.$iframe.closest(".embeddable-container");
+      const $helpIcon = $container.find(".help-icon");
+      if (hint) {
+        $helpIcon.removeClass("hidden");
+      } else {
+        $container.find(".help-icon").addClass("hidden");
+      }
+      $container.find(".help-content .text").text(hint || "");
     });
 
     this.addListener("supportedFeatures", (info: LaraInteractiveApi.ISupportedFeaturesRequest) => {


### PR DESCRIPTION
[#172877675]

It might not be super beautiful as it depends on CSS classes, but at least seems to be simple, self-contained, and testable. IframeSaver gets some HTML elements in the constructor (disable button), but it would only spread this logic into more files. I guess that this code might be refactored soon anyway? (when we update change iframe-saver or replace code handling displaying questions).