### PR TITLE
Option 1: Fixed answer_finder when summary is loaded first [#174832397]

### DIFF
--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -44,6 +44,11 @@ class InteractiveRunState < ActiveRecord::Base
     mapping[type] || "iframe_interactive"
   end
 
+  def self.default_answer(conditions)
+    # return the interactive (refered to as question by the answer finder) as the answer
+    conditions[:question]
+  end
+
   def question
     interactive
   end

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -245,4 +245,8 @@ class ManagedInteractive < ActiveRecord::Base
   def prompt
     name
   end
+
+  def question
+    self
+  end
 end

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -176,4 +176,8 @@ class MwInteractive < ActiveRecord::Base
     # mirror managed_interactive has thumbnail_url which proxies to library_interactive
     image_url
   end
+
+  def question
+    self
+  end
 end

--- a/spec/models/embeddable/answer_finder_spec.rb
+++ b/spec/models/embeddable/answer_finder_spec.rb
@@ -1,10 +1,13 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Embeddable::AnswerFinder do
-  let(:open_response)  { FactoryGirl.create(:open_response)  }
-  let(:multiple_choice){ FactoryGirl.create(:multiple_choice)}
-  let(:html)           { FactoryGirl.create(:xhtml)          }
-  let(:image)          { FactoryGirl.create(:image_question) }
+  let(:open_response)       { FactoryGirl.create(:open_response)       }
+  let(:multiple_choice)     { FactoryGirl.create(:multiple_choice)     }
+  let(:html)                { FactoryGirl.create(:xhtml)               }
+  let(:image)               { FactoryGirl.create(:image_question)      }
+  let(:mw_interactive)      { FactoryGirl.create(:mw_interactive)      }
+  let(:managed_interactive) { FactoryGirl.create(:managed_interactive) }
+
   let(:run)            { FactoryGirl.create(:run)            }
 
   describe "#find_answer" do
@@ -18,6 +21,10 @@ describe Embeddable::AnswerFinder do
         expect(answer).to be_an_instance_of Embeddable::MultipleChoiceAnswer
         answer = finder.find_answer(image)
         expect(answer).to be_an_instance_of Embeddable::ImageQuestionAnswer
+        answer = finder.find_answer(mw_interactive)
+        expect(answer).to be_an_instance_of MwInteractive
+        answer = finder.find_answer(managed_interactive)
+        expect(answer).to be_an_instance_of ManagedInteractive
       end
 
       context 'when the question is an ImageQuestion with an author-defined background' do

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -38,6 +38,21 @@ describe InteractiveRunState do
         end
       end
     end
+    describe "InteractiveRunState#default_answer" do
+      let(:interactive1) { FactoryGirl.create(:mw_interactive) }
+      let(:interactive2) { FactoryGirl.create(:managed_interactive) }
+      let(:run_state1) { InteractiveRunState.by_run_and_interactive(run, interactive1) }
+      let(:run_state2) { InteractiveRunState.by_run_and_interactive(run, interactive2) }
+      it "should return the interactive based on the conditions" do
+        make run_state1
+        make run_state2
+        answer1 = InteractiveRunState.default_answer({run: run, question: interactive1})
+        answer2 = InteractiveRunState.default_answer({run: run, question: interactive2})
+        expect(answer1).to eq interactive1
+        expect(answer2).to eq interactive2
+        expect(run.interactive_run_states.length).to eq 2
+      end
+    end
   end
 
   describe "instance methods" do


### PR DESCRIPTION
This is the first option - it defines a default_answer on the interactive run state model