### PR TITLE
Interactive and InteractiveRunState: support metadata in #portal_hash

### DIFF
--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -19,7 +19,7 @@ module BaseInteractive
 
     result[:native_width] = result[:width]
     result[:native_height] = result[:height]
-    result[:is_required] = result[:required]
+    result[:is_required] = !!result[:required]
     # If name is not available, but prompt is, this should make Portal details report a bit more readable.
     unless result[:name].present?
       result[:name] = result[:prompt]

--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -25,14 +25,6 @@ module BaseInteractive
       result[:name] = result[:prompt]
     end
 
-    if result[:type] === "iframe_interactive"
-      # When interactive doesn't pretend to be a basic question type, use regular ID number (instead of embeddable_id
-      # used by default by report_service_hash) to be backward compatible with existing interactives that are
-      # already exported to Portal. `embeddable_id` is safer when type is overwritten by interative metadata,
-      # but in this case it's not necessary and lets us not break existing interactives.
-      result[:id] = id
-    end
-
     # Open response and multiple choice properties are the same as in report_service_hash and/or properties mapped above.
     # Portal expects less fields that will be actually sent, but it doesn't seem to cause any problems.
     result

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -56,31 +56,28 @@ class InteractiveRunState < ActiveRecord::Base
   end
 
   def portal_hash
-    # There are two options how interactive can be saved in Portal:
-    # - When reporting url is provided, it means that the interactive is supposed to be saved as an URL.
-    #   It's useful if state can be saved in the URL or is kept by the interactive itself (e.g. CODAP / docstore)
-    # - Otherwise, interactive state JSON is sent to the Portal. Later, the same state will be provided to teacher report
-    #   and sent to the interactive using LARA Interactive API.
-    if interactive.has_report_url
-      {
-        "type" => "external_link",
-        "question_type" => interactive.class.portal_type,
-        "question_id" => interactive.id.to_s,
-        # there is a chance that answer will be set to 'nil' here. That will happen
-        # if there is no state or the state doesn't have a report url. In practice
-        # this nil should not actually be sent to the portal because the
-        # maybe_send_to_portal method below should only send it if reporting_url is present.
-        "answer" => reporting_url,
-        "is_final" => false
-      }
-    else
-      {
-        "type" => "interactive",
-        "question_id" => interactive.id.to_s,
-        "answer" => report_state.to_json,
-        "is_final" => false
-      }
+    result = report_service_hash
+
+    # Portal expects different types than report service.
+    type_mapping = {
+      "interactive_state" => "interactive",
+      "open_response_answer" => "open_response",
+      "multiple_choice_answer" => "multiple_choice",
+    }
+    result[:type] = type_mapping[result[:type]]
+    # not very consistent naming, but that's what portal expects
+    result[:question_type] = "iframe interactive"
+
+    result[:is_final] = result[:submitted]
+
+    if result[:type] === "multiple_choice"
+      result[:answer_ids] = result[:answer][:choice_ids]
+      # multiple_choice_answer.rb also sends answer_texts.
+      # This property is skipped here, as Portal doesn't use it anyway.
     end
+
+    # Portal expects less fields that will be actually sent, but it doesn't seem to cause any problems.
+    result
   end
 
   def parsed_interactive_state

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -68,25 +68,23 @@ class InteractiveRunState < ActiveRecord::Base
     result[:type] = type_mapping[result[:type]]
     result[:is_final] = !!result[:submitted]
 
-    if result[:type] === "interactive"
-      # When interactive doesn't pretend to be a basic question type, use regular ID number (instead of embeddable_id
-      # used by default by report_service_hash) to be backward compatible with existing interactives that are
-      # already exported to Portal. `embeddable_id` is safer when type is overwritten by interative metadata,
-      # but in this case it's not necessary and lets us not break existing interactives.
-      result[:question_id] = interactive.id.to_s
-    elsif result[:type] === "external_link"
-      # Not very consistent naming (missing underscore), but that's what portal expects.
+    if result[:type] === "external_link"
+      # Not very consistent naming (missing underscore), but that's what Portal expects.
       # Note that question type is only necessary for external_link answer type.
       result[:question_type] = "iframe interactive"
-      # When interactive doesn't pretend to be a basic question type, use regular ID number (instead of embeddable_id
-      # used by default by report_service_hash) to be backward compatible with existing interactives that are
-      # already exported to Portal. `embeddable_id` is safer when type is overwritten by interative metadata,
-      # but in this case it's not necessary and lets us not break existing interactives.
-      result[:question_id] = interactive.id.to_s
     elsif result[:type] === "multiple_choice"
       result[:answer_ids] = result[:answer][:choice_ids]
       # multiple_choice_answer.rb also sends answer_texts.
       # This property is skipped here, as Portal doesn't use it anyway.
+    end
+
+    if (result[:type] === "interactive" || result[:type] === "external_link") && interactive.instance_of?(MwInteractive)
+      # When interactive doesn't pretend to be a basic question type, use regular ID number (instead of embeddable_id
+      # used by default) to be backward compatible with existing MwInteractives that are already exported to Portal.
+      # `embeddable_id` is safer when type is overwritten by interative metadata, but in this case it's not
+      # necessary and lets us not break existing interactives. Note that `ManagedInteractive` states should use
+      # default question_id based on embeddable_id.
+      result[:question_id] = interactive.id.to_s
     end
 
     # Portal expects less fields that will be actually sent, but it doesn't seem to cause any problems.

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -31,6 +31,18 @@ class MwInteractive < ActiveRecord::Base
     "iframe interactive"
   end
 
+  def portal_hash
+    result = super # BaseInteractive#portal_hash
+    if result[:type] === "iframe_interactive"
+      # When interactive doesn't pretend to be a basic question type, use regular ID number (instead of embeddable_id
+      # used by default) to be backward compatible with existing MwInteractives that are already exported to Portal.
+      # `embeddable_id` is safer when type is overwritten by interative metadata, but in this case it's not necessary
+      # and lets us not break existing interactives.
+      result[:id] = id
+    end
+    result
+  end
+
   def to_hash
     # Deliberately ignoring user (will be set in duplicate)
     {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,9 +41,4 @@ LightweightStandalone::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
-
-  if ENV["RAILS_STDOUT_LOGGING"].present?
-    # Disable logging to file. It might have performance impact while using Docker for Mac (slow filesystem sync).
-    config.logger = Logger.new(STDOUT)
-  end
 end

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -192,7 +192,8 @@ describe InteractiveRunState do
         end
 
         describe "when interactive is NOT an instance of MwInteractive" do
-          let(:interactive) { FactoryGirl.create(:managed_interactive) }
+          let(:library_interactive) { FactoryGirl.create(:library_interactive, has_report_url: false) }
+          let(:interactive) { FactoryGirl.create(:managed_interactive, library_interactive: library_interactive) }
 
           it "should provide required set of properties and the question_id should be embeddable ID" do
             expect(subject).to include({

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -144,7 +144,46 @@ describe InteractiveRunState do
 
       # the portal requires this type. So if you change it,
       # you need to change the portal too
-      it { should include("question_type" => "iframe interactive") }
+      it { should include(question_type: "iframe interactive") }
+
+      describe "when interactive run state pretends to be open response answer" do
+        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
+        let(:run_data) { JSON({answerType: "open_response_answer", answerText: "Test answer"}) }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
+
+        it "should overwrite type and provide supported fields to Portal" do
+          expect(subject).to include({
+            type: "open_response",
+            answer: "Test answer"
+          })
+        end
+      end
+
+      describe "when interactive run state pretends to be multiple choice answer" do
+        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
+        let(:run_data) { JSON({answerType: "multiple_choice_answer", selectedChoiceIds: ["a", "b"]}) }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
+
+        it "should overwrite type and provide supported fields to Portal" do
+          expect(subject).to include({
+            type: "multiple_choice",
+            answer_ids: ["a", "b"]
+          })
+        end
+      end
+
+      describe "when interactive run state pretends to be multiple choice answer" do
+        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
+        let(:run_data) { JSON({answerType: "multiple_choice_answer", selectedChoiceIds: ["a", "b"]}) }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
+
+        it "should overwrite type and provide supported fields to Portal" do
+          expect(subject).to include({
+            type: "multiple_choice",
+            answer_ids: ["a", "b"]
+          })
+        end
+      end
     end
 
     # this key is generated automatically when created

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -134,53 +134,72 @@ describe InteractiveRunState do
 
     # this hash is depended on by the Portal
     describe "portal_hash" do
-      # Only when reporting_url is available.
-      let(:interactive)     { FactoryGirl.create(:mw_interactive,
-        enable_learner_state: true, has_report_url: true) }
-      let(:run_data) {'{"second": 2, "lara_options": {"reporting_url": "test.com"}}'}
-      let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
-
       subject { interactive_run_state.portal_hash }
 
-      # the portal requires this type. So if you change it,
-      # you need to change the portal too
-      it { should include(question_type: "iframe interactive") }
+      describe "when interactive has a report url" do
+        # Only when reporting_url is available.
+        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: true) }
+        let(:run_data) { '{"second": 2, "lara_options": {"reporting_url": "test.com"}}' }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data) }
+
+        it "should provide required set of properties" do
+          expect(subject).to include({
+            type: "external_link",
+            question_type: "iframe interactive", # missing underscore, as that's what Portal actually expects
+            question_id: interactive.id.to_s,
+            answer: "test.com",
+            is_final: false
+          })
+        end
+      end
+
+      describe "when interactive doesn't have a report url" do
+        # Only when reporting_url is available.
+        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true, has_report_url: false) }
+        let(:run_data) { '{"someProp": 123}' }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data) }
+
+        it "should provide required set of properties" do
+          expect(subject).to include({
+            type: "interactive",
+            question_id: interactive.id.to_s,
+            is_final: false
+          })
+          expect(JSON.parse(subject[:answer])).to include({
+            "version" => 1,
+            "mode" => "report",
+            "interactiveState" => '{"someProp": 123}'
+          })
+        end
+      end
 
       describe "when interactive run state pretends to be open response answer" do
         let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
-        let(:run_data) { JSON({answerType: "open_response_answer", answerText: "Test answer"}) }
-        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
+        let(:run_data) { JSON({answerType: "open_response_answer", answerText: "Test answer", submitted: true}) }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data) }
 
         it "should overwrite type and provide supported fields to Portal" do
           expect(subject).to include({
             type: "open_response",
-            answer: "Test answer"
+            question_id: "mw_interactive_#{interactive.id.to_s}",
+            answer: "Test answer",
+            is_final: true
           })
         end
       end
 
       describe "when interactive run state pretends to be multiple choice answer" do
         let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
-        let(:run_data) { JSON({answerType: "multiple_choice_answer", selectedChoiceIds: ["a", "b"]}) }
+        let(:run_data) { JSON({answerType: "multiple_choice_answer", selectedChoiceIds: ["a", "b"], submitted: true}) }
         let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
 
         it "should overwrite type and provide supported fields to Portal" do
           expect(subject).to include({
             type: "multiple_choice",
-            answer_ids: ["a", "b"]
-          })
-        end
-      end
-
-      describe "when interactive run state pretends to be multiple choice answer" do
-        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
-        let(:run_data) { JSON({answerType: "multiple_choice_answer", selectedChoiceIds: ["a", "b"]}) }
-        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data)}
-
-        it "should overwrite type and provide supported fields to Portal" do
-          expect(subject).to include({
-            type: "multiple_choice",
-            answer_ids: ["a", "b"]
+            question_id: "mw_interactive_#{interactive.id.to_s}",
+            answer_ids: ["a", "b"],
+            # answer_texts is not used by portal anymore (even though it's sent in multiple_choice_answer.rb)
+            is_final: true
           })
         end
       end

--- a/spec/models/managed_interactive_spec.rb
+++ b/spec/models/managed_interactive_spec.rb
@@ -111,28 +111,10 @@ describe ManagedInteractive do
         type: 'iframe_interactive',
         id: managed_interactive.id,
         display_in_iframe: managed_interactive.reportable_in_iframe?,
-
-        library_interactive_id: managed_interactive.library_interactive_id,
-        name: managed_interactive.name,
-        url_fragment: managed_interactive.url_fragment,
-        authored_state: managed_interactive.authored_state,
-        is_hidden: managed_interactive.is_hidden,
-        is_full_width: managed_interactive.is_full_width,
         show_in_featured_question_report: managed_interactive.show_in_featured_question_report,
-        inherit_aspect_ratio_method: managed_interactive.inherit_aspect_ratio_method,
-        custom_aspect_ratio_method: managed_interactive.custom_aspect_ratio_method,
-        inherit_native_width: managed_interactive.inherit_native_width,
-        custom_native_width: managed_interactive.custom_native_width,
-        inherit_native_height: managed_interactive.inherit_native_height,
-        custom_native_height: managed_interactive.custom_native_height,
-        inherit_click_to_play: managed_interactive.inherit_click_to_play,
-        custom_click_to_play: managed_interactive.custom_click_to_play,
-        inherit_full_window: managed_interactive.inherit_full_window,
-        custom_full_window: managed_interactive.custom_full_window,
-        inherit_click_to_play_prompt: managed_interactive.inherit_click_to_play_prompt,
-        custom_click_to_play_prompt: managed_interactive.custom_click_to_play_prompt,
-        inherit_image_url: managed_interactive.inherit_image_url,
-        custom_image_url: managed_interactive.custom_image_url
+        name: managed_interactive.name,
+        native_width: managed_interactive.native_width,
+        native_height: managed_interactive.native_height
       )
     end
   end

--- a/spec/models/managed_interactive_spec.rb
+++ b/spec/models/managed_interactive_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe ManagedInteractive do
+  it_behaves_like "a base interactive", :managed_interactive
+
   let(:library_interactive) { FactoryGirl.create(:library_interactive,
                                                  :name => 'Test Library managed_Interactive',
                                                  :base_url => 'http://concord.org/',

--- a/spec/models/managed_interactive_spec.rb
+++ b/spec/models/managed_interactive_spec.rb
@@ -107,20 +107,6 @@ describe ManagedInteractive do
     end
   end
 
-  describe "#portal_hash" do
-    it 'returns properties supported by Portal' do
-      expect(managed_interactive.portal_hash).to include(
-        type: 'iframe_interactive',
-        id: managed_interactive.id,
-        display_in_iframe: managed_interactive.reportable_in_iframe?,
-        show_in_featured_question_report: managed_interactive.show_in_featured_question_report,
-        name: managed_interactive.name,
-        native_width: managed_interactive.native_width,
-        native_height: managed_interactive.native_height
-      )
-    end
-  end
-
   describe "#to_interactive_json" do
     it 'has useful values' do
       expect(JSON.parse(managed_interactive.to_interactive_json)).to eq(JSON.parse({

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe MwInteractive do
+  it_behaves_like "a base interactive", :mw_interactive
+
   let (:interactive_options) { {linked_interactive_id: 1} }
   let (:interactive) { FactoryGirl.create(:mw_interactive, interactive_options) }
   let (:page) { FactoryGirl.create(:page) }
@@ -73,65 +75,6 @@ describe MwInteractive do
         is_full_width: interactive.is_full_width,
         authored_state: interactive.authored_state
       })
-    end
-  end
-
-  describe "#portal_hash" do
-    it 'returns properties supported by Portal' do
-      expect(interactive.portal_hash).to include(
-        type: 'iframe_interactive',
-        id: interactive.id,
-        name: interactive.name,
-        url: interactive.url,
-        native_width: interactive.native_width,
-        native_height: interactive.native_height,
-        display_in_iframe: interactive.reportable_in_iframe?,
-        show_in_featured_question_report: interactive.show_in_featured_question_report
-      )
-    end
-
-    describe "when interactive pretends to be open response question" do
-      let (:interactive) { FactoryGirl.create(:mw_interactive,
-        authored_state: JSON({questionType: "open_response", prompt: "Test prompt", required: true}) ) }
-
-      it 'returns properties supported by Portal' do
-        expect(interactive.portal_hash).to include(
-          type: 'open_response',
-          prompt: "Test prompt",
-          required: true,
-          id: interactive.embeddable_id,
-          name: interactive.name,
-          url: interactive.url,
-          native_width: interactive.native_width,
-          native_height: interactive.native_height,
-          display_in_iframe: interactive.reportable_in_iframe?,
-          show_in_featured_question_report: interactive.show_in_featured_question_report
-        )
-      end
-    end
-
-    describe "when interactive pretends to be multiple choice question" do
-      let (:interactive) { FactoryGirl.create(:mw_interactive,
-        authored_state: JSON({
-          questionType: "multiple_choice", prompt: "Test prompt", required: true,
-          choices: [{id: "1", content: "Choice A", correct: true}]
-        }) ) }
-
-      it 'returns properties supported by Portal' do
-        expect(interactive.portal_hash).to include(
-          type: 'multiple_choice',
-          prompt: "Test prompt",
-          required: true,
-          choices: [{id: "1", content: "Choice A", correct: true}],
-          id: interactive.embeddable_id,
-          name: interactive.name,
-          url: interactive.url,
-          native_width: interactive.native_width,
-          native_height: interactive.native_height,
-          display_in_iframe: interactive.reportable_in_iframe?,
-          show_in_featured_question_report: interactive.show_in_featured_question_report
-        )
-      end
     end
   end
 

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -89,6 +89,50 @@ describe MwInteractive do
         show_in_featured_question_report: interactive.show_in_featured_question_report
       )
     end
+
+    describe "when interactive pretends to be open response question" do
+      let (:interactive) { FactoryGirl.create(:mw_interactive,
+        authored_state: JSON({questionType: "open_response", prompt: "Test prompt", required: true}) ) }
+
+      it 'returns properties supported by Portal' do
+        expect(interactive.portal_hash).to include(
+          type: 'open_response',
+          prompt: "Test prompt",
+          required: true,
+          id: interactive.embeddable_id,
+          name: interactive.name,
+          url: interactive.url,
+          native_width: interactive.native_width,
+          native_height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?,
+          show_in_featured_question_report: interactive.show_in_featured_question_report
+        )
+      end
+    end
+
+    describe "when interactive pretends to be multiple choice question" do
+      let (:interactive) { FactoryGirl.create(:mw_interactive,
+        authored_state: JSON({
+          questionType: "multiple_choice", prompt: "Test prompt", required: true,
+          choices: [{id: "1", content: "Choice A", correct: true}]
+        }) ) }
+
+      it 'returns properties supported by Portal' do
+        expect(interactive.portal_hash).to include(
+          type: 'multiple_choice',
+          prompt: "Test prompt",
+          required: true,
+          choices: [{id: "1", content: "Choice A", correct: true}],
+          id: interactive.embeddable_id,
+          name: interactive.name,
+          url: interactive.url,
+          native_width: interactive.native_width,
+          native_height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?,
+          show_in_featured_question_report: interactive.show_in_featured_question_report
+        )
+      end
+    end
   end
 
   # This approach is temporary, it is specific for ITSI style authoring.

--- a/spec/support/shared_examples/base_interactive.rb
+++ b/spec/support/shared_examples/base_interactive.rb
@@ -9,7 +9,6 @@ shared_examples "a base interactive" do |model_factory|
       expect(interactive.portal_hash).to include(
         type: 'iframe_interactive',
         is_required: false,
-        id: interactive.id,
         name: interactive.name,
         url: interactive.url,
         native_width: interactive.native_width,
@@ -17,6 +16,13 @@ shared_examples "a base interactive" do |model_factory|
         display_in_iframe: interactive.reportable_in_iframe?,
         show_in_featured_question_report: interactive.show_in_featured_question_report
       )
+      if interactive.instance_of?(MwInteractive)
+        # To be backward compatible with MwInteractives already exported to Portal.
+        expect(interactive.portal_hash[:id]).to eql(interactive.id)
+      else
+        # e.g. ManagedInteractive
+        expect(interactive.portal_hash[:id]).to eql(interactive.embeddable_id)
+      end
     end
 
     describe "when interactive pretends to be open response question" do

--- a/spec/support/shared_examples/base_interactive.rb
+++ b/spec/support/shared_examples/base_interactive.rb
@@ -1,0 +1,66 @@
+# These shared examples are used by two model specs:
+# mw_interactive.rb and managed_interactive.rb
+
+shared_examples "a base interactive" do |model_factory|
+  describe "#portal_hash" do
+    let (:interactive) { FactoryGirl.create(model_factory) }
+
+    it 'returns properties supported by Portal' do
+      expect(interactive.portal_hash).to include(
+        type: 'iframe_interactive',
+        is_required: false,
+        id: interactive.id,
+        name: interactive.name,
+        url: interactive.url,
+        native_width: interactive.native_width,
+        native_height: interactive.native_height,
+        display_in_iframe: interactive.reportable_in_iframe?,
+        show_in_featured_question_report: interactive.show_in_featured_question_report
+      )
+    end
+
+    describe "when interactive pretends to be open response question" do
+      let (:authored_state) { JSON({questionType: "open_response", prompt: "Test prompt", required: true}) }
+      let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
+
+      it 'returns properties supported by Portal' do
+        expect(interactive.portal_hash).to include(
+          type: 'open_response',
+          prompt: "Test prompt",
+          is_required: true,
+          id: interactive.embeddable_id,
+          name: interactive.name,
+          url: interactive.url,
+          native_width: interactive.native_width,
+          native_height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?,
+          show_in_featured_question_report: interactive.show_in_featured_question_report
+        )
+      end
+    end
+
+    describe "when interactive pretends to be multiple choice question" do
+      let (:authored_state) do JSON({
+        questionType: "multiple_choice", prompt: "Test prompt", required: true,
+        choices: [{id: "1", content: "Choice A", correct: true}, {id: "2", content: "Choice B", correct: false}]
+      }) end
+      let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
+
+      it 'returns properties supported by Portal' do
+        expect(interactive.portal_hash).to include(
+          type: 'multiple_choice',
+          prompt: "Test prompt",
+          is_required: true,
+          choices: [{id: "1", content: "Choice A", correct: true}, {id: "2", content: "Choice B", correct: false}],
+          id: interactive.embeddable_id,
+          name: interactive.name,
+          url: interactive.url,
+          native_width: interactive.native_width,
+          native_height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?,
+          show_in_featured_question_report: interactive.show_in_featured_question_report
+        )
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/base_interactive.rb
+++ b/spec/support/shared_examples/base_interactive.rb
@@ -2,9 +2,9 @@
 # mw_interactive.rb and managed_interactive.rb
 
 shared_examples "a base interactive" do |model_factory|
-  describe "#portal_hash" do
-    let (:interactive) { FactoryGirl.create(model_factory) }
+  let (:interactive) { FactoryGirl.create(model_factory) }
 
+  describe "#portal_hash" do
     it 'returns properties supported by Portal' do
       expect(interactive.portal_hash).to include(
         type: 'iframe_interactive',
@@ -59,6 +59,72 @@ shared_examples "a base interactive" do |model_factory|
           native_height: interactive.native_height,
           display_in_iframe: interactive.reportable_in_iframe?,
           show_in_featured_question_report: interactive.show_in_featured_question_report
+        )
+      end
+    end
+  end
+
+  describe "#report_service_hash" do
+    it 'returns properties supported by Report Service' do
+      expect(interactive.report_service_hash).to include(
+        type: 'iframe_interactive',
+        id: interactive.embeddable_id,
+        name: interactive.name,
+        url: interactive.url,
+        width: interactive.native_width,
+        height: interactive.native_height,
+        display_in_iframe: interactive.reportable_in_iframe?,
+        show_in_featured_question_report: interactive.show_in_featured_question_report,
+        question_number: interactive.index_in_activity
+      )
+    end
+
+    describe "when interactive pretends to be open response question" do
+      let (:authored_state) { JSON({questionType: "open_response", prompt: "Test prompt", required: true}) }
+      let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
+
+      it 'returns properties supported by Portal' do
+        expect(interactive.report_service_hash).to include(
+          # Open response props:
+          type: 'open_response',
+          id: interactive.embeddable_id,
+          prompt: "Test prompt",
+          required: true,
+          show_in_featured_question_report: interactive.show_in_featured_question_report,
+          question_number: interactive.index_in_activity,
+          # Interactive props:
+          name: interactive.name,
+          url: interactive.url,
+          width: interactive.native_width,
+          height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?
+        )
+      end
+    end
+
+    describe "when interactive pretends to be multiple choice question" do
+      let (:authored_state) do JSON({
+        questionType: "multiple_choice", prompt: "Test prompt", required: true,
+        choices: [{id: "1", content: "Choice A", correct: true}, {id: "2", content: "Choice B", correct: false}]
+      }) end
+      let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
+
+      it 'returns properties supported by Portal' do
+        expect(interactive.report_service_hash).to include(
+          # Open response props:
+          type: 'multiple_choice',
+          id: interactive.embeddable_id,
+          prompt: "Test prompt",
+          required: true,
+          choices: [{id: "1", content: "Choice A", correct: true}, {id: "2", content: "Choice B", correct: false}],
+          show_in_featured_question_report: interactive.show_in_featured_question_report,
+          question_number: interactive.index_in_activity,
+          # Interactive props:
+          name: interactive.name,
+          url: interactive.url,
+          width: interactive.native_width,
+          height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?
         )
       end
     end


### PR DESCRIPTION
[#172778790]
[#173015432]

I tested it manually and Portal details report seems to be working fine. `portal_hash` is now based on report_service_hash, but it applies necessary transformations.

It's not related, but I disabled STDOUT logging in test env, as it was impossible to see anything when tests are running due to db logs :wink: