### PR TITLE
Wrap 'pre' text example interactive.

### DIFF
--- a/lara-typescript/src/example-interactive/index.css
+++ b/lara-typescript/src/example-interactive/index.css
@@ -17,6 +17,7 @@ select, button {
 
 fieldset {
   margin-bottom: 10px;
+  min-width: 0px;
 }
 
 .centered {
@@ -55,5 +56,6 @@ fieldset {
 }
 
 .pre {
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }

--- a/public/example-interactive/index.css
+++ b/public/example-interactive/index.css
@@ -17,6 +17,7 @@ select, button {
 
 fieldset {
   margin-bottom: 10px;
+  min-width: 0px;
 }
 
 .centered {
@@ -55,5 +56,6 @@ fieldset {
 }
 
 .pre {
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
By default the fieldset element sets its width to be minimum of the content width so
that prevents any wrapping.

[#174481683]

