### PR TITLE
Rename Managed Interactive to Library Interactive in the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To use SSO with the portal you need to make sure your `PORTAL_HOST` is set corre
 
 The rake task above assumes your local lara instance is running at http://app.lara.docker
 If it is running somewhere else, then you can log into the portal as an admin and edit
-the Auth Client created by the rake task. 
+the Auth Client created by the rake task.
 
 ## Users and administration
 User authentication is handled by [Devise](https://github.com/plataformatec/devise). Currently, the confirmation plugin is not enabled, so anyone who fills out the registration form at `/users/sign_up` will be automatically confirmed as a user. To get author or administrator privilege, the newly-registered user would need to be given those privileges by an existing admin user (on deployed systems e.g. staging or production).
@@ -130,7 +130,8 @@ To support new Embeddables:
 * Add a view directory at `app/views/embeddable/<embeddable_name>`
 * Provide a `_lightweight.html.haml` partial within that view directory (for showing the Embeddable within an InteractivePage)
 * Provide a `_author.html.haml` partial as well (for editing the Embeddable)
-* Add the Embeddable's name as a string to the the `Embeddable::Types` constant in `app/models/embeddable.rb`.
+* Add the Embeddable to the the `Embeddable::Types` constant in `app/models/embeddable.rb`.
+* Add a human name for the embeddable to the activerecord.models section in config/locales/en.yml
 * There may be additional steps needed if the Embeddable is a question (i.e. it prompts the user for some kind of response which needs to be saved). Note `LightweightActivity#questions` for example.
 
 ## Current work: reporting

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To support new Embeddables:
 * Add a view directory at `app/views/embeddable/<embeddable_name>`
 * Provide a `_lightweight.html.haml` partial within that view directory (for showing the Embeddable within an InteractivePage)
 * Provide a `_author.html.haml` partial as well (for editing the Embeddable)
-* Add the Embeddable to the the `Embeddable::Types` constant in `app/models/embeddable.rb`.
+* Add the Embeddable to the `Embeddable::Types` constant in `app/models/embeddable.rb`.
 * Add a human name for the embeddable to the activerecord.models section in config/locales/en.yml
 * There may be additional steps needed if the Embeddable is a question (i.e. it prompts the user for some kind of response which needs to be saved). Note `LightweightActivity#questions` for example.
 

--- a/app/controllers/interactive_controller.rb
+++ b/app/controllers/interactive_controller.rb
@@ -6,11 +6,12 @@ class InteractiveController < ApplicationController
 
   def update
     set_page
+    interactive_type_name = @interactive.class.model_name.human.downcase
     if (@interactive.update_attributes(get_interactive_params))
       # respond success
-      flash[:notice] = "Your #{@interactive.class.string_name} was updated."
+      flash[:notice] = "Your #{interactive_type_name} was updated."
     else
-      flash[:warning] = "There was a problem updating your #{@interactive.class.string_name}."
+      flash[:warning] = "There was a problem updating your #{interactive_type_name}."
     end
     respond_to do |format|
       if @page

--- a/app/helpers/embeddable_helper.rb
+++ b/app/helpers/embeddable_helper.rb
@@ -1,13 +1,13 @@
 module EmbeddableHelper
 
   def embeddable_selector
-    embeddable_types = Embeddable::Types.map { |k,v| [v, k.to_s] }
+    embeddable_types = Embeddable::Types.map { |type| [type.model_name.human, type.to_s] }
     plugin_items = ApprovedScript.authoring_menu_items("embeddable").map { |ami| [ami.name, Embeddable::EmbeddablePlugin.to_s, {"data-approved-script-id" => ami.approved_script_id, "data-component-label" => ami.component_label}] }
     select_tag :embeddable_type, options_for_select(embeddable_types + plugin_items)
   end
 
   def embeddable_interactives_selector
-    select_tag :embeddable_type, options_for_select(Embeddable::InteractiveTypes.map { |k,v| [v, k.to_s] })
+    select_tag :embeddable_type, options_for_select(Embeddable::InteractiveTypes.map { |type| [type.model_name.human, type.to_s] })
   end
 
   def available_wrapped_embeddable_plugins(embeddable)

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -1,32 +1,33 @@
 module Embeddable
-  QuestionTypes = {
-    Embeddable::ImageQuestion  => "Image question",
-    Embeddable::MultipleChoice => "Multiple choice",
-    Embeddable::OpenResponse   => "Open response",
-    Embeddable::Xhtml          => "Text box",
-    Embeddable::Labbook        => "Labbook",
-    QuestionTracker            => "Tracked Question",
-    Embeddable::ExternalScript => "External Script",
-  }
+  # The Order here determins the order in the authoring selection menu
+  QuestionTypes = [
+    Embeddable::OpenResponse,
+    Embeddable::MultipleChoice,
+    Embeddable::Xhtml,
+    Embeddable::ImageQuestion,
+    Embeddable::Labbook,
+    QuestionTracker,
+    Embeddable::ExternalScript,
+  ]
 
-  InteractiveTypes = {
-    MwInteractive      => "Iframe Interactive",
-    ManagedInteractive => "Managed Interactive",
-    ImageInteractive   => "Image",
-    VideoInteractive   => "Video"
-  }
+  InteractiveTypes = [
+    MwInteractive,
+    ManagedInteractive,
+    ImageInteractive,
+    VideoInteractive,
+  ]
 
   # Types is just sum of question and interactives.
-  Types = QuestionTypes.merge(InteractiveTypes)
+  Types = QuestionTypes + InteractiveTypes
 
   def self.is_question?(e)
     # Support both instance and class.
-    QuestionTypes.keys.include?(e.class) || QuestionTypes.keys.include?(e)
+    QuestionTypes.include?(e.class) || QuestionTypes.include?(e)
   end
 
   def self.is_interactive?(e)
     # Support both instance and class.
-    InteractiveTypes.keys.include?(e.class) || InteractiveTypes.keys.include?(e)
+    InteractiveTypes.include?(e.class) || InteractiveTypes.include?(e)
   end
 
   def self.table_name_prefix
@@ -34,7 +35,7 @@ module Embeddable
   end
 
   def self.valid_type(class_string)
-    return class_string == Embeddable::EmbeddablePlugin.to_s || Types.detect{|k,v| k.to_s == class_string }
+    return class_string == Embeddable::EmbeddablePlugin.to_s || Types.detect{|type| type.to_s == class_string }
   end
 
   def self.create_for_string(class_string)

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -1,5 +1,5 @@
 module Embeddable
-  # The Order here determins the order in the authoring selection menu
+  # The Order here determines the order in the authoring selection menu
   QuestionTypes = [
     Embeddable::OpenResponse,
     Embeddable::MultipleChoice,

--- a/app/models/embeddable.rb
+++ b/app/models/embeddable.rb
@@ -20,11 +20,6 @@ module Embeddable
   # Types is just sum of question and interactives.
   Types = QuestionTypes + InteractiveTypes
 
-  def self.is_question?(e)
-    # Support both instance and class.
-    QuestionTypes.include?(e.class) || QuestionTypes.include?(e)
-  end
-
   def self.is_interactive?(e)
     # Support both instance and class.
     InteractiveTypes.include?(e.class) || InteractiveTypes.include?(e)

--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -8,10 +8,6 @@ class ImageInteractive < ActiveRecord::Base
   has_one :interactive_page, :through => :page_item
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'
 
-  def self.string_name
-    "image interactive"
-  end
-
   def self.portal_type
     "unsupported"
   end

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -93,10 +93,6 @@ class InteractivePage < ActiveRecord::Base
     section_embeddables(nil)
   end
 
-  def main_questions
-    section_embeddables(nil).select{ |e| Embeddable::is_question?(e) }
-  end
-
   def visible_embeddables
     embeddables.select{ |e| !e.is_hidden }
   end

--- a/app/models/library_interactive.rb
+++ b/app/models/library_interactive.rb
@@ -1,5 +1,6 @@
 require 'digest'
 
+# In the UI the Managed Interactive model also called a Library Interactive
 class LibraryInteractive < ActiveRecord::Base
   include HasAspectRatio
 

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -1,3 +1,6 @@
+# In the UI the ManagedInteractive model is called Library Interactive
+# There is also a LibraryInteractive model which are the items in the
+# interactive library
 class ManagedInteractive < ActiveRecord::Base
   include BaseInteractive
   include Embeddable

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -27,10 +27,6 @@ class MwInteractive < ActiveRecord::Base
 
   after_update :update_labbook_options
 
-  def self.string_name
-    "iframe interactive"
-  end
-
   def self.portal_type
     "iframe interactive"
   end

--- a/app/models/question_tracker.rb
+++ b/app/models/question_tracker.rb
@@ -43,7 +43,7 @@ class QuestionTracker < ActiveRecord::Base
   end
 
   def type
-    Embeddable::Types[master_question.class]
+    master_question.class.model_name.human
   end
 
   def use_count

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -17,10 +17,6 @@ class VideoInteractive < ActiveRecord::Base
 
   validates_numericality_of :height, :width
 
-  def self.string_name
-    "video interactive"
-  end
-
   def self.portal_type
     "unsupported"
   end

--- a/app/views/managed_interactives/_author.html.haml
+++ b/app/views/managed_interactives/_author.html.haml
@@ -2,7 +2,7 @@
   .drag_handle
   = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'managed_int', :allow_hide => allow_hide }
 .embeddable_options
-  Managed interactive
+  = ManagedInteractive.model_name.human
   .model-edit
     .interactive-content
       %div{:id => "authorable-interactive-#{embeddable.id}"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,11 +170,16 @@ en:
       MAX: 'Use all available space.'
   activerecord:
     models:
+      # Question Types
       "embeddable/external_script": "External script"
-      "image_interactive": "Image interactive"
       "embeddable/image_question": "Image question"
-      "embeddable/multiple_choice": "Multiple choice question"
-      "mw_interactive": "Iframe interactive"
-      "embeddable/open_response": "Open response question"
-      "video_interactive": "Video"
+      "embeddable/labbook": "Labbook"
+      "embeddable/multiple_choice": "Multiple choice"
+      "embeddable/open_response": "Open response"
       "embeddable/xhtml": "Text block"
+      "question_tracker": "Tracked Question"
+      # Interactive types
+      "image_interactive": "Image"
+      "managed_interactive": "Library Interactive"
+      "mw_interactive": "Iframe Interactive"
+      "video_interactive": "Video"

--- a/spec/controllers/image_interactives_controller_spec.rb
+++ b/spec/controllers/image_interactives_controller_spec.rb
@@ -56,7 +56,7 @@ describe ImageInteractivesController do
           new_values_hash = { :caption => 'I made this up', :url => 'http://mw.concord.org/modeler/_assets/img/mw.png' }
           post :update, :id => int.id, :page_id => page.id, :image_interactive => new_values_hash
           expect(response).to redirect_to(edit_activity_page_path(activity, page))
-          expect(flash[:notice]).to eq('Your image interactive was updated.')
+          expect(flash[:notice]).to eq('Your image was updated.')
         end
 
         # it 'returns to the edit page with an error on failure' do

--- a/spec/controllers/managed_interactives_controller_spec.rb
+++ b/spec/controllers/managed_interactives_controller_spec.rb
@@ -19,6 +19,7 @@ describe ManagedInteractivesController do
 
   context 'when the logged-in user is an author' do
     # Authorization is tested in spec/models/user_spec.rb
+    # In the UI a Managed interactive is called a Library Interactive
     context 'when editing an existing Managed Interactive' do
       describe 'edit' do
         it 'shows a form with values of the Managed Interactive filled in' do
@@ -50,14 +51,16 @@ describe ManagedInteractivesController do
           new_values_hash = { :name => 'Edited name', :url_fragment => '/foo' }
           post :update, :id => int.id, :page_id => page.id, :managed_interactive => new_values_hash
           expect(response).to redirect_to(edit_activity_page_path(activity, page))
-          expect(flash[:notice]).to eq('Your managed interactive was updated.')
+          # In the UI a Managed interactive is called a Library Interactive
+          expect(flash[:notice]).to eq('Your library interactive was updated.')
         end
 
         it 'returns to the edit page with an error on failure' do
           new_values_hash = { :custom_native_width => 'Ha!' }
           post :update, :id => int.id, :page_id => page.id, :managed_interactive => new_values_hash
           expect(response).to redirect_to(edit_activity_page_path(activity, page))
-          expect(flash[:warning]).to eq('There was a problem updating your managed interactive.')
+          # In the UI a Managed interactive is called a Library Interactive
+          expect(flash[:warning]).to eq('There was a problem updating your library interactive.')
         end
       end
     end

--- a/spec/controllers/video_interactives_controller_spec.rb
+++ b/spec/controllers/video_interactives_controller_spec.rb
@@ -55,7 +55,7 @@ describe VideoInteractivesController do
           new_values_hash = { :caption => 'I made this up', :poster_url => 'http://mw.concord.org/modeler/_assets/img/mw.png' }
           post :update, :id => int.id, :page_id => page.id, :video_interactive => new_values_hash
           expect(response).to redirect_to(edit_activity_page_path(activity, page))
-          expect(flash[:notice]).to eq('Your video interactive was updated.')
+          expect(flash[:notice]).to eq('Your video was updated.')
         end
 
         # it 'returns to the edit page with an error on failure' do

--- a/spec/support/shared_examples/attached_to_embeddable.rb
+++ b/spec/support/shared_examples/attached_to_embeddable.rb
@@ -59,9 +59,9 @@ shared_examples "attached to embeddable" do
 
     let(:expected_identifier_1) { AttachedToEmbeddable::NO_EMBEDDABLE_SELECT }
     let(:expected_identifier_2) { AttachedToEmbeddable::NEXT_EMBEDDABLE_SELECT }
-    let(:expected_identifier_3) { ["Open response question (1)", "#{embeddable_a.id}-Embeddable::OpenResponse"]}
-    let(:expected_identifier_4) { ["Open response question (2)", "#{embeddable_b.id}-Embeddable::OpenResponse"]}
-    let(:expected_identifier_5) { ["Open response question (hidden)(3)", "#{hidden_open_response_embeddable.id}-Embeddable::OpenResponse"]}
+    let(:expected_identifier_3) { ["Open response (1)", "#{embeddable_a.id}-Embeddable::OpenResponse"]}
+    let(:expected_identifier_4) { ["Open response (2)", "#{embeddable_b.id}-Embeddable::OpenResponse"]}
+    let(:expected_identifier_5) { ["Open response (hidden)(3)", "#{hidden_open_response_embeddable.id}-Embeddable::OpenResponse"]}
 
     let(:embeddables) { [embeddable_a, embeddable_b, hidden_open_response_embeddable] }
     it "should have good options" do

--- a/spec/support/shared_examples/attached_to_interactive.rb
+++ b/spec/support/shared_examples/attached_to_interactive.rb
@@ -38,9 +38,9 @@ shared_examples "attached to interactive" do
     let(:interactive_b)         { FactoryGirl.create(:mw_interactive) }
 
     let(:expected_identifier_1) { AttachedToInteractive::NO_INTERACTIVE_SELECT }
-    let(:expected_identifier_2) { ["Iframe interactive (1)", "#{interactive_a.id}-MwInteractive"]}
-    let(:expected_identifier_3) { ["Iframe interactive (2)", "#{interactive_b.id}-MwInteractive"]}
-    let(:expected_identifier_4) { ["Iframe interactive (hidden)(3)", "#{hidden_mw_interactive.id}-MwInteractive"]}
+    let(:expected_identifier_2) { ["Iframe Interactive (1)", "#{interactive_a.id}-MwInteractive"]}
+    let(:expected_identifier_3) { ["Iframe Interactive (2)", "#{interactive_b.id}-MwInteractive"]}
+    let(:expected_identifier_4) { ["Iframe Interactive (hidden)(3)", "#{hidden_mw_interactive.id}-MwInteractive"]}
 
     let(:interactives) { [interactive_a, interactive_b, hidden_mw_interactive] }
     it "should have good options" do


### PR DESCRIPTION
I also took the time to clean up the duplicate use of localized model names and couple of custom name mappings
It doesn't look like this will break anything, but lets see when the full tests run