### PR TITLE
Add lightbox support to interactive API

### DIFF
--- a/app/assets/javascripts/jquery.colorbox.js
+++ b/app/assets/javascripts/jquery.colorbox.js
@@ -1,6 +1,7 @@
 /*jslint browser: true, sloppy: true, todo: true, devel: true, white: true */
 /*global $ */
-
+/* [CC] This file has been modified substantially from its original version,
+	so updating to a newer version of the library would be non-trivial. */
 /*!
 	Colorbox v1.4.32 - 2013-10-16
 	jQuery lightbox and modal window plugin
@@ -998,7 +999,8 @@
                             photo.width = photo.width * percent;
                         }
 					};
-                    if (photo.width > photo.height) {
+					// [CC] Note that the sizing code has been substantially modified by CC.
+                    // if (photo.width > photo.height) {
                         if (settings.maxw && photo.width > settings.maxw) {
                             // Reduce to the max width || max height
                             percent = (photo.width - settings.maxw) / photo.width;
@@ -1026,7 +1028,7 @@
                             }
                             setResize();
                         }
-                    } else {
+                    // } else {
                         if (settings.maxh && photo.height > settings.maxh) {
                             // Reduce to the max width || max height
                             percent = (photo.height - settings.maxh) / photo.height;
@@ -1054,7 +1056,7 @@
                             }
                             setResize();
                         }
-                    }
+                    // }
 				}
 
 				if (settings.h) {

--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -27439,7 +27439,7 @@ exports.InteractiveIframe = function (props) {
     var handleSupportedFeatures = function (info) {
         if (info.features.aspectRatio &&
             authoredAspectRatioMethod === "DEFAULT") {
-            setAspectRatio(parseInt(info.features.aspectRatio));
+            setAspectRatio(parseInt(info.features.aspectRatio, 10));
         }
         if (onSupportedFeaturesUpdate) {
             onSupportedFeaturesUpdate(info);
@@ -28854,4 +28854,3 @@ module.exports = __WEBPACK_EXTERNAL_MODULE_react_dom__;
 
 /******/ });
 });
-//# sourceMappingURL=lara-typescript.js.map

--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -316,5 +316,3 @@
 .react-tabs__tab-panel--selected {
   display: block; }
 
-
-/*# sourceMappingURL=lara-typescript.css.map*/

--- a/docs/interactive-api-client/README.md
+++ b/docs/interactive-api-client/README.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.4.0-pre.10
+# @concord-consortium/lara-interactive-api - v0.5.0-pre.1
 
 ## [API documentation](globals.md)
 

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.4.0-pre.10
+# @concord-consortium/lara-interactive-api - v0.5.0-pre.1
 
 ## Index
 

--- a/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
 
 # Interface: IAggregateInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthinfo.md
+++ b/docs/interactive-api-client/interfaces/iauthinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
 
 # Interface: IAuthInfo
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
 
 # Interface: IAuthoringCustomReportField
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
 
 # Interface: IAuthoringCustomReportFields
 

--- a/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
 
 # Interface: IAuthoringInitInteractive ‹**AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
 
 # Interface: IAuthoringInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
 
 # Interface: IAuthoringMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
 
 # Interface: IAuthoringOpenResponseMetadata
 

--- a/docs/interactive-api-client/interfaces/ibaseshowmodal.md
+++ b/docs/interactive-api-client/interfaces/ibaseshowmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
 
 # Interface: IBaseShowModal
 

--- a/docs/interactive-api-client/interfaces/iclientoptions.md
+++ b/docs/interactive-api-client/interfaces/iclientoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IClientOptions](iclientoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IClientOptions](iclientoptions.md)
 
 # Interface: IClientOptions ‹**InteractiveState, AuthoredState, DialogState, GlobalInteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/iclosedmodal.md
+++ b/docs/interactive-api-client/interfaces/iclosedmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
 
 # Interface: IClosedModal
 

--- a/docs/interactive-api-client/interfaces/iclosemodal.md
+++ b/docs/interactive-api-client/interfaces/iclosemodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
 
 # Interface: ICloseModal
 

--- a/docs/interactive-api-client/interfaces/icontextmember.md
+++ b/docs/interactive-api-client/interfaces/icontextmember.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
 
 # Interface: IContextMember
 

--- a/docs/interactive-api-client/interfaces/icontextmembership.md
+++ b/docs/interactive-api-client/interfaces/icontextmembership.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
 
 # Interface: IContextMembership
 

--- a/docs/interactive-api-client/interfaces/icustommessage.md
+++ b/docs/interactive-api-client/interfaces/icustommessage.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
 
 # Interface: ICustomMessage
 

--- a/docs/interactive-api-client/interfaces/idialoginitinteractive.md
+++ b/docs/interactive-api-client/interfaces/idialoginitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
 
 # Interface: IDialogInitInteractive ‹**InteractiveState, AuthoredState, DialogState**›
 

--- a/docs/interactive-api-client/interfaces/igetauthinforequest.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
 
 # Interface: IGetAuthInfoRequest
 

--- a/docs/interactive-api-client/interfaces/igetauthinforesponse.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforesponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
 
 # Interface: IGetAuthInfoResponse
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtoptions.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtOptions](igetfirebasejwtoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtOptions](igetfirebasejwtoptions.md)
 
 # Interface: IGetFirebaseJwtOptions
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
 
 # Interface: IGetFirebaseJwtRequest
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
 
 # Interface: IGetFirebaseJwtResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
 
 # Interface: IGetInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
 
 # Interface: IGetInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
 
 # Interface: IGetInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
 
 # Interface: IGetInteractiveSnapshotOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
 
 # Interface: IGetInteractiveSnapshotRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
 
 # Interface: IGetInteractiveSnapshotResponse
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
 
 # Interface: IGetLibraryInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
 
 # Interface: IGetLibraryInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
 
 # Interface: IGetLibraryInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/ihintrequest.md
+++ b/docs/interactive-api-client/interfaces/ihintrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
 
 # Interface: IHintRequest
 

--- a/docs/interactive-api-client/interfaces/ihookoptions.md
+++ b/docs/interactive-api-client/interfaces/ihookoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IHookOptions](ihookoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IHookOptions](ihookoptions.md)
 
 # Interface: IHookOptions
 

--- a/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
 
 # Interface: IInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/iinteractivestateprops.md
+++ b/docs/interactive-api-client/interfaces/iinteractivestateprops.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
 
 # Interface: IInteractiveStateProps ‹**InteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
 
 # Interface: ILibraryInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/ilinkedauthoredinteractive.md
+++ b/docs/interactive-api-client/interfaces/ilinkedauthoredinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ILinkedAuthoredInteractive](ilinkedauthoredinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ILinkedAuthoredInteractive](ilinkedauthoredinteractive.md)
 
 # Interface: ILinkedAuthoredInteractive
 

--- a/docs/interactive-api-client/interfaces/ilinkedruntimeinteractive.md
+++ b/docs/interactive-api-client/interfaces/ilinkedruntimeinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ILinkedRuntimeInteractive](ilinkedruntimeinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ILinkedRuntimeInteractive](ilinkedruntimeinteractive.md)
 
 # Interface: ILinkedRuntimeInteractive
 

--- a/docs/interactive-api-client/interfaces/inavigationoptions.md
+++ b/docs/interactive-api-client/interfaces/inavigationoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
 
 # Interface: INavigationOptions
 

--- a/docs/interactive-api-client/interfaces/ireportinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/ireportinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
 
 # Interface: IReportInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
+++ b/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
 
 # Interface: IRuntimeCustomReportValues
 

--- a/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
 
 # Interface: IRuntimeInitInteractive ‹**InteractiveState, AuthoredState, GlobalInteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
 
 # Interface: IRuntimeInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
 
 # Interface: IRuntimeMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
 
 # Interface: IRuntimeMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iruntimeopenresponsemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimeopenresponsemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IRuntimeOpenResponseMetadata](iruntimeopenresponsemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IRuntimeOpenResponseMetadata](iruntimeopenresponsemetadata.md)
 
 # Interface: IRuntimeOpenResponseMetadata
 

--- a/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
+++ b/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
 
 # Interface: ISetLinkedInteractives
 

--- a/docs/interactive-api-client/interfaces/ishowalert.md
+++ b/docs/interactive-api-client/interfaces/ishowalert.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
 
 # Interface: IShowAlert
 

--- a/docs/interactive-api-client/interfaces/ishowdialog.md
+++ b/docs/interactive-api-client/interfaces/ishowdialog.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
 
 # Interface: IShowDialog ‹**DialogState**›
 

--- a/docs/interactive-api-client/interfaces/ishowlightbox.md
+++ b/docs/interactive-api-client/interfaces/ishowlightbox.md
@@ -12,11 +12,39 @@
 
 ### Properties
 
+* [allowUpscale](ishowlightbox.md#optional-allowupscale)
+* [isImage](ishowlightbox.md#optional-isimage)
+* [size](ishowlightbox.md#optional-size)
+* [title](ishowlightbox.md#optional-title)
 * [type](ishowlightbox.md#type)
 * [url](ishowlightbox.md#url)
 * [uuid](ishowlightbox.md#uuid)
 
 ## Properties
+
+### `Optional` allowUpscale
+
+• **allowUpscale**? : *undefined | false | true*
+
+___
+
+### `Optional` isImage
+
+• **isImage**? : *undefined | false | true*
+
+___
+
+### `Optional` size
+
+• **size**? : *undefined | object*
+
+___
+
+### `Optional` title
+
+• **title**? : *undefined | string*
+
+___
 
 ###  type
 

--- a/docs/interactive-api-client/interfaces/ishowlightbox.md
+++ b/docs/interactive-api-client/interfaces/ishowlightbox.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
 
 # Interface: IShowLightbox
 

--- a/docs/interactive-api-client/interfaces/isupportedfeatures.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeatures.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
 
 # Interface: ISupportedFeatures
 

--- a/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
 
 # Interface: ISupportedFeaturesRequest
 

--- a/docs/interactive-api-client/interfaces/ithemeinfo.md
+++ b/docs/interactive-api-client/interfaces/ithemeinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.4.0-pre.10](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.1](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
 
 # Interface: IThemeInfo
 

--- a/lara-typescript/README.md
+++ b/lara-typescript/README.md
@@ -83,6 +83,13 @@ cd [the client you want to test (e.g. concord-consortium/question-interactives)]
 npm link @concord-consortium/lara-interactive-api
 ```
 
+Note that for local changes to the interactive API to take effect you must build locally after making changes:
+
+```
+cd lara-typescript
+npm run build
+```
+
 To unlink:
 
 ```

--- a/lara-typescript/package-lock.json
+++ b/lara-typescript/package-lock.json
@@ -10876,6 +10876,11 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",

--- a/lara-typescript/src/interactive-api-client/api.spec.ts
+++ b/lara-typescript/src/interactive-api-client/api.spec.ts
@@ -207,13 +207,14 @@ describe("api", () => {
     expect(mockedPhone.messages).toEqual([{ type: "showModal", content: options }]);
   });
 
-  it("does not yet implement showModal [lightbox]", () => {
+  it("should implement showModal [lightbox]", () => {
     const options: IShowLightbox = {
       uuid: "foo",
       type: "lightbox",
       url: "https://concord.org"
     };
-    expect(() => api.showModal(options)).toThrow(/not yet implemented/);
+    api.showModal(options);
+    expect(mockedPhone.messages).toEqual([{ type: "showModal", content: options }]);
   });
 
   it("does not yet implement showModal [dialog]", () => {

--- a/lara-typescript/src/interactive-api-client/api.ts
+++ b/lara-typescript/src/interactive-api-client/api.ts
@@ -228,7 +228,7 @@ export const setRuntimeCustomReportValues = (values: IRuntimeCustomReportValues)
  * @todo Implement this function.
  */
 export const showModal = (options: IShowModal) => {
-  if (options.type === "alert") {
+  if ((options.type === "alert") || (options.type === "lightbox")) {
     getClient().post("showModal", options);
   }
   else {

--- a/lara-typescript/src/interactive-api-client/package-lock.json
+++ b/lara-typescript/src/interactive-api-client/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@concord-consortium/lara-interactive-api",
+  "version": "0.5.0-pre.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "iframe-phone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/iframe-phone/-/iframe-phone-1.3.1.tgz",
+      "integrity": "sha512-pipd9e4l5AE0K3+ZcQxb/+zd1pvCWbu6wuQlxdqChIfwe9jnnm2HwcNra/GvLovDxe36+uZusFMN0rNKlFIvdQ=="
+    }
+  }
+}

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.4.0-pre.10",
+  "version": "0.5.0-pre.1",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/lara-typescript/src/interactive-api-client/types.ts
+++ b/lara-typescript/src/interactive-api-client/types.ts
@@ -250,6 +250,10 @@ export interface IShowAlert extends IBaseShowModal {
 export interface IShowLightbox extends IBaseShowModal {
   type: "lightbox";
   url: string;
+  title?: string;
+  isImage?: boolean;
+  size?: { width: number, height: number };
+  allowUpscale?: boolean;
 }
 
 export interface IShowDialog<DialogState = {}> extends IBaseShowModal {

--- a/lara-typescript/src/interactive-api-parent/iframe-saver-plugin.ts
+++ b/lara-typescript/src/interactive-api-parent/iframe-saver-plugin.ts
@@ -1,0 +1,5 @@
+import { IFrameSaverClientMessage } from "../interactive-api-client";
+
+export interface IFrameSaverPlugin {
+  listeners: Partial<Record<IFrameSaverClientMessage, (content: any) => void>>;
+}

--- a/lara-typescript/src/interactive-api-parent/iframe-saver-plugin.ts
+++ b/lara-typescript/src/interactive-api-parent/iframe-saver-plugin.ts
@@ -1,5 +1,10 @@
-import { IFrameSaverClientMessage } from "../interactive-api-client";
-
-export interface IFrameSaverPlugin {
-  listeners: Partial<Record<IFrameSaverClientMessage, (content: any) => void>>;
+// define our own subset of the iFramePhone API because the MockPhone is not
+// sufficiently compatible with the actual iFramePhone API to replace it in
+// tests, but the two do agree on the subset that we actually need.
+export interface IFramePhoneStub {
+  addListener: (type: string, fn: (content?: any) => void) => void;
+  removeListener: (type: string) => void;
+  post: (type: string, content?: any) => void;
 }
+export type IFrameSaverPluginDisconnectFn = () => void;
+export type IFrameSaverPlugin = (iframePhone: IFramePhoneStub) => IFrameSaverPluginDisconnectFn;

--- a/lara-typescript/src/interactive-api-parent/iframe-saver.spec.ts
+++ b/lara-typescript/src/interactive-api-parent/iframe-saver.spec.ts
@@ -1,21 +1,9 @@
 import { mockIFramePhone, MockedIframePhoneManager, setAutoConnect } from "./mock-iframe-phone";
 import { IFrameSaver } from "./iframe-saver";
-import { IShowModal, ICloseModal } from "../interactive-api-client";
 
 const parentEl = document.createElement("iframe");
 
 jest.mock("iframe-phone", () => mockIFramePhone(parentEl));
-
-const mockShowModal = jest.fn();
-const mockCloseModal = jest.fn();
-jest.mock("./modal-api-plugin", () => ({
-  ModalApiPlugin: jest.fn().mockImplementation(() => ({
-    listeners: {
-      showModal: mockShowModal,
-      closeModal: mockCloseModal
-    }
-  }))
-}));
 
 const successResponse = {
   status: 200,
@@ -241,24 +229,13 @@ describe("IFrameSaver", () => {
   describe("showModal/closeModal iframe-phone messages", () => {
 
     beforeEach(() => {
-      jest.clearAllMocks();
       saver = getSaver();
       MockedIframePhoneManager.connect();
     });
 
-    it("should show/hide modal iframe lightbox", () => {
-      expect(mockShowModal).not.toHaveBeenCalled();
-      expect(mockCloseModal).not.toHaveBeenCalled();
-      const showOptions: IShowModal = {
-        uuid: "modal-uuid", type: "lightbox", url: "https://concord.org" };
-      const showMessage: any = { type: "showModal", content: showOptions };
-      MockedIframePhoneManager.postMessageFrom($("#interactive")[0], showMessage);
-      expect(mockShowModal).toHaveBeenCalled();
-      expect(mockCloseModal).not.toHaveBeenCalled();
-      const closeOptions: ICloseModal = { uuid: "modal-uuid" };
-      const closeMessage: any = { type: "closeModal", content: closeOptions };
-      MockedIframePhoneManager.postMessageFrom($("#interactive")[0], closeMessage);
-      expect(mockCloseModal).toHaveBeenCalled();
+    it("should have installed listeners for showModal/closeModal", () => {
+      expect(MockedIframePhoneManager.hasListener("showModal")).toBe(true);
+      expect(MockedIframePhoneManager.hasListener("closeModal")).toBe(true);
     });
 
   });

--- a/lara-typescript/src/interactive-api-parent/iframe-saver.ts
+++ b/lara-typescript/src/interactive-api-parent/iframe-saver.ts
@@ -1,7 +1,7 @@
 import { ParentEndpoint } from "iframe-phone";
 import * as LaraInteractiveApi from "../interactive-api-client";
 import { IframePhoneManager } from "./iframe-phone-manager";
-import { IFrameSaverPlugin } from "./iframe-saver-plugin";
+import { IFrameSaverPluginDisconnectFn } from "./iframe-saver-plugin";
 import { ModalApiPlugin } from "./modal-api-plugin";
 
 const getAuthoredState = ($dataDiv: JQuery) => {
@@ -106,7 +106,7 @@ export class IFrameSaver {
   private alreadySetup: boolean;
   private iframePhone: ParentEndpoint;
   private successCallback: SuccessCallback | null | undefined;
-  private plugins: IFrameSaverPlugin[];
+  private plugins: IFrameSaverPluginDisconnectFn[];
 
   constructor($iframe: JQuery, $dataDiv: JQuery, $deleteButton: JQuery) {
     this.$iframe = $iframe;
@@ -138,7 +138,7 @@ export class IFrameSaver {
 
     this.iframePhone = IframePhoneManager.getPhone($iframe[0] as HTMLIFrameElement, () => this.phoneAnswered());
 
-    this.plugins = [ModalApiPlugin()];
+    this.plugins = [ModalApiPlugin(this.iframePhone)];
   }
 
   public save(successCallback?: SuccessCallback | null) {
@@ -259,19 +259,6 @@ export class IFrameSaver {
 
     this.addListener("getFirebaseJWT", (request?: IGetFirebaseJwtRequestOptionalRequestId) => {
       return this.getFirebaseJwt(request);
-    });
-
-    // add listeners from "plugins"
-    this.plugins.forEach(plugin => {
-      if (plugin.listeners) {
-        for (const m in plugin.listeners) {
-          if (Object.prototype.hasOwnProperty.call(plugin.listeners, m)) {
-            const msg = m as LaraInteractiveApi.IFrameSaverClientMessage;
-            const listener = msg && plugin.listeners[msg];
-            listener && this.addListener(msg, listener);
-          }
-        }
-      }
     });
 
     if (this.learnerStateSavingEnabled()) {

--- a/lara-typescript/src/interactive-api-parent/iframe-saver.ts
+++ b/lara-typescript/src/interactive-api-parent/iframe-saver.ts
@@ -1,8 +1,8 @@
 import { ParentEndpoint } from "iframe-phone";
 import * as LaraInteractiveApi from "../interactive-api-client";
 import { IframePhoneManager } from "./iframe-phone-manager";
-import { IHintRequest, IShowModal, IShowAlert, ICloseModal, ModalType } from "../interactive-api-client";
-import { addPopup } from "../plugin-api";
+import { IFrameSaverPlugin } from "./iframe-saver-plugin";
+import { ModalApiPlugin } from "./modal-api-plugin";
 
 const getAuthoredState = ($dataDiv: JQuery) => {
   let authoredState = $dataDiv.data("authored-state");
@@ -77,11 +77,6 @@ type IGetAuthInfoResponseOptionalRequestId = LaraInteractiveApi.IGetAuthInfoResp
 type IGetFirebaseJwtRequestOptionalRequestId = LaraInteractiveApi.IGetFirebaseJwtRequest;
 type IGetFirebaseJwtResponseOptionalRequestId = LaraInteractiveApi.IGetFirebaseJwtResponse;
 
-interface ModalState {
-  type: ModalType;
-  $content: JQuery<HTMLElement>;
-}
-
 export class IFrameSaver {
 
   private static instances: IFrameSaver[] = [];
@@ -111,7 +106,7 @@ export class IFrameSaver {
   private alreadySetup: boolean;
   private iframePhone: ParentEndpoint;
   private successCallback: SuccessCallback | null | undefined;
-  private modals: Record<string, ModalState>;
+  private plugins: IFrameSaverPlugin[];
 
   constructor($iframe: JQuery, $dataDiv: JQuery, $deleteButton: JQuery) {
     this.$iframe = $iframe;
@@ -143,7 +138,7 @@ export class IFrameSaver {
 
     this.iframePhone = IframePhoneManager.getPhone($iframe[0] as HTMLIFrameElement, () => this.phoneAnswered());
 
-    this.modals = {};
+    this.plugins = [ModalApiPlugin()];
   }
 
   public save(successCallback?: SuccessCallback | null) {
@@ -193,7 +188,7 @@ export class IFrameSaver {
   }
 
   private phoneAnswered() {
-    // Workaround IframePhone problem - phone_answered cabllack can be triggered multiple times:
+    // Workaround IframePhone problem - phone_answered callback can be triggered multiple times:
     // https://www.pivotaltracker.com/story/show/89602814
     if (this.alreadySetup) {
       return;
@@ -229,7 +224,7 @@ export class IFrameSaver {
       this.$iframe.trigger("sizeUpdate");
     });
 
-    this.addListener("hint", (hintRequest: IHintRequest) => {
+    this.addListener("hint", (hintRequest: LaraInteractiveApi.IHintRequest) => {
       const $container = this.$iframe.closest(".embeddable-container");
       const $helpIcon = $container.find(".help-icon");
       if (hintRequest.text) {
@@ -238,18 +233,6 @@ export class IFrameSaver {
         $container.find(".help-icon").addClass("hidden");
       }
       $container.find(".help-content .text").text(hintRequest.text || "");
-    });
-
-    this.addListener("showModal", (options: IShowModal) => {
-      if (options.type === "alert") {
-        this.showAlert(options);
-      }
-    });
-
-    this.addListener("closeModal", (options: ICloseModal) => {
-      if (this.modals[options.uuid]?.type === "alert") {
-        this.closeAlert(options);
-      }
     });
 
     this.addListener("supportedFeatures", (info: LaraInteractiveApi.ISupportedFeaturesRequest) => {
@@ -276,6 +259,19 @@ export class IFrameSaver {
 
     this.addListener("getFirebaseJWT", (request?: IGetFirebaseJwtRequestOptionalRequestId) => {
       return this.getFirebaseJwt(request);
+    });
+
+    // add listeners from "plugins"
+    this.plugins.forEach(plugin => {
+      if (plugin.listeners) {
+        for (const m in plugin.listeners) {
+          if (Object.prototype.hasOwnProperty.call(plugin.listeners, m)) {
+            const msg = m as LaraInteractiveApi.IFrameSaverClientMessage;
+            const listener = msg && plugin.listeners[msg];
+            listener && this.addListener(msg, listener);
+          }
+        }
+      }
     });
 
     if (this.learnerStateSavingEnabled()) {
@@ -468,40 +464,4 @@ export class IFrameSaver {
     this.iframePhone.addListener(message, listener);
   }
 
-  private showAlert(options: IShowAlert) {
-    const { style, title: _title, text } = options;
-    let title: string;
-    let titlebarColor: string | undefined;
-    let message: string;
-    if (style === "correct") {
-      title = _title != null ? _title : "Correct";
-      titlebarColor = "#75a643";
-      message = text || "Yes! You are correct.";
-    }
-    else if (style === "incorrect") {
-      title = _title != null ? _title : "Incorrect";
-      titlebarColor = "#b45532";
-      message = text || "Sorry, that is incorrect.";
-    }
-    else {
-      title = _title || "";
-      message = text || "";
-    }
-
-    const $content = $(`<div class='check-answer'><p class='response'>${message}</p></div`);
-    this.modals[options.uuid] = { type: options.type, $content };
-    addPopup({
-      content: $content[0],
-      title,
-      titlebarColor,
-      modal: true
-    });
-  }
-
-  private closeAlert(options: ICloseModal) {
-    const $content = this.modals[options.uuid]?.$content;
-    if ($content?.is(":ui-dialog")) {
-      $content.dialog("close");
-    }
-  }
 }

--- a/lara-typescript/src/interactive-api-parent/mock-iframe-phone.ts
+++ b/lara-typescript/src/interactive-api-parent/mock-iframe-phone.ts
@@ -84,6 +84,11 @@ export class MockIframePhoneManager {
     this._phonesToConnect.length = 0;
   }
 
+  public hasListener(type: string) {
+    return Object.keys(this._phones)
+            .some(phoneId => this._phones[phoneId].hasListener(type));
+  }
+
   // Posts fake message from given element (e.g. iframe). Current window is the receiver.
   // If there is a mock iframe phones connected to source element, it will be notified.
   public postMessageFrom(source: HTMLElement, message: any) {
@@ -185,6 +190,10 @@ export class MockPhone {
     }
     this.messages.push(message as IMessage);
     MockedIframePhoneManager.messages._add({source: window, target: this.targetElement, message});
+  }
+
+  public hasListener(type: string) {
+    return !!this.listeners[type];
   }
 
   public addListener(type: string, fn: Listener) {

--- a/lara-typescript/src/interactive-api-parent/modal-api-plugin.spec.ts
+++ b/lara-typescript/src/interactive-api-parent/modal-api-plugin.spec.ts
@@ -1,8 +1,17 @@
 import { hasModal, ModalApiPlugin } from "./modal-api-plugin";
 import { IShowModal, ICloseModal } from "../interactive-api-client";
+import { MockPhone } from "./mock-iframe-phone";
 import "../../../app/assets/javascripts/jquery.colorbox";
 
-const { showModal, closeModal } = ModalApiPlugin().listeners;
+const parentEl = document.createElement("iframe");
+const mockPhone = new MockPhone(parentEl);
+const disconnect = ModalApiPlugin(mockPhone);
+
+afterAll(() => {
+  disconnect();
+  expect(mockPhone.hasListener("showModal")).toBe(false);
+  expect(mockPhone.hasListener("closeModal")).toBe(false);
+});
 
 describe("ModalApiPlugin should show/close alerts", () => {
 
@@ -11,12 +20,12 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect(hasModal(uuid)).toBe(false);
     expect($(".ui-dialog").length).toBe(0);
     const showOptions: IShowModal = { uuid, type: "alert", style: "correct" };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     expect(hasModal(uuid)).toBe(true);
     expect($(".ui-dialog").length).toBe(1);
     expect($(".ui-dialog").find(".ui-dialog-titlebar").text()).toMatch(/^Correct/);
     const closeOptions: ICloseModal = { uuid };
-    closeModal?.(closeOptions);
+    mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
     expect(hasModal(uuid)).toBe(false);
     expect($(".ui-dialog").length).toBe(0);
   });
@@ -26,12 +35,12 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect(hasModal(uuid)).toBe(false);
     expect($(".ui-dialog").length).toBe(0);
     const showOptions: IShowModal = { uuid, type: "alert", style: "incorrect" };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     expect(hasModal(uuid)).toBe(true);
     expect($(".ui-dialog").length).toBe(1);
     expect($(".ui-dialog").find(".ui-dialog-titlebar").text()).toMatch(/^Incorrect/);
     const closeOptions: ICloseModal = { uuid };
-    closeModal?.(closeOptions);
+    mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
     expect(hasModal(uuid)).toBe(false);
     expect($(".ui-dialog").length).toBe(0);
   });
@@ -41,18 +50,18 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect(hasModal(uuid)).toBe(false);
     expect($(".ui-dialog").length).toBe(0);
     const showOptions: IShowModal = { uuid, type: "alert", style: "info", text: "Information" };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     expect(hasModal(uuid)).toBe(true);
     expect($(".ui-dialog").length).toBe(1);
     expect($(".ui-dialog").find(".ui-dialog-content").text()).toMatch(/^Information/);
     const closeOptions: ICloseModal = { uuid };
-    closeModal?.(closeOptions);
+    mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
     expect(hasModal(uuid)).toBe(false);
     expect($(".ui-dialog").length).toBe(0);
   });
 });
 
-describe("ModalApiPlugin should show/close alerts", () => {
+describe("ModalApiPlugin should show/close lightboxes", () => {
   const $colorbox = ($ as any).colorbox;
 
   beforeEach(() => {
@@ -89,12 +98,12 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect($("#colorbox").length).toBe(0);
     expect(hasModal(uuid)).toBe(false);
     const showOptions: IShowModal = { uuid, type: "lightbox", isImage: true, url: "https://concord.org" };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     waitForElement("#colorbox", () => {
       expect(hasModal(uuid)).toBe(true);
 
       const closeOptions: ICloseModal = { uuid };
-      closeModal?.(closeOptions);
+      mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
       waitForNoElement("#colorbox", () => {
         expect(hasModal(uuid)).toBe(false);
         done();
@@ -107,12 +116,12 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect($("#colorbox").length).toBe(0);
     expect(hasModal(uuid)).toBe(false);
     const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org" };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     waitForElement("#colorbox iframe", () => {
       expect(hasModal(uuid)).toBe(true);
 
       const closeOptions: ICloseModal = { uuid };
-      closeModal?.(closeOptions);
+      mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
       waitForNoElement("#colorbox", () => {
         expect(hasModal(uuid)).toBe(false);
         expect($("#colorbox iframe").length).toBe(0);
@@ -127,12 +136,12 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect(hasModal(uuid)).toBe(false);
     const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org",
                                       size: { width: 800, height: 600 } };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     waitForElement("#colorbox iframe", () => {
       expect(hasModal(uuid)).toBe(true);
 
       const closeOptions: ICloseModal = { uuid };
-      closeModal?.(closeOptions);
+      mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
       waitForNoElement("#colorbox", () => {
         expect(hasModal(uuid)).toBe(false);
         expect($("#colorbox iframe").length).toBe(0);
@@ -147,12 +156,12 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect(hasModal(uuid)).toBe(false);
     const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org",
                                       size: { width: 8000, height: 600 } };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     waitForElement("#colorbox iframe", () => {
       expect(hasModal(uuid)).toBe(true);
 
       const closeOptions: ICloseModal = { uuid };
-      closeModal?.(closeOptions);
+      mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
       waitForNoElement("#colorbox", () => {
         expect(hasModal(uuid)).toBe(false);
         expect($("#colorbox iframe").length).toBe(0);
@@ -167,12 +176,12 @@ describe("ModalApiPlugin should show/close alerts", () => {
     expect(hasModal(uuid)).toBe(false);
     const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org",
                                       size: { width: 800, height: 6000 } };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     waitForElement("#colorbox iframe", () => {
       expect(hasModal(uuid)).toBe(true);
 
       const closeOptions: ICloseModal = { uuid };
-      closeModal?.(closeOptions);
+      mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
       waitForNoElement("#colorbox", () => {
         expect(hasModal(uuid)).toBe(false);
         expect($("#colorbox iframe").length).toBe(0);
@@ -180,15 +189,18 @@ describe("ModalApiPlugin should show/close alerts", () => {
       });
     });
   });
+});
+
+describe("ModalApiPlugin should show/close dialogs", () => {
 
   it("should implement showDialog/closeDialog functions", () => {
     const uuid = "dialog";
     expect(hasModal(uuid)).toBe(false);
     const showOptions: IShowModal = { uuid, type: "dialog", url: "https://concord.org", dialogState: {} };
-    showModal?.(showOptions);
+    mockPhone.fakeServerMessage({ type: "showModal", content: showOptions });
     expect(hasModal(uuid)).toBe(true);
     const closeOptions: ICloseModal = { uuid };
-    closeModal?.(closeOptions);
+    mockPhone.fakeServerMessage({ type: "closeModal", content: closeOptions });
     expect(hasModal(uuid)).toBe(false);
   });
 });

--- a/lara-typescript/src/interactive-api-parent/modal-api-plugin.spec.ts
+++ b/lara-typescript/src/interactive-api-parent/modal-api-plugin.spec.ts
@@ -1,0 +1,194 @@
+import { hasModal, ModalApiPlugin } from "./modal-api-plugin";
+import { IShowModal, ICloseModal } from "../interactive-api-client";
+import "../../../app/assets/javascripts/jquery.colorbox";
+
+const { showModal, closeModal } = ModalApiPlugin().listeners;
+
+describe("ModalApiPlugin should show/close alerts", () => {
+
+  it("should show/hide correct alert", () => {
+    const uuid = "correct-alert";
+    expect(hasModal(uuid)).toBe(false);
+    expect($(".ui-dialog").length).toBe(0);
+    const showOptions: IShowModal = { uuid, type: "alert", style: "correct" };
+    showModal?.(showOptions);
+    expect(hasModal(uuid)).toBe(true);
+    expect($(".ui-dialog").length).toBe(1);
+    expect($(".ui-dialog").find(".ui-dialog-titlebar").text()).toMatch(/^Correct/);
+    const closeOptions: ICloseModal = { uuid };
+    closeModal?.(closeOptions);
+    expect(hasModal(uuid)).toBe(false);
+    expect($(".ui-dialog").length).toBe(0);
+  });
+
+  it("should show/hide incorrect alert", () => {
+    const uuid = "incorrect-alert";
+    expect(hasModal(uuid)).toBe(false);
+    expect($(".ui-dialog").length).toBe(0);
+    const showOptions: IShowModal = { uuid, type: "alert", style: "incorrect" };
+    showModal?.(showOptions);
+    expect(hasModal(uuid)).toBe(true);
+    expect($(".ui-dialog").length).toBe(1);
+    expect($(".ui-dialog").find(".ui-dialog-titlebar").text()).toMatch(/^Incorrect/);
+    const closeOptions: ICloseModal = { uuid };
+    closeModal?.(closeOptions);
+    expect(hasModal(uuid)).toBe(false);
+    expect($(".ui-dialog").length).toBe(0);
+  });
+
+  it("should show/hide info alert", () => {
+    const uuid = "info-alert";
+    expect(hasModal(uuid)).toBe(false);
+    expect($(".ui-dialog").length).toBe(0);
+    const showOptions: IShowModal = { uuid, type: "alert", style: "info", text: "Information" };
+    showModal?.(showOptions);
+    expect(hasModal(uuid)).toBe(true);
+    expect($(".ui-dialog").length).toBe(1);
+    expect($(".ui-dialog").find(".ui-dialog-content").text()).toMatch(/^Information/);
+    const closeOptions: ICloseModal = { uuid };
+    closeModal?.(closeOptions);
+    expect(hasModal(uuid)).toBe(false);
+    expect($(".ui-dialog").length).toBe(0);
+  });
+});
+
+describe("ModalApiPlugin should show/close alerts", () => {
+  const $colorbox = ($ as any).colorbox;
+
+  beforeEach(() => {
+    $colorbox.remove();
+  });
+
+  // cf. https://swizec.com/blog/how-to-properly-wait-for-dom-elements-to-show-up-in-modern-browsers/swizec/6663
+  function waitForElement(selector: string, callback: () => void) {
+    function wait() {
+      if (!$(selector).length) {
+        window.requestAnimationFrame(wait);
+      }
+      else {
+        callback();
+      }
+    }
+    wait();
+  }
+
+  function waitForNoElement(selector: string, callback: () => void) {
+    function wait() {
+      if ($(selector).length && ($(selector).css("display") !== "none")) {
+        window.requestAnimationFrame(wait);
+      }
+      else {
+        setTimeout(() => callback(), 10);
+      }
+    }
+    wait();
+  }
+
+  it("should show/hide modal image lightbox", done => {
+    const uuid = "image-lightbox";
+    expect($("#colorbox").length).toBe(0);
+    expect(hasModal(uuid)).toBe(false);
+    const showOptions: IShowModal = { uuid, type: "lightbox", isImage: true, url: "https://concord.org" };
+    showModal?.(showOptions);
+    waitForElement("#colorbox", () => {
+      expect(hasModal(uuid)).toBe(true);
+
+      const closeOptions: ICloseModal = { uuid };
+      closeModal?.(closeOptions);
+      waitForNoElement("#colorbox", () => {
+        expect(hasModal(uuid)).toBe(false);
+        done();
+      });
+    });
+  });
+
+  it("should show/hide modal iframe lightbox", done => {
+    const uuid = "iframe-lightbox";
+    expect($("#colorbox").length).toBe(0);
+    expect(hasModal(uuid)).toBe(false);
+    const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org" };
+    showModal?.(showOptions);
+    waitForElement("#colorbox iframe", () => {
+      expect(hasModal(uuid)).toBe(true);
+
+      const closeOptions: ICloseModal = { uuid };
+      closeModal?.(closeOptions);
+      waitForNoElement("#colorbox", () => {
+        expect(hasModal(uuid)).toBe(false);
+        expect($("#colorbox iframe").length).toBe(0);
+        done();
+      });
+    });
+  });
+
+  it("should show/hide modal iframe lightbox with size", done => {
+    const uuid = "iframe-lightbox-size";
+    expect($("#colorbox").length).toBe(0);
+    expect(hasModal(uuid)).toBe(false);
+    const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org",
+                                      size: { width: 800, height: 600 } };
+    showModal?.(showOptions);
+    waitForElement("#colorbox iframe", () => {
+      expect(hasModal(uuid)).toBe(true);
+
+      const closeOptions: ICloseModal = { uuid };
+      closeModal?.(closeOptions);
+      waitForNoElement("#colorbox", () => {
+        expect(hasModal(uuid)).toBe(false);
+        expect($("#colorbox iframe").length).toBe(0);
+        done();
+      });
+    });
+  });
+
+  it("should show/hide wide modal iframe lightbox with size", done => {
+    const uuid = "iframe-lightbox-wide";
+    expect($("#colorbox").length).toBe(0);
+    expect(hasModal(uuid)).toBe(false);
+    const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org",
+                                      size: { width: 8000, height: 600 } };
+    showModal?.(showOptions);
+    waitForElement("#colorbox iframe", () => {
+      expect(hasModal(uuid)).toBe(true);
+
+      const closeOptions: ICloseModal = { uuid };
+      closeModal?.(closeOptions);
+      waitForNoElement("#colorbox", () => {
+        expect(hasModal(uuid)).toBe(false);
+        expect($("#colorbox iframe").length).toBe(0);
+        done();
+      });
+    });
+  });
+
+  it("should show/hide tall modal iframe lightbox with size", done => {
+    const uuid = "iframe-lightbox-tall";
+    expect($("#colorbox").length).toBe(0);
+    expect(hasModal(uuid)).toBe(false);
+    const showOptions: IShowModal = { uuid, type: "lightbox", url: "https://concord.org",
+                                      size: { width: 800, height: 6000 } };
+    showModal?.(showOptions);
+    waitForElement("#colorbox iframe", () => {
+      expect(hasModal(uuid)).toBe(true);
+
+      const closeOptions: ICloseModal = { uuid };
+      closeModal?.(closeOptions);
+      waitForNoElement("#colorbox", () => {
+        expect(hasModal(uuid)).toBe(false);
+        expect($("#colorbox iframe").length).toBe(0);
+        done();
+      });
+    });
+  });
+
+  it("should implement showDialog/closeDialog functions", () => {
+    const uuid = "dialog";
+    expect(hasModal(uuid)).toBe(false);
+    const showOptions: IShowModal = { uuid, type: "dialog", url: "https://concord.org", dialogState: {} };
+    showModal?.(showOptions);
+    expect(hasModal(uuid)).toBe(true);
+    const closeOptions: ICloseModal = { uuid };
+    closeModal?.(closeOptions);
+    expect(hasModal(uuid)).toBe(false);
+  });
+});

--- a/lara-typescript/src/interactive-api-parent/modal-api-plugin.ts
+++ b/lara-typescript/src/interactive-api-parent/modal-api-plugin.ts
@@ -13,31 +13,33 @@ export function hasModal(uuid: string) {
   return !!modalMap[uuid];
 }
 
-export function ModalApiPlugin(): IFrameSaverPlugin {
-  return {
-    listeners: {
-      showModal: (options: IShowModal) => {
-        const fnMap: Record<ModalType, (opts: IShowModal) => void> = {
-          alert: (opts: IShowAlert) => showAlert(opts),
-          lightbox: (opts: IShowLightbox) => showLightbox(opts),
-          dialog: (opts: IShowDialog) => showDialog(opts)
-        };
-        const showFn = fnMap[options.type];
-        showFn?.(options);
-      },
-      closeModal: (options: ICloseModal) => {
-        const fnMap: Record<ModalType, (opts: ICloseModal) => void> = {
-          alert: (opts: ICloseModal) => closeAlert(opts),
-          lightbox: (opts: ICloseModal) => closeLightbox(opts),
-          dialog: (opts: ICloseModal) => closeDialog(opts)
-        };
-        const type = modalMap[options.uuid]?.type;
-        const closeFn = type && fnMap[type];
-        closeFn?.(options);
-      }
-    }
+export const ModalApiPlugin: IFrameSaverPlugin = iframePhone => {
+
+  iframePhone.addListener("showModal", (options: IShowModal) => {
+    const fnMap: Record<ModalType, (opts: IShowModal) => void> = {
+      alert: (opts: IShowAlert) => showAlert(opts),
+      lightbox: (opts: IShowLightbox) => showLightbox(opts),
+      dialog: (opts: IShowDialog) => showDialog(opts)
+    };
+    const showFn = fnMap[options.type];
+    showFn?.(options);
+  });
+  iframePhone.addListener("closeModal", (options: ICloseModal) => {
+    const fnMap: Record<ModalType, (opts: ICloseModal) => void> = {
+      alert: (opts: ICloseModal) => closeAlert(opts),
+      lightbox: (opts: ICloseModal) => closeLightbox(opts),
+      dialog: (opts: ICloseModal) => closeDialog(opts)
+    };
+    const type = modalMap[options.uuid]?.type;
+    const closeFn = type && fnMap[type];
+    closeFn?.(options);
+  });
+
+  return () => {
+    iframePhone.removeListener("showModal");
+    iframePhone.removeListener("closeModal");
   };
-}
+};
 
 function showAlert(options: IShowAlert) {
   const { style, title: _title, text } = options;

--- a/lara-typescript/src/interactive-api-parent/modal-api-plugin.ts
+++ b/lara-typescript/src/interactive-api-parent/modal-api-plugin.ts
@@ -9,6 +9,10 @@ interface ModalState {
 }
 const modalMap: Record<string, ModalState> = {};
 
+export function hasModal(uuid: string) {
+  return !!modalMap[uuid];
+}
+
 export function ModalApiPlugin(): IFrameSaverPlugin {
   return {
     listeners: {
@@ -131,9 +135,11 @@ function closeLightbox(options: ICloseModal) {
 }
 
 function showDialog(options: IShowDialog) {
-  // dialog
+  // placeholder
+  modalMap[options.uuid] = { type: "dialog", $content: $(".ui-dialog") };
 }
 
 function closeDialog(options: ICloseModal) {
-  // dialog
+  // placeholder
+  delete modalMap[options.uuid];
 }

--- a/lara-typescript/src/interactive-api-parent/modal-api-plugin.ts
+++ b/lara-typescript/src/interactive-api-parent/modal-api-plugin.ts
@@ -1,0 +1,139 @@
+import { ICloseModal, IShowAlert, IShowDialog, IShowLightbox, IShowModal, ModalType
+        } from "../interactive-api-client";
+import { IFrameSaverPlugin } from "./iframe-saver-plugin";
+import { addPopup } from "../plugin-api";
+
+interface ModalState {
+  type: ModalType;
+  $content: JQuery<HTMLElement>;
+}
+const modalMap: Record<string, ModalState> = {};
+
+export function ModalApiPlugin(): IFrameSaverPlugin {
+  return {
+    listeners: {
+      showModal: (options: IShowModal) => {
+        const fnMap: Record<ModalType, (opts: IShowModal) => void> = {
+          alert: (opts: IShowAlert) => showAlert(opts),
+          lightbox: (opts: IShowLightbox) => showLightbox(opts),
+          dialog: (opts: IShowDialog) => showDialog(opts)
+        };
+        const showFn = fnMap[options.type];
+        showFn?.(options);
+      },
+      closeModal: (options: ICloseModal) => {
+        const fnMap: Record<ModalType, (opts: ICloseModal) => void> = {
+          alert: (opts: ICloseModal) => closeAlert(opts),
+          lightbox: (opts: ICloseModal) => closeLightbox(opts),
+          dialog: (opts: ICloseModal) => closeDialog(opts)
+        };
+        const type = modalMap[options.uuid]?.type;
+        const closeFn = type && fnMap[type];
+        closeFn?.(options);
+      }
+    }
+  };
+}
+
+function showAlert(options: IShowAlert) {
+  const { style, title: _title, text } = options;
+  let title: string;
+  let titlebarColor: string | undefined;
+  let message: string;
+  if (style === "correct") {
+    title = _title != null ? _title : "Correct";
+    titlebarColor = "#75a643";
+    message = text || "Yes! You are correct.";
+  }
+  else if (style === "incorrect") {
+    title = _title != null ? _title : "Incorrect";
+    titlebarColor = "#b45532";
+    message = text || "Sorry, that is incorrect.";
+  }
+  else {
+    title = _title || "";
+    message = text || "";
+  }
+
+  const $content = $(`<div class='check-answer'><p class='response'>${message}</p></div`);
+  modalMap[options.uuid] = { type: options.type, $content };
+  addPopup({
+    content: $content[0],
+    title,
+    titlebarColor,
+    modal: true,
+    onClose: () => delete modalMap[options.uuid]
+  });
+}
+
+function closeAlert(options: ICloseModal) {
+  const $content = modalMap[options.uuid]?.$content;
+  if ($content?.is(":ui-dialog")) {
+    $content.dialog("close");
+  }
+}
+
+function showLightbox(options: IShowLightbox) {
+  const getSizeOptions = () => {
+    const { isImage, size } = options;
+    // colorbox implementation detail
+    const kChromeSize = { width: 42, height: 70 };
+    const availableWidth = window.innerWidth - kChromeSize.width;
+    const availableHeight = window.innerHeight - kChromeSize.height;
+    const sizeOpts: { width?: number, height?: number, scalePhotos?: boolean } = {};
+    // images are auto-sized correctly without intervention
+    if (isImage) {
+      // prevent scaling up unless requested
+      const requiresUpscaling = (!!size?.width && size.width < availableWidth) &&
+                                (!!size?.height && size.height < availableHeight);
+      sizeOpts.scalePhotos = !requiresUpscaling || options.allowUpscale;
+      return sizeOpts;
+    }
+    // for iframes, if size is specified, then maintain aspect ratio
+    if (size) {
+      const aspectRatio = size.width / size.height;
+      if (size.height > availableHeight) {
+        // height is constraining dimension
+        sizeOpts.width = availableHeight * aspectRatio;
+        sizeOpts.height = availableHeight;
+      }
+      else {
+        sizeOpts.width = size.width;
+        sizeOpts.height = size.height;
+      }
+      if (size.width > availableWidth) {
+        // width is constraining dimension
+        sizeOpts.width = availableWidth;
+        sizeOpts.height = availableWidth / aspectRatio;
+      }
+      return sizeOpts;
+    }
+    // otherwise use available space
+    sizeOpts.width = availableWidth;
+    sizeOpts.height = availableHeight;
+    return sizeOpts;
+  };
+  ($ as any).colorbox({
+    iframe: !options.isImage,
+    photo: !!options.isImage,
+    href: options.url,
+    title: options.title,
+    maxWidth: "100%",
+    maxHeight: "100%",
+    ...getSizeOptions(),
+    onOpen: () => modalMap[options.uuid] = { type: "lightbox", $content: ($ as any).colorbox.element() },
+    onClosed: () => delete modalMap[options.uuid]
+  });
+}
+
+function closeLightbox(options: ICloseModal) {
+  ($ as any).colorbox.close();
+}
+
+function showDialog(options: IShowDialog) {
+  // dialog
+}
+
+function closeDialog(options: ICloseModal) {
+  // dialog
+}

--- a/lara-typescript/src/page-item-authoring/common/components/interactive-iframe.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-iframe.tsx
@@ -51,7 +51,7 @@ export const InteractiveIframe: React.FC<Props> = (props) => {
   const handleSupportedFeatures = (info: any) => {
     if (info.features.aspectRatio &&
         authoredAspectRatioMethod === "DEFAULT") {
-      setAspectRatio(parseInt(info.features.aspectRatio));
+      setAspectRatio(parseInt(info.features.aspectRatio, 10));
     }
     if (onSupportedFeaturesUpdate) {
       onSupportedFeaturesUpdate(info);
@@ -97,9 +97,9 @@ export const InteractiveIframe: React.FC<Props> = (props) => {
   }, [src, resetCount]);
 
   let computedHeight = 300;
-  if(height !== null) {
+  if (height !== null) {
     computedHeight = Number(height);
-  } else if(iframe.current && aspectRatio) {
+  } else if (iframe.current && aspectRatio) {
     computedHeight = Math.round(iframe.current.offsetWidth / aspectRatio);
   }
 


### PR DESCRIPTION
- adds lightbox support to `showModal()` /`closeModal()` APIs.
- supports two "modes" (as does the `$.colorbox()` library on which it's based)
  - if `isImage` is true, the specified url is presented in an `<img>` tag
  - otherwise, the specified url is presented in an `<iframe>` tag
- implements a plugin-like architecture for installing handlers in `IFrameSaver`
- modifies our previous modification of the `$.colorbox()` plugin that implements the lightbox so that it no longer assumes that wide images need only be constrained horizontally and tall images need only be constrained vertically.
- fixes some unrelated lint errors on master

Note: all of the issues reported by CodeClimate predate this PR.