### PR TITLE
Fix wrapped embeddable height issue.

### DIFF
--- a/app/views/interactive_pages/_list_embeddables.html.haml
+++ b/app/views/interactive_pages/_list_embeddables.html.haml
@@ -8,13 +8,17 @@
           -# e variable is actually either embeddable (for interactives, plugins, etc.) or embeddable answer
           -# (open response, multiple choice and all the question types). If the latter, get a real question object.
           - question = e.respond_to?(:question) ? e.question : e
-          .question{ class: question_css_class(e), id: question.embeddable_dom_id }
-            -# The embeddable-root CSS class is important as it is used by sizing calculations
-            -# it needs to be different than the .question div above. The div above is set to
-            -# 45% width when inside of a full width page or block, and the div below
-            -# width is set dynamically depending on the interactive sizing
-            .embeddable-root
-              -# The embeddable-container CSS class is important, as it is referenced by plugins and passed to a plugin instance.
+          -# The question div is managed by the question_css_class, it determines if this is a full-width (100%)
+          -# question or 'normal' question (45%)
+          .question{ class: question_css_class(e) }
+            -# The embeddable-root CSS class is used by sizing calculations, it gets set to 100% width, during
+            -# the calculation, and then it might be set to a lower percentage width in order to preserve an aspect ratio
+            -# The div with the id of question.embeddable_dom_id is used by wrapping plugins as the 'container'
+            .embeddable-root{ id: question.embeddable_dom_id }
+              -# The embeddable-container CSS class is used by wrapping plugins, the wrapping plugin gets a
+              -# container div for itself see above, and a container (embeddable-container) for the embeddable
+              -# it is wrapping. In the v2 plugin api this second container is called the wrappedEmbeddableDiv
+              -# the wrapping plugin injects itself between these 2 divs.
               .embeddable-container
                 - if Embeddable::is_interactive?(e)
                   = render_interactive(e)

--- a/app/views/plugins/_author.haml
+++ b/app/views/plugins/_author.haml
@@ -38,7 +38,17 @@
                   - else
                     - partial_name = "#{wrapped_embeddable.class.name.underscore.pluralize}/lightweight"
                     = render(partial: partial_name, locals: { embeddable: wrapped_embeddable })
-          -# reload-on-close is used so that the css loaded for the preview is not seen
+          -# The authored UI of the plugin is injected in this plugin-out div.
+          -# The plugin also receives the question-mod block above as the wrapped embeddable
+          -# container. This approach doesn't match the dom structure at runtime, but it does provide
+          -# a basic preview. A better approach would be to give the plugin an independent dom element
+          -# for its authoring UI, and then also a dom element for it is preview content, plus
+          -# a dom element for the actual wrapped content. This would let us setup the preview
+          -# in a way that matches the runtime. We might even be able to to use the runtime partials
+          -#  app/views/interactive_pages/_list_embeddables.html.haml or
+          -#  app/views/interactive_pages/_interactive.html.haml
+          -# reload-on-close is used so that the css loaded during the the preview is cleaned up
+          -# by reloading the browser window even if the user just cancels the dialog
           .plugin-output.content-mod.reload-on-close{id: output_id}
         - else
           .plugin-output{id: output_id}

--- a/script/embeddable_stats.rb
+++ b/script/embeddable_stats.rb
@@ -75,3 +75,5 @@ def print_embeddable_stats2(embeddable_type, host = "authoring.concord.org")
   nil
 end
 
+# Count of pages that don't have a matching lightweight activity
+InteractivePage.joins('LEFT OUTER JOIN lightweight_activities ON lightweight_activities.id = interactive_pages.lightweight_activity_id').where('lightweight_activities.id is null').count


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/174422945

This fixes the problem because the plugin system uses the element with the embeddable_dom_id
as the output container for the plugin. It also passes the .embeddable-container inside of this
div as the wrapped container. Then the plugin adds its content in the output container
and moves the wrapped container div inside of its content. With the previous structure
that meant that the embeddable-root div got lost because it was in between these two divs.

The rest of the changes here are comments to try to explain all of this complexity.