### PR TITLE
Fix transform_codap_and_sage_urls script

### DIFF
--- a/script/transform_codap_and_sage_urls.rb
+++ b/script/transform_codap_and_sage_urls.rb
@@ -53,9 +53,14 @@ end
 
 def master_cfm_to_production_cfm(url_string)
   url = URI(url_string)
+  # Parse server query param and remove CFM master branch query params
   new_query = Rack::Utils.parse_nested_query(url.query)
 
-  # Parse server query param and remove CFM master branch query params
+  unless new_query["server"]
+    # nothing to do
+    return url_string
+  end
+
   server_url = URI(new_query["server"])
   server_query_params =  Rack::Utils.parse_nested_query(server_url.query)
   # SageModeler requires branch name and 3 separate URL params


### PR DESCRIPTION
This error happened only on LARA staging. Some interactives URLs didn't have `server` URL param, for example:
```
{
    "id": 210656,
    "old_url": "https://cloud-file-manager.concord.org/branch/master/autolaunch/autolaunch.html?documentId=https%3A%2F%2Fcfm-shared.concord.org%2FcBlsMw3L41NU6Dti1JH1%2Ffile.json",
    "new_url": "https://cloud-file-manager.concord.org/branch/master/autolaunch/autolaunch.html?documentId=https%3A%2F%2Fcfm-shared.concord.org%2FcBlsMw3L41NU6Dti1JH1%2Ffile.json"
  },
```
I bet it was result of some manual URL modifications. But pushing this fix anyway, as it's better to ignore that than crash the script (if we ever have to run the script again).