### PR TITLE
Optimize interactive state saving

### DIFF
--- a/docs/interactive-api-client/README.md
+++ b/docs/interactive-api-client/README.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.5.0-pre.2
+# @concord-consortium/lara-interactive-api - v0.5.0-pre.3
 
 ## [API documentation](globals.md)
 

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.5.0-pre.2
+# @concord-consortium/lara-interactive-api - v0.5.0-pre.3
 
 ## Index
 
@@ -82,6 +82,10 @@
 * [LoggerClientMessage](globals.md#loggerclientmessage)
 * [ModalType](globals.md#modaltype)
 * [ServerMessage](globals.md#servermessage)
+
+### Variables
+
+* [setInteractiveStateTimeout](globals.md#const-setinteractivestatetimeout)
 
 ### Functions
 
@@ -232,6 +236,12 @@ ___
 ###  ServerMessage
 
 Ƭ **ServerMessage**: *[IframePhoneServerMessage](globals.md#iframephoneservermessage) | [DeprecatedIFrameSaverServerMessage](globals.md#deprecatediframesaverservermessage) | [IframeSaverServerMessage](globals.md#iframesaverservermessage) | [GlobalIFrameSaverServerMessage](globals.md#globaliframesaverservermessage)*
+
+## Variables
+
+### `Const` setInteractiveStateTimeout
+
+• **setInteractiveStateTimeout**: *2000* = 2000
 
 ## Functions
 

--- a/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
 
 # Interface: IAggregateInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthinfo.md
+++ b/docs/interactive-api-client/interfaces/iauthinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
 
 # Interface: IAuthInfo
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
 
 # Interface: IAuthoringCustomReportField
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
 
 # Interface: IAuthoringCustomReportFields
 

--- a/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
 
 # Interface: IAuthoringInitInteractive ‹**AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
 
 # Interface: IAuthoringInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
 
 # Interface: IAuthoringMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
 
 # Interface: IAuthoringOpenResponseMetadata
 

--- a/docs/interactive-api-client/interfaces/ibaseshowmodal.md
+++ b/docs/interactive-api-client/interfaces/ibaseshowmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
 
 # Interface: IBaseShowModal
 

--- a/docs/interactive-api-client/interfaces/iclosedmodal.md
+++ b/docs/interactive-api-client/interfaces/iclosedmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
 
 # Interface: IClosedModal
 

--- a/docs/interactive-api-client/interfaces/iclosemodal.md
+++ b/docs/interactive-api-client/interfaces/iclosemodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
 
 # Interface: ICloseModal
 

--- a/docs/interactive-api-client/interfaces/icontextmember.md
+++ b/docs/interactive-api-client/interfaces/icontextmember.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
 
 # Interface: IContextMember
 

--- a/docs/interactive-api-client/interfaces/icontextmembership.md
+++ b/docs/interactive-api-client/interfaces/icontextmembership.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
 
 # Interface: IContextMembership
 

--- a/docs/interactive-api-client/interfaces/icustommessage.md
+++ b/docs/interactive-api-client/interfaces/icustommessage.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
 
 # Interface: ICustomMessage
 

--- a/docs/interactive-api-client/interfaces/idialoginitinteractive.md
+++ b/docs/interactive-api-client/interfaces/idialoginitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
 
 # Interface: IDialogInitInteractive ‹**InteractiveState, AuthoredState, DialogState**›
 

--- a/docs/interactive-api-client/interfaces/igetauthinforequest.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
 
 # Interface: IGetAuthInfoRequest
 

--- a/docs/interactive-api-client/interfaces/igetauthinforesponse.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforesponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
 
 # Interface: IGetAuthInfoResponse
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
 
 # Interface: IGetFirebaseJwtRequest
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
 
 # Interface: IGetFirebaseJwtResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
 
 # Interface: IGetInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
 
 # Interface: IGetInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
 
 # Interface: IGetInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
 
 # Interface: IGetInteractiveSnapshotOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
 
 # Interface: IGetInteractiveSnapshotRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
 
 # Interface: IGetInteractiveSnapshotResponse
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
 
 # Interface: IGetLibraryInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
 
 # Interface: IGetLibraryInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
 
 # Interface: IGetLibraryInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/ihintrequest.md
+++ b/docs/interactive-api-client/interfaces/ihintrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
 
 # Interface: IHintRequest
 

--- a/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
 
 # Interface: IInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/iinteractivestateprops.md
+++ b/docs/interactive-api-client/interfaces/iinteractivestateprops.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
 
 # Interface: IInteractiveStateProps ‹**InteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/ijwtclaims.md
+++ b/docs/interactive-api-client/interfaces/ijwtclaims.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IJwtClaims](ijwtclaims.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IJwtClaims](ijwtclaims.md)
 
 # Interface: IJwtClaims
 

--- a/docs/interactive-api-client/interfaces/ijwtresponse.md
+++ b/docs/interactive-api-client/interfaces/ijwtresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IJwtResponse](ijwtresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IJwtResponse](ijwtresponse.md)
 
 # Interface: IJwtResponse
 

--- a/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
 
 # Interface: ILibraryInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/ilinkedauthoredinteractive.md
+++ b/docs/interactive-api-client/interfaces/ilinkedauthoredinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ILinkedAuthoredInteractive](ilinkedauthoredinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ILinkedAuthoredInteractive](ilinkedauthoredinteractive.md)
 
 # Interface: ILinkedAuthoredInteractive
 

--- a/docs/interactive-api-client/interfaces/ilinkedruntimeinteractive.md
+++ b/docs/interactive-api-client/interfaces/ilinkedruntimeinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ILinkedRuntimeInteractive](ilinkedruntimeinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ILinkedRuntimeInteractive](ilinkedruntimeinteractive.md)
 
 # Interface: ILinkedRuntimeInteractive
 

--- a/docs/interactive-api-client/interfaces/inavigationoptions.md
+++ b/docs/interactive-api-client/interfaces/inavigationoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
 
 # Interface: INavigationOptions
 

--- a/docs/interactive-api-client/interfaces/iportalclaims.md
+++ b/docs/interactive-api-client/interfaces/iportalclaims.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IPortalClaims](iportalclaims.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IPortalClaims](iportalclaims.md)
 
 # Interface: IPortalClaims
 

--- a/docs/interactive-api-client/interfaces/ireportinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/ireportinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
 
 # Interface: IReportInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
+++ b/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
 
 # Interface: IRuntimeCustomReportValues
 

--- a/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
 
 # Interface: IRuntimeInitInteractive ‹**InteractiveState, AuthoredState, GlobalInteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
 
 # Interface: IRuntimeInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
 
 # Interface: IRuntimeMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
 
 # Interface: IRuntimeMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iruntimeopenresponsemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimeopenresponsemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IRuntimeOpenResponseMetadata](iruntimeopenresponsemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IRuntimeOpenResponseMetadata](iruntimeopenresponsemetadata.md)
 
 # Interface: IRuntimeOpenResponseMetadata
 

--- a/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
+++ b/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
 
 # Interface: ISetLinkedInteractives
 

--- a/docs/interactive-api-client/interfaces/ishowalert.md
+++ b/docs/interactive-api-client/interfaces/ishowalert.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
 
 # Interface: IShowAlert
 

--- a/docs/interactive-api-client/interfaces/ishowdialog.md
+++ b/docs/interactive-api-client/interfaces/ishowdialog.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
 
 # Interface: IShowDialog ‹**DialogState**›
 

--- a/docs/interactive-api-client/interfaces/ishowlightbox.md
+++ b/docs/interactive-api-client/interfaces/ishowlightbox.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
 
 # Interface: IShowLightbox
 

--- a/docs/interactive-api-client/interfaces/isupportedfeatures.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeatures.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
 
 # Interface: ISupportedFeatures
 

--- a/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
 
 # Interface: ISupportedFeaturesRequest
 

--- a/docs/interactive-api-client/interfaces/ithemeinfo.md
+++ b/docs/interactive-api-client/interfaces/ithemeinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.2](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
+[@concord-consortium/lara-interactive-api - v0.5.0-pre.3](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
 
 # Interface: IThemeInfo
 

--- a/lara-typescript/src/interactive-api-client/api.spec.ts
+++ b/lara-typescript/src/interactive-api-client/api.spec.ts
@@ -30,12 +30,19 @@ describe("api", () => {
       mode: "runtime",
       interactiveState: {foo: "bar"}
     });
+    // interactive state shouldn't be dirty after initial load.
+    expect(getClient().managedState.interactiveStateDirty).toEqual(false);
   });
 
-  it("supports setInteractiveState and getInteractiveState", () => {
+  it("supports setInteractiveState and getInteractiveState", (done) => {
     api.setInteractiveState({foo: true});
-    expect(mockedPhone.messages).toEqual([{type: "interactiveState", content: {foo: true}}]);
     expect(api.getInteractiveState()).toEqual({foo: true});
+    expect(getClient().managedState.interactiveStateDirty).toEqual(true);
+    setTimeout(() => {
+      expect(mockedPhone.messages).toEqual([{type: "interactiveState", content: {foo: true}}]);
+      expect(getClient().managedState.interactiveStateDirty).toEqual(false);
+      done();
+    }, api.setInteractiveStateTimeout + 1);
   });
 
   it("supports setAuthoredState and getAuthoredState", () => {

--- a/lara-typescript/src/interactive-api-client/api.ts
+++ b/lara-typescript/src/interactive-api-client/api.ts
@@ -42,6 +42,8 @@ export const getInteractiveState = <InteractiveState>(): InteractiveState | null
   return getClient().managedState.interactiveState;
 };
 
+let setInteractiveStateTimeoutId: number;
+export const setInteractiveStateTimeout = 2000; // ms
 /**
  * Note that state will become frozen and should never be mutated.
  * Each time you update state, make sure that a new object is passed.
@@ -62,7 +64,11 @@ export const getInteractiveState = <InteractiveState>(): InteractiveState | null
 export const setInteractiveState = <InteractiveState>(newInteractiveState: InteractiveState | null) => {
   const client = getClient();
   client.managedState.interactiveState = newInteractiveState;
-  client.post("interactiveState", newInteractiveState);
+  window.clearTimeout(setInteractiveStateTimeoutId);
+  setInteractiveStateTimeoutId = window.setTimeout(() => {
+    client.post("interactiveState", newInteractiveState);
+    client.managedState.interactiveStateDirty = false;
+  }, setInteractiveStateTimeout);
 };
 
 export const getAuthoredState = <AuthoredState>(): AuthoredState | null => {

--- a/lara-typescript/src/interactive-api-client/client.spec.ts
+++ b/lara-typescript/src/interactive-api-client/client.spec.ts
@@ -90,8 +90,10 @@ describe("Client", () => {
     it("automatically supports the getInteractiveState message", () => {
       const client = new Client();
       client.managedState.interactiveState = {test: 123};
+      expect(client.managedState.interactiveStateDirty).toEqual(true);
       mockedPhone.fakeServerMessage({type: "getInteractiveState"});
       expect(mockedPhone.messages).toEqual([{type: "interactiveState", content: {test: 123}}]);
+      expect(client.managedState.interactiveStateDirty).toEqual(false);
     });
 
     it("automatically supports the loadInteractiveGlobal message", () => {
@@ -136,6 +138,22 @@ describe("Client", () => {
       // listener should be removed now
       mockedPhone.fakeServerMessage({type: "authInfo", content: {test: 321}});
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns user when he tries to leave the page and interactive state is dirty", () => {
+      const spy = jest.spyOn(window, "addEventListener");
+      const client = new Client();
+      expect(spy).toHaveBeenCalled();
+      expect(spy.mock.calls[0][0]).toEqual("beforeunload");
+      const callback: any = spy.mock.calls[0][1];
+
+      const event: any = {};
+      callback(event);
+      expect(event.returnValue).toBeUndefined();
+
+      client.managedState.interactiveState = {newState: 123};
+      callback(event);
+      expect(event.returnValue).toBeDefined();
     });
   });
 });

--- a/lara-typescript/src/interactive-api-client/managed-state.ts
+++ b/lara-typescript/src/interactive-api-client/managed-state.ts
@@ -9,6 +9,8 @@ type ManagedStateEvent =
   "initInteractive";
 
 export class ManagedState {
+  public interactiveStateDirty = false;
+
   private _initMessage: Readonly<IInitInteractive<any, any, any, any>> | null = null;
   // State variables are kept separately from initMessage, as they might get updated. For client user convenience,
   // this state is kept here and all the updates emit appropriate event.
@@ -44,6 +46,7 @@ export class ManagedState {
     }
     this._interactiveState = value;
     this.emit("interactiveStateUpdated", value);
+    this.interactiveStateDirty = true;
   }
 
   public get authoredState() {

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.5.0-pre.2",
+  "version": "0.5.0-pre.3",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
[#173231403]

There are two main changes here:

1. Interactive API `setInteractiveState` delays sending iframe-phone message by 2s. It means that when user is typing, state updates should be accumulated into one message that will be sent 2s after he stops typing. This should greatly limit number of AJAX requests coming from iframe-saver.

2. Interactive API keeps track if interactiveState is "dirty" and if it is, it displays a warning to a user who tries to reload or leave the page. This wasn't implemented before and user could reload the page and loose data. LARA was only trying to prevent data loss when user was using LARA navigation buttons if I interpret the code correctly. 

@scytacki, when we talked about it, you mentioned that "getInteractiveState" request coming from LARA can be accidentally answered by random "setInteractiveState" call from iframe. And we thought about using `requestId`. I was investigating that, but using requestId from parent side isn't easy and I ran out of time. For example, it won't be trivial to differentiate responses to "getInteractiveState" coming from interactives that don't support `requestId` and regular "interactiveState" messages triggered by `setInteractiveState` API call, etc.

I think that iframe-parent communication is almost immediate in contrast to AJAX calls to LARA server. So, iframe-phone calls shouldn't queue in practice and we shouldn't get these false answers. Especially now when there are much less iframe-phone messages being sent. The problem with my data loss (that I could replicate when I simulate slow connection in dev tools) was about the long queue of AJAX requests that were getting lost (and that were enabling page navigation due to iframe-saver / save-on-change code). Of course, this can still happen, but just much less likely without AJAX traffic jam. And I guess LARA SPA will have to deal with this problem anyway.

