### PR TITLE
Added code so library interactives cannot be changed [#173082945]

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -26781,9 +26781,14 @@ exports.ManagedInteractiveAuthoring = function (props) {
     var selectedOption = libraryInteractive ? createSelectOption(libraryInteractive) : undefined;
     var handleSelectChange = function (newSelectedOption) {
         var selectedLibraryInteractive = libraryInteractives.list.find(function (li) { return li.id === newSelectedOption.value; });
-        setLibraryInteractive(selectedLibraryInteractive);
-        if (libraryInteractiveIdRef.current) {
-            libraryInteractiveIdRef.current.value = newSelectedOption.value.toString();
+        if (selectedLibraryInteractive) {
+            var confirmMessage = "Use " + selectedLibraryInteractive.name + "?  Once selected it can't be changed.";
+            if (confirm(confirmMessage)) {
+                setLibraryInteractive(selectedLibraryInteractive);
+                if (libraryInteractiveIdRef.current) {
+                    libraryInteractiveIdRef.current.value = newSelectedOption.value.toString();
+                }
+            }
         }
     };
     var handleUrlFragmentChange = function (newUrlFragment) { return setUrlFragment(newUrlFragment); };
@@ -26850,7 +26855,9 @@ exports.ManagedInteractiveAuthoring = function (props) {
             React.createElement("legend", null, "Library Interactive"),
             React.createElement("input", { type: "hidden", id: formField("library_interactive_id").id, name: formField("library_interactive_id").name, ref: libraryInteractiveIdRef, defaultValue: libraryInteractive ? "" + libraryInteractive.id : "" }),
             React.createElement("input", { type: "hidden", id: formField("authored_state").id, name: formField("authored_state").name, ref: libraryInteractiveAuthoredStateRef, defaultValue: managedInteractive.authored_state }),
-            React.createElement(react_select_1.default, { value: selectedOption, onChange: handleSelectChange, options: selectOptions })),
+            selectedOption
+                ? selectedOption.label
+                : React.createElement(react_select_1.default, { value: selectedOption, onChange: handleSelectChange, options: selectOptions })),
         renderRequiredFields(),
         renderTabs());
 };

--- a/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
@@ -73,9 +73,14 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
 
   const handleSelectChange = (newSelectedOption: ISelectOption) => {
     const selectedLibraryInteractive = libraryInteractives.list.find(li => li.id === newSelectedOption.value);
-    setLibraryInteractive(selectedLibraryInteractive);
-    if (libraryInteractiveIdRef.current) {
-      libraryInteractiveIdRef.current.value = newSelectedOption.value.toString();
+    if (selectedLibraryInteractive) {
+      const confirmMessage = `Use ${selectedLibraryInteractive.name}?  Once selected it can't be changed.`;
+      if (confirm(confirmMessage)) {
+        setLibraryInteractive(selectedLibraryInteractive);
+        if (libraryInteractiveIdRef.current) {
+          libraryInteractiveIdRef.current.value = newSelectedOption.value.toString();
+        }
+      }
     }
   };
 
@@ -203,7 +208,10 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
         ref={libraryInteractiveAuthoredStateRef}
         defaultValue={managedInteractive.authored_state}
       />
-      <Select value={selectedOption} onChange={handleSelectChange} options={selectOptions} />
+      {selectedOption
+        ? selectedOption.label
+        : <Select value={selectedOption} onChange={handleSelectChange} options={selectOptions} />
+      }
     </fieldset>
 
     {renderRequiredFields()}


### PR DESCRIPTION
To avoid issues with both resizing the authoring tab and clearing the authored state disallow changing of the library interactive once selected.