### PR TITLE
Several tweaks to interactive sizing

### DIFF
--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -22,7 +22,7 @@ function interactiveSizing () {
     var aspectRatio = $iframe.data('aspect-ratio');
     var resizeMethod = $iframe.data('aspect-ratio-method');
     var maxHeight = window.innerHeight;
-    var $container = $iframe.parents(".embeddable-root");
+    var $container = $iframe.parents(".embeddable-container");
 
     // Reset dimensions.
     // FIXME: this causes problems with plugin wrappers.  The
@@ -60,6 +60,13 @@ function interactiveSizing () {
       // might be stale.  However what we are looking at is the difference between that height and the
       // iframe.height(). So long as the stuff around the iframe is not also changing its height then the difference
       // should be constant even as the iframe is changing size.
+      // NOTE: the wrapping plugin content is inside of the embeddable-root element
+      // but outside of the embeddable container. We've decided not to include that
+      // wrapping plugin content in the height calculation.
+      // The width of the wrapping content is matched though.
+      // Part of the reason for this decision is that large wrapping plugin content
+      // could easily be more than the size of the screen, so if we included this
+      // content in the calucation below the interactive would have zero space for itself
       var wrappingContentHeight = $container.height() - $iframe.height();
       maxHeight -= wrappingContentHeight;
     }

--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -53,7 +53,7 @@ function interactiveSizing () {
       // wrapping the interactive. If the height of the interactive is limited by maxHeight
       // either by MAX or DEFAULT mode, then the intention is for the full interactive
       // to be visible without scrolling.  Additionally this means the interactive
-      // will remained pinned when it is in the the interactive box.
+      // will remain pinned when it is in the the interactive box.
       // NOTE: this looks like a catch-22, but it normally isn't. The value of $container.height() comes from the CSS
       // calculation of the height of the interactive plus all of the extra stuff around it.
       // If the page layout is changing (window resize or columns collapsing), then the $container.height() used in this calcuation

--- a/app/assets/javascripts/interactive-sizing.js
+++ b/app/assets/javascripts/interactive-sizing.js
@@ -56,7 +56,7 @@ function interactiveSizing () {
       // will remain pinned when it is in the the interactive box.
       // NOTE: this looks like a catch-22, but it normally isn't. The value of $container.height() comes from the CSS
       // calculation of the height of the interactive plus all of the extra stuff around it.
-      // If the page layout is changing (window resize or columns collapsing), then the $container.height() used in this calcuation
+      // If the page layout is changing (window resize or columns collapsing), then the $container.height() used in this calculation
       // might be stale.  However what we are looking at is the difference between that height and the
       // iframe.height(). So long as the stuff around the iframe is not also changing its height then the difference
       // should be constant even as the iframe is changing size.

--- a/app/assets/javascripts/runtime-init.js
+++ b/app/assets/javascripts/runtime-init.js
@@ -1,6 +1,22 @@
 /*jslint browser: true, sloppy: true, todo: true, devel: true, white: true */
 /*global $ */
 
+// Some themes pin the header and some do not
+var _headerIsPinnedInThisTheme = null;
+function headerIsPinnedInThisTheme() {
+  // This currently seems to be the best way to check this. Themes just change
+  // CSS so there isn't a way for them add content to the dom or run javascript
+  // This is fragile though because someone might mess with .conten-hdr and then
+  // this will break.
+  // We cache the value since this won't change
+  if (_headerIsPinnedInThisTheme !== null) {
+    return _headerIsPinnedInThisTheme;
+  } else {
+    _headerIsPinnedInThisTheme = $('.site-width > .content-hdr').is(':visible');
+    return _headerIsPinnedInThisTheme;
+  }
+}
+
 $(document).ready(function () {
   var headerTop = null;
 
@@ -13,7 +29,7 @@ $(document).ready(function () {
     var windowTop = $(window).scrollTop();
 
     // Activity nav fixing, if there is one
-    if (headerTop) {
+    if (headerIsPinnedInThisTheme()) {
       if (windowTop >= headerTop / 2) {
         $('.activity-nav-mod.header-nav').addClass('fixed');
         $('.content-hdr').addClass('extra-pad');

--- a/app/assets/javascripts/runtime-init.js
+++ b/app/assets/javascripts/runtime-init.js
@@ -6,7 +6,7 @@ var _headerIsPinnedInThisTheme = null;
 function headerIsPinnedInThisTheme() {
   // This currently seems to be the best way to check this. Themes just change
   // CSS so there isn't a way for them add content to the dom or run javascript
-  // This is fragile though because someone might mess with .conten-hdr and then
+  // This is fragile though because someone might mess with .content-hdr and then
   // this will break.
   // We cache the value since this won't change
   if (_headerIsPinnedInThisTheme !== null) {

--- a/app/assets/javascripts/runtime-init.js
+++ b/app/assets/javascripts/runtime-init.js
@@ -5,7 +5,7 @@
 var _headerIsPinnedInThisTheme = null;
 function headerIsPinnedInThisTheme() {
   // This currently seems to be the best way to check this. Themes just change
-  // CSS so there isn't a way for them add content to the dom or run javascript
+  // CSS so there isn't a way for them to add content to the dom or run javascript
   // This is fragile though because someone might mess with .content-hdr and then
   // this will break.
   // We cache the value since this won't change

--- a/app/assets/javascripts/scroll-interactive-mod.js
+++ b/app/assets/javascripts/scroll-interactive-mod.js
@@ -1,8 +1,18 @@
-// Space between window top border and the interactive container.
-window.SCROLL_INTERACTIVE_MOD_OFFSET = 75; // px
+/*global $, headerIsPinnedInThisTheme, LARA */
+
+// Space between window top border and the interactive container when it is pinned
+function scrollInteractiveModOffset(){
+  if (headerIsPinnedInThisTheme()) {
+    // If the heaer is pinned then we need to leave room for that pinned header
+    // currently we fix this at 75px and assume all headers are that tall.
+    // If we could compute this it would be better.
+    return 75;
+  }
+  return 0;
+}
 
 $(window).ready(function () {
-  var offset = window.SCROLL_INTERACTIVE_MOD_OFFSET;
+  var offset = scrollInteractiveModOffset();
   var $sticky = $('.pinned');
   if ($sticky.length === 0) {
     return;

--- a/app/assets/javascripts/scroll-interactive-mod.js
+++ b/app/assets/javascripts/scroll-interactive-mod.js
@@ -4,11 +4,13 @@
 function scrollInteractiveModOffset(){
   if (headerIsPinnedInThisTheme()) {
     // If the heaer is pinned then we need to leave room for that pinned header
-    // currently we fix this at 75px and assume all headers are that tall.
+    // currently all headers are 75px and we set this at 80px to provide a little
+    // extra space so it is easy to see where the top of the interactive is
     // If we could compute this it would be better.
-    return 75;
+    return 80;
   }
-  return 0;
+  // Add a 5 pixel header so it is easier to see where the top of the interactive is
+  return 5;
 }
 
 $(window).ready(function () {

--- a/app/views/interactive_pages/_interactive.html.haml
+++ b/app/views/interactive_pages/_interactive.html.haml
@@ -1,6 +1,7 @@
 .interactive-mod{class: layout == 'l-full-width' ? nil : 'pinned'}
   - page.interactive_box_visible_embeddables.each do |interactive|
-    %div{ id: interactive.embeddable_dom_id }
-      -# This CSS class is important, as it might be referenced by plugins and passed to a plugin instance.
+    -# The embeddable-root class is important, it is used in sizing calculations
+    .embeddable-root{ id: interactive.embeddable_dom_id }
+      -# The embeddable-container class is important, as it is referenced by plugins and passed to a plugin instance.
       .embeddable-container
         = render_interactive(interactive)

--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -8,8 +8,9 @@
           -# e variable is actually either embeddable (for interactives, plugins, etc.) or embeddable answer
           -# (open response, multiple choice and all the question types). If the latter, get a real question object.
           - question = e.respond_to?(:question) ? e.question : e
-          .question{ class: question_css_class(e), id: question.embeddable_dom_id }
-            -#This CSS class is important, as it might be referenced by plugins and passed to a plugin instance.
+          -# The embeddable-root CSS class is important as it is used by sizing calculations
+          .question.embeddable-root{ class: question_css_class(e), id: question.embeddable_dom_id }
+            -# The embeddable-container CSS class is important, as it is referenced by plugins and passed to a plugin instance.
             .embeddable-container
               - if Embeddable::is_interactive?(e)
                 = render_interactive(e)

--- a/app/views/mw_interactives/_show.html.haml
+++ b/app/views/mw_interactives/_show.html.haml
@@ -58,8 +58,6 @@
 - if labbook && !interactive.full_window
   .question
     = render partial: 'embeddable/labbook_answers/lightweight', locals: { embeddable: labbook }
-- else
-  %br
 
 :javascript
   $(document).ready(function() {

--- a/app/views/plugins/_author.haml
+++ b/app/views/plugins/_author.haml
@@ -27,8 +27,10 @@
       %div{style: ""}
         - if show_wrapped_embeddable
           .wrapped-embeddable.questions-mod{id: wrapped_id}
-            .question{ class: question_css_class(wrapped_embeddable) }
-              -#This CSS class is important, as it might be referenced by plugins and passed to a plugin instance.
+            -# The embeddable-root class is important it is used for sizing calculations.
+            -# in this particular case the sizing calculations might not apply, but it is kept for consistency
+            .question.embeddable-root{ class: question_css_class(wrapped_embeddable) }
+              -# The embeddable-container class is important, it is referenced by plugins and passed to a plugin instance.
               .embeddable-container
                 - if Embeddable::is_interactive?(wrapped_embeddable)
                   = render_interactive(wrapped_embeddable)


### PR DESCRIPTION
- figure out if the theme has a pinned header, if it does not then pin the interactive to the top of the screen instead of with a margin. Perviously the interactive would always be pinned with a margin for the header even if the theme didn't have one.
- include the size of the pinned header (if there is one) in the maxHeight calculation in full width layout of interactive box and and assessment block interactives. This maxHeight calcuation is used when an interactive is set to "use all available space" or "default aspect ratio, or set by interactive".
- remove special handling of multiple interactives in the interactive box. Currently when there are multiple interactives, the height limiting is disabled. Note: with the handle of multiple interactives, the height limiting is only based on the window height. So if you embed multiple interactives it is unlikely that the interactive box will be pinned.
- match the width of wrapping plugins to the width of the interactive.
- update the interactive size when a wrapping plugin updates the wrapping content

Additionally this removes a random `<br>` that was at the end of the interactive.
This might be related to the fact that interactive iframe has a display:inline instead of display:block
Removing it fixed some extra whitespace and I couldn't see any negatives.

This includes several updates to comments as well.

[#173456421]