### PR TITLE
Provide linkedInteractives in initMessage in the authoring mode

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -28813,7 +28813,6 @@ var react_1 = __webpack_require__(/*! react */ "react");
 var interactive_iframe_1 = __webpack_require__(/*! ./interactive-iframe */ "./src/page-item-authoring/common/components/interactive-iframe.tsx");
 exports.InteractiveAuthoring = function (props) {
     var interactive = props.interactive, onAuthoredStateChange = props.onAuthoredStateChange, allowReset = props.allowReset, authoringApiUrls = props.authoringApiUrls;
-    var iframe = react_1.useRef(null);
     var _a = react_1.useState(false), authoringSupported = _a[0], setAuthoringSupported = _a[1];
     var _b = react_1.useState(typeof interactive.authored_state === "string"
         ? JSON.parse(interactive.authored_state || "{}")
@@ -28842,7 +28841,8 @@ exports.InteractiveAuthoring = function (props) {
                 colorB: "green"
             }
         },
-        interactiveItemId: interactiveItemId
+        interactiveItemId: interactiveItemId,
+        linkedInteractives: interactive.linked_interactives
     };
     return (React.createElement("div", { className: "authoring-mw-interactive" },
         allowReset
@@ -29310,12 +29310,12 @@ var react_select_1 = __webpack_require__(/*! react-select */ "./node_modules/rea
 var react_tabs_1 = __webpack_require__(/*! react-tabs */ "./node_modules/react-tabs/esm/index.js");
 var use_library_interactives_1 = __webpack_require__(/*! ../common/hooks/use-library-interactives */ "./src/page-item-authoring/common/hooks/use-library-interactives.tsx");
 var interactive_authoring_1 = __webpack_require__(/*! ../common/components/interactive-authoring */ "./src/page-item-authoring/common/components/interactive-authoring.tsx");
-__webpack_require__(/*! react-tabs/style/react-tabs.css */ "./node_modules/react-tabs/style/react-tabs.css");
 var rails_form_field_1 = __webpack_require__(/*! ../common/utils/rails-form-field */ "./src/page-item-authoring/common/utils/rails-form-field.ts");
 var customize_1 = __webpack_require__(/*! ./customize */ "./src/page-item-authoring/managed-interactives/customize.tsx");
 var checkbox_1 = __webpack_require__(/*! ../common/components/checkbox */ "./src/page-item-authoring/common/components/checkbox.tsx");
 var use_current_user_1 = __webpack_require__(/*! ../common/hooks/use-current-user */ "./src/page-item-authoring/common/hooks/use-current-user.ts");
 var authored_state_1 = __webpack_require__(/*! ../common/components/authored-state */ "./src/page-item-authoring/common/components/authored-state.tsx");
+__webpack_require__(/*! react-tabs/style/react-tabs.css */ "./node_modules/react-tabs/style/react-tabs.css");
 var formField = rails_form_field_1.RailsFormField("managed_interactive");
 exports.ManagedInteractiveAuthoring = function (props) {
     var managedInteractive = props.managedInteractive, defaultClickToPlayPrompt = props.defaultClickToPlayPrompt, authoringApiUrls = props.authoringApiUrls;
@@ -29373,7 +29373,8 @@ exports.ManagedInteractiveAuthoring = function (props) {
                 ? libraryInteractive.aspect_ratio_method
                 : managedInteractive.custom_aspect_ratio_method,
             authored_state: managedInteractive.authored_state,
-            interactive_item_id: managedInteractive.interactive_item_id
+            interactive_item_id: managedInteractive.interactive_item_id,
+            linked_interactives: managedInteractive.linked_interactives
         };
         var handleAuthoredStateChange = function (newAuthoredState) {
             if (libraryInteractiveAuthoredStateRef.current) {
@@ -29521,10 +29522,10 @@ var react_tabs_1 = __webpack_require__(/*! react-tabs */ "./node_modules/react-t
 var interactive_authoring_1 = __webpack_require__(/*! ../common/components/interactive-authoring */ "./src/page-item-authoring/common/components/interactive-authoring.tsx");
 var rails_form_field_1 = __webpack_require__(/*! ../common/utils/rails-form-field */ "./src/page-item-authoring/common/utils/rails-form-field.ts");
 var customize_1 = __webpack_require__(/*! ./customize */ "./src/page-item-authoring/mw-interactives/customize.tsx");
-__webpack_require__(/*! react-tabs/style/react-tabs.css */ "./node_modules/react-tabs/style/react-tabs.css");
 var checkbox_1 = __webpack_require__(/*! ../common/components/checkbox */ "./src/page-item-authoring/common/components/checkbox.tsx");
 var use_current_user_1 = __webpack_require__(/*! ../common/hooks/use-current-user */ "./src/page-item-authoring/common/hooks/use-current-user.ts");
 var authored_state_1 = __webpack_require__(/*! ../common/components/authored-state */ "./src/page-item-authoring/common/components/authored-state.tsx");
+__webpack_require__(/*! react-tabs/style/react-tabs.css */ "./node_modules/react-tabs/style/react-tabs.css");
 var formField = rails_form_field_1.RailsFormField("mw_interactive");
 exports.MWInteractiveAuthoring = function (props) {
     var interactive = props.interactive, defaultClickToPlayPrompt = props.defaultClickToPlayPrompt, authoringApiUrls = props.authoringApiUrls;
@@ -29560,7 +29561,8 @@ exports.MWInteractiveAuthoring = function (props) {
             aspect_ratio: interactive.aspect_ratio,
             aspect_ratio_method: interactive.aspect_ratio_method,
             authored_state: interactive.authored_state,
-            interactive_item_id: interactive.interactive_item_id
+            interactive_item_id: interactive.interactive_item_id,
+            linked_interactives: interactive.linked_interactives
         };
         var hasAuthoringUrl = authoringUrl && authoringUrl.trim().length > 0;
         return (React.createElement(react_tabs_1.Tabs, null,

--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -11,6 +11,27 @@ module BaseInteractive
     end
   end
 
+  # used for react-based authoring
+  def to_authoring_hash
+    hash = to_hash
+    hash[:id] = id
+    hash[:linked_interactive_id] = linked_interactive_id
+    hash[:linked_interactive_type] = linked_interactive_type
+    hash[:aspect_ratio] = aspect_ratio
+    hash[:interactive_item_id] = interactive_item_id
+    hash[:linked_interactive_item_id] = linked_interactive_item_id
+    # Note that linked_interactives is independent from linked_interactive_id and linked_interactive_type fields
+    hash[:linked_interactives] = linked_interactives_list
+    hash
+  end
+
+  def authoring_api_urls(protocol, host)
+    {
+      get_interactive_list: interactive_page ? Rails.application.routes.url_helpers.api_v1_get_interactive_list_url(id: interactive_page.id, protocol: protocol, host: host) : nil,
+      set_linked_interactives: interactive_page ? Rails.application.routes.url_helpers.api_v1_set_linked_interactives_url(id: interactive_page.id, protocol: protocol, host: host) : nil
+    }
+  end
+
   def portal_hash
     result = report_service_hash
     # When Portal receives iframe_interactive, it expects:

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -136,18 +136,6 @@ class ManagedInteractive < ActiveRecord::Base
     }
   end
 
-  # used for react-based authoring
-  def to_authoring_hash
-    hash = to_hash
-    hash[:id] = id
-    hash[:linked_interactive_id] = linked_interactive_id
-    hash[:linked_interactive_type] = linked_interactive_type
-    hash[:aspect_ratio] = aspect_ratio
-    hash[:interactive_item_id] = interactive_item_id
-    hash[:linked_interactive_item_id] = linked_interactive_item_id
-    hash
-  end
-
   def to_authoring_preview_hash
     # in preview mode we look like an interactive
     hash = to_interactive

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -143,13 +143,6 @@ class ManagedInteractive < ActiveRecord::Base
     hash
   end
 
-  def authoring_api_urls(protocol, host)
-    {
-      get_interactive_list: interactive_page ? Rails.application.routes.url_helpers.api_v1_get_interactive_list_url(id: interactive_page.id, protocol: protocol, host: host) : nil,
-      set_linked_interactives: interactive_page ? Rails.application.routes.url_helpers.api_v1_set_linked_interactives_url(id: interactive_page.id, protocol: protocol, host: host) : nil
-    }
-  end
-
   def to_interactive
     # NOTE: model_library_url is missing as there is no analog
     {

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -70,22 +70,8 @@ class MwInteractive < ActiveRecord::Base
     }
   end
 
-  # used for react-based authoring
-  def to_authoring_hash()
-    hash = to_hash
-    hash[:id] = id
-    hash[:linked_interactive_id] = linked_interactive_id
-    hash[:linked_interactive_type] = linked_interactive_type
-    hash[:aspect_ratio] = aspect_ratio
-    hash[:interactive_item_id] = interactive_item_id
-    hash[:linked_interactive_item_id] = linked_interactive_item_id
-    hash
-  end
-
   def to_authoring_preview_hash
-    hash = to_authoring_hash
-    hash[:linked_interactives] = linked_interactives_list
-    hash
+    to_authoring_hash
   end
 
   def authoring_api_urls(protocol, host)

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -74,13 +74,6 @@ class MwInteractive < ActiveRecord::Base
     to_authoring_hash
   end
 
-  def authoring_api_urls(protocol, host)
-    {
-      get_interactive_list: interactive_page ? Rails.application.routes.url_helpers.api_v1_get_interactive_list_url(id: interactive_page.id, protocol: protocol, host: host) : nil,
-      set_linked_interactives: interactive_page ? Rails.application.routes.url_helpers.api_v1_set_linked_interactives_url(id: interactive_page.id, protocol: protocol, host: host) : nil
-    }
-  end
-
   def duplicate
     # Generate a new object with those values
     MwInteractive.new(self.to_hash)

--- a/app/views/managed_interactives/edit.html.haml
+++ b/app/views/managed_interactives/edit.html.haml
@@ -13,7 +13,6 @@
 :javascript
   $(document).ready( function() {
     LARA.PageItemAuthoring.renderManagedInteractiveAuthoring(document.getElementById("admin-interactive-#{@interactive.id}"), {
-      interactive: #{@interactive.to_interactive.to_json},
       managedInteractive: #{@interactive.to_authoring_hash().to_json},
       libraryInteractive: #{@interactive.library_interactive ? @interactive.library_interactive.to_json : "undefined"},
       defaultClickToPlayPrompt: #{MwInteractive::DEFAULT_CLICK_TO_PLAY_PROMPT.to_json},

--- a/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iauthoringinitinteractive.md
@@ -17,6 +17,7 @@
 * [authoredState](iauthoringinitinteractive.md#authoredstate)
 * [error](iauthoringinitinteractive.md#error)
 * [interactiveItemId](iauthoringinitinteractive.md#interactiveitemid)
+* [linkedInteractives](iauthoringinitinteractive.md#linkedinteractives)
 * [mode](iauthoringinitinteractive.md#mode)
 * [themeInfo](iauthoringinitinteractive.md#themeinfo)
 * [version](iauthoringinitinteractive.md#version)
@@ -38,6 +39,12 @@ ___
 ###  interactiveItemId
 
 • **interactiveItemId**: *string*
+
+___
+
+###  linkedInteractives
+
+• **linkedInteractives**: *[ILinkedInteractive](ilinkedinteractive.md)[]*
 
 ___
 

--- a/lara-typescript/src/interactive-api-client/types.ts
+++ b/lara-typescript/src/interactive-api-client/types.ts
@@ -64,6 +64,7 @@ export interface IAuthoringInitInteractive<AuthoredState = {}> {
   authoredState: AuthoredState | null;
   themeInfo: IThemeInfo;
   interactiveItemId: string;
+  linkedInteractives: ILinkedInteractive[];
 }
 
 export interface IReportInitInteractive<InteractiveState = {}, AuthoredState = {}> {

--- a/lara-typescript/src/page-item-authoring/common/components/interactive-authoring.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-authoring.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
-import { useRef, useState } from "react";
-
+import { useState } from "react";
 import { InteractiveIframe } from "./interactive-iframe";
 import { AuthoringApiUrls } from "../types";
-import { IInitInteractive } from "../../../interactive-api-client";
+import { IInitInteractive, ILinkedInteractive } from "../../../interactive-api-client";
 
 interface Props {
   interactive: {
@@ -12,6 +11,7 @@ interface Props {
     aspect_ratio_method: string;
     authored_state: string | object;
     interactive_item_id: string;
+    linked_interactives: ILinkedInteractive[];
   };
   onAuthoredStateChange: (authoredState: string | object) => void;
   allowReset: boolean;
@@ -20,7 +20,6 @@ interface Props {
 
 export const InteractiveAuthoring: React.FC<Props> = (props) => {
   const {interactive, onAuthoredStateChange, allowReset, authoringApiUrls} = props;
-  const iframe = useRef<HTMLIFrameElement|null>(null);
   const [authoringSupported, setAuthoringSupported] = useState(false);
   const [authoredState, setAuthoredState] = useState<object|null>(
     typeof interactive.authored_state === "string"
@@ -55,7 +54,8 @@ export const InteractiveAuthoring: React.FC<Props> = (props) => {
         colorB: "green"
       }
     },
-    interactiveItemId
+    interactiveItemId,
+    linkedInteractives: interactive.linked_interactives
   };
 
   return (

--- a/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
@@ -2,17 +2,16 @@ import * as React from "react";
 import { useState, useRef } from "react";
 import Select from "react-select";
 import { Tabs, TabList, Tab, TabPanel} from "react-tabs";
-
 import { useLibraryInteractives, ILibraryInteractive } from "../common/hooks/use-library-interactives";
 import { InteractiveAuthoring } from "../common/components/interactive-authoring";
-
-import "react-tabs/style/react-tabs.css";
 import { RailsFormField } from "../common/utils/rails-form-field";
 import { CustomizeManagedInteractive } from "./customize";
 import { Checkbox } from "../common/components/checkbox";
 import { useCurrentUser } from "../common/hooks/use-current-user";
 import { AuthoredState } from "../common/components/authored-state";
 import { AuthoringApiUrls } from "../common/types";
+import { ILinkedInteractive } from "../../interactive-api-client";
+import "react-tabs/style/react-tabs.css";
 
 interface Props {
   managedInteractive: IManagedInteractive;
@@ -55,6 +54,7 @@ export interface IManagedInteractive {
   custom_image_url: string;
   interactive_item_id: string;
   linked_interactive_item_id: string;
+  linked_interactives: ILinkedInteractive[];
 }
 
 const formField = RailsFormField<IManagedInteractive>("managed_interactive");
@@ -138,7 +138,8 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
         ? libraryInteractive.aspect_ratio_method
         : managedInteractive.custom_aspect_ratio_method,
       authored_state: managedInteractive.authored_state,
-      interactive_item_id: managedInteractive.interactive_item_id
+      interactive_item_id: managedInteractive.interactive_item_id,
+      linked_interactives: managedInteractive.linked_interactives
     };
 
     const handleAuthoredStateChange = (newAuthoredState: string | object) => {

--- a/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
@@ -1,16 +1,15 @@
 import * as React from "react";
 import { useRef, useState } from "react";
 import { Tabs, TabList, Tab, TabPanel} from "react-tabs";
-
 import { InteractiveAuthoring } from "../common/components/interactive-authoring";
 import { RailsFormField } from "../common/utils/rails-form-field";
 import { CustomizeMWInteractive } from "./customize";
-
-import "react-tabs/style/react-tabs.css";
 import { Checkbox } from "../common/components/checkbox";
 import { useCurrentUser } from "../common/hooks/use-current-user";
 import { AuthoredState } from "../common/components/authored-state";
 import { AuthoringApiUrls } from "../common/types";
+import {ILinkedInteractive} from "../../interactive-api-client";
+import "react-tabs/style/react-tabs.css";
 
 interface Props {
   interactive: IMWInteractive;
@@ -42,6 +41,7 @@ export interface IMWInteractive {
   linked_interactive_type: string;
   interactive_item_id: string;
   linked_interactive_item_id: string;
+  linked_interactives: ILinkedInteractive[];
 }
 
 const formField = RailsFormField<IMWInteractive>("mw_interactive");
@@ -111,7 +111,8 @@ export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
       aspect_ratio: interactive.aspect_ratio,
       aspect_ratio_method: interactive.aspect_ratio_method,
       authored_state: interactive.authored_state,
-      interactive_item_id: interactive.interactive_item_id
+      interactive_item_id: interactive.interactive_item_id,
+      linked_interactives: interactive.linked_interactives
     };
 
     const hasAuthoringUrl = authoringUrl && authoringUrl.trim().length > 0;

--- a/spec/models/managed_interactive_spec.rb
+++ b/spec/models/managed_interactive_spec.rb
@@ -83,6 +83,7 @@ describe ManagedInteractive do
       expected[:aspect_ratio] = managed_interactive.aspect_ratio
       expected[:interactive_item_id] = managed_interactive.interactive_item_id
       expected[:linked_interactive_item_id] = managed_interactive.linked_interactive_item_id
+      expected[:linked_interactives] = managed_interactive.linked_interactives_list
       expect(managed_interactive.to_authoring_hash).to eq(expected)
     end
   end

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -63,6 +63,7 @@ describe MwInteractive do
       expected[:aspect_ratio] = interactive.aspect_ratio
       expected[:interactive_item_id] = interactive.interactive_item_id
       expected[:linked_interactive_item_id] = interactive.linked_interactive_item_id
+      expected[:linked_interactives] = interactive.linked_interactives_list
       expect(interactive.to_authoring_hash).to eq(expected)
     end
   end


### PR DESCRIPTION
[#172781754]

`linkedInteractives` was provided only in the runtime so far. It's useful/necessary in the authoring as well, so the authoring interface can access the current linked interactives list and set UI widget values based on that.

Semi-related changes:
- I'm a bit lost in all the interactive hashes, but I tried to move ones that were identical to BaseInteractive class.
- I've removed one unused property in authoring initialization. Now, it seems like `ManagedInteractive#to_interactive` could be easily removed. It's only called by the `#to_authoring_preview_hash`. I was also wondering if `#to_authoring_preview_hash` could be unified in MwInteractive and ManagedInteractive. 