### PR TITLE
Fix a bug in lara-interactive-api hooks causing issues in Safari

### DIFF
--- a/docs/interactive-api-client/README.md
+++ b/docs/interactive-api-client/README.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.5.0-pre.4
+# @concord-consortium/lara-interactive-api - v0.5.0
 
 ## [API documentation](globals.md)
 

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -1,6 +1,6 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](README.md) › [Globals](globals.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](README.md) › [Globals](globals.md)
 
-# @concord-consortium/lara-interactive-api - v0.5.0-pre.4
+# @concord-consortium/lara-interactive-api - v0.5.0
 
 ## Index
 

--- a/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iaggregateinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAggregateInitInteractive](iaggregateinitinteractive.md)
 
 # Interface: IAggregateInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthinfo.md
+++ b/docs/interactive-api-client/interfaces/iauthinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthInfo](iauthinfo.md)
 
 # Interface: IAuthInfo
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfield.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportField](iauthoringcustomreportfield.md)
 
 # Interface: IAuthoringCustomReportField
 

--- a/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
+++ b/docs/interactive-api-client/interfaces/iauthoringcustomreportfields.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringCustomReportFields](iauthoringcustomreportfields.md)
 
 # Interface: IAuthoringCustomReportFields
 

--- a/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringInitInteractive](iauthoringinitinteractive.md)
 
 # Interface: IAuthoringInitInteractive ‹**AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringInteractiveMetadata](iauthoringinteractivemetadata.md)
 
 # Interface: IAuthoringInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringMetadataBase](iauthoringmetadatabase.md)
 
 # Interface: IAuthoringMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceChoiceMetadata](iauthoringmultiplechoicechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringMultipleChoiceMetadata](iauthoringmultiplechoicemetadata.md)
 
 # Interface: IAuthoringMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringopenresponsemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IAuthoringOpenResponseMetadata](iauthoringopenresponsemetadata.md)
 
 # Interface: IAuthoringOpenResponseMetadata
 

--- a/docs/interactive-api-client/interfaces/ibaseshowmodal.md
+++ b/docs/interactive-api-client/interfaces/ibaseshowmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IBaseShowModal](ibaseshowmodal.md)
 
 # Interface: IBaseShowModal
 

--- a/docs/interactive-api-client/interfaces/iclosedmodal.md
+++ b/docs/interactive-api-client/interfaces/iclosedmodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IClosedModal](iclosedmodal.md)
 
 # Interface: IClosedModal
 

--- a/docs/interactive-api-client/interfaces/iclosemodal.md
+++ b/docs/interactive-api-client/interfaces/iclosemodal.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ICloseModal](iclosemodal.md)
 
 # Interface: ICloseModal
 

--- a/docs/interactive-api-client/interfaces/icontextmember.md
+++ b/docs/interactive-api-client/interfaces/icontextmember.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IContextMember](icontextmember.md)
 
 # Interface: IContextMember
 

--- a/docs/interactive-api-client/interfaces/icontextmembership.md
+++ b/docs/interactive-api-client/interfaces/icontextmembership.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IContextMembership](icontextmembership.md)
 
 # Interface: IContextMembership
 

--- a/docs/interactive-api-client/interfaces/icustommessage.md
+++ b/docs/interactive-api-client/interfaces/icustommessage.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ICustomMessage](icustommessage.md)
 
 # Interface: ICustomMessage
 

--- a/docs/interactive-api-client/interfaces/icustomreportfieldsauthoredstate.md
+++ b/docs/interactive-api-client/interfaces/icustomreportfieldsauthoredstate.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ICustomReportFieldsAuthoredState](icustomreportfieldsauthoredstate.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ICustomReportFieldsAuthoredState](icustomreportfieldsauthoredstate.md)
 
 # Interface: ICustomReportFieldsAuthoredState
 

--- a/docs/interactive-api-client/interfaces/icustomreportfieldsauthoredstatefield.md
+++ b/docs/interactive-api-client/interfaces/icustomreportfieldsauthoredstatefield.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ICustomReportFieldsAuthoredStateField](icustomreportfieldsauthoredstatefield.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ICustomReportFieldsAuthoredStateField](icustomreportfieldsauthoredstatefield.md)
 
 # Interface: ICustomReportFieldsAuthoredStateField
 

--- a/docs/interactive-api-client/interfaces/icustomreportfieldsinteractivestate.md
+++ b/docs/interactive-api-client/interfaces/icustomreportfieldsinteractivestate.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ICustomReportFieldsInteractiveState](icustomreportfieldsinteractivestate.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ICustomReportFieldsInteractiveState](icustomreportfieldsinteractivestate.md)
 
 # Interface: ICustomReportFieldsInteractiveState
 

--- a/docs/interactive-api-client/interfaces/idialoginitinteractive.md
+++ b/docs/interactive-api-client/interfaces/idialoginitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IDialogInitInteractive](idialoginitinteractive.md)
 
 # Interface: IDialogInitInteractive ‹**InteractiveState, AuthoredState, DialogState**›
 

--- a/docs/interactive-api-client/interfaces/igetauthinforequest.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetAuthInfoRequest](igetauthinforequest.md)
 
 # Interface: IGetAuthInfoRequest
 

--- a/docs/interactive-api-client/interfaces/igetauthinforesponse.md
+++ b/docs/interactive-api-client/interfaces/igetauthinforesponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetAuthInfoResponse](igetauthinforesponse.md)
 
 # Interface: IGetAuthInfoResponse
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtRequest](igetfirebasejwtrequest.md)
 
 # Interface: IGetFirebaseJwtRequest
 

--- a/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
+++ b/docs/interactive-api-client/interfaces/igetfirebasejwtresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetFirebaseJwtResponse](igetfirebasejwtresponse.md)
 
 # Interface: IGetFirebaseJwtResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetInteractiveListOptions](igetinteractivelistoptions.md)
 
 # Interface: IGetInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetInteractiveListRequest](igetinteractivelistrequest.md)
 
 # Interface: IGetInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetInteractiveListResponse](igetinteractivelistresponse.md)
 
 # Interface: IGetInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotOptions](igetinteractivesnapshotoptions.md)
 
 # Interface: IGetInteractiveSnapshotOptions
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotRequest](igetinteractivesnapshotrequest.md)
 
 # Interface: IGetInteractiveSnapshotRequest
 

--- a/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
+++ b/docs/interactive-api-client/interfaces/igetinteractivesnapshotresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetInteractiveSnapshotResponse](igetinteractivesnapshotresponse.md)
 
 # Interface: IGetInteractiveSnapshotResponse
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListOptions](igetlibraryinteractivelistoptions.md)
 
 # Interface: IGetLibraryInteractiveListOptions
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListRequest](igetlibraryinteractivelistrequest.md)
 
 # Interface: IGetLibraryInteractiveListRequest
 

--- a/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
+++ b/docs/interactive-api-client/interfaces/igetlibraryinteractivelistresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IGetLibraryInteractiveListResponse](igetlibraryinteractivelistresponse.md)
 
 # Interface: IGetLibraryInteractiveListResponse
 

--- a/docs/interactive-api-client/interfaces/ihintrequest.md
+++ b/docs/interactive-api-client/interfaces/ihintrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IHintRequest](ihintrequest.md)
 
 # Interface: IHintRequest
 

--- a/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/iinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IInteractiveListResponseItem](iinteractivelistresponseitem.md)
 
 # Interface: IInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/iinteractivestateprops.md
+++ b/docs/interactive-api-client/interfaces/iinteractivestateprops.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IInteractiveStateProps](iinteractivestateprops.md)
 
 # Interface: IInteractiveStateProps ‹**InteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/ijwtclaims.md
+++ b/docs/interactive-api-client/interfaces/ijwtclaims.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IJwtClaims](ijwtclaims.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IJwtClaims](ijwtclaims.md)
 
 # Interface: IJwtClaims
 

--- a/docs/interactive-api-client/interfaces/ijwtresponse.md
+++ b/docs/interactive-api-client/interfaces/ijwtresponse.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IJwtResponse](ijwtresponse.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IJwtResponse](ijwtresponse.md)
 
 # Interface: IJwtResponse
 

--- a/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
+++ b/docs/interactive-api-client/interfaces/ilibraryinteractivelistresponseitem.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ILibraryInteractiveListResponseItem](ilibraryinteractivelistresponseitem.md)
 
 # Interface: ILibraryInteractiveListResponseItem
 

--- a/docs/interactive-api-client/interfaces/ilinkedinteractive.md
+++ b/docs/interactive-api-client/interfaces/ilinkedinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ILinkedInteractive](ilinkedinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ILinkedInteractive](ilinkedinteractive.md)
 
 # Interface: ILinkedInteractive
 

--- a/docs/interactive-api-client/interfaces/inavigationoptions.md
+++ b/docs/interactive-api-client/interfaces/inavigationoptions.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [INavigationOptions](inavigationoptions.md)
 
 # Interface: INavigationOptions
 

--- a/docs/interactive-api-client/interfaces/iportalclaims.md
+++ b/docs/interactive-api-client/interfaces/iportalclaims.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IPortalClaims](iportalclaims.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IPortalClaims](iportalclaims.md)
 
 # Interface: IPortalClaims
 

--- a/docs/interactive-api-client/interfaces/ireportinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/ireportinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IReportInitInteractive](ireportinitinteractive.md)
 
 # Interface: IReportInitInteractive ‹**InteractiveState, AuthoredState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
+++ b/docs/interactive-api-client/interfaces/iruntimecustomreportvalues.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IRuntimeCustomReportValues](iruntimecustomreportvalues.md)
 
 # Interface: IRuntimeCustomReportValues
 

--- a/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IRuntimeInitInteractive](iruntimeinitinteractive.md)
 
 # Interface: IRuntimeInitInteractive ‹**InteractiveState, AuthoredState, GlobalInteractiveState**›
 

--- a/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinteractivemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IRuntimeInteractiveMetadata](iruntimeinteractivemetadata.md)
 
 # Interface: IRuntimeInteractiveMetadata
 

--- a/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IRuntimeMetadataBase](iruntimemetadatabase.md)
 
 # Interface: IRuntimeMetadataBase
 

--- a/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimemultiplechoicemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IRuntimeMultipleChoiceMetadata](iruntimemultiplechoicemetadata.md)
 
 # Interface: IRuntimeMultipleChoiceMetadata
 

--- a/docs/interactive-api-client/interfaces/iruntimeopenresponsemetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimeopenresponsemetadata.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IRuntimeOpenResponseMetadata](iruntimeopenresponsemetadata.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IRuntimeOpenResponseMetadata](iruntimeopenresponsemetadata.md)
 
 # Interface: IRuntimeOpenResponseMetadata
 

--- a/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
+++ b/docs/interactive-api-client/interfaces/isetlinkedinteractives.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractives](isetlinkedinteractives.md)
 
 # Interface: ISetLinkedInteractives
 

--- a/docs/interactive-api-client/interfaces/isetlinkedinteractivesrequest.md
+++ b/docs/interactive-api-client/interfaces/isetlinkedinteractivesrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractivesRequest](isetlinkedinteractivesrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ISetLinkedInteractivesRequest](isetlinkedinteractivesrequest.md)
 
 # Interface: ISetLinkedInteractivesRequest
 

--- a/docs/interactive-api-client/interfaces/ishowalert.md
+++ b/docs/interactive-api-client/interfaces/ishowalert.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IShowAlert](ishowalert.md)
 
 # Interface: IShowAlert
 

--- a/docs/interactive-api-client/interfaces/ishowdialog.md
+++ b/docs/interactive-api-client/interfaces/ishowdialog.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IShowDialog](ishowdialog.md)
 
 # Interface: IShowDialog ‹**DialogState**›
 

--- a/docs/interactive-api-client/interfaces/ishowlightbox.md
+++ b/docs/interactive-api-client/interfaces/ishowlightbox.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IShowLightbox](ishowlightbox.md)
 
 # Interface: IShowLightbox
 

--- a/docs/interactive-api-client/interfaces/isupportedfeatures.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeatures.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ISupportedFeatures](isupportedfeatures.md)
 
 # Interface: ISupportedFeatures
 

--- a/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
+++ b/docs/interactive-api-client/interfaces/isupportedfeaturesrequest.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [ISupportedFeaturesRequest](isupportedfeaturesrequest.md)
 
 # Interface: ISupportedFeaturesRequest
 

--- a/docs/interactive-api-client/interfaces/ithemeinfo.md
+++ b/docs/interactive-api-client/interfaces/ithemeinfo.md
@@ -1,4 +1,4 @@
-[@concord-consortium/lara-interactive-api - v0.5.0-pre.4](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
+[@concord-consortium/lara-interactive-api - v0.5.0](../README.md) › [Globals](../globals.md) › [IThemeInfo](ithemeinfo.md)
 
 # Interface: IThemeInfo
 

--- a/lara-typescript/package-lock.json
+++ b/lara-typescript/package-lock.json
@@ -310,6 +310,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
@@ -1454,6 +1464,51 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.22.0.tgz",
+      "integrity": "sha512-soXVCM/F2WxMidqGlZsSvTkmLsmi72q5N2IrB7o1aTFpMCfEL+Kl0kzv+2Lk/dLxny/c7CWUDa+yjve5VEsjMg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "dom-accessibility-api": "^0.4.6",
+        "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.8.tgz",
+      "integrity": "sha512-clgpFR6QHiRRcdhFfAKDhH8UXpNASyfkkANhtCsCVBnai+O+mK1rGtMES+Apc7ql5Wyxu7j8dcLiC4pV5VblHA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@testing-library/dom": "^7.17.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@testing-library/react-hooks": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz",
@@ -1463,6 +1518,12 @@
         "@babel/runtime": "^7.5.4",
         "@types/testing-library__react-hooks": "^3.0.0"
       }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.8",
@@ -2086,6 +2147,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arr-diff": {
@@ -3390,6 +3461,12 @@
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
       "dev": true
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3840,6 +3917,12 @@
           "dev": true
         }
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.7.tgz",
+      "integrity": "sha512-5+GzhTpCQYHz4NjL8loYTDVBnXIjNLBadWQBKxXk+osFEplLt3EsSYBu2YZcdZ8QqrvCHgW6TSMGMbmgfhrn2g==",
+      "dev": true
     },
     "dom-helpers": {
       "version": "5.1.4",

--- a/lara-typescript/package.json
+++ b/lara-typescript/package.json
@@ -66,6 +66,7 @@
   },
   "homepage": "https://github.com/concord-consortium/lara/tree/master/lara-typescript#readme",
   "devDependencies": {
+    "@testing-library/react": "^10.4.8",
     "@testing-library/react-hooks": "^3.2.1",
     "@types/deep-freeze": "^0.1.2",
     "@types/dompurify": "^2.0.2",

--- a/lara-typescript/src/interactive-api-client/hooks.spec.tsx
+++ b/lara-typescript/src/interactive-api-client/hooks.spec.tsx
@@ -100,9 +100,9 @@ describe("useInteractiveState", () => {
       const managedStateUpdated = React.useRef(false);
 
       if (!managedStateUpdated.current) {
-        // Immediate update of authoredState. In real life it wouldn't be done in the component obviously,
-        // but that's an easy way to ensure problematic timing - after initial render of the useAuthoredState hook,
-        // but before useEffect defined in useAuthoredState is called. This is regression test related to this issue:
+        // Immediate update of interactiveState. In real life it wouldn't be done in the component obviously,
+        // but that's an easy way to ensure problematic timing - after initial render of the useInteractiveState hook,
+        // but before useEffect defined in useInteractiveState is called. This is regression test related to this issue:
         // https://www.pivotaltracker.com/story/show/174154314
         getClient().managedState.interactiveState = "new state 123";
         // Prevent infinite loop, update authoredState just once.
@@ -254,10 +254,10 @@ describe("useGlobalInteractiveState", () => {
       const managedStateUpdated = React.useRef(false);
 
       if (!managedStateUpdated.current) {
-        // Immediate update of authoredState. In real life it wouldn't be done in the component obviously,
-        // but that's an easy way to ensure problematic timing - after initial render of the useAuthoredState hook,
-        // but before useEffect defined in useAuthoredState is called. This is regression test related to this issue:
-        // https://www.pivotaltracker.com/story/show/174154314
+        // Immediate update of globalInteractiveState. In real life it wouldn't be done in the component obviously,
+        // but that's an easy way to ensure problematic timing - after initial render of the useGlobalInteractiveState
+        // hook, but before useEffect defined in useGlobalInteractiveState is called. This is regression test related
+        // to this issue: https://www.pivotaltracker.com/story/show/174154314
         getClient().managedState.globalInteractiveState = "new state 123";
         // Prevent infinite loop, update authoredState just once.
         managedStateUpdated.current = true;

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -12,11 +12,14 @@ const handleUpdate = <S>(newStateOrUpdateFunc: S | null | UpdateFunc<S>, prevSta
 };
 
 export const useInteractiveState = <InteractiveState>() => {
-  const [ interactiveState, setInteractiveState ] = useState<InteractiveState | null>(
-    client.getInteractiveState<InteractiveState>()
-  );
+  const [ interactiveState, setInteractiveState ] = useState<InteractiveState | null>(null);
 
   useEffect(() => {
+    // Note that we need to update authoredState exactly in this moment, right before setting up event listeners.
+    // It can't be done above using initial useState value. There's a little delay between initial render and calling
+    // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
+    // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+    setInteractiveState(client.getInteractiveState<InteractiveState>());
     // Setup client event listeners. They will ensure that another instance of this hook (or anything else
     // using client directly) makes changes to interactive state, this hook will receive these changes.
     const handleStateUpdate = (newState: InteractiveState) => {
@@ -39,9 +42,14 @@ export const useInteractiveState = <InteractiveState>() => {
 };
 
 export const useAuthoredState = <AuthoredState>() => {
-  const [ authoredState, setAuthoredState ] = useState<AuthoredState | null>(client.getAuthoredState<AuthoredState>());
+  const [ authoredState, setAuthoredState ] = useState<AuthoredState | null>(null);
 
   useEffect(() => {
+    // Note that we need to update interactiveState exactly in this moment, right before setting up event listeners.
+    // It can't be done above using initial useState value. There's a little delay between initial render and calling
+    // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
+    // it was actually  happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+    setAuthoredState(client.getAuthoredState<AuthoredState>());
     // Setup client event listeners. They will ensure that another instance of this hook (or anything else
     // using client directly) makes changes to authored state, this hook will receive these changes.
     const handleStateUpdate = (newState: AuthoredState) => {
@@ -64,11 +72,14 @@ export const useAuthoredState = <AuthoredState>() => {
 };
 
 export const useGlobalInteractiveState = <GlobalInteractiveState>() => {
-  const [ globalInteractiveState, setGlobalInteractiveState ] = useState<GlobalInteractiveState | null>(
-    client.getGlobalInteractiveState<GlobalInteractiveState>()
-  );
+  const [ globalInteractiveState, setGlobalInteractiveState ] = useState<GlobalInteractiveState | null>(null);
 
   useEffect(() => {
+    // Note that we need to update globalInteractiveState exactly in this moment, right before setting up event
+    // listeners. It can't be done above using initial useState value. There's a little delay between initial render
+    // and calling useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
+    // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+    setGlobalInteractiveState(client.getGlobalInteractiveState<GlobalInteractiveState>());
     // Setup client event listeners. They will ensure that another instance of this hook (or anything else
     // using client directly) makes changes to global interactive state, this hook will receive these changes.
     const handleStateUpdate = (newState: GlobalInteractiveState) => {

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -15,10 +15,6 @@ export const useInteractiveState = <InteractiveState>() => {
   const [ interactiveState, setInteractiveState ] = useState<InteractiveState | null>(null);
 
   useEffect(() => {
-    // Note that we need to update authoredState exactly in this moment, right before setting up event listeners.
-    // It can't be done above using initial useState value. There's a little delay between initial render and calling
-    // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
-    // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
     setInteractiveState(client.getInteractiveState<InteractiveState>());
     // Setup client event listeners. They will ensure that another instance of this hook (or anything else
     // using client directly) makes changes to interactive state, this hook will receive these changes.
@@ -45,10 +41,13 @@ export const useAuthoredState = <AuthoredState>() => {
   const [ authoredState, setAuthoredState ] = useState<AuthoredState | null>(null);
 
   useEffect(() => {
-    // Note that we need to update interactiveState exactly in this moment, right before setting up event listeners.
+    // Note that we need to update authoredState exactly in this moment, right before setting up event listeners.
     // It can't be done above using initial useState value. There's a little delay between initial render and calling
-    // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
-    // it was actually  happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+    // useEffect. If client's authoredState gets updated before the listener is added, this hook will have outdated
+    // value. It's not only a theoretical issue, it was actually happening in Safari:
+    // https://www.pivotaltracker.com/story/show/174154314
+    // initInteractive message that includes authoredAuthored message was received between initial render and calling
+    // client.addAuthoredStateListener, so the state update was lost.
     setAuthoredState(client.getAuthoredState<AuthoredState>());
     // Setup client event listeners. They will ensure that another instance of this hook (or anything else
     // using client directly) makes changes to authored state, this hook will receive these changes.
@@ -75,10 +74,6 @@ export const useGlobalInteractiveState = <GlobalInteractiveState>() => {
   const [ globalInteractiveState, setGlobalInteractiveState ] = useState<GlobalInteractiveState | null>(null);
 
   useEffect(() => {
-    // Note that we need to update globalInteractiveState exactly in this moment, right before setting up event
-    // listeners. It can't be done above using initial useState value. There's a little delay between initial render
-    // and calling useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
-    // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
     setGlobalInteractiveState(client.getGlobalInteractiveState<GlobalInteractiveState>());
     // Setup client event listeners. They will ensure that another instance of this hook (or anything else
     // using client directly) makes changes to global interactive state, this hook will receive these changes.

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.5.0-pre.4",
+  "version": "0.5.0",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -31985,8 +31985,13 @@ var handleUpdate = function (newStateOrUpdateFunc, prevState) {
     }
 };
 exports.useInteractiveState = function () {
-    var _a = react_1.useState(client.getInteractiveState()), interactiveState = _a[0], setInteractiveState = _a[1];
+    var _a = react_1.useState(null), interactiveState = _a[0], setInteractiveState = _a[1];
     react_1.useEffect(function () {
+        // Note that we need to update authoredState exactly in this moment, right before setting up event listeners.
+        // It can't be done above using initial useState value. There's a little delay between initial render and calling
+        // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
+        // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+        setInteractiveState(client.getInteractiveState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to interactive state, this hook will receive these changes.
         var handleStateUpdate = function (newState) {
@@ -32006,8 +32011,13 @@ exports.useInteractiveState = function () {
     return { interactiveState: interactiveState, setInteractiveState: handleSetInteractiveState };
 };
 exports.useAuthoredState = function () {
-    var _a = react_1.useState(client.getAuthoredState()), authoredState = _a[0], setAuthoredState = _a[1];
+    var _a = react_1.useState(null), authoredState = _a[0], setAuthoredState = _a[1];
     react_1.useEffect(function () {
+        // Note that we need to update interactiveState exactly in this moment, right before setting up event listeners.
+        // It can't be done above using initial useState value. There's a little delay between initial render and calling
+        // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
+        // it was actually  happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+        setAuthoredState(client.getAuthoredState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to authored state, this hook will receive these changes.
         var handleStateUpdate = function (newState) {
@@ -32027,8 +32037,13 @@ exports.useAuthoredState = function () {
     return { authoredState: authoredState, setAuthoredState: handleSetAuthoredState };
 };
 exports.useGlobalInteractiveState = function () {
-    var _a = react_1.useState(client.getGlobalInteractiveState()), globalInteractiveState = _a[0], setGlobalInteractiveState = _a[1];
+    var _a = react_1.useState(null), globalInteractiveState = _a[0], setGlobalInteractiveState = _a[1];
     react_1.useEffect(function () {
+        // Note that we need to update globalInteractiveState exactly in this moment, right before setting up event
+        // listeners. It can't be done above using initial useState value. There's a little delay between initial render
+        // and calling useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
+        // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+        setGlobalInteractiveState(client.getGlobalInteractiveState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to global interactive state, this hook will receive these changes.
         var handleStateUpdate = function (newState) {

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -31987,10 +31987,6 @@ var handleUpdate = function (newStateOrUpdateFunc, prevState) {
 exports.useInteractiveState = function () {
     var _a = react_1.useState(null), interactiveState = _a[0], setInteractiveState = _a[1];
     react_1.useEffect(function () {
-        // Note that we need to update authoredState exactly in this moment, right before setting up event listeners.
-        // It can't be done above using initial useState value. There's a little delay between initial render and calling
-        // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
-        // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
         setInteractiveState(client.getInteractiveState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to interactive state, this hook will receive these changes.
@@ -32013,10 +32009,13 @@ exports.useInteractiveState = function () {
 exports.useAuthoredState = function () {
     var _a = react_1.useState(null), authoredState = _a[0], setAuthoredState = _a[1];
     react_1.useEffect(function () {
-        // Note that we need to update interactiveState exactly in this moment, right before setting up event listeners.
+        // Note that we need to update authoredState exactly in this moment, right before setting up event listeners.
         // It can't be done above using initial useState value. There's a little delay between initial render and calling
-        // useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
-        // it was actually  happening in Safari: https://www.pivotaltracker.com/story/show/174154314
+        // useEffect. If client's authoredState gets updated before the listener is added, this hook will have outdated
+        // value. It's not only a theoretical issue, it was actually happening in Safari:
+        // https://www.pivotaltracker.com/story/show/174154314
+        // initInteractive message that includes authoredAuthored message was received between initial render and calling
+        // client.addAuthoredStateListener, so the state update was lost.
         setAuthoredState(client.getAuthoredState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to authored state, this hook will receive these changes.
@@ -32039,10 +32038,6 @@ exports.useAuthoredState = function () {
 exports.useGlobalInteractiveState = function () {
     var _a = react_1.useState(null), globalInteractiveState = _a[0], setGlobalInteractiveState = _a[1];
     react_1.useEffect(function () {
-        // Note that we need to update globalInteractiveState exactly in this moment, right before setting up event
-        // listeners. It can't be done above using initial useState value. There's a little delay between initial render
-        // and calling useEffect. If update happens then, the state would be lost. It's not only a theoretical issue,
-        // it was actually happening in Safari: https://www.pivotaltracker.com/story/show/174154314
         setGlobalInteractiveState(client.getGlobalInteractiveState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to global interactive state, this hook will receive these changes.


### PR DESCRIPTION
This PR fixes an issue in Safari: https://www.pivotaltracker.com/story/show/174154314

`useAuthoredState` (also other `use...State` hooks) was getting the initial value of authoredState from the Client during the first render (the first hook function execution). Later, it was adding authoredState observers in `useEffect(..., [])` callback. Since useEffect is executed asynchronously, probably with some small delay, there was a period of time between getting initial authoredState value and setting up observers when authoredState was not observed. And sometimes the update was happening exactly in this short period (Safari only, around 50% of cases). 

The fix was to ensure that we read the most recent version of authoredState right before setting up observers in the same synchronous function. So there's no possibility now that some updates will be missed.

I hope comments should be clear enough. I've also added a spec that tests against this specific case.

I've updated NPM package version to 0.5.0 without pre- suffix, so we can start using normal version numbers. 

