### PR TITLE
Add support for custom messages

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -27716,7 +27716,7 @@ module.exports = g;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.offInteractiveAvailable = exports.onInteractiveAvailable = exports.emitInteractiveAvailable = exports.offLog = exports.onLog = exports.emitLog = void 0;
+exports.offInteractiveSupportedFeatures = exports.onInteractiveSupportedFeatures = exports.emitInteractiveSupportedFeatures = exports.offInteractiveAvailable = exports.onInteractiveAvailable = exports.emitInteractiveAvailable = exports.offLog = exports.onLog = exports.emitLog = void 0;
 var eventemitter2_1 = __webpack_require__(/*! eventemitter2 */ "./node_modules/eventemitter2/lib/eventemitter2.js");
 var emitter = new eventemitter2_1.EventEmitter2({
     maxListeners: Infinity
@@ -27738,6 +27738,15 @@ exports.onInteractiveAvailable = function (handler) {
 };
 exports.offInteractiveAvailable = function (handler) {
     emitter.off("interactiveAvailable", handler);
+};
+exports.emitInteractiveSupportedFeatures = function (event) {
+    emitter.emit("interactiveSupportedFeatures", event);
+};
+exports.onInteractiveSupportedFeatures = function (handler) {
+    emitter.on("interactiveSupportedFeatures", handler);
+};
+exports.offInteractiveSupportedFeatures = function (handler) {
+    emitter.off("interactiveSupportedFeatures", handler);
 };
 
 
@@ -30089,7 +30098,19 @@ exports.generateEmbeddableRuntimeContext = function (context) {
                 }
             });
         },
-        interactiveAvailable: context.interactiveAvailable
+        onInteractiveSupportedFeatures: function (handler) {
+            // Add generic listener and filter events to limit them just to this given embeddable.
+            events_1.onInteractiveSupportedFeatures(function (event) {
+                if (event.container === context.container) {
+                    handler(event);
+                }
+            });
+        },
+        interactiveAvailable: context.interactiveAvailable,
+        sendCustomMessage: function (message) {
+            var _a;
+            (_a = context.sendCustomMessage) === null || _a === void 0 ? void 0 : _a.call(context, message);
+        }
     };
 };
 

--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -27762,7 +27762,7 @@ exports.offInteractiveSupportedFeatures = function (handler) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PageItemAuthoring = exports.Events = exports.Plugins = exports.InteractiveAPI = exports.PluginAPI_V3 = void 0;
+exports.initializeLara = exports.PageItemAuthoring = exports.Events = exports.Plugins = exports.InteractiveAPI = exports.PluginAPI_V3 = void 0;
 __webpack_require__(/*! ./plugin-api/normalize.scss */ "./src/plugin-api/normalize.scss");
 var PluginAPI = __webpack_require__(/*! ./plugin-api */ "./src/plugin-api/index.ts");
 exports.PluginAPI_V3 = PluginAPI;
@@ -27776,11 +27776,17 @@ var PageItemAuthoring = __webpack_require__(/*! ./page-item-authoring */ "./src/
 exports.PageItemAuthoring = PageItemAuthoring;
 // Note that LARA namespace is defined for the first time by V2 API. Once V2 is removed, this code should also be
 // removed and "library": "LARA" option in webpack.config.js should be re-enabled.
+window.LARA || (window.LARA = {}); // create if it doesn't exist
 window.LARA.PluginAPI_V3 = PluginAPI;
 window.LARA.Plugins = Plugins;
 window.LARA.Events = Events;
 window.LARA.InteractiveAPI = InteractiveAPI;
 window.LARA.PageItemAuthoring = PageItemAuthoring;
+// for clients that don't require LARA to be a global on window
+function initializeLara() {
+    return window.LARA;
+}
+exports.initializeLara = initializeLara;
 
 
 /***/ }),

--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -29650,6 +29650,14 @@ exports.decorateContent = function (words, replace, wordClass, listeners) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.events = void 0;
 var events_1 = __webpack_require__(/*! ../events */ "./src/events/index.ts");
+// Export event types as a part of Plugin API.
+var events_2 = __webpack_require__(/*! ../events */ "./src/events/index.ts");
+Object.defineProperty(exports, "onLog", { enumerable: true, get: function () { return events_2.onLog; } });
+Object.defineProperty(exports, "offLog", { enumerable: true, get: function () { return events_2.offLog; } });
+Object.defineProperty(exports, "onInteractiveAvailable", { enumerable: true, get: function () { return events_2.onInteractiveAvailable; } });
+Object.defineProperty(exports, "offInteractiveAvailable", { enumerable: true, get: function () { return events_2.offInteractiveAvailable; } });
+Object.defineProperty(exports, "onInteractiveSupportedFeatures", { enumerable: true, get: function () { return events_2.onInteractiveSupportedFeatures; } });
+Object.defineProperty(exports, "offInteractiveSupportedFeatures", { enumerable: true, get: function () { return events_2.offInteractiveSupportedFeatures; } });
 /**
  * Functions related to event observing provided by LARA.
  */
@@ -29674,6 +29682,15 @@ exports.events = {
      * Removes InteractiveAvailable event handler.
      */
     offInteractiveAvailable: function (handler) { return events_1.offInteractiveAvailable(handler); },
+    /**
+     * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
+     * Currently uses when click to play mode is enabled and the click to play overlay is clicked.
+     */
+    onInteractiveSupportedFeatures: function (handler) { return events_1.onInteractiveSupportedFeatures(handler); },
+    /**
+     * Removes InteractiveAvailable event handler.
+     */
+    offInteractiveSupportedFeatures: function (handler) { return events_1.offInteractiveAvailable(handler); },
 };
 
 

--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -29690,7 +29690,7 @@ exports.events = {
     /**
      * Removes InteractiveAvailable event handler.
      */
-    offInteractiveSupportedFeatures: function (handler) { return events_1.offInteractiveAvailable(handler); },
+    offInteractiveSupportedFeatures: function (handler) { return events_1.offInteractiveSupportedFeatures(handler); }
 };
 
 

--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -29674,7 +29674,7 @@ exports.events = {
      */
     offLog: function (handler) { return events_1.offLog(handler); },
     /**
-     * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
+     * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availability state.
      * Currently uses when click to play mode is enabled and the click to play overlay is clicked.
      */
     onInteractiveAvailable: function (handler) { return events_1.onInteractiveAvailable(handler); },
@@ -29683,12 +29683,11 @@ exports.events = {
      */
     offInteractiveAvailable: function (handler) { return events_1.offInteractiveAvailable(handler); },
     /**
-     * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
-     * Currently uses when click to play mode is enabled and the click to play overlay is clicked.
+     * Subscribes to InteractiveSupportedFeatures events. Gets called when any interactive calls setSupportedFeatures().
      */
     onInteractiveSupportedFeatures: function (handler) { return events_1.onInteractiveSupportedFeatures(handler); },
     /**
-     * Removes InteractiveAvailable event handler.
+     * Removes InteractiveSupportedFeatures event handler.
      */
     offInteractiveSupportedFeatures: function (handler) { return events_1.offInteractiveSupportedFeatures(handler); }
 };

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -75,6 +75,8 @@
 * [IAuthoringClientMessage](globals.md#iauthoringclientmessage)
 * [IAuthoringMetadata](globals.md#iauthoringmetadata)
 * [IAuthoringServerMessage](globals.md#iauthoringservermessage)
+* [ICustomMessageHandler](globals.md#icustommessagehandler)
+* [ICustomMessageOptions](globals.md#icustommessageoptions)
 * [IInitInteractive](globals.md#iinitinteractive)
 * [IRuntimeClientMessage](globals.md#iruntimeclientmessage)
 * [IRuntimeMetadata](globals.md#iruntimemetadata)
@@ -94,6 +96,7 @@
 ### Functions
 
 * [addAuthoredStateListener](globals.md#const-addauthoredstatelistener)
+* [addCustomMessageListener](globals.md#const-addcustommessagelistener)
 * [addGlobalInteractiveStateListener](globals.md#const-addglobalinteractivestatelistener)
 * [addInteractiveStateListener](globals.md#const-addinteractivestatelistener)
 * [closeModal](globals.md#const-closemodal)
@@ -110,6 +113,7 @@
 * [inIframe](globals.md#const-iniframe)
 * [log](globals.md#const-log)
 * [removeAuthoredStateListener](globals.md#const-removeauthoredstatelistener)
+* [removeCustomMessageListener](globals.md#const-removecustommessagelistener)
 * [removeGlobalInteractiveStateListener](globals.md#const-removeglobalinteractivestatelistener)
 * [removeInteractiveStateListener](globals.md#const-removeinteractivestatelistener)
 * [setAuthoredState](globals.md#const-setauthoredstate)
@@ -122,6 +126,7 @@
 * [setSupportedFeatures](globals.md#const-setsupportedfeatures)
 * [showModal](globals.md#const-showmodal)
 * [useAuthoredState](globals.md#const-useauthoredstate)
+* [useCustomMessages](globals.md#const-usecustommessages)
 * [useGlobalInteractiveState](globals.md#const-useglobalinteractivestate)
 * [useInitMessage](globals.md#const-useinitmessage)
 * [useInteractiveState](globals.md#const-useinteractivestate)
@@ -179,6 +184,28 @@ ___
 ###  IAuthoringServerMessage
 
 Ƭ **IAuthoringServerMessage**: *"interactiveList"*
+
+___
+
+###  ICustomMessageHandler
+
+Ƭ **ICustomMessageHandler**: *function*
+
+#### Type declaration:
+
+▸ (`message`: [ICustomMessage](interfaces/icustommessage.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`message` | [ICustomMessage](interfaces/icustommessage.md) |
+
+___
+
+###  ICustomMessageOptions
+
+Ƭ **ICustomMessageOptions**: *Record‹string, any›*
 
 ___
 
@@ -273,6 +300,20 @@ ___
 Name | Type |
 ------ | ------ |
 `authoredState` | AuthoredState |
+
+**Returns:** *void*
+
+___
+
+### `Const` addCustomMessageListener
+
+▸ **addCustomMessageListener**(`callback`: [ICustomMessageHandler](globals.md#icustommessagehandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`callback` | [ICustomMessageHandler](globals.md#icustommessagehandler) |
 
 **Returns:** *void*
 
@@ -508,6 +549,14 @@ ___
 Name | Type |
 ------ | ------ |
 `authoredState` | AuthoredState |
+
+**Returns:** *void*
+
+___
+
+### `Const` removeCustomMessageListener
+
+▸ **removeCustomMessageListener**(): *void*
 
 **Returns:** *void*
 
@@ -760,6 +809,20 @@ ___
 * **authoredState**: *null | AuthoredState*
 
 * **setAuthoredState**: *handleSetAuthoredState* = handleSetAuthoredState
+
+___
+
+### `Const` useCustomMessages
+
+▸ **useCustomMessages**(`callback`: [ICustomMessageHandler](globals.md#icustommessagehandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`callback` | [ICustomMessageHandler](globals.md#icustommessagehandler) |
+
+**Returns:** *void*
 
 ___
 

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -77,6 +77,7 @@
 * [IAuthoringServerMessage](globals.md#iauthoringservermessage)
 * [ICustomMessageHandler](globals.md#icustommessagehandler)
 * [ICustomMessageOptions](globals.md#icustommessageoptions)
+* [ICustomMessagesHandledMap](globals.md#icustommessageshandledmap)
 * [IInitInteractive](globals.md#iinitinteractive)
 * [IRuntimeClientMessage](globals.md#iruntimeclientmessage)
 * [IRuntimeMetadata](globals.md#iruntimemetadata)
@@ -209,6 +210,12 @@ ___
 
 ___
 
+###  ICustomMessagesHandledMap
+
+Ƭ **ICustomMessagesHandledMap**: *Record‹string, boolean | [ICustomMessageOptions](globals.md#icustommessageoptions)›*
+
+___
+
 ###  IInitInteractive
 
 Ƭ **IInitInteractive**: *[IRuntimeInitInteractive](interfaces/iruntimeinitinteractive.md)‹InteractiveState, AuthoredState, GlobalInteractiveState› | [IAuthoringInitInteractive](interfaces/iauthoringinitinteractive.md)‹AuthoredState› | [IReportInitInteractive](interfaces/ireportinitinteractive.md)‹InteractiveState, AuthoredState› | [IDialogInitInteractive](interfaces/idialoginitinteractive.md)‹InteractiveState, AuthoredState, DialogState›*
@@ -307,13 +314,14 @@ ___
 
 ### `Const` addCustomMessageListener
 
-▸ **addCustomMessageListener**(`callback`: [ICustomMessageHandler](globals.md#icustommessagehandler)): *void*
+▸ **addCustomMessageListener**(`callback`: [ICustomMessageHandler](globals.md#icustommessagehandler), `handles?`: [ICustomMessagesHandledMap](globals.md#icustommessageshandledmap)): *void*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
 `callback` | [ICustomMessageHandler](globals.md#icustommessagehandler) |
+`handles?` | [ICustomMessagesHandledMap](globals.md#icustommessageshandledmap) |
 
 **Returns:** *void*
 
@@ -814,13 +822,14 @@ ___
 
 ### `Const` useCustomMessages
 
-▸ **useCustomMessages**(`callback`: [ICustomMessageHandler](globals.md#icustommessagehandler)): *void*
+▸ **useCustomMessages**(`callback`: [ICustomMessageHandler](globals.md#icustommessagehandler), `handles?`: [ICustomMessagesHandledMap](globals.md#icustommessageshandledmap)): *void*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
 `callback` | [ICustomMessageHandler](globals.md#icustommessagehandler) |
+`handles?` | [ICustomMessagesHandledMap](globals.md#icustommessageshandledmap) |
 
 **Returns:** *void*
 

--- a/docs/interactive-api-client/interfaces/icustommessage.md
+++ b/docs/interactive-api-client/interfaces/icustommessage.md
@@ -17,7 +17,7 @@
 
 ###  content
 
-• **content**: *object*
+• **content**: *Record‹string, any›*
 
 ___
 

--- a/docs/lara-plugin-api/globals.md
+++ b/docs/lara-plugin-api/globals.md
@@ -445,7 +445,7 @@ Name | Type |
 
 ▸ **offInteractiveSupportedFeatures**(`handler`: [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler)): *void*
 
-Removes InteractiveAvailable event handler.
+Removes InteractiveSupportedFeatures event handler.
 
 **Parameters:**
 
@@ -473,7 +473,7 @@ Name | Type |
 
 ▸ **onInteractiveAvailable**(`handler`: [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler)): *void*
 
-Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
+Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availability state.
 Currently uses when click to play mode is enabled and the click to play overlay is clicked.
 
 **Parameters:**
@@ -488,8 +488,7 @@ Name | Type |
 
 ▸ **onInteractiveSupportedFeatures**(`handler`: [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler)): *void*
 
-Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
-Currently uses when click to play mode is enabled and the click to play overlay is clicked.
+Subscribes to InteractiveSupportedFeatures events. Gets called when any interactive calls setSupportedFeatures().
 
 **Parameters:**
 

--- a/docs/lara-plugin-api/globals.md
+++ b/docs/lara-plugin-api/globals.md
@@ -443,7 +443,7 @@ Name | Type |
 
 ###  offInteractiveSupportedFeatures
 
-▸ **offInteractiveSupportedFeatures**(`handler`: [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler)): *void*
+▸ **offInteractiveSupportedFeatures**(`handler`: [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler)): *void*
 
 Removes InteractiveAvailable event handler.
 
@@ -451,7 +451,7 @@ Removes InteractiveAvailable event handler.
 
 Name | Type |
 ------ | ------ |
-`handler` | [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler) |
+`handler` | [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler) |
 
 **Returns:** *void*
 

--- a/docs/lara-plugin-api/globals.md
+++ b/docs/lara-plugin-api/globals.md
@@ -11,6 +11,7 @@
 * [IEventListener](interfaces/ieventlistener.md)
 * [IInteractiveAvailableEvent](interfaces/iinteractiveavailableevent.md)
 * [IInteractiveState](interfaces/iinteractivestate.md)
+* [IInteractiveSupportedFeaturesEvent](interfaces/iinteractivesupportedfeaturesevent.md)
 * [IJwtClaims](interfaces/ijwtclaims.md)
 * [IJwtResponse](interfaces/ijwtresponse.md)
 * [ILogData](interfaces/ilogdata.md)
@@ -30,6 +31,7 @@
 
 * [IEventListeners](globals.md#ieventlisteners)
 * [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler)
+* [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler)
 * [ILogEventHandler](globals.md#ilogeventhandler)
 
 ### Functions
@@ -37,6 +39,12 @@
 * [addPopup](globals.md#const-addpopup)
 * [addSidebar](globals.md#const-addsidebar)
 * [decorateContent](globals.md#const-decoratecontent)
+* [offInteractiveAvailable](globals.md#const-offinteractiveavailable)
+* [offInteractiveSupportedFeatures](globals.md#const-offinteractivesupportedfeatures)
+* [offLog](globals.md#const-offlog)
+* [onInteractiveAvailable](globals.md#const-oninteractiveavailable)
+* [onInteractiveSupportedFeatures](globals.md#const-oninteractivesupportedfeatures)
+* [onLog](globals.md#const-onlog)
 * [registerPlugin](globals.md#const-registerplugin)
 
 ### Object literals
@@ -68,6 +76,24 @@ InteractiveAvailable event handler.
 Name | Type |
 ------ | ------ |
 `event` | [IInteractiveAvailableEvent](interfaces/iinteractiveavailableevent.md) |
+
+___
+
+###  IInteractiveSupportedFeaturesEventHandler
+
+Ƭ **IInteractiveSupportedFeaturesEventHandler**: *function*
+
+SupportedFeatures event handler.
+
+#### Type declaration:
+
+▸ (`event`: [IInteractiveSupportedFeaturesEvent](interfaces/iinteractivesupportedfeaturesevent.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | [IInteractiveSupportedFeaturesEvent](interfaces/iinteractivesupportedfeaturesevent.md) |
 
 ___
 
@@ -156,6 +182,90 @@ Name | Type | Description |
 `replace` | string | The replacement string. Can include '$1' representing the matched word. |
 `wordClass` | string | CSS class used in replacement string. Necessary only if `listeners` are provided too. |
 `listeners` | [IEventListeners](globals.md#ieventlisteners) | One or more { type, listener } tuples. Note that events are added to `wordClass` described above. It's client code responsibility to use this class in the `replace` string.  |
+
+**Returns:** *void*
+
+___
+
+### `Const` offInteractiveAvailable
+
+▸ **offInteractiveAvailable**(`handler`: [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler) |
+
+**Returns:** *void*
+
+___
+
+### `Const` offInteractiveSupportedFeatures
+
+▸ **offInteractiveSupportedFeatures**(`handler`: [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler) |
+
+**Returns:** *void*
+
+___
+
+### `Const` offLog
+
+▸ **offLog**(`handler`: [ILogEventHandler](globals.md#ilogeventhandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [ILogEventHandler](globals.md#ilogeventhandler) |
+
+**Returns:** *void*
+
+___
+
+### `Const` onInteractiveAvailable
+
+▸ **onInteractiveAvailable**(`handler`: [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler) |
+
+**Returns:** *void*
+
+___
+
+### `Const` onInteractiveSupportedFeatures
+
+▸ **onInteractiveSupportedFeatures**(`handler`: [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler) |
+
+**Returns:** *void*
+
+___
+
+### `Const` onLog
+
+▸ **onLog**(`handler`: [ILogEventHandler](globals.md#ilogeventhandler)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [ILogEventHandler](globals.md#ilogeventhandler) |
 
 **Returns:** *void*
 
@@ -331,6 +441,20 @@ Name | Type |
 
 **Returns:** *void*
 
+###  offInteractiveSupportedFeatures
+
+▸ **offInteractiveSupportedFeatures**(`handler`: [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler)): *void*
+
+Removes InteractiveAvailable event handler.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler) |
+
+**Returns:** *void*
+
 ###  offLog
 
 ▸ **offLog**(`handler`: [ILogEventHandler](globals.md#ilogeventhandler)): *void*
@@ -357,6 +481,21 @@ Currently uses when click to play mode is enabled and the click to play overlay 
 Name | Type |
 ------ | ------ |
 `handler` | [IInteractiveAvailableEventHandler](globals.md#iinteractiveavailableeventhandler) |
+
+**Returns:** *void*
+
+###  onInteractiveSupportedFeatures
+
+▸ **onInteractiveSupportedFeatures**(`handler`: [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler)): *void*
+
+Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
+Currently uses when click to play mode is enabled and the click to play overlay is clicked.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | [IInteractiveSupportedFeaturesEventHandler](globals.md#iinteractivesupportedfeatureseventhandler) |
 
 **Returns:** *void*
 

--- a/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
+++ b/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
@@ -129,13 +129,13 @@ are available.
 
 #### Type declaration:
 
-▸ (`handler`: IInteractiveSupportedFeaturesEventHandler): *void*
+▸ (`handler`: [IInteractiveSupportedFeaturesEventHandler](../globals.md#iinteractivesupportedfeatureseventhandler)): *void*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`handler` | IInteractiveSupportedFeaturesEventHandler |
+`handler` | [IInteractiveSupportedFeaturesEventHandler](../globals.md#iinteractivesupportedfeatureseventhandler) |
 
 ___
 

--- a/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
+++ b/docs/lara-plugin-api/interfaces/iembeddableruntimecontext.md
@@ -16,6 +16,8 @@
 * [interactiveAvailable](iembeddableruntimecontext.md#interactiveavailable)
 * [laraJson](iembeddableruntimecontext.md#larajson)
 * [onInteractiveAvailable](iembeddableruntimecontext.md#oninteractiveavailable)
+* [onInteractiveSupportedFeatures](iembeddableruntimecontext.md#oninteractivesupportedfeatures)
+* [sendCustomMessage](iembeddableruntimecontext.md#sendcustommessage)
 
 ## Properties
 
@@ -113,3 +115,44 @@ the interactive starts as not available and this handler is called when the clic
 Name | Type |
 ------ | ------ |
 `handler` | [IInteractiveAvailableEventHandler](../globals.md#iinteractiveavailableeventhandler) |
+
+___
+
+###  onInteractiveSupportedFeatures
+
+• **onInteractiveSupportedFeatures**: *function*
+
+Function that subscribes provided handler to event that gets called when the interactive's supported features are
+are available.
+
+**`param`** Event handler function.
+
+#### Type declaration:
+
+▸ (`handler`: IInteractiveSupportedFeaturesEventHandler): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`handler` | IInteractiveSupportedFeaturesEventHandler |
+
+___
+
+###  sendCustomMessage
+
+• **sendCustomMessage**: *function*
+
+Function that sends a custom message to the embeddable.
+
+**`param`** The message to be sent
+
+#### Type declaration:
+
+▸ (`message`: ICustomMessage): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`message` | ICustomMessage |

--- a/docs/lara-plugin-api/interfaces/iinteractivesupportedfeaturesevent.md
+++ b/docs/lara-plugin-api/interfaces/iinteractivesupportedfeaturesevent.md
@@ -1,0 +1,32 @@
+[@concord-consortium/lara-plugin-api - v3.1.2](../README.md) › [Globals](../globals.md) › [IInteractiveSupportedFeaturesEvent](iinteractivesupportedfeaturesevent.md)
+
+# Interface: IInteractiveSupportedFeaturesEvent
+
+Data passed to InteractiveSupportedFeatures event handlers.
+
+## Hierarchy
+
+* **IInteractiveSupportedFeaturesEvent**
+
+## Index
+
+### Properties
+
+* [container](iinteractivesupportedfeaturesevent.md#container)
+* [supportedFeatures](iinteractivesupportedfeaturesevent.md#supportedfeatures)
+
+## Properties
+
+###  container
+
+• **container**: *HTMLElement*
+
+Interactive container of the interactive that was just started.
+
+___
+
+###  supportedFeatures
+
+• **supportedFeatures**: *ISupportedFeatures*
+
+Supported features

--- a/lara-typescript/src/events/index.spec.ts
+++ b/lara-typescript/src/events/index.spec.ts
@@ -1,5 +1,5 @@
 import * as events from "./index";
-import { IInteractiveAvailableEvent } from "./index";
+import { IInteractiveAvailableEvent, IInteractiveSupportedFeaturesEvent } from "./index";
 
 describe("Events helper", () => {
   describe("Log event", () => {
@@ -24,6 +24,19 @@ describe("Events helper", () => {
       expect(handler).toHaveBeenNthCalledWith(1, e);
       events.offInteractiveAvailable(handler);
       events.emitInteractiveAvailable(e);
+      expect(handler).toHaveBeenNthCalledWith(1, e);
+    });
+  });
+
+  describe("InteractiveSupportedFeatures event", () => {
+    it("provides working API for event handling", () => {
+      const handler = jest.fn();
+      events.onInteractiveSupportedFeatures(handler);
+      const e: IInteractiveSupportedFeaturesEvent = { container: document.createElement("div"), supportedFeatures: {} };
+      events.emitInteractiveSupportedFeatures(e);
+      expect(handler).toHaveBeenNthCalledWith(1, e);
+      events.offInteractiveSupportedFeatures(handler);
+      events.emitInteractiveSupportedFeatures(e);
       expect(handler).toHaveBeenNthCalledWith(1, e);
     });
   });

--- a/lara-typescript/src/events/index.ts
+++ b/lara-typescript/src/events/index.ts
@@ -1,3 +1,4 @@
+import { ISupportedFeatures } from "../interactive-api-client/types";
 import { EventEmitter2 } from "eventemitter2";
 
 /**
@@ -35,6 +36,25 @@ export interface IInteractiveAvailableEvent {
  */
 export type IInteractiveAvailableEventHandler = (event: IInteractiveAvailableEvent) => void;
 
+/**
+ * Data passed to InteractiveSupportedFeatures event handlers.
+ */
+export interface IInteractiveSupportedFeaturesEvent {
+  /**
+   * Interactive container of the interactive that was just started.
+   */
+  container: HTMLElement;
+  /**
+   * Supported features
+   */
+  supportedFeatures: ISupportedFeatures;
+}
+
+/**
+ * SupportedFeatures event handler.
+ */
+export type IInteractiveSupportedFeaturesEventHandler = (event: IInteractiveSupportedFeaturesEvent) => void;
+
 const emitter = new EventEmitter2({
   maxListeners: Infinity
 });
@@ -57,4 +77,14 @@ export const onInteractiveAvailable = (handler: IInteractiveAvailableEventHandle
 };
 export const offInteractiveAvailable = (handler: IInteractiveAvailableEventHandler) => {
   emitter.off("interactiveAvailable", handler);
+};
+
+export const emitInteractiveSupportedFeatures = (event: IInteractiveSupportedFeaturesEvent) => {
+  emitter.emit("interactiveSupportedFeatures", event);
+};
+export const onInteractiveSupportedFeatures = (handler: IInteractiveSupportedFeaturesEventHandler) => {
+  emitter.on("interactiveSupportedFeatures", handler);
+};
+export const offInteractiveSupportedFeatures = (handler: IInteractiveSupportedFeaturesEventHandler) => {
+  emitter.off("interactiveSupportedFeatures", handler);
 };

--- a/lara-typescript/src/example-interactive/src/components/runtime.tsx
+++ b/lara-typescript/src/example-interactive/src/components/runtime.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 const { useEffect, useState } = React;
-import { IRuntimeInitInteractive, getFirebaseJwt } from "../../../interactive-api-client";
+import { IRuntimeInitInteractive, getFirebaseJwt, useCustomMessages, ICustomMessage } from "../../../interactive-api-client";
 import { IAuthoredState } from "./types";
 
 interface Props {
@@ -22,6 +22,11 @@ export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
     }
   }, [authoredState]);
 
+  const [customMessages, setCustomMessages] = useState<ICustomMessage[]>([]);
+  useCustomMessages((msg: ICustomMessage) => {
+    setCustomMessages(messages => [...messages, msg]);
+  });
+
   return (
     <div className="padded">
       <fieldset>
@@ -31,6 +36,25 @@ export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
       <fieldset>
         <legend>FirebaseJWT Response</legend>
         <div className="padded monospace pre">{rawFirebaseJwt}</div>
+      </fieldset>
+      <fieldset>
+        <legend>Custom Messages Received</legend>
+        <div className="padded monospace pre">
+          <table>
+            <thead>
+              <th>Type</th>
+              <th>Content</th>
+            </thead>
+            <tbody>
+              {customMessages.map((msg, i) => (
+                <tr key={`${i}-${msg.type}`}>
+                  <td>{msg.type}</td>
+                  <td>{msg.content}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </fieldset>
     </div>
   );

--- a/lara-typescript/src/example-interactive/src/components/runtime.tsx
+++ b/lara-typescript/src/example-interactive/src/components/runtime.tsx
@@ -25,7 +25,7 @@ export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
   const [customMessages, setCustomMessages] = useState<ICustomMessage[]>([]);
   useCustomMessages((msg: ICustomMessage) => {
     setCustomMessages(messages => [...messages, msg]);
-  });
+  }, { "*": true });
 
   return (
     <div className="padded">

--- a/lara-typescript/src/index.ts
+++ b/lara-typescript/src/index.ts
@@ -6,6 +6,12 @@ import * as Plugins from "./plugins";
 import * as Events from "./events";
 import * as PageItemAuthoring from "./page-item-authoring";
 
+export interface LaraGlobalType {
+  PluginAPI_V3: typeof PluginAPI;
+  Plugins: typeof Plugins;
+  Events: typeof Events;
+}
+
 export {
   PluginAPI as PluginAPI_V3,
   InteractiveAPI,
@@ -16,8 +22,14 @@ export {
 
 // Note that LARA namespace is defined for the first time by V2 API. Once V2 is removed, this code should also be
 // removed and "library": "LARA" option in webpack.config.js should be re-enabled.
+(window as any).LARA || ((window as any).LARA = {});  // create if it doesn't exist
 (window as any).LARA.PluginAPI_V3 = PluginAPI;
 (window as any).LARA.Plugins = Plugins;
 (window as any).LARA.Events = Events;
 (window as any).LARA.InteractiveAPI = InteractiveAPI;
 (window as any).LARA.PageItemAuthoring = PageItemAuthoring;
+
+// for clients that don't require LARA to be a global on window
+export function initializeLara(): LaraGlobalType {
+  return (window as any).LARA;
+}

--- a/lara-typescript/src/interactive-api-client/api.spec.ts
+++ b/lara-typescript/src/interactive-api-client/api.spec.ts
@@ -72,6 +72,12 @@ describe("api", () => {
     expect(mockedPhone.messages).toEqual([{type: "log", content: {action: "test action", data: {param1: 1}}}]);
   });
 
+  it("supports [add|remove]CustomMessageListener", () => {
+    const handler = jest.fn();
+    api.addCustomMessageListener(handler, { handles: { foo: true } });
+    api.removeCustomMessageListener();
+  });
+
   it("supports setSupportedFeatures", () => {
     api.setSupportedFeatures({ interactiveState: true, authoredState: true, aspectRatio: 1 });
     expect(mockedPhone.messages).toEqual([{

--- a/lara-typescript/src/interactive-api-client/api.ts
+++ b/lara-typescript/src/interactive-api-client/api.ts
@@ -19,7 +19,8 @@ import {
   IHintRequest,
   IJwtResponse,
   IGetInteractiveListRequest,
-  ISetLinkedInteractivesRequest
+  ISetLinkedInteractivesRequest,
+  ICustomMessageHandler
 } from "./types";
 import { getClient } from "./client";
 
@@ -240,6 +241,14 @@ export const showModal = (options: IShowModal) => {
   else {
     THROW_NOT_IMPLEMENTED_YET(`showModal { type: "${options.type}" }`);
   }
+};
+
+export const addCustomMessageListener = (callback: ICustomMessageHandler) => {
+  getClient().addListener("customMessage", callback);
+};
+
+export const removeCustomMessageListener = () => {
+  getClient().removeListener("customMessage");
 };
 
 /**

--- a/lara-typescript/src/interactive-api-client/api.ts
+++ b/lara-typescript/src/interactive-api-client/api.ts
@@ -20,7 +20,8 @@ import {
   IJwtResponse,
   IGetInteractiveListRequest,
   ISetLinkedInteractivesRequest,
-  ICustomMessageHandler
+  ICustomMessageHandler,
+  ICustomMessagesHandledMap
 } from "./types";
 import { getClient } from "./client";
 
@@ -133,12 +134,20 @@ export const setGlobalInteractiveState = <GlobalInteractiveState>(newGlobalState
   client.post("interactiveStateGlobal", newGlobalState);
 };
 
+export const addCustomMessageListener = (callback: ICustomMessageHandler, handles?: ICustomMessagesHandledMap) => {
+  getClient().addCustomMessageListener(callback, handles);
+};
+
+export const removeCustomMessageListener = () => {
+  getClient().removeCustomMessageListener();
+};
+
 export const setSupportedFeatures = (features: ISupportedFeatures) => {
   const request: ISupportedFeaturesRequest = {
     apiVersion: 1,
     features
   };
-  getClient().post("supportedFeatures", request);
+  getClient().setSupportedFeatures(request);
 };
 
 export const setHeight = (height: number | string) => {
@@ -241,14 +250,6 @@ export const showModal = (options: IShowModal) => {
   else {
     THROW_NOT_IMPLEMENTED_YET(`showModal { type: "${options.type}" }`);
   }
-};
-
-export const addCustomMessageListener = (callback: ICustomMessageHandler) => {
-  getClient().addListener("customMessage", callback);
-};
-
-export const removeCustomMessageListener = () => {
-  getClient().removeListener("customMessage");
 };
 
 /**

--- a/lara-typescript/src/interactive-api-client/client.spec.ts
+++ b/lara-typescript/src/interactive-api-client/client.spec.ts
@@ -103,7 +103,7 @@ describe("Client", () => {
       expect(client.managedState.globalInteractiveState).toEqual({ test: 123 });
     });
 
-    it("lets you add and remove custom message listener", () => {
+    it("lets you add and remove arbitrary message listener", () => {
       const client = new Client();
       const listener = jest.fn();
       client.addListener("authInfo", listener);
@@ -116,7 +116,7 @@ describe("Client", () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
-    it("lets you add custom message listener with requestId", () => {
+    it("lets you add arbitrary message listener with requestId", () => {
       const client = new Client();
       const listener = jest.fn();
       const requestId = 123;
@@ -138,6 +138,14 @@ describe("Client", () => {
       // listener should be removed now
       mockedPhone.fakeServerMessage({type: "authInfo", content: {test: 321}});
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("can add/remove custom message listener and pass supported messages to setSupportedFeatures", () => {
+      const client = new Client();
+      const listener = jest.fn();
+      client.addCustomMessageListener(listener, { handles: { foo: true } });
+      client.setSupportedFeatures({ apiVersion: 1, features: {} });
+      expect(client.removeCustomMessageListener()).toBe(true);
     });
 
     it("warns user when he tries to leave the page and interactive state is dirty", () => {

--- a/lara-typescript/src/interactive-api-client/hooks.spec.tsx
+++ b/lara-typescript/src/interactive-api-client/hooks.spec.tsx
@@ -269,3 +269,13 @@ describe("useGlobalInteractiveState", () => {
     expect(container.textContent).toEqual("new state 123");
   });
 });
+
+describe("useCustomMessages", () => {
+
+  it("does something", () => {
+    const handler = jest.fn();
+    renderHook(() => hooks.useCustomMessages(handler, { foo: true }));
+    getClient().setSupportedFeatures({ apiVersion: 1, features: {} });
+  });
+
+});

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { IInitInteractive } from "./types";
+import { ICustomMessageHandler, IInitInteractive } from "./types";
 import * as client from "./api";
 
 type UpdateFunc<S> = (prevState: S | null) => S;
@@ -114,4 +114,12 @@ export const useInitMessage = <InteractiveState = {}, AuthoredState = {}, Dialog
   }, []);
 
   return initMessage;
+};
+
+export const useCustomMessages = (callback: ICustomMessageHandler) => {
+  useEffect(() => {
+    client.addCustomMessageListener(callback);
+
+    return () => client.removeCustomMessageListener();
+  }, []);
 };

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ICustomMessageHandler, IInitInteractive } from "./types";
+import { ICustomMessageHandler, ICustomMessagesHandledMap, IInitInteractive } from "./types";
 import * as client from "./api";
 
 type UpdateFunc<S> = (prevState: S | null) => S;
@@ -116,9 +116,9 @@ export const useInitMessage = <InteractiveState = {}, AuthoredState = {}, Dialog
   return initMessage;
 };
 
-export const useCustomMessages = (callback: ICustomMessageHandler) => {
+export const useCustomMessages = (callback: ICustomMessageHandler, handles?: ICustomMessagesHandledMap) => {
   useEffect(() => {
-    client.addCustomMessageListener(callback);
+    client.addCustomMessageListener(callback, handles);
 
     return () => client.removeCustomMessageListener();
   }, []);

--- a/lara-typescript/src/interactive-api-client/types.ts
+++ b/lara-typescript/src/interactive-api-client/types.ts
@@ -204,12 +204,14 @@ export interface IContextMembership {
 // client requests only (no responses from lara)
 //
 
+export type ICustomMessageOptions = Record<string, any>;
+
 export interface ISupportedFeatures {
   aspectRatio?: number;
   authoredState?: boolean;
   interactiveState?: boolean;
   customMessages?: {
-    handles?: string[];
+    handles?: Record<string, boolean | ICustomMessageOptions>;
     // TODO: extend later to allow for sending custom messages from interactive
   };
 }
@@ -284,8 +286,9 @@ export interface IClosedModal {
 
 export interface ICustomMessage {
   type: string;
-  content: object;
+  content: Record<string, any>;
 }
+export type ICustomMessageHandler = (message: ICustomMessage) => void;
 
 export interface ISetLinkedInteractives {
   linkedInteractives?: ILinkedInteractive[];

--- a/lara-typescript/src/interactive-api-client/types.ts
+++ b/lara-typescript/src/interactive-api-client/types.ts
@@ -205,13 +205,14 @@ export interface IContextMembership {
 //
 
 export type ICustomMessageOptions = Record<string, any>;
+export type ICustomMessagesHandledMap = Record<string, boolean | ICustomMessageOptions>;
 
 export interface ISupportedFeatures {
   aspectRatio?: number;
   authoredState?: boolean;
   interactiveState?: boolean;
   customMessages?: {
-    handles?: Record<string, boolean | ICustomMessageOptions>;
+    handles?: ICustomMessagesHandledMap;
     // TODO: extend later to allow for sending custom messages from interactive
   };
 }

--- a/lara-typescript/src/plugin-api/events.spec.ts
+++ b/lara-typescript/src/plugin-api/events.spec.ts
@@ -7,6 +7,8 @@ describe("Events", () => {
     jest.spyOn(EventsImpl, "offLog");
     jest.spyOn(EventsImpl, "onInteractiveAvailable");
     jest.spyOn(EventsImpl, "offInteractiveAvailable");
+    jest.spyOn(EventsImpl, "onInteractiveSupportedFeatures");
+    jest.spyOn(EventsImpl, "offInteractiveSupportedFeatures");
     const handler = jest.fn();
     events.onLog(handler);
     expect(EventsImpl.onLog).toHaveBeenCalledWith(handler);
@@ -16,5 +18,9 @@ describe("Events", () => {
     expect(EventsImpl.onInteractiveAvailable).toHaveBeenCalledWith(handler);
     events.offInteractiveAvailable(handler);
     expect(EventsImpl.offInteractiveAvailable).toHaveBeenCalledWith(handler);
+    events.onInteractiveSupportedFeatures(handler);
+    expect(EventsImpl.onInteractiveSupportedFeatures).toHaveBeenCalledWith(handler);
+    events.offInteractiveSupportedFeatures(handler);
+    expect(EventsImpl.offInteractiveSupportedFeatures).toHaveBeenCalledWith(handler);
   });
 });

--- a/lara-typescript/src/plugin-api/events.ts
+++ b/lara-typescript/src/plugin-api/events.ts
@@ -1,8 +1,16 @@
 import {
-  onLog, offLog, onInteractiveAvailable, offInteractiveAvailable, IInteractiveAvailableEventHandler, ILogEventHandler
+  onLog, offLog, ILogEventHandler,
+  onInteractiveAvailable, offInteractiveAvailable, IInteractiveAvailableEventHandler,
+  onInteractiveSupportedFeatures, IInteractiveSupportedFeaturesEventHandler
 } from "../events";
 // Export event types as a part of Plugin API.
-export { ILogEventHandler, IInteractiveAvailableEventHandler, ILogData, IInteractiveAvailableEvent } from "../events";
+export {
+  onLog, offLog, ILogData, ILogEventHandler,
+  onInteractiveAvailable, offInteractiveAvailable,
+  IInteractiveAvailableEvent, IInteractiveAvailableEventHandler,
+  onInteractiveSupportedFeatures, offInteractiveSupportedFeatures,
+  IInteractiveSupportedFeaturesEvent, IInteractiveSupportedFeaturesEventHandler
+} from "../events";
 
 /**
  * Functions related to event observing provided by LARA.
@@ -29,4 +37,14 @@ export const events = {
    * Removes InteractiveAvailable event handler.
    */
   offInteractiveAvailable: (handler: IInteractiveAvailableEventHandler) => offInteractiveAvailable(handler),
+  /**
+   * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
+   * Currently uses when click to play mode is enabled and the click to play overlay is clicked.
+   */
+  onInteractiveSupportedFeatures:
+    (handler: IInteractiveSupportedFeaturesEventHandler) => onInteractiveSupportedFeatures(handler),
+  /**
+   * Removes InteractiveAvailable event handler.
+   */
+  offInteractiveSupportedFeatures: (handler: IInteractiveAvailableEventHandler) => offInteractiveAvailable(handler),
 };

--- a/lara-typescript/src/plugin-api/events.ts
+++ b/lara-typescript/src/plugin-api/events.ts
@@ -1,7 +1,7 @@
 import {
   onLog, offLog, ILogEventHandler,
   onInteractiveAvailable, offInteractiveAvailable, IInteractiveAvailableEventHandler,
-  onInteractiveSupportedFeatures, IInteractiveSupportedFeaturesEventHandler
+  onInteractiveSupportedFeatures, offInteractiveSupportedFeatures, IInteractiveSupportedFeaturesEventHandler
 } from "../events";
 // Export event types as a part of Plugin API.
 export {
@@ -46,5 +46,6 @@ export const events = {
   /**
    * Removes InteractiveAvailable event handler.
    */
-  offInteractiveSupportedFeatures: (handler: IInteractiveAvailableEventHandler) => offInteractiveAvailable(handler),
+  offInteractiveSupportedFeatures:
+    (handler: IInteractiveSupportedFeaturesEventHandler) => offInteractiveSupportedFeatures(handler)
 };

--- a/lara-typescript/src/plugin-api/events.ts
+++ b/lara-typescript/src/plugin-api/events.ts
@@ -29,7 +29,7 @@ export const events = {
    */
   offLog: (handler: ILogEventHandler) => offLog(handler),
   /**
-   * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
+   * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availability state.
    * Currently uses when click to play mode is enabled and the click to play overlay is clicked.
    */
   onInteractiveAvailable: (handler: IInteractiveAvailableEventHandler) => onInteractiveAvailable(handler),
@@ -38,13 +38,12 @@ export const events = {
    */
   offInteractiveAvailable: (handler: IInteractiveAvailableEventHandler) => offInteractiveAvailable(handler),
   /**
-   * Subscribes to InteractiveAvailable events. Gets called when any interactive changes its availablity state.
-   * Currently uses when click to play mode is enabled and the click to play overlay is clicked.
+   * Subscribes to InteractiveSupportedFeatures events. Gets called when any interactive calls setSupportedFeatures().
    */
   onInteractiveSupportedFeatures:
     (handler: IInteractiveSupportedFeaturesEventHandler) => onInteractiveSupportedFeatures(handler),
   /**
-   * Removes InteractiveAvailable event handler.
+   * Removes InteractiveSupportedFeatures event handler.
    */
   offInteractiveSupportedFeatures:
     (handler: IInteractiveSupportedFeaturesEventHandler) => offInteractiveSupportedFeatures(handler)

--- a/lara-typescript/src/plugin-api/types.ts
+++ b/lara-typescript/src/plugin-api/types.ts
@@ -1,5 +1,6 @@
-import { ILogData, IInteractiveAvailableEventHandler } from "../events";
-import { IPortalClaims, IJwtClaims, IJwtResponse } from "../shared/types";
+import { ILogData, IInteractiveAvailableEventHandler, IInteractiveSupportedFeaturesEventHandler } from "../events";
+import { ICustomMessage } from "../interactive-api-client/types";
+import { IJwtResponse } from "../shared/types";
 
 // Export some shared types.
 export { IPortalClaims, IJwtClaims, IJwtResponse } from "../shared/types";
@@ -113,6 +114,19 @@ export interface IEmbeddableRuntimeContext {
   onInteractiveAvailable: (handler: IInteractiveAvailableEventHandler) => void;
   /** True if the interactive is immediately available */
   interactiveAvailable: boolean;
+  /****************************************************************************
+   Function that subscribes provided handler to event that gets called when the interactive's supported features are
+   are available.
+
+   @param handler Event handler function.
+   ****************************************************************************/
+  onInteractiveSupportedFeatures: (handler: IInteractiveSupportedFeaturesEventHandler) => void;
+  /****************************************************************************
+   Function that sends a custom message to the embeddable.
+
+   @param message The message to be sent
+   ****************************************************************************/
+  sendCustomMessage: (message: ICustomMessage) => void;
 }
 
 export interface IPluginAuthoringContext {

--- a/lara-typescript/src/plugins/embeddable-runtime-context.spec.ts
+++ b/lara-typescript/src/plugins/embeddable-runtime-context.spec.ts
@@ -1,6 +1,6 @@
 import { generateEmbeddableRuntimeContext } from "./embeddable-runtime-context";
 import { IInteractiveState } from "../plugin-api";
-import { emitInteractiveAvailable } from "../events";
+import { emitInteractiveAvailable, emitInteractiveSupportedFeatures } from "../events";
 import * as fetch from "jest-fetch-mock";
 import { IEmbeddableContextOptions } from "./plugin-context";
 (window as any).fetch = fetch;
@@ -127,6 +127,27 @@ describe("Embeddable runtime context helper", () => {
       const event = { container: embeddableContext.container, available: true };
       emitInteractiveAvailable(event);
       expect(handler).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe("#onInteractiveSupportedFeatures", () => {
+    it("accepts handler and calls it when this particular interactive specifies its supported features", () => {
+      const runtimeContext = generateEmbeddableRuntimeContext(embeddableContext);
+      const handler = jest.fn();
+      runtimeContext.onInteractiveSupportedFeatures(handler);
+      // Different container => different interactive. Handler should not be called.
+      emitInteractiveSupportedFeatures({ container: document.createElement("div"), supportedFeatures: {} });
+      expect(handler).toHaveBeenCalledTimes(0);
+      const event = { container: embeddableContext.container, supportedFeatures: {} };
+      emitInteractiveSupportedFeatures(event);
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe("#sendCustomMessage", () => {
+    it("provides sendCustomMessage function", () => {
+      const runtimeContext = generateEmbeddableRuntimeContext(embeddableContext);
+      runtimeContext.sendCustomMessage({ type: "foo", content: { bar: true } });
     });
   });
 });

--- a/lara-typescript/src/plugins/embeddable-runtime-context.ts
+++ b/lara-typescript/src/plugins/embeddable-runtime-context.ts
@@ -1,5 +1,8 @@
 import { IEmbeddableRuntimeContext, IInteractiveState } from "../plugin-api";
-import { onInteractiveAvailable, IInteractiveAvailableEvent, IInteractiveAvailableEventHandler } from "../events";
+import { onInteractiveAvailable, IInteractiveAvailableEvent, IInteractiveAvailableEventHandler,
+        onInteractiveSupportedFeatures, IInteractiveSupportedFeaturesEvent, IInteractiveSupportedFeaturesEventHandler
+        } from "../events";
+import { ICustomMessage } from "../interactive-api-client/types";
 import { IEmbeddableContextOptions } from "./plugin-context";
 
 const getInteractiveState = (interactiveStateUrl: string | null): Promise<IInteractiveState> | null => {
@@ -50,6 +53,17 @@ export const generateEmbeddableRuntimeContext = (context: IEmbeddableContextOpti
         }
       });
     },
-    interactiveAvailable: context.interactiveAvailable
+    onInteractiveSupportedFeatures: (handler: IInteractiveSupportedFeaturesEventHandler) => {
+      // Add generic listener and filter events to limit them just to this given embeddable.
+      onInteractiveSupportedFeatures((event: IInteractiveSupportedFeaturesEvent) => {
+        if (event.container === context.container) {
+          handler(event);
+        }
+      });
+    },
+    interactiveAvailable: context.interactiveAvailable,
+    sendCustomMessage: (message: ICustomMessage) => {
+      context.sendCustomMessage?.(message);
+    }
   };
 };

--- a/lara-typescript/src/plugins/plugin-context.ts
+++ b/lara-typescript/src/plugins/plugin-context.ts
@@ -1,5 +1,6 @@
 import { IPluginRuntimeContext, IJwtResponse, IClassInfo, IPluginAuthoringContext } from "../plugin-api";
 import { ILogData } from "../events";
+import { ICustomMessage } from "../interactive-api-client/types";
 import { generateEmbeddableRuntimeContext } from "./embeddable-runtime-context";
 import * as $ from "jquery";
 
@@ -82,9 +83,11 @@ export interface IEmbeddableContextOptions {
   interactiveStateUrl: string | null;
   /** True if the interactive is immediately available for use */
   interactiveAvailable: boolean;
+  /** Callback function which plugin can use to send custom messages to interactive */
+  sendCustomMessage?: (message: ICustomMessage) => void;
 }
 
-const ajaxPromise = (url: string, data: object): Promise<string> => {
+const ajaxPromise = (url: string, data: any): Promise<string> => {
   return new Promise((resolve, reject) => {
     $.ajax({
       url,

--- a/lara-typescript/src/plugins/plugins.ts
+++ b/lara-typescript/src/plugins/plugins.ts
@@ -23,7 +23,7 @@ const pluginClasses: { [label: string]: IRegisterPluginOptions } = {};
  * to override the plugin's passed label.  This removes the previous need for the plugin's label to
  * match the label in LARA's database.
  */
-let nextPluginLabel: string = "";
+let nextPluginLabel = "";
 export const setNextPluginLabel = (override: string) => {
   nextPluginLabel = override;
 };

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -31520,7 +31520,7 @@ exports.RuntimeComponent = function (_a) {
     var _c = useState([]), customMessages = _c[0], setCustomMessages = _c[1];
     interactive_api_client_1.useCustomMessages(function (msg) {
         setCustomMessages(function (messages) { return __spreadArrays(messages, [msg]); });
-    });
+    }, { "*": true });
     return (React.createElement("div", { className: "padded" },
         React.createElement("fieldset", null,
             React.createElement("legend", null, "Runtime Init Message"),
@@ -31582,7 +31582,7 @@ var __assign = (this && this.__assign) || function () {
     return __assign.apply(this, arguments);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInteractiveSnapshot = exports.getLibraryInteractiveList = exports.setLinkedInteractives = exports.getInteractiveList = exports.closeModal = exports.removeCustomMessageListener = exports.addCustomMessageListener = exports.showModal = exports.removeGlobalInteractiveStateListener = exports.addGlobalInteractiveStateListener = exports.removeAuthoredStateListener = exports.addAuthoredStateListener = exports.removeInteractiveStateListener = exports.addInteractiveStateListener = exports.log = exports.getFirebaseJwt = exports.getAuthInfo = exports.setNavigation = exports.setHint = exports.setHeight = exports.setSupportedFeatures = exports.setGlobalInteractiveState = exports.getGlobalInteractiveState = exports.setAuthoredState = exports.getAuthoredState = exports.setInteractiveState = exports.setInteractiveStateTimeout = exports.getInteractiveState = exports.getMode = exports.getInitInteractiveMessage = void 0;
+exports.getInteractiveSnapshot = exports.getLibraryInteractiveList = exports.setLinkedInteractives = exports.getInteractiveList = exports.closeModal = exports.showModal = exports.removeGlobalInteractiveStateListener = exports.addGlobalInteractiveStateListener = exports.removeAuthoredStateListener = exports.addAuthoredStateListener = exports.removeInteractiveStateListener = exports.addInteractiveStateListener = exports.log = exports.getFirebaseJwt = exports.getAuthInfo = exports.setNavigation = exports.setHint = exports.setHeight = exports.setSupportedFeatures = exports.removeCustomMessageListener = exports.addCustomMessageListener = exports.setGlobalInteractiveState = exports.getGlobalInteractiveState = exports.setAuthoredState = exports.getAuthoredState = exports.setInteractiveState = exports.setInteractiveStateTimeout = exports.getInteractiveState = exports.getMode = exports.getInitInteractiveMessage = void 0;
 var client_1 = __webpack_require__(/*! ./client */ "./src/interactive-api-client/client.ts");
 var THROW_NOT_IMPLEMENTED_YET = function (method) {
     throw new Error(method + " is not yet implemented in the client!");
@@ -31683,12 +31683,18 @@ exports.setGlobalInteractiveState = function (newGlobalState) {
     client.managedState.globalInteractiveState = newGlobalState;
     client.post("interactiveStateGlobal", newGlobalState);
 };
+exports.addCustomMessageListener = function (callback, handles) {
+    client_1.getClient().addCustomMessageListener(callback, handles);
+};
+exports.removeCustomMessageListener = function () {
+    client_1.getClient().removeCustomMessageListener();
+};
 exports.setSupportedFeatures = function (features) {
     var request = {
         apiVersion: 1,
         features: features
     };
-    client_1.getClient().post("supportedFeatures", request);
+    client_1.getClient().setSupportedFeatures(request);
 };
 exports.setHeight = function (height) {
     client_1.getClient().post("height", height);
@@ -31782,12 +31788,6 @@ exports.showModal = function (options) {
         THROW_NOT_IMPLEMENTED_YET("showModal { type: \"" + options.type + "\" }");
     }
 };
-exports.addCustomMessageListener = function (callback) {
-    client_1.getClient().addListener("customMessage", callback);
-};
-exports.removeCustomMessageListener = function () {
-    client_1.getClient().removeListener("customMessage");
-};
 /**
  * @todo Implement this function.
  */
@@ -31851,11 +31851,33 @@ exports.getInteractiveSnapshot = function (options) {
 
 "use strict";
 
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Client = exports.getClient = void 0;
-// iframe phone uses 1 listener per message type so we multipex over 1 listener in this code
+// iframe phone uses 1 listener per message type so we multiplex over 1 listener in this code
 // to allow callbacks to optionally be tied to a requestId.  This allows us to have multiple listeners
-// to the same message and auto-removing listeners when a requestId is given
+// to the same message and auto-removing listeners when a requestId is given.
 var iframePhone = __webpack_require__(/*! iframe-phone */ "./node_modules/iframe-phone/main.js");
 var in_frame_1 = __webpack_require__(/*! ./in-frame */ "./src/interactive-api-client/in-frame.ts");
 var managed_state_1 = __webpack_require__(/*! ./managed-state */ "./src/interactive-api-client/managed-state.ts");
@@ -31879,6 +31901,15 @@ var Client = /** @class */ (function () {
         this.managedState = new managed_state_1.ManagedState();
         this.listeners = {};
         this.requestId = 1;
+        this.setSupportedFeatures = function (request) {
+            var newRequest = request;
+            if (_this.customMessagesHandled) {
+                var features = request.features, others = __rest(request, ["features"]);
+                features.customMessages = { handles: _this.customMessagesHandled };
+                newRequest = __assign({ features: features }, others);
+            }
+            _this.post("supportedFeatures", newRequest);
+        };
         if (!in_frame_1.inIframe()) {
             throw new Error("Interactive API is meant to be used in iframe");
         }
@@ -31947,6 +31978,14 @@ var Client = /** @class */ (function () {
             return true;
         }
         return false;
+    };
+    Client.prototype.addCustomMessageListener = function (callback, handles) {
+        if (handles)
+            this.customMessagesHandled = handles;
+        this.addListener("customMessage", callback);
+    };
+    Client.prototype.removeCustomMessageListener = function () {
+        return this.removeListener("customMessage");
     };
     Client.prototype.connect = function () {
         var _this = this;
@@ -32133,9 +32172,9 @@ exports.useInitMessage = function () {
     }, []);
     return initMessage;
 };
-exports.useCustomMessages = function (callback) {
+exports.useCustomMessages = function (callback, handles) {
     react_1.useEffect(function () {
-        client.addCustomMessageListener(callback);
+        client.addCustomMessageListener(callback, handles);
         return function () { return client.removeCustomMessageListener(); };
     }, []);
 };

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -31490,6 +31490,13 @@ exports.ReportComponent = function (_a) {
 
 "use strict";
 
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.RuntimeComponent = void 0;
 var React = __webpack_require__(/*! react */ "./node_modules/react/index.js");
@@ -31510,13 +31517,27 @@ exports.RuntimeComponent = function (_a) {
             });
         }
     }, [authoredState]);
+    var _c = useState([]), customMessages = _c[0], setCustomMessages = _c[1];
+    interactive_api_client_1.useCustomMessages(function (msg) {
+        setCustomMessages(function (messages) { return __spreadArrays(messages, [msg]); });
+    });
     return (React.createElement("div", { className: "padded" },
         React.createElement("fieldset", null,
             React.createElement("legend", null, "Runtime Init Message"),
             React.createElement("div", { className: "padded monospace pre" }, JSON.stringify(initMessage, null, 2))),
         React.createElement("fieldset", null,
             React.createElement("legend", null, "FirebaseJWT Response"),
-            React.createElement("div", { className: "padded monospace pre" }, rawFirebaseJwt))));
+            React.createElement("div", { className: "padded monospace pre" }, rawFirebaseJwt)),
+        React.createElement("fieldset", null,
+            React.createElement("legend", null, "Custom Messages Received"),
+            React.createElement("div", { className: "padded monospace pre" },
+                React.createElement("table", null,
+                    React.createElement("thead", null,
+                        React.createElement("th", null, "Type"),
+                        React.createElement("th", null, "Content")),
+                    React.createElement("tbody", null, customMessages.map(function (msg, i) { return (React.createElement("tr", { key: i + "-" + msg.type },
+                        React.createElement("td", null, msg.type),
+                        React.createElement("td", null, msg.content))); })))))));
 };
 
 
@@ -31561,7 +31582,7 @@ var __assign = (this && this.__assign) || function () {
     return __assign.apply(this, arguments);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getInteractiveSnapshot = exports.getLibraryInteractiveList = exports.setLinkedInteractives = exports.getInteractiveList = exports.closeModal = exports.showModal = exports.removeGlobalInteractiveStateListener = exports.addGlobalInteractiveStateListener = exports.removeAuthoredStateListener = exports.addAuthoredStateListener = exports.removeInteractiveStateListener = exports.addInteractiveStateListener = exports.log = exports.getFirebaseJwt = exports.getAuthInfo = exports.setNavigation = exports.setHint = exports.setHeight = exports.setSupportedFeatures = exports.setGlobalInteractiveState = exports.getGlobalInteractiveState = exports.setAuthoredState = exports.getAuthoredState = exports.setInteractiveState = exports.setInteractiveStateTimeout = exports.getInteractiveState = exports.getMode = exports.getInitInteractiveMessage = void 0;
+exports.getInteractiveSnapshot = exports.getLibraryInteractiveList = exports.setLinkedInteractives = exports.getInteractiveList = exports.closeModal = exports.removeCustomMessageListener = exports.addCustomMessageListener = exports.showModal = exports.removeGlobalInteractiveStateListener = exports.addGlobalInteractiveStateListener = exports.removeAuthoredStateListener = exports.addAuthoredStateListener = exports.removeInteractiveStateListener = exports.addInteractiveStateListener = exports.log = exports.getFirebaseJwt = exports.getAuthInfo = exports.setNavigation = exports.setHint = exports.setHeight = exports.setSupportedFeatures = exports.setGlobalInteractiveState = exports.getGlobalInteractiveState = exports.setAuthoredState = exports.getAuthoredState = exports.setInteractiveState = exports.setInteractiveStateTimeout = exports.getInteractiveState = exports.getMode = exports.getInitInteractiveMessage = void 0;
 var client_1 = __webpack_require__(/*! ./client */ "./src/interactive-api-client/client.ts");
 var THROW_NOT_IMPLEMENTED_YET = function (method) {
     throw new Error(method + " is not yet implemented in the client!");
@@ -31760,6 +31781,12 @@ exports.showModal = function (options) {
     else {
         THROW_NOT_IMPLEMENTED_YET("showModal { type: \"" + options.type + "\" }");
     }
+};
+exports.addCustomMessageListener = function (callback) {
+    client_1.getClient().addListener("customMessage", callback);
+};
+exports.removeCustomMessageListener = function () {
+    client_1.getClient().removeListener("customMessage");
 };
 /**
  * @todo Implement this function.
@@ -32001,7 +32028,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
+exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
 var handleUpdate = function (newStateOrUpdateFunc, prevState) {
@@ -32105,6 +32132,12 @@ exports.useInitMessage = function () {
         }); })();
     }, []);
     return initMessage;
+};
+exports.useCustomMessages = function (callback) {
+    react_1.useEffect(function () {
+        client.addCustomMessageListener(callback);
+        return function () { return client.removeCustomMessageListener(); };
+    }, []);
 };
 
 


### PR DESCRIPTION
- provides API for interactives to listen for custom messages
- provides `useCustomMessages` hook to simplify listener management
- expands supported features API to allow configurable support for custom messages
- adds (as-yet-untested) code to example interactive to display custom messages received

[[#173989045]](https://www.pivotaltracker.com/story/show/173989045)

[ActivityPlayer #60](https://github.com/concord-consortium/activity-player/pull/60) contains the corresponding ActivityPlayer changes.

Note that while there is no plugin code using these features yet I'm opening up the PR for review so as to get feedback on the implementation of the API and whether there's anything I missed.