### PR TITLE
Added interactive_item_id and linked_interactive_item_id [#174065897]

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -29162,7 +29162,7 @@ var checkbox_1 = __webpack_require__(/*! ../common/components/checkbox */ "./src
 var formField = rails_form_field_1.RailsFormField("managed_interactive");
 exports.CustomizeManagedInteractive = function (props) {
     var managedInteractive = props.managedInteractive, libraryInteractive = props.libraryInteractive, defaultClickToPlayPrompt = props.defaultClickToPlayPrompt;
-    var inherit_aspect_ratio_method = managedInteractive.inherit_aspect_ratio_method, custom_aspect_ratio_method = managedInteractive.custom_aspect_ratio_method, custom_native_width = managedInteractive.custom_native_width, custom_native_height = managedInteractive.custom_native_height, inherit_click_to_play = managedInteractive.inherit_click_to_play, custom_click_to_play = managedInteractive.custom_click_to_play, inherit_click_to_play_prompt = managedInteractive.inherit_click_to_play_prompt, custom_click_to_play_prompt = managedInteractive.custom_click_to_play_prompt, inherit_full_window = managedInteractive.inherit_full_window, custom_full_window = managedInteractive.custom_full_window, inherit_image_url = managedInteractive.inherit_image_url, custom_image_url = managedInteractive.custom_image_url, linked_interactive_id = managedInteractive.linked_interactive_id, linked_interactive_type = managedInteractive.linked_interactive_type, show_in_featured_question_report = managedInteractive.show_in_featured_question_report;
+    var inherit_aspect_ratio_method = managedInteractive.inherit_aspect_ratio_method, custom_aspect_ratio_method = managedInteractive.custom_aspect_ratio_method, custom_native_width = managedInteractive.custom_native_width, custom_native_height = managedInteractive.custom_native_height, inherit_click_to_play = managedInteractive.inherit_click_to_play, custom_click_to_play = managedInteractive.custom_click_to_play, inherit_click_to_play_prompt = managedInteractive.inherit_click_to_play_prompt, custom_click_to_play_prompt = managedInteractive.custom_click_to_play_prompt, inherit_full_window = managedInteractive.inherit_full_window, custom_full_window = managedInteractive.custom_full_window, inherit_image_url = managedInteractive.inherit_image_url, custom_image_url = managedInteractive.custom_image_url, linked_interactive_id = managedInteractive.linked_interactive_id, linked_interactive_type = managedInteractive.linked_interactive_type, show_in_featured_question_report = managedInteractive.show_in_featured_question_report, linked_interactive_item_id = managedInteractive.linked_interactive_item_id;
     var _a = react_1.useState(inherit_aspect_ratio_method), inheritAspectRatio = _a[0], setInheritAspectRatio = _a[1];
     var _b = react_1.useState({
         width: custom_native_width,
@@ -29201,10 +29201,7 @@ exports.CustomizeManagedInteractive = function (props) {
             React.createElement(React.Fragment, null,
                 React.createElement("fieldset", null,
                     React.createElement("legend", null, "Link Saved Work From"),
-                    React.createElement("input", { type: "text", name: formField("linked_interactive_id").name, defaultValue: "" + (linked_interactive_id || "") }),
-                    React.createElement("select", { name: formField("linked_interactive_type").name, defaultValue: "" + (linked_interactive_type || "") },
-                        React.createElement("option", { value: "MWInteractive" }, "Iframe Interactive"),
-                        React.createElement("option", { value: "ManagedInteractive" }, "Library Interactive")),
+                    React.createElement("input", { type: "text", name: formField("linked_interactive_item_id").name, defaultValue: "" + (linked_interactive_item_id || "") }),
                     React.createElement("div", { className: "warning" },
                         React.createElement("em", null, "Warning"),
                         ": Please do not link to another interactive unless the interactive knows how to load prior work.")),
@@ -29446,7 +29443,7 @@ var checkbox_1 = __webpack_require__(/*! ../common/components/checkbox */ "./src
 var formField = rails_form_field_1.RailsFormField("mw_interactive");
 exports.CustomizeMWInteractive = function (props) {
     var interactive = props.interactive, defaultClickToPlayPrompt = props.defaultClickToPlayPrompt;
-    var native_width = interactive.native_width, native_height = interactive.native_height, enable_learner_state = interactive.enable_learner_state, show_delete_data_button = interactive.show_delete_data_button, has_report_url = interactive.has_report_url, click_to_play = interactive.click_to_play, click_to_play_prompt = interactive.click_to_play_prompt, full_window = interactive.full_window, image_url = interactive.image_url, show_in_featured_question_report = interactive.show_in_featured_question_report, aspect_ratio_method = interactive.aspect_ratio_method, linked_interactive_id = interactive.linked_interactive_id, linked_interactive_type = interactive.linked_interactive_type;
+    var native_width = interactive.native_width, native_height = interactive.native_height, enable_learner_state = interactive.enable_learner_state, show_delete_data_button = interactive.show_delete_data_button, has_report_url = interactive.has_report_url, click_to_play = interactive.click_to_play, click_to_play_prompt = interactive.click_to_play_prompt, full_window = interactive.full_window, image_url = interactive.image_url, show_in_featured_question_report = interactive.show_in_featured_question_report, aspect_ratio_method = interactive.aspect_ratio_method, linked_interactive_id = interactive.linked_interactive_id, linked_interactive_type = interactive.linked_interactive_type, linked_interactive_item_id = interactive.linked_interactive_item_id;
     var _a = react_1.useState({
         width: native_width,
         height: native_height,
@@ -29479,10 +29476,7 @@ exports.CustomizeMWInteractive = function (props) {
                 React.createElement(checkbox_1.Checkbox, { name: formField("show_in_featured_question_report").name, defaultChecked: show_in_featured_question_report, label: "Show in featured question report" })),
             React.createElement("fieldset", null,
                 React.createElement("legend", null, "Link Saved Work From"),
-                React.createElement("input", { type: "text", name: formField("linked_interactive_id").name, defaultValue: "" + (linked_interactive_id || "") }),
-                React.createElement("select", { name: formField("linked_interactive_type").name, defaultValue: "" + (linked_interactive_type || "") },
-                    React.createElement("option", { value: "MWInteractive" }, "MWInteractive"),
-                    React.createElement("option", { value: "ManagedInteractive" }, "ManagedInteractive")),
+                React.createElement("input", { type: "text", name: formField("linked_interactive_item_id").name, defaultValue: "" + (linked_interactive_item_id || "") }),
                 React.createElement("div", { className: "warning" },
                     React.createElement("em", null, "Warning"),
                     ": Please do not link to another interactive unless the interactive knows how to load prior work.")));

--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -108,4 +108,24 @@ module BaseInteractive
     list
   end
 
+  def make_interactive_item_id(interactive)
+    interactive.page_item ? "interactive_#{interactive.page_item.id}" : nil
+  end
+
+  def interactive_item_id
+    make_interactive_item_id(self)
+  end
+
+  def linked_interactive_item_id
+    linked_interactive ? make_interactive_item_id(linked_interactive) : nil
+  end
+
+  def linked_interactive_item_id=(val)
+    matches = val.nil? ? nil : val.match(/^interactive_(.+)$/)
+    page_item = matches ? PageItem.find(matches[1]) : nil
+    if page_item
+      self.linked_interactive = page_item.embeddable
+    end
+  end
+
 end

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -21,6 +21,7 @@ class ManagedInteractive < ActiveRecord::Base
     :inherit_full_window, :custom_full_window,
     :inherit_click_to_play_prompt, :custom_click_to_play_prompt,
     :inherit_image_url, :custom_image_url
+    :linked_interactive_item_id
 
   default_value_for :custom_native_width, ASPECT_RATIO_DEFAULT_WIDTH
   default_value_for :custom_native_height, ASPECT_RATIO_DEFAULT_HEIGHT
@@ -139,7 +140,8 @@ class ManagedInteractive < ActiveRecord::Base
     hash[:linked_interactive_id] = linked_interactive_id
     hash[:linked_interactive_type] = linked_interactive_type
     hash[:aspect_ratio] = aspect_ratio
-    hash[:interactive_item_id] = page_item ? "interactive_#{page_item.id}" : nil
+    hash[:interactive_item_id] = interactive_item_id
+    hash[:linked_interactive_item_id] = linked_interactive_item_id
     hash
   end
 

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -8,7 +8,7 @@ class MwInteractive < ActiveRecord::Base
     :click_to_play_prompt, :image_url, :is_hidden, :linked_interactive_id, :linked_interactive_type,
     :full_window, :model_library_url, :authored_state, :no_snapshots,
     :show_delete_data_button, :show_in_featured_question_report, :is_full_width,
-    :aspect_ratio_method
+    :aspect_ratio_method, :linked_interactive_item_id
 
   default_value_for :native_width, ASPECT_RATIO_DEFAULT_WIDTH
   default_value_for :native_height, ASPECT_RATIO_DEFAULT_HEIGHT
@@ -74,7 +74,8 @@ class MwInteractive < ActiveRecord::Base
     hash[:linked_interactive_id] = linked_interactive_id
     hash[:linked_interactive_type] = linked_interactive_type
     hash[:aspect_ratio] = aspect_ratio
-    hash[:interactive_item_id] = page_item ? "interactive_#{page_item.id}" : nil
+    hash[:interactive_item_id] = interactive_item_id
+    hash[:linked_interactive_item_id] = linked_interactive_item_id
     hash
   end
 

--- a/app/views/managed_interactives/edit.html.haml
+++ b/app/views/managed_interactives/edit.html.haml
@@ -1,7 +1,7 @@
 - form_url = defined?(@page) ? page_managed_interactive_path(@page, @interactive) : managed_interactive_path(@interactive)
 .managed-interactive-edit-id
   Interactive ID:
-  %span.managed-interactve-id=@interactive.id
+  %span.managed-interactve-id=@interactive.interactive_item_id
 = form_for @interactive, :url => form_url, :html => {:class => "styled-admin-form"} do |f|
   = f.error_messages
 

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -1,7 +1,7 @@
 - form_url = defined?(@page) ? page_mw_interactive_path(@page, @interactive) : mw_interactive_path(@interactive)
 .mw-interactive-edit-id
   Interactive ID:
-  %span.mw-interactve-id=@interactive.id
+  %span.mw-interactve-id=@interactive.interactive_item_id
 = form_for @interactive, :url => form_url, :html => {:class => "styled-admin-form"} do |f|
   = f.error_messages
 

--- a/lara-typescript/src/page-item-authoring/managed-interactives/customize.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/customize.tsx
@@ -37,7 +37,8 @@ export const CustomizeManagedInteractive: React.FC<Props> = (props) => {
     custom_image_url,
     linked_interactive_id,
     linked_interactive_type,
-    show_in_featured_question_report
+    show_in_featured_question_report,
+    linked_interactive_item_id
   } = managedInteractive;
 
   const [inheritAspectRatio, setInheritAspectRatio] = useState(inherit_aspect_ratio_method);
@@ -86,16 +87,9 @@ export const CustomizeManagedInteractive: React.FC<Props> = (props) => {
           <legend>Link Saved Work From</legend>
           <input
             type="text"
-            name={formField("linked_interactive_id").name}
-            defaultValue={`${linked_interactive_id || ""}`}
+            name={formField("linked_interactive_item_id").name}
+            defaultValue={`${linked_interactive_item_id || ""}`}
           />
-          <select
-            name={formField("linked_interactive_type").name}
-            defaultValue={`${linked_interactive_type || ""}`}
-          >
-            <option value="MWInteractive">Iframe Interactive</option>
-            <option value="ManagedInteractive">Library Interactive</option>
-          </select>
           <div className="warning">
             <em>Warning</em>: Please do not link to another interactive
             unless the interactive knows how to load prior work.

--- a/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
@@ -54,6 +54,7 @@ export interface IManagedInteractive {
   inherit_image_url: boolean;
   custom_image_url: string;
   interactive_item_id: string;
+  linked_interactive_item_id: string;
 }
 
 const formField = RailsFormField<IManagedInteractive>("managed_interactive");

--- a/lara-typescript/src/page-item-authoring/mw-interactives/customize.tsx
+++ b/lara-typescript/src/page-item-authoring/mw-interactives/customize.tsx
@@ -31,7 +31,8 @@ export const CustomizeMWInteractive: React.FC<Props> = (props) => {
     show_in_featured_question_report,
     aspect_ratio_method,
     linked_interactive_id,
-    linked_interactive_type
+    linked_interactive_type,
+    linked_interactive_item_id
   } = interactive;
 
   const [aspectRatioValues, setAspectRatioValues] = useState<IAspectRatioChooserValues>({
@@ -107,16 +108,9 @@ export const CustomizeMWInteractive: React.FC<Props> = (props) => {
         <legend>Link Saved Work From</legend>
         <input
           type="text"
-          name={formField("linked_interactive_id").name}
-          defaultValue={`${linked_interactive_id || ""}`}
+          name={formField("linked_interactive_item_id").name}
+          defaultValue={`${linked_interactive_item_id || ""}`}
         />
-        <select
-          name={formField("linked_interactive_type").name}
-          defaultValue={`${linked_interactive_type || ""}`}
-        >
-          <option value="MWInteractive">MWInteractive</option>
-          <option value="ManagedInteractive">ManagedInteractive</option>
-        </select>
         <div className="warning">
           <em>Warning</em>: Please do not link to another interactive
           unless the interactive knows how to load prior work.

--- a/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
@@ -41,6 +41,7 @@ export interface IMWInteractive {
   linked_interactive_id: number;
   linked_interactive_type: string;
   interactive_item_id: string;
+  linked_interactive_item_id: string;
 }
 
 const formField = RailsFormField<IMWInteractive>("mw_interactive");

--- a/spec/controllers/api/v1/interactive_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/interactive_pages_controller_spec.rb
@@ -99,11 +99,11 @@ describe Api::V1::InteractivePagesController do
         expect(response.body).to eql({
           success: true,
           interactives: [
-            {id: "interactive_#{interactive3.page_item.id}", pageId: page.id, name: interactive3.name, section: "assessment_block", url: interactive3.url, thumbnailUrl: nil, supportsSnapshots: true},
-            {id: "interactive_#{interactive2.page_item.id}", pageId: page.id, name: interactive2.name, section: InteractivePage::HEADER_BLOCK, url: interactive2.url, thumbnailUrl: nil, supportsSnapshots: false},
-            {id: "interactive_#{interactive5.page_item.id}", pageId: page.id, name: interactive5.name, section: InteractivePage::HEADER_BLOCK, url: "http://bar.com/test2", thumbnailUrl: "http://thumbnail.url", supportsSnapshots: false},
-            {id: "interactive_#{interactive1.page_item.id}", pageId: page.id, name: interactive1.name, section: InteractivePage::INTERACTIVE_BOX, url: interactive1.url, thumbnailUrl: nil, supportsSnapshots: true},
-            {id: "interactive_#{interactive4.page_item.id}", pageId: page.id, name: interactive4.name, section: InteractivePage::INTERACTIVE_BOX, url: "http://foo.com/test1", thumbnailUrl: nil, supportsSnapshots: true}
+            {id: interactive3.interactive_item_id, pageId: page.id, name: interactive3.name, section: "assessment_block", url: interactive3.url, thumbnailUrl: nil, supportsSnapshots: true},
+            {id: interactive2.interactive_item_id, pageId: page.id, name: interactive2.name, section: InteractivePage::HEADER_BLOCK, url: interactive2.url, thumbnailUrl: nil, supportsSnapshots: false},
+            {id: interactive5.interactive_item_id, pageId: page.id, name: interactive5.name, section: InteractivePage::HEADER_BLOCK, url: "http://bar.com/test2", thumbnailUrl: "http://thumbnail.url", supportsSnapshots: false},
+            {id: interactive1.interactive_item_id, pageId: page.id, name: interactive1.name, section: InteractivePage::INTERACTIVE_BOX, url: interactive1.url, thumbnailUrl: nil, supportsSnapshots: true},
+            {id: interactive4.interactive_item_id, pageId: page.id, name: interactive4.name, section: InteractivePage::INTERACTIVE_BOX, url: "http://foo.com/test1", thumbnailUrl: nil, supportsSnapshots: true}
           ]
         }.to_json)
       end
@@ -115,9 +115,9 @@ describe Api::V1::InteractivePagesController do
         expect(response.body).to eql({
           success: true,
           interactives: [
-            {id: "interactive_#{interactive3.page_item.id}", pageId: page.id, name: interactive3.name, section: "assessment_block", url: interactive3.url, thumbnailUrl: nil, supportsSnapshots: true},
-            {id: "interactive_#{interactive1.page_item.id}", pageId: page.id, name: interactive1.name, section: InteractivePage::INTERACTIVE_BOX, url: interactive1.url, thumbnailUrl: nil, supportsSnapshots: true},
-            {id: "interactive_#{interactive4.page_item.id}", pageId: page.id, name: interactive4.name, section: InteractivePage::INTERACTIVE_BOX, url: "http://foo.com/test1", thumbnailUrl: nil, supportsSnapshots: true}
+            {id: interactive3.interactive_item_id, pageId: page.id, name: interactive3.name, section: "assessment_block", url: interactive3.url, thumbnailUrl: nil, supportsSnapshots: true},
+            {id: interactive1.interactive_item_id, pageId: page.id, name: interactive1.name, section: InteractivePage::INTERACTIVE_BOX, url: interactive1.url, thumbnailUrl: nil, supportsSnapshots: true},
+            {id: interactive4.interactive_item_id, pageId: page.id, name: interactive4.name, section: InteractivePage::INTERACTIVE_BOX, url: "http://foo.com/test1", thumbnailUrl: nil, supportsSnapshots: true}
           ]
         }.to_json)
       end
@@ -129,8 +129,8 @@ describe Api::V1::InteractivePagesController do
         expect(response.body).to eql({
           success: true,
           interactives: [
-            {id: "interactive_#{interactive2.page_item.id}", pageId: page.id, name: interactive2.name, section: InteractivePage::HEADER_BLOCK, url: interactive2.url, thumbnailUrl: nil, supportsSnapshots: false},
-            {id: "interactive_#{interactive5.page_item.id}", pageId: page.id, name: interactive5.name, section: InteractivePage::HEADER_BLOCK, url: "http://bar.com/test2", thumbnailUrl: "http://thumbnail.url", supportsSnapshots: false}
+            {id: interactive2.interactive_item_id, pageId: page.id, name: interactive2.name, section: InteractivePage::HEADER_BLOCK, url: interactive2.url, thumbnailUrl: nil, supportsSnapshots: false},
+            {id: interactive5.interactive_item_id, pageId: page.id, name: interactive5.name, section: InteractivePage::HEADER_BLOCK, url: "http://bar.com/test2", thumbnailUrl: "http://thumbnail.url", supportsSnapshots: false}
           ]
         }.to_json)
       end
@@ -221,7 +221,7 @@ describe Api::V1::InteractivePagesController do
         it "returns an error" do
           xhr :post, "set_linked_interactives", {
             id: other_page.id,
-            sourceId: "interactive_#{other_interactive.page_item.id}",
+            sourceId: other_interactive.interactive_item_id,
           }
           expect(response.status).to eq(200)
           expect(response.content_type).to eq("application/json")
@@ -235,11 +235,11 @@ describe Api::V1::InteractivePagesController do
       it "allows a 1:1 link" do
         xhr :post, "set_linked_interactives", {
           id: page.id,
-          sourceId: "interactive_#{interactive1.page_item.id}",
+          sourceId: interactive1.interactive_item_id,
           linkedInteractives: [
-            {id: "interactive_#{interactive2.page_item.id}", label: "two"}
+            {id: interactive2.interactive_item_id, label: "two"}
           ],
-          linkedState: "interactive_#{interactive3.page_item.id}"
+          linkedState: interactive3.interactive_item_id
         }
         expect(response.status).to eq(200)
         expect(response.content_type).to eq("application/json")
@@ -251,12 +251,12 @@ describe Api::V1::InteractivePagesController do
       it "allows a 1:N link" do
         xhr :post, "set_linked_interactives", {
           id: page.id,
-          sourceId: "interactive_#{interactive1.page_item.id}",
+          sourceId: interactive1.interactive_item_id,
           linkedInteractives: [
-            {id: "interactive_#{interactive2.page_item.id}", label: "two"},
-            {id: "interactive_#{interactive3.page_item.id}", label: "three"}
+            {id: interactive2.interactive_item_id, label: "two"},
+            {id: interactive3.interactive_item_id, label: "three"}
           ],
-          linkedState: "interactive_#{interactive3.page_item.id}"
+          linkedState: interactive3.interactive_item_id
         }
         expect(response.status).to eq(200)
         expect(response.content_type).to eq("application/json")

--- a/spec/models/managed_interactive_spec.rb
+++ b/spec/models/managed_interactive_spec.rb
@@ -81,7 +81,8 @@ describe ManagedInteractive do
       expected[:linked_interactive_id] = managed_interactive.linked_interactive_id
       expected[:linked_interactive_type] = managed_interactive.linked_interactive_type
       expected[:aspect_ratio] = managed_interactive.aspect_ratio
-      expected[:interactive_item_id] = "interactive_#{managed_interactive.page_item.id}"
+      expected[:interactive_item_id] = managed_interactive.interactive_item_id
+      expected[:linked_interactive_item_id] = managed_interactive.linked_interactive_item_id
       expect(managed_interactive.to_authoring_hash).to eq(expected)
     end
   end
@@ -355,6 +356,53 @@ describe ManagedInteractive do
       # without a library interactive it defaults to false
       managed_interactive.library_interactive = nil
       expect(managed_interactive.no_snapshots).to be false
+    end
+  end
+
+  # this is only tested here and not also in mw_interactive as it all uses code in the base_interactive
+  describe "interactive_item_id" do
+
+    before :each do
+      page.add_interactive(managed_interactive)
+      managed_interactive.reload
+      page.reload
+    end
+
+    it "has a getter" do
+      expect(managed_interactive.interactive_item_id).to eq "interactive_#{managed_interactive.page_item.id}"
+    end
+
+    it "does not have a setter" do
+      expect(managed_interactive.respond_to?('interactive_item_id=')).to be false
+    end
+  end
+
+  describe "linked_interactive_item_id" do
+
+    let(:mw_interactive2) { FactoryGirl.create(:mw_interactive) }
+
+    before :each do
+      page.add_interactive(mw_interactive)
+      page.add_interactive(mw_interactive2)
+      page.add_interactive(managed_interactive)
+      managed_interactive.reload
+      mw_interactive.reload
+      page.reload
+    end
+
+    it "has a getter" do
+      expect(managed_interactive.linked_interactive).to eq mw_interactive
+      expect(managed_interactive.linked_interactive_item_id).to eq mw_interactive.interactive_item_id
+      expect(mw_interactive.interactive_item_id).to_not eq nil
+      expect(managed_interactive.linked_interactive_item_id).to_not eq nil
+    end
+
+    it "has a setter" do
+      expect(managed_interactive.linked_interactive).to eq mw_interactive
+      managed_interactive.linked_interactive_item_id = mw_interactive2.interactive_item_id
+      managed_interactive.save!
+      managed_interactive.reload
+      expect(managed_interactive.linked_interactive).to eq mw_interactive2
     end
   end
 end

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -61,7 +61,8 @@ describe MwInteractive do
       expected[:linked_interactive_id] = interactive.linked_interactive_id
       expected[:linked_interactive_type] = interactive.linked_interactive_type
       expected[:aspect_ratio] = interactive.aspect_ratio
-      expected[:interactive_item_id] = "interactive_#{interactive.page_item.id}"
+      expected[:interactive_item_id] = interactive.interactive_item_id
+      expected[:linked_interactive_item_id] = interactive.linked_interactive_item_id
       expect(interactive.to_authoring_hash).to eq(expected)
     end
   end


### PR DESCRIPTION
The interactive_item_id getter DRYs up the code that writes out the id used to link interactives.  The linked_interactive_item_id getter & setter allow for hiding the type of the linked interactive.