### PR TITLE
use MutationObserver to only show the plugin question when it adds co…

### DIFF
--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -122,16 +122,18 @@
     -# we are observing changes before the plugin can modify the content
     :javascript
       (function ($plugin_output) {
+        var $plugin_question = $plugin_output.closest(".question");
+
         // hide the parent question until the plugin adds content
-        $plugin_output.closest(".question").addClass("hidden");
+        $plugin_question.addClass("hidden");
 
         // show the question when the plugin adds content, hide it again if the plugin
         // removes all of its content
         var observer = new MutationObserver(function (mutationsList, observer) {
           if($plugin_output.contents().length !== 0) {
-            $plugin_output.closest(".question").removeClass("hidden");
+            $plugin_question.removeClass("hidden");
           } else {
-            $plugin_output.closest(".question").addClass("hidden");
+            $plugin_question.addClass("hidden");
           }
         });
         observer.observe($plugin_output[0], {childList: true})

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -115,25 +115,27 @@
     .plugin-output{id: output_id}
     - runtime_div_selector = "##{output_id}"
     - wrapped_selector = nil
-    -# hide the parent question until (if ever) the plugin adds content,
-    -# currently plugins can't be added directly to the interactive box, if that
+    -# WARNING: currently plugins can't be added directly to the interactive box, if that
     -# changes then this code will have to be updated because there is not a
-    -# .question parent
-    -# document.ready is not used so we can avoid flashing content and also be ready
-    -# for changes before the plugin has a chance to modify the content
+    -# `.question` parent in the interactive box.
+    -# NOTE: document.ready is not used so we can avoid flashing content and also to make sure
+    -# we are observing changes before the plugin can modify the content
     :javascript
-      $("##{output_id}").closest(".question").addClass("hidden");
-      (function () {
+      (function ($plugin_output) {
+        // hide the parent question until the plugin adds content
+        $plugin_output.closest(".question").addClass("hidden");
+
+        // show the question when the plugin adds content, hide it again if the plugin
+        // removes all of its content
         var observer = new MutationObserver(function (mutationsList, observer) {
-          // show the question if the output div is not empty, hide it otherwise
-          if($("##{output_id}").contents().length) {
-            $("##{output_id}").closest(".question").removeClass("hidden");
+          if($plugin_output.contents().length !== 0) {
+            $plugin_output.closest(".question").removeClass("hidden");
           } else {
-            $("##{output_id}").closest(".question").addClass("hidden");
+            $plugin_output.closest(".question").addClass("hidden");
           }
         });
-        observer.observe($("##{output_id}")[0], {childList: true})
-      })()
+        observer.observe($plugin_output[0], {childList: true})
+      })($("##{output_id}"))
   - interactive_state_url = nil
   - if wrapped_embedd && wrapped_embedd.respond_to?(:interactive_run_states)
     - irs = InteractiveRunState.by_run_and_interactive(@run, wrapped_embedd)

--- a/app/views/plugins/_show.haml
+++ b/app/views/plugins/_show.haml
@@ -115,6 +115,25 @@
     .plugin-output{id: output_id}
     - runtime_div_selector = "##{output_id}"
     - wrapped_selector = nil
+    -# hide the parent question until (if ever) the plugin adds content,
+    -# currently plugins can't be added directly to the interactive box, if that
+    -# changes then this code will have to be updated because there is not a
+    -# .question parent
+    -# document.ready is not used so we can avoid flashing content and also be ready
+    -# for changes before the plugin has a chance to modify the content
+    :javascript
+      $("##{output_id}").closest(".question").addClass("hidden");
+      (function () {
+        var observer = new MutationObserver(function (mutationsList, observer) {
+          // show the question if the output div is not empty, hide it otherwise
+          if($("##{output_id}").contents().length) {
+            $("##{output_id}").closest(".question").removeClass("hidden");
+          } else {
+            $("##{output_id}").closest(".question").addClass("hidden");
+          }
+        });
+        observer.observe($("##{output_id}")[0], {childList: true})
+      })()
   - interactive_state_url = nil
   - if wrapped_embedd && wrapped_embedd.respond_to?(:interactive_run_states)
     - irs = InteractiveRunState.by_run_and_interactive(@run, wrapped_embedd)


### PR DESCRIPTION
The story describes several options. I went with the Mutation observer for the best flexibility backward compatibility.

https://www.pivotaltracker.com/story/show/174448841
