### PR TITLE
Hide hidden questions

### DIFF
--- a/app/assets/stylesheets/partials/_runtime-interactives.scss
+++ b/app/assets/stylesheets/partials/_runtime-interactives.scss
@@ -66,6 +66,9 @@
     font-style: italic;
     font-size: 0.9em;
   }
+  &.hidden {
+    display: none;
+  }
 }
 
 .challenge {


### PR DESCRIPTION
[#173038370]

It should fix unwanted padding at the top of assessment block, caused by hidden questions (in fact plugins): https://authoring.staging.concord.org/activities/20634/pages/307494/
