### PR TITLE
Add PORTAL_PROTOCOL env to portal-proxy overlay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,27 @@ Create file /etc/resolver/docker with the following contents.
 
 If you have a local webserver running on localhost:80 you either need to move that to a different port, or change the port mapping used by dingy. You can do that by changing the argument `-p 80:80` to `-p [new port]:80`
 
+## Enabling SSL for Dinghy reverse proxy on OS X
+
+**Warning:** Switching to SSL might break some things. You will probably need to
+update database entities:
+ * external_activities in the Portal
+ * runs and sequence_runs in LARA (remote_endpoints)
+ * maybe some SSO paths?
+
+Installing certificates, and configuring the docker overlay:
+1. install [mkcert](https://github.com/FiloSottile/mkcert) :  `brew install mkcert`
+2. Create and install the trusted CA in keychain:   `mkcert -install`
+3. Ensure you have a certificate directory: `mkdir -p ~/.dinghy/certs`
+4. Make certs:
+    1. `cd ~/.dinghy/certs`
+    2. `mkcert -cert-file app.lara.docker.crt -key-file app.lara.docker.key app.lara.docker`
+    3. `mkcert -cert-file app.portal.docker.crt -key-file app.portal.docker.key app.portal.docker`
+5. You should be using `docker-compose-portal-proxy.yml` in your docker overlays. Check for the
+`COMPOSE_FILE=` entry in `.env` includes that overlay.
+6. Edit your `.env` file to include `PORTAL_PROTOCOL=https`
+
+
 ## Editing CSS
 
 This project was setup with [Compass](http://compass-style.org/), however, you shouldn't ever need to run `compass watch`. The asset pipeline should take care of itself in development mode.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       SHUTTERBUG_URI:
       # Enables logging to stdout instead of file.
       RAILS_STDOUT_LOGGING: "true"
+      PORTAL_PROTOCOL: "http" #set to https in .env
     # no ports are published, see below for details
     depends_on:
       - db

--- a/docker/dev/docker-compose-portal-proxy.yml
+++ b/docker/dev/docker-compose-portal-proxy.yml
@@ -45,7 +45,7 @@ services:
   app:
     environment:
       CONCORD_CONFIGURED_PORTALS: LOCALHOST HAS_STAGING
-      CONCORD_LOCALHOST_URL: http://${PORTAL_HOST}/
+      CONCORD_LOCALHOST_URL: ${PORTAL_PROTOCOL}://${PORTAL_HOST}/
       CONCORD_LOCALHOST_CLIENT_ID: localhost
       CONCORD_LOCALHOST_CLIENT_SECRET: 'unsecure local secret'
       # the code requires at least 2 portals configured this second one to has Staging


### PR DESCRIPTION
The default value is set to `http` as by `docker-compose.yml`

README.md includes information about setting up SSL in dinghy