### PR TITLE
Add more clearance to make all form elements accessible.

### DIFF
--- a/app/assets/stylesheets/partials/authoring/modal_edit.scss
+++ b/app/assets/stylesheets/partials/authoring/modal_edit.scss
@@ -10,10 +10,10 @@
 
   form[class^="edit_"], form.styled-admin-form {
     height: auto;
-    max-height: calc(100% - 105px);
-    min-height: calc(100% - 105px);
+    max-height: calc(100% - 150px);
+    min-height: calc(100% - 150px);
     overflow: scroll;
-    padding-bottom: 105px;
+    padding-bottom: 150px;
     position: relative;
 
     fieldset {

--- a/app/assets/stylesheets/partials/authoring/modal_edit.scss
+++ b/app/assets/stylesheets/partials/authoring/modal_edit.scss
@@ -10,11 +10,15 @@
 
   form[class^="edit_"], form.styled-admin-form {
     height: auto;
-    max-height: calc(100% - 150px);
-    min-height: calc(100% - 150px);
+    max-height: calc(100% - 100px);
     overflow: scroll;
-    padding-bottom: 150px;
     position: relative;
+
+    &:after { // provides clearance for .submit-container
+      content: "";
+      display: block;
+      height: 100px;
+    }
 
     fieldset {
       width: calc(100% - 2px);


### PR DESCRIPTION
This fixes the problem reported in this PT story: https://www.pivotaltracker.com/story/show/173541459

I think there may be a better solution, but it would involve more work. I'm not 100% sure, but I suspect the reason why the window shade form needs more clearance is because the button element that appears at the top of the form has a negative `top` value in its CSS. It may be similar to how that causes issues with overlapping in the page authoring form.

