### PR TITLE
Add call to getFirebaseJWT() from Example Interactive

### DIFF
--- a/docs/example-interactive.md
+++ b/docs/example-interactive.md
@@ -1,13 +1,13 @@
 # Example Interactive
 
-# What is it?
+## What is it?
 
 The example interactive source is in `lara-typescript/src/example-interactive` and serves as a test bed for interactives,
 allowing developers and testers to test out additions or changes to the interactive iframe api.
 
-# Using the example interactive
+## Using the example interactive
 
-The example interactive is deployed as part of build.
+The example interactive is deployed as part of the build.
 It can be found at `[lara-host]/example-interactive/`.
 For example the most recent production build is here:
 https://authoring.concord.org/example-interactive/
@@ -16,17 +16,17 @@ If you are expanding the example interactive, it can be run locally:
 
 1. `cd lara-typescript`
 2. `npm init` (if not already done)
-3. `npm build` (this builds both the api and the example interactive)
+3. `npm run build` (this builds both the api and the example interactive)
 4. `npm run example-interactive` (this starts a live-server instance of the example interactive on port 8888)
 5. In another window run `docker-compose up` (to run lara)
 6. Create or edit an activity and add `http://localhost:8888` as the url for either in interactive or managed interactive.
 
 When you make a change to the example interactive source, and you've already started the live server above:
-1. `npm build`
+1. `npm run build`
 
 In other words, the example-interactive is not automatically rebuilt when you change the source.
 
-# Adding to the example interactive
+## Adding to the example interactive
 
 1. Choose which mode you want (authoring, dialog, report or runtime)
 2. Edit the component for that mode

--- a/lara-typescript/src/example-interactive/src/components/app.tsx
+++ b/lara-typescript/src/example-interactive/src/components/app.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useEffect, useRef } from "react";
+const { useEffect } = React;
 import ResizeObserver from "resize-observer-polyfill";
 
 import { useInitMessage, setSupportedFeatures, setHeight } from "../../../interactive-api-client";
@@ -7,12 +7,13 @@ import { AuthoringComponent } from "./authoring";
 import { DialogComponent } from "./dialog";
 import { ReportComponent } from "./report";
 import { RuntimeComponent } from "./runtime";
+import { IAuthoredState } from "./types";
 
 interface Props {
 }
 
 export const AppComponent: React.FC<Props> = (props) => {
-  const initMessage = useInitMessage();
+  const initMessage = useInitMessage<{}, IAuthoredState>();
 
   // TODO: this should really be moved into a client hook file so it can be reused
   useEffect(() => {

--- a/lara-typescript/src/example-interactive/src/components/authoring.tsx
+++ b/lara-typescript/src/example-interactive/src/components/authoring.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { useState } from "react";
-import { IAuthoringInitInteractive, IAuthoringClientMessage } from "../../../interactive-api-client";
+import { IAuthoringInitInteractive, IAuthoringClientMessage, useAuthoredState } from "../../../interactive-api-client";
 import { GetInteractiveListComponent } from "./authoring-apis/get-interactive-list";
 import { SetLinkedInteractivesComponent } from "./authoring-apis/set-linked-interactives";
+import { IAuthoredState } from "./types";
 
 interface Props {
-  initMessage: IAuthoringInitInteractive;
+  initMessage: IAuthoringInitInteractive<IAuthoredState>;
 }
 
 export interface AuthoringApiProps {
@@ -17,6 +18,7 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
   const [selectedAuthoringApi, setSelectedAuthoringApi] = useState<IAuthoringClientMessage>("getInteractiveList");
   const [authoringApiError, setAuthoringApiError] = useState<any>();
   const [authoringApiOutput, setAuthoringApiOutput] = useState<any>();
+  const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
 
   const handleClearAuthoringApiError = () => setAuthoringApiError(undefined);
   const handleClearAuthoringApiOutput = () => setAuthoringApiOutput(undefined);
@@ -34,6 +36,10 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
       default:
         return undefined;
     }
+  };
+
+  const handleFirebaseAppChange: (event: React.ChangeEvent<HTMLInputElement>) => void = e => {
+    setAuthoredState({ firebaseApp: e.target.value });
   };
 
   return (
@@ -69,6 +75,16 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
       <fieldset>
         <legend>Authoring Init Message</legend>
         <div className="padded monospace pre">{JSON.stringify(initMessage, null, 2)}</div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Authoring Options</legend>
+        <label>
+          Firebase App:&nbsp;
+          <input type="text"
+            value={authoredState?.firebaseApp}
+            onChange={handleFirebaseAppChange} />
+        </label>
       </fieldset>
 
     </div>

--- a/lara-typescript/src/example-interactive/src/components/runtime.tsx
+++ b/lara-typescript/src/example-interactive/src/components/runtime.tsx
@@ -1,16 +1,36 @@
 import * as React from "react";
-import { IRuntimeInitInteractive } from "../../../interactive-api-client";
+const { useEffect, useState } = React;
+import { IRuntimeInitInteractive, getFirebaseJwt } from "../../../interactive-api-client";
+import { IAuthoredState } from "./types";
 
 interface Props {
-  initMessage: IRuntimeInitInteractive;
+  initMessage: IRuntimeInitInteractive<{}, IAuthoredState>;
 }
 
 export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
+  const [rawFirebaseJwt, setRawFirebaseJWT] = useState<string>();
+  const { authoredState } = initMessage;
+  useEffect(() => {
+    if (authoredState?.firebaseApp) {
+      getFirebaseJwt(authoredState.firebaseApp)
+        .then(response => {
+          setRawFirebaseJWT(response.token);
+        })
+        .catch(e => {
+          setRawFirebaseJWT(`ERROR: ${e.toString()}`);
+        });
+    }
+  }, [authoredState]);
+
   return (
     <div className="padded">
       <fieldset>
         <legend>Runtime Init Message</legend>
         <div className="padded monospace pre">{JSON.stringify(initMessage, null, 2)}</div>
+      </fieldset>
+      <fieldset>
+        <legend>FirebaseJWT Response</legend>
+        <div className="padded monospace pre">{rawFirebaseJwt}</div>
       </fieldset>
     </div>
   );

--- a/lara-typescript/src/example-interactive/src/components/types.ts
+++ b/lara-typescript/src/example-interactive/src/components/types.ts
@@ -1,0 +1,5 @@
+import { IRuntimeInitInteractive } from "../../../interactive-api-client";
+
+export interface IAuthoredState {
+  firebaseApp?: string;
+}

--- a/lara-typescript/src/interactive-api-client/client.ts
+++ b/lara-typescript/src/interactive-api-client/client.ts
@@ -42,7 +42,7 @@ export class Client {
       throw new Error("Interactive API is meant to be used in iframe");
     }
     if (phoneInitialized()) {
-      throw new Error("IframePhone has been initialized previously. Only once Client instance is allowed.");
+      throw new Error("IframePhone has been initialized previously. Only one Client instance is allowed.");
     }
     this.connect();
 


### PR DESCRIPTION
This adds a new `Authoring Options` block to the authoring UI which currently contains a single field:

<img width="298" alt="AuthoringOptions" src="https://user-images.githubusercontent.com/235234/90593331-7d351500-e19c-11ea-9706-4d94df4cc46b.png">

The `Firebase App` field corresponds to the `firebase-app` value used to request a firebase JWT from the portal, e.g. `collaborative-learning` for CLUE. At runtime, the portal response is provided in a corresponding field in the runtime UI:

<img width="364" alt="RuntimeResponse" src="https://user-images.githubusercontent.com/235234/90593461-d13ff980-e19c-11ea-8b0d-23254ba4c973.png">

If the user is properly authenticated to the portal and the portal grants access to the specified firebase app, then the response will be the firebase JWT as a string token. If the user is not properly authenticated to the portal and/or doesn't have access to the specified firebase app, then an error message is returned as seen above.