### PR TITLE
fix half width interactives

### DIFF
--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -8,12 +8,13 @@
           -# e variable is actually either embeddable (for interactives, plugins, etc.) or embeddable answer
           -# (open response, multiple choice and all the question types). If the latter, get a real question object.
           - question = e.respond_to?(:question) ? e.question : e
-          -# The embeddable-root CSS class is important as it is used by sizing calculations
-          .question.embeddable-root{ class: question_css_class(e), id: question.embeddable_dom_id }
-            -# The embeddable-container CSS class is important, as it is referenced by plugins and passed to a plugin instance.
-            .embeddable-container
-              - if Embeddable::is_interactive?(e)
-                = render_interactive(e)
-              - else
-                - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
-                = render(partial: partial_name, locals: { embeddable: e })
+          .question{ class: question_css_class(e), id: question.embeddable_dom_id }
+            -# The embeddable-root CSS class is important as it is used by sizing calculations
+            .embeddable-root
+              -# The embeddable-container CSS class is important, as it is referenced by plugins and passed to a plugin instance.
+              .embeddable-container
+                - if Embeddable::is_interactive?(e)
+                  = render_interactive(e)
+                - else
+                  - partial_name = "#{e.class.name.underscore.pluralize}/lightweight"
+                  = render(partial: partial_name, locals: { embeddable: e })

--- a/app/views/plugins/_author.haml
+++ b/app/views/plugins/_author.haml
@@ -27,16 +27,17 @@
       %div{style: ""}
         - if show_wrapped_embeddable
           .wrapped-embeddable.questions-mod{id: wrapped_id}
-            -# The embeddable-root class is important it is used for sizing calculations.
-            -# in this particular case the sizing calculations might not apply, but it is kept for consistency
-            .question.embeddable-root{ class: question_css_class(wrapped_embeddable) }
-              -# The embeddable-container class is important, it is referenced by plugins and passed to a plugin instance.
-              .embeddable-container
-                - if Embeddable::is_interactive?(wrapped_embeddable)
-                  = render_interactive(wrapped_embeddable)
-                - else
-                  - partial_name = "#{wrapped_embeddable.class.name.underscore.pluralize}/lightweight"
-                  = render(partial: partial_name, locals: { embeddable: wrapped_embeddable })
+            .question{ class: question_css_class(wrapped_embeddable) }
+              -# The embeddable-root class is important it is used for sizing calculations.
+              -# in this particular case the sizing calculations might not apply, but it is kept for consistency
+              .embeddable-root
+                -# The embeddable-container class is important, it is referenced by plugins and passed to a plugin instance.
+                .embeddable-container
+                  - if Embeddable::is_interactive?(wrapped_embeddable)
+                    = render_interactive(wrapped_embeddable)
+                  - else
+                    - partial_name = "#{wrapped_embeddable.class.name.underscore.pluralize}/lightweight"
+                    = render(partial: partial_name, locals: { embeddable: wrapped_embeddable })
           -# reload-on-close is used so that the css loaded for the preview is not seen
           .plugin-output.content-mod.reload-on-close{id: output_id}
         - else


### PR DESCRIPTION
Without this change a half width interactive in the assessment block on a full width layout page or a half width interactive in header block would take up the full width the page.

The reason was because LARA was trying to set the width of the div based on its css class. And meanwhile the width of same div was being set by the interactive sizing code. 

This PR splits that div into two divs, so each side can control its own div.

So now there is one more divs for most interactives:
- question - used by LARA to make it half or full width as well as adding margins
- embeddable-root - used for interactive sizing
- embeddable-container - used by plugins to wrap the embeddable content
- interactive-container - used by interactive-api to find interactives on the page and initialize them
- interactive_data_div - contains data needed by the interactive-api 

I did not change the way interactives are rendered in the interactive box. Inside of this box they do no have a `question` class and there is no width changing by LARA, so there was no conflict with sizing.

[#174011661]