### PR TITLE
Add a default value for PORTAL_PROTOCOL, and error for PORTAL_HOST

### DIFF
--- a/docker/dev/docker-compose-portal-proxy.yml
+++ b/docker/dev/docker-compose-portal-proxy.yml
@@ -45,7 +45,7 @@ services:
   app:
     environment:
       CONCORD_CONFIGURED_PORTALS: LOCALHOST HAS_STAGING
-      CONCORD_LOCALHOST_URL: ${PORTAL_PROTOCOL}://${PORTAL_HOST}/
+      CONCORD_LOCALHOST_URL: ${PORTAL_PROTOCOL:-http}://${PORTAL_HOST:?Need to define PORTAL_HOST}/
       CONCORD_LOCALHOST_CLIENT_ID: localhost
       CONCORD_LOCALHOST_CLIENT_SECRET: 'unsecure local secret'
       # the code requires at least 2 portals configured this second one to has Staging


### PR DESCRIPTION
PORTAL_PROTOCOL is defined in the environment section of the main docker-compose file,
But that doesn't make it available to the other sections of the file.
Adding a default here `:-http` prevents a warning and SSO errors when it is not defined.

Also this adds a `:?[err]`  to the PORTAL_HOST variable which tells docker it is mandatory