### PR TITLE
Add stamps for NGSA Objects

### DIFF
--- a/app/assets/javascripts/image_question_drawing_tool.js.coffee
+++ b/app/assets/javascripts/image_question_drawing_tool.js.coffee
@@ -16,6 +16,16 @@ class ImageQuestionDrawingTool
         'https://interactions-resources.concord.org/stamps/medium-particle.svg'
         'https://interactions-resources.concord.org/stamps/fast-particle.svg'
         'https://interactions-resources.concord.org/stamps/low-density-particles.svg'
+      ],
+      'Objects': [
+        'https://interactions-resources.concord.org/stamps/car-facing-east.svg'
+        'https://interactions-resources.concord.org/stamps/car-facing-west.svg'
+        'https://interactions-resources.concord.org/stamps/front-crushed-east.svg'
+        'https://interactions-resources.concord.org/stamps/front-crushed-west.svg'
+        'https://interactions-resources.concord.org/stamps/N-S-magnet.svg'
+        'https://interactions-resources.concord.org/stamps/S-N-magnet.svg'
+        'https://interactions-resources.concord.org/stamps/new-phone.svg'
+        'https://interactions-resources.concord.org/stamps/broken-phone.svg'
       ]
     },
     # LARA provides simple proxy (/image-proxy?url=). It's useful even if we use


### PR DESCRIPTION
Some images are too large as of this PR, the files on S3 will be edited before the story is delivered. However, the urls will all remain the same, so this PR can be brought in.