### PR TITLE
Fix a bug causing weird behavior when two embeddables with different types have the same ID

### DIFF
--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -133,7 +133,7 @@ class InteractivePagesController < ApplicationController
   def remove_embeddable
     authorize! :update, @page
     update_activity_changed_by
-    PageItem.find_by_interactive_page_id_and_embeddable_id(params[:id], params[:embeddable_id]).destroy
+    PageItem.find_by_interactive_page_id_and_embeddable_type_and_embeddable_id(params[:id], params[:embeddable_type], params[:embeddable_id]).destroy
     # We aren't removing the embeddable itself. But we would remove the tracked_question of the embeddable.
     redirect_to edit_activity_page_path(@activity, @page)
   end
@@ -141,7 +141,7 @@ class InteractivePagesController < ApplicationController
   def toggle_hideshow_embeddable
     authorize! :update, @page
     update_activity_changed_by
-    PageItem.find_by_interactive_page_id_and_embeddable_id(params[:id], params[:embeddable_id]).toggle_hideshow_embeddable
+    PageItem.find_by_interactive_page_id_and_embeddable_type_and_embeddable_id(params[:id], params[:embeddable_type], params[:embeddable_id]).toggle_hideshow_embeddable
     if request.xhr?
       respond_with_nothing
     else

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -130,18 +130,18 @@ class InteractivePagesController < ApplicationController
     edit_embeddable_redirect(e)
   end
 
-  def remove_embeddable
+  def remove_page_item
     authorize! :update, @page
     update_activity_changed_by
-    PageItem.find_by_interactive_page_id_and_embeddable_type_and_embeddable_id(params[:id], params[:embeddable_type], params[:embeddable_id]).destroy
+    @page_item.destroy
     # We aren't removing the embeddable itself. But we would remove the tracked_question of the embeddable.
     redirect_to edit_activity_page_path(@activity, @page)
   end
 
-  def toggle_hideshow_embeddable
+  def toggle_hideshow_page_item
     authorize! :update, @page
     update_activity_changed_by
-    PageItem.find_by_interactive_page_id_and_embeddable_type_and_embeddable_id(params[:id], params[:embeddable_type], params[:embeddable_id]).toggle_hideshow_embeddable
+    @page_item.toggle_hideshow_embeddable
     if request.xhr?
       respond_with_nothing
     else
@@ -210,6 +210,10 @@ class InteractivePagesController < ApplicationController
       @activity = LightweightActivity.find(params[:activity_id], :include => :pages)
       @page = @activity.pages.find(params[:id])
       # TODO: Exception handling if the ID'd Page doesn't belong to the ID'd Activity
+    elsif params[:page_item_id]
+      @page_item = PageItem.find_by_id(params[:page_item_id])
+      @page = @page_item.interactive_page
+      @activity = @page.lightweight_activity
     else
       # I don't like this method much.
       @page = InteractivePage.find(params[:id], :include => :lightweight_activity)

--- a/app/views/managed_interactives/_author.html.haml
+++ b/app/views/managed_interactives/_author.html.haml
@@ -2,8 +2,8 @@
   .embeddable_options
     .model-edit
       .interactive-content
-        %div{:id => "authorable-interactive-#{embeddable.id}"}
-  %div{:id => "interactive-preview-#{embeddable.id}"}
+        %div{:id => "authorable-interactive-#{embeddable.embeddable_dom_id}"}
+  %div{:id => "interactive-preview-#{embeddable.embeddable_dom_id}"}
   = render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }
 .embeddable_tools
   = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'managed_int', :allow_hide => allow_hide }
@@ -11,7 +11,7 @@
 - userInfo = current_user.nil? ? {loggedIn: false, authProvider: nil, email: nil} : {loggedIn: true, authProvider: (Concord::AuthPortal.url_for_strategy_name(current_user.most_recent_authentication.provider) rescue nil), email: current_user.email}
 :javascript
   $(document).ready( function() {
-    LARA.PageItemAuthoring.renderInteractiveAuthoringPreview(document.getElementById("interactive-preview-#{embeddable.id}"), {
+    LARA.PageItemAuthoring.renderInteractiveAuthoringPreview(document.getElementById("interactive-preview-#{embeddable.embeddable_dom_id}"), {
       interactive: #{embeddable.to_authoring_preview_hash().to_json},
       user: #{userInfo.to_json}
     });

--- a/app/views/mw_interactives/_author.html.haml
+++ b/app/views/mw_interactives/_author.html.haml
@@ -2,8 +2,8 @@
   .embeddable_options
     .model-edit
       .interactive-content
-        %div{:id => "authorable-interactive-#{embeddable.id}"}
-  %div{:id => "interactive-preview-#{embeddable.id}"}
+        %div{:id => "authorable-interactive-#{embeddable.embeddable_dom_id}"}
+  %div{:id => "interactive-preview-#{embeddable.embeddable_dom_id}"}
   = render :partial => "shared/embedded_editor_wrapper_plugins", :locals => { :embeddable => embeddable }
 .embeddable_tools
   = render :partial => "shared/embedded_editor_links", :locals => { :embeddable => embeddable, :page => page, :type => 'mw_int', :allow_hide => allow_hide }
@@ -11,7 +11,7 @@
 - userInfo = current_user.nil? ? {loggedIn: false, authProvider: nil, email: nil} : {loggedIn: true, authProvider: (Concord::AuthPortal.url_for_strategy_name(current_user.most_recent_authentication.provider) rescue nil), email: current_user.email}
 :javascript
   $(document).ready( function() {
-    LARA.PageItemAuthoring.renderInteractiveAuthoringPreview(document.getElementById("interactive-preview-#{embeddable.id}"), {
+    LARA.PageItemAuthoring.renderInteractiveAuthoringPreview(document.getElementById("interactive-preview-#{embeddable.embeddable_dom_id}"), {
       interactive: #{embeddable.to_authoring_preview_hash().to_json},
       user: #{userInfo.to_json}
     });

--- a/app/views/shared/_embedded_editor_links.html.haml
+++ b/app/views/shared/_embedded_editor_links.html.haml
@@ -50,19 +50,19 @@
     = t("TRACKED_QUESTION.CANT_EDIT")
 - else
   - if allow_hide
-    = link_to "show", page_hideshow_embeddable_path(page, embeddable),
+    = link_to "show", page_hideshow_embeddable_path(page, embeddable.class.to_s, embeddable.id),
       :remote => true,
       :method => :post,
       :id => "show-#{dash_id}",
       :onclick => "toggle_hide_#{under_id}()"
-    = link_to "hide", page_hideshow_embeddable_path(page, embeddable),
+    = link_to "hide", page_hideshow_embeddable_path(page, embeddable.class.to_s, embeddable.id),
       :remote => true,
       :method => :post,
       :id => "hide-#{dash_id}",
       :onclick => @activity.active_runs > 0 ? "confirm('#{confirm_hide}') && toggle_hide_#{under_id}()" : "toggle_hide_#{under_id}()"
   = link_to "edit", edit_path, :remote => true, :id => "edit-embed-#{dash_id}"
 
-= link_to "remove", page_remove_embeddable_path(page, embeddable), :method => :post, :data => {:confirm => confirm_delete }
+= link_to "remove", page_remove_embeddable_path(page, embeddable.class.to_s, embeddable.id), :method => :post, :data => {:confirm => confirm_delete }
 - if params["edit_#{type}".to_sym].to_i == embeddable.id
   :javascript
     $("a[id^=edit-embed-#{dash_id}]").click()

--- a/app/views/shared/_embedded_editor_links.html.haml
+++ b/app/views/shared/_embedded_editor_links.html.haml
@@ -50,19 +50,19 @@
     = t("TRACKED_QUESTION.CANT_EDIT")
 - else
   - if allow_hide
-    = link_to "show", page_hideshow_embeddable_path(page, embeddable.class.to_s, embeddable.id),
+    = link_to "show", toggle_hideshow_page_item_path(embeddable.p_item),
       :remote => true,
       :method => :post,
       :id => "show-#{dash_id}",
       :onclick => "toggle_hide_#{under_id}()"
-    = link_to "hide", page_hideshow_embeddable_path(page, embeddable.class.to_s, embeddable.id),
+    = link_to "hide", toggle_hideshow_page_item_path(embeddable.p_item),
       :remote => true,
       :method => :post,
       :id => "hide-#{dash_id}",
       :onclick => @activity.active_runs > 0 ? "confirm('#{confirm_hide}') && toggle_hide_#{under_id}()" : "toggle_hide_#{under_id}()"
   = link_to "edit", edit_path, :remote => true, :id => "edit-embed-#{dash_id}"
 
-= link_to "remove", page_remove_embeddable_path(page, embeddable.class.to_s, embeddable.id), :method => :post, :data => {:confirm => confirm_delete }
+= link_to "remove", remove_page_item_path(embeddable.p_item), :method => :post, :data => {:confirm => confirm_delete }
 - if params["edit_#{type}".to_sym].to_i == embeddable.id
   :javascript
     $("a[id^=edit-embed-#{dash_id}]").click()

--- a/app/views/shared/_embedded_editor_wrapper_plugins.html.haml
+++ b/app/views/shared/_embedded_editor_wrapper_plugins.html.haml
@@ -19,7 +19,7 @@
         .item
           #{plugin.name}
         .edit= link_to t("PLUGIN.EDIT"), edit_embeddable_embeddable_plugin_path(plugin), :remote => true, id: "edit-embed-#{dash_id}"
-        .delete= link_to t("PLUGIN.DELETE"), page_remove_embeddable_path(@page, plugin.class.to_s, plugin.id), method: :post, data: { confirm: t("PLUGIN.DELETE_WARNING") }
+        .delete= link_to t("PLUGIN.DELETE"), remove_page_item_path(plugin.p_item), method: :post, data: { confirm: t("PLUGIN.DELETE_WARNING") }
         - if params["edit_embeddable_plugin".to_sym].to_i == plugin.id
           :javascript
             $("a[id^=edit-embed-#{dash_id}]").click()

--- a/app/views/shared/_embedded_editor_wrapper_plugins.html.haml
+++ b/app/views/shared/_embedded_editor_wrapper_plugins.html.haml
@@ -19,7 +19,7 @@
         .item
           #{plugin.name}
         .edit= link_to t("PLUGIN.EDIT"), edit_embeddable_embeddable_plugin_path(plugin), :remote => true, id: "edit-embed-#{dash_id}"
-        .delete= link_to t("PLUGIN.DELETE"), page_remove_embeddable_path(@page, plugin), method: :post, data: { confirm: t("PLUGIN.DELETE_WARNING") }
+        .delete= link_to t("PLUGIN.DELETE"), page_remove_embeddable_path(@page, plugin.class.to_s, plugin.id), method: :post, data: { confirm: t("PLUGIN.DELETE_WARNING") }
         - if params["edit_embeddable_plugin".to_sym].to_i == plugin.id
           :javascript
             $("a[id^=edit-embed-#{dash_id}]").click()

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,8 +215,8 @@ LightweightStandalone::Application.routes.draw do
   # These routes didn't work as nested resources
   delete "/embeddable/multiple_choice/:id/remove_choice/:choice_id" => 'embeddable/multiple_choices#remove_choice', :as => 'remove_choice_embeddable_multiple_choice', :constraints => { :id => /\d+/, :choice_id => /\d+/ }
   delete "/video_interactives/:id/remove_source/:source_id" => "video_interactives#remove_source", :as => 'remove_source_video_interactive', :constraints => { :id => /\d+/, :source_id => /\d+/ }
-  post "/pages/:id/remove_embeddable/:embeddable_id" => 'interactive_pages#remove_embeddable', :as => 'page_remove_embeddable', :constraints => { :id => /\d+/, :embeddable_id => /\d+/ }
-  post "/pages/:id/hideshow_embeddable/:embeddable_id" => 'interactive_pages#toggle_hideshow_embeddable', :as => 'page_hideshow_embeddable', :constraints => { :id => /\d+/, :embeddable_id => /\d+/ }
+  post "/pages/:id/remove_embeddable/:embeddable_type/:embeddable_id" => 'interactive_pages#remove_embeddable', :as => 'page_remove_embeddable', :constraints => { :id => /\d+/, :embeddable_id => /\d+/ }
+  post "/pages/:id/hideshow_embeddable/:embeddable_type/:embeddable_id" => 'interactive_pages#toggle_hideshow_embeddable', :as => 'page_hideshow_embeddable', :constraints => { :id => /\d+/, :embeddable_id => /\d+/ }
   get "/embeddable/multiple_choice/:id/check" => 'embeddable/multiple_choices#check', :as => 'check_multiple_choice_answer', :constraints => { :id => /\d+/ }
   get "/activities/:activity_id/pages/:id/:run_key" => 'interactive_pages#show', :as => 'page_with_run', :constraints => { :id => /\d+/, :activity_id => /\d+/, :run_key => /[-\w]{36}/ }
   get "/activities/:activity_id/summary/:run_key" => 'lightweight_activities#summary', :as => 'summary_with_run', :constraints => { :activity_id => /\d+/, :run_key => /[-\w]{36}/ }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,8 +215,8 @@ LightweightStandalone::Application.routes.draw do
   # These routes didn't work as nested resources
   delete "/embeddable/multiple_choice/:id/remove_choice/:choice_id" => 'embeddable/multiple_choices#remove_choice', :as => 'remove_choice_embeddable_multiple_choice', :constraints => { :id => /\d+/, :choice_id => /\d+/ }
   delete "/video_interactives/:id/remove_source/:source_id" => "video_interactives#remove_source", :as => 'remove_source_video_interactive', :constraints => { :id => /\d+/, :source_id => /\d+/ }
-  post "/pages/:id/remove_embeddable/:embeddable_type/:embeddable_id" => 'interactive_pages#remove_embeddable', :as => 'page_remove_embeddable', :constraints => { :id => /\d+/, :embeddable_id => /\d+/ }
-  post "/pages/:id/hideshow_embeddable/:embeddable_type/:embeddable_id" => 'interactive_pages#toggle_hideshow_embeddable', :as => 'page_hideshow_embeddable', :constraints => { :id => /\d+/, :embeddable_id => /\d+/ }
+  post "/remove_page_item/:page_item_id" => 'interactive_pages#remove_page_item', :as => 'remove_page_item', :constraints => { :page_item_id => /\d+/ }
+  post "/hideshow_page_item/:page_item_id" => 'interactive_pages#toggle_hideshow_page_item', :as => 'toggle_hideshow_page_item', :constraints => { :page_item_id => /\d+/ }
   get "/embeddable/multiple_choice/:id/check" => 'embeddable/multiple_choices#check', :as => 'check_multiple_choice_answer', :constraints => { :id => /\d+/ }
   get "/activities/:activity_id/pages/:id/:run_key" => 'interactive_pages#show', :as => 'page_with_run', :constraints => { :id => /\d+/, :activity_id => /\d+/, :run_key => /[-\w]{36}/ }
   get "/activities/:activity_id/summary/:run_key" => 'lightweight_activities#summary', :as => 'summary_with_run', :constraints => { :activity_id => /\d+/, :run_key => /[-\w]{36}/ }

--- a/docs/example-interactive.md
+++ b/docs/example-interactive.md
@@ -10,7 +10,7 @@ allowing developers and testers to test out additions or changes to the interact
 The example interactive is deployed as part of the build.
 It can be found at `[lara-host]/example-interactive/`.
 For example the most recent production build is here:
-https://authoring.concord.org/example-interactive/
+https://authoring.concord.org/example-interactive/index.html
 
 If you are expanding the example interactive, it can be run locally:
 

--- a/spec/controllers/interactive_page_controller_spec.rb
+++ b/spec/controllers/interactive_page_controller_spec.rb
@@ -431,7 +431,7 @@ describe InteractivePagesController do
         page1.add_embeddable(embeddable)
         page1.reload
         embed_count = page1.embeddables.length
-        post :remove_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_id => embeddable.id
+        post :remove_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_type => embeddable.class.to_s, :embeddable_id => embeddable.id
 
         page1.reload
         expect(page1.embeddables.length).to eq(embed_count - 1)
@@ -441,7 +441,7 @@ describe InteractivePagesController do
       it 'redirects to the edit page' do
         embeddable = FactoryGirl.create(:xhtml)
         page1.add_embeddable(embeddable)
-        post :remove_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_id => embeddable.id
+        post :remove_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_type => embeddable.class.to_s, :embeddable_id => embeddable.id
 
         act.reload
         expect(act.changed_by).to eq(@user)

--- a/spec/controllers/interactive_page_controller_spec.rb
+++ b/spec/controllers/interactive_page_controller_spec.rb
@@ -425,13 +425,13 @@ describe InteractivePagesController do
       end
     end
 
-    describe 'remove_embeddable' do
+    describe 'remove_page_item' do
       it 'removes the identified embeddable from the page' do
         embeddable = FactoryGirl.create(:xhtml)
         page1.add_embeddable(embeddable)
         page1.reload
         embed_count = page1.embeddables.length
-        post :remove_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_type => embeddable.class.to_s, :embeddable_id => embeddable.id
+        post :remove_page_item, :page_item_id => embeddable.p_item.id
 
         page1.reload
         expect(page1.embeddables.length).to eq(embed_count - 1)
@@ -441,7 +441,7 @@ describe InteractivePagesController do
       it 'redirects to the edit page' do
         embeddable = FactoryGirl.create(:xhtml)
         page1.add_embeddable(embeddable)
-        post :remove_embeddable, :activity_id => act.id, :id => page1.id, :embeddable_type => embeddable.class.to_s, :embeddable_id => embeddable.id
+        post :remove_page_item, :page_item_id => embeddable.p_item.id
 
         act.reload
         expect(act.changed_by).to eq(@user)

--- a/spec/features/hide_show_questions_spec.rb
+++ b/spec/features/hide_show_questions_spec.rb
@@ -8,7 +8,7 @@ feature "Activity page", :js => true do
   let(:activity_page) { activity.pages.first }
   let(:question)     { activity.reportable_items.find {|q| q.class == Embeddable::OpenResponse} }
   let(:activity_page_url) { edit_activity_page_path(activity, activity_page) }
-  let(:hideshow_url) { page_hideshow_embeddable_path(activity_page, question) }
+  let(:hideshow_url) { page_hideshow_embeddable_path(activity_page, question.class.to_s, question.id) }
 
   before :each do
     login_as user, :scope => :user

--- a/spec/features/hide_show_questions_spec.rb
+++ b/spec/features/hide_show_questions_spec.rb
@@ -8,7 +8,7 @@ feature "Activity page", :js => true do
   let(:activity_page) { activity.pages.first }
   let(:question)     { activity.reportable_items.find {|q| q.class == Embeddable::OpenResponse} }
   let(:activity_page_url) { edit_activity_page_path(activity, activity_page) }
-  let(:hideshow_url) { page_hideshow_embeddable_path(activity_page, question.class.to_s, question.id) }
+  let(:hideshow_url) { toggle_hideshow_page_item_path(question.p_item) }
 
   before :each do
     login_as user, :scope => :user

--- a/spec/views/embeddable/_author.html.haml_spec.rb
+++ b/spec/views/embeddable/_author.html.haml_spec.rb
@@ -5,20 +5,27 @@ describe "The standard authoring view of the labbook" do
     I18n.t('LABBOOK.WONT_DISPLAY')
   end
 
-  let(:lb_stubs)      { {show_in_runtime?: false,
-                         action_label: 'appears on button',
-                         why_not_show_in_runtime: 'LABBOOK.UNKNOWN_REASON' } }
   let(:activity_stubs){ { active_runs: 0} }
   let(:fake_activity) { double("activity", activity_stubs) }
-  let(:labbook)       { mock_model(Embeddable::Labbook, lb_stubs)}
   let(:_page)         { mock_model(InteractivePage)}
   let(:_locals)       { { page: _page, embeddable: labbook, allow_hide: true } }
+  let(:show_in_runtime) { true }
+  let(:labbook) do
+    lb = Embeddable::Labbook.create
+    lb.interactive_pages << _page
+    unless show_in_runtime
+      # Snapshot type won't show in runtime, as it also needs to point to another interactive.
+      lb.action_type = Embeddable::Labbook::SNAPSHOT_ACTION
+    end
+    lb
+  end
 
   before :each do
     assign('activity', fake_activity)
   end
 
   describe "When the labbook won't show in the runtime" do
+    let(:show_in_runtime) { false }
     it "displays a warning message to authors" do
       render :partial => "embeddable/labbooks/author", :locals => _locals
       expect(rendered).to match (/#{warning_text}/)
@@ -27,7 +34,7 @@ describe "The standard authoring view of the labbook" do
   end
 
   describe "When the labbok will display in the runtime" do
-    let(:lb_stubs)      { {show_in_runtime?: true, action_label: 'appears on button' } }
+    let(:show_in_runtime) { true }
     it "does not display a warning message to authors" do
       render :partial => "embeddable/labbooks/author", :locals => _locals
       expect(rendered).not_to match (/#{warning_text}/)


### PR DESCRIPTION
More details here:
https://www.pivotaltracker.com/story/show/174967192
It was affecting authoring page, hide/show and remove links.

Also, I've also updated example-interactive.md docs (not related to the issue above, just to skip another branch and PR for this tiny fix). 
