### PR TITLE
Interactive API: automatically parse strings in LARA init message

### DIFF
--- a/docs/interactive-api-client/README.md
+++ b/docs/interactive-api-client/README.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.4.0-pre.4
+# @concord-consortium/lara-interactive-api - v0.4.0-pre.6
 
 ## [API documentation](globals.md)
 

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.4.0-pre.4
+# @concord-consortium/lara-interactive-api - v0.4.0-pre.6
 
 ## Index
 

--- a/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
 
 # Interface: IAggregateInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthinfo.md
+++ b/docs/interactive-api-client/interfaces/iauthinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
 
 # Interface: IAuthInfo
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
 
 # Interface: IAuthoringCustomReportField
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
 
 # Interface: IAuthoringCustomReportFields
 

--- a/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
 
 # Interface: IAuthoringInitInteractive ‹**AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
 
 # Interface: IAuthoringInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
 
 # Interface: IAuthoringMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
 
 # Interface: IAuthoringOpenResponseMetadata
 

--- a/docs/interactive-api-client/interfaces/ibaseshowmodal.md
+++ b/docs/interactive-api-client/interfaces/ibaseshowmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
 
 # Interface: IBaseShowModal
 

--- a/docs/interactive-api-client/interfaces/iclientoptions.md
+++ b/docs/interactive-api-client/interfaces/iclientoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IClientOptions](iclientoptions.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IClientOptions](iclientoptions.md)
 
 # Interface: IClientOptions ‹**InteractiveState, AuthoredState, DialogState, GlobalInteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/iclosedmodal.md
+++ b/docs/interactive-api-client/interfaces/iclosedmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
 
 # Interface: IClosedModal
 

--- a/docs/interactive-api-client/interfaces/iclosemodal.md
+++ b/docs/interactive-api-client/interfaces/iclosemodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
 
 # Interface: ICloseModal
 

--- a/docs/interactive-api-client/interfaces/icontextmember.md
+++ b/docs/interactive-api-client/interfaces/icontextmember.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
 
 # Interface: IContextMember
 

--- a/docs/interactive-api-client/interfaces/icontextmembership.md
+++ b/docs/interactive-api-client/interfaces/icontextmembership.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
 
 # Interface: IContextMembership
 

--- a/docs/interactive-api-client/interfaces/icustommessage.md
+++ b/docs/interactive-api-client/interfaces/icustommessage.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
 
 # Interface: ICustomMessage
 

--- a/docs/interactive-api-client/interfaces/idialoginitinteractive.md
+++ b/docs/interactive-api-client/interfaces/idialoginitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
 
 # Interface: IDialogInitInteractive ‹**InteractiveState, AuthoredState, DialogState**›
 

--- a/docs/interactive-api-client/interfaces/igetauthinforequest.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
 
 # Interface: IGetAuthInfoRequest
 

--- a/docs/interactive-api-client/interfaces/igetauthinforesponse.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforesponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
 
 # Interface: IGetAuthInfoResponse
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtoptions.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtOptions](igetfirebasejwtoptions.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtOptions](igetfirebasejwtoptions.md)
 
 # Interface: IGetFirebaseJwtOptions
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
 
 # Interface: IGetFirebaseJwtRequest
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
 
 # Interface: IGetFirebaseJwtResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
 
 # Interface: IGetInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
 
 # Interface: IGetInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
 
 # Interface: IGetInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
 
 # Interface: IGetInteractiveSnapshotOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
 
 # Interface: IGetInteractiveSnapshotRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
 
 # Interface: IGetInteractiveSnapshotResponse
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
 
 # Interface: IGetLibraryInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
 
 # Interface: IGetLibraryInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
 
 # Interface: IGetLibraryInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/ihintrequest.md
+++ b/docs/interactive-api-client/interfaces/ihintrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
 
 # Interface: IHintRequest
 

--- a/docs/interactive-api-client/interfaces/ihookoptions.md
+++ b/docs/interactive-api-client/interfaces/ihookoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IHookOptions](ihookoptions.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IHookOptions](ihookoptions.md)
 
 # Interface: IHookOptions
 

--- a/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
 
 # Interface: IInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/iinteractivestateprops.md
+++ b/docs/interactive-api-client/interfaces/iinteractivestateprops.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
 
 # Interface: IInteractiveStateProps ‹**InteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
 
 # Interface: ILibraryInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/ilinkedauthoredinteractive.md
+++ b/docs/interactive-api-client/interfaces/ilinkedauthoredinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ILinkedAuthoredInteractive](ilinkedauthoredinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ILinkedAuthoredInteractive](ilinkedauthoredinteractive.md)
 
 # Interface: ILinkedAuthoredInteractive
 

--- a/docs/interactive-api-client/interfaces/ilinkedruntimeinteractive.md
+++ b/docs/interactive-api-client/interfaces/ilinkedruntimeinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ILinkedRuntimeInteractive](ilinkedruntimeinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ILinkedRuntimeInteractive](ilinkedruntimeinteractive.md)
 
 # Interface: ILinkedRuntimeInteractive
 

--- a/docs/interactive-api-client/interfaces/inavigationoptions.md
+++ b/docs/interactive-api-client/interfaces/inavigationoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
 
 # Interface: INavigationOptions
 

--- a/docs/interactive-api-client/interfaces/ireportinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/ireportinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
 
 # Interface: IReportInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
+++ b/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
 
 # Interface: IRuntimeCustomReportValues
 

--- a/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
 
 # Interface: IRuntimeInitInteractive ‹**InteractiveState, AuthoredState, GlobalInteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
 
 # Interface: IRuntimeInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
 
 # Interface: IRuntimeMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
 
 # Interface: IRuntimeMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
+++ b/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
 
 # Interface: ISetLinkedInteractives
 

--- a/docs/interactive-api-client/interfaces/ishowalert.md
+++ b/docs/interactive-api-client/interfaces/ishowalert.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
 
 # Interface: IShowAlert
 

--- a/docs/interactive-api-client/interfaces/ishowdialog.md
+++ b/docs/interactive-api-client/interfaces/ishowdialog.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
 
 # Interface: IShowDialog ‹**DialogState**›
 

--- a/docs/interactive-api-client/interfaces/ishowlightbox.md
+++ b/docs/interactive-api-client/interfaces/ishowlightbox.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
 
 # Interface: IShowLightbox
 

--- a/docs/interactive-api-client/interfaces/isupportedfeatures.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeatures.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
 
 # Interface: ISupportedFeatures
 

--- a/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
 
 # Interface: ISupportedFeaturesRequest
 

--- a/docs/interactive-api-client/interfaces/ithemeinfo.md
+++ b/docs/interactive-api-client/interfaces/ithemeinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.4](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
+[@concord-consortium/lara-interactive-api - v0.4.0-pre.6](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
 
 # Interface: IThemeInfo
 

--- a/lara-typescript/src/interactive-api-client/client.spec.ts
+++ b/lara-typescript/src/interactive-api-client/client.spec.ts
@@ -71,6 +71,22 @@ describe("Client", () => {
       expect(client.managedState.globalInteractiveState).toEqual({ globalState: true });
     });
 
+    it("handles init message and saves interactive, authored and global interactive states even if they're provided as strings", () => {
+      const client = new Client();
+      mockedPhone.fakeServerMessage({
+        type: "initInteractive",
+        content: {
+          mode: "runtime",
+          interactiveState: "{ \"interactiveState\": true }",
+          authoredState: "{ \"authoredState\": true }",
+          globalInteractiveState: "{ \"globalState\": true }"
+        }
+      });
+      expect(client.managedState.interactiveState).toEqual({ interactiveState: true });
+      expect(client.managedState.authoredState).toEqual({ authoredState: true });
+      expect(client.managedState.globalInteractiveState).toEqual({ globalState: true });
+    });
+
     it("automatically supports the getInteractiveState message", () => {
       const client = new Client();
       client.managedState.interactiveState = {test: 123};

--- a/lara-typescript/src/interactive-api-client/client.ts
+++ b/lara-typescript/src/interactive-api-client/client.ts
@@ -14,6 +14,10 @@ interface IListenerMap {
   [key: string]: IRequestCallback[];
 }
 
+const parseJSONIfString = (data: any) => {
+  return typeof data === "string" ?  JSON.parse(data) : data;
+};
+
 const phoneInitialized = () => iframePhone.getIFrameEndpoint().getListenerNames().length > 0;
 
 let clientInstance: Client;
@@ -110,12 +114,14 @@ export class Client {
     this.addListener("initInteractive", (newInitMessage: IInitInteractive<any, any, any, any>) => {
       this.managedState.initMessage = newInitMessage;
 
-      this.managedState.authoredState = newInitMessage.authoredState;
+      // parseJSONIfString is used below quite a few times, as LARA and report are not consistent about format.
+      // Sometimes they send string (report page), sometimes already parsed JSON (authoring, runtime).
+      this.managedState.authoredState = parseJSONIfString(newInitMessage.authoredState);
       if (newInitMessage.mode === "runtime" || newInitMessage.mode === "report") {
-        this.managedState.interactiveState = newInitMessage.interactiveState;
+        this.managedState.interactiveState = parseJSONIfString(newInitMessage.interactiveState);
       }
       if (newInitMessage.mode === "runtime") {
-        this.managedState.globalInteractiveState = newInitMessage.globalInteractiveState;
+        this.managedState.globalInteractiveState = parseJSONIfString(newInitMessage.globalInteractiveState);
       }
     });
 
@@ -124,7 +130,7 @@ export class Client {
     });
 
     this.addListener("loadInteractiveGlobal", (globalState: any) => {
-      this.managedState.globalInteractiveState = globalState;
+      this.managedState.globalInteractiveState = parseJSONIfString(globalState);
     });
 
     this.phone.initialize();

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.4.0-pre.4",
+  "version": "0.4.0-pre.6",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
LARA sometimes passes authored and interactive states as JS objects, sometimes as JSON strings. Also, the portal-report is not consistent. Handle that in the Client.