### PR TITLE
Fix more issues related to non-unique IDs, add note about existing bug

### DIFF
--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -93,6 +93,9 @@ module InteractiveRunHelper
       :data => data,
       # Note that iframe is hidden in print mode. It won't have enough time to load anyway.
       :class => 'interactive screen-only',
+      # PJ 10/2/2020: I think this is a bug as IDs might not be unique for MwInteractive and ManagedInteractive.
+      # Updating this ID might affect multiple LARA elements - click to play, taking snapshot, etc., so it should
+      # be fixed and tested carefully.
       :id => "interactive_#{interactive.id}"
     }
     capture_haml do

--- a/app/views/managed_interactives/edit.html.haml
+++ b/app/views/managed_interactives/edit.html.haml
@@ -5,14 +5,14 @@
 = form_for @interactive, :url => form_url, :html => {:class => "styled-admin-form"} do |f|
   = f.error_messages
 
-  %div{:id => "admin-interactive-#{@interactive.id}"}
+  %div{:id => "admin-interactive-#{@interactive.interactive_item_id}"}
   .submit-container
     = f.button "Cancel", :class => 'close', :type => 'button'
     = f.submit "Save", :class => 'embeddable-save', :default => 'default'
 
 :javascript
   $(document).ready( function() {
-    LARA.PageItemAuthoring.renderManagedInteractiveAuthoring(document.getElementById("admin-interactive-#{@interactive.id}"), {
+    LARA.PageItemAuthoring.renderManagedInteractiveAuthoring(document.getElementById("admin-interactive-#{@interactive.interactive_item_id}"), {
       managedInteractive: #{@interactive.to_authoring_hash().to_json},
       libraryInteractive: #{@interactive.library_interactive ? @interactive.library_interactive.to_json : "undefined"},
       defaultClickToPlayPrompt: #{MwInteractive::DEFAULT_CLICK_TO_PLAY_PROMPT.to_json},

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -5,7 +5,7 @@
 = form_for @interactive, :url => form_url, :html => {:class => "styled-admin-form"} do |f|
   = f.error_messages
 
-  %div{:id => "admin-interactive-#{@interactive.id}"}
+  %div{:id => "admin-interactive-#{@interactive.interactive_item_id}"}
 
   .submit-container
     = f.button "Cancel", :class => 'close', :type => 'button'
@@ -13,7 +13,7 @@
 
 :javascript
   $(document).ready( function() {
-    LARA.PageItemAuthoring.renderMWInteractiveAuthoring(document.getElementById("admin-interactive-#{@interactive.id}"), {
+    LARA.PageItemAuthoring.renderMWInteractiveAuthoring(document.getElementById("admin-interactive-#{@interactive.interactive_item_id}"), {
       interactive: #{@interactive.to_authoring_hash().to_json},
       defaultClickToPlayPrompt: #{MwInteractive::DEFAULT_CLICK_TO_PLAY_PROMPT.to_json},
       authoringApiUrls: #{@interactive.authoring_api_urls(request.protocol, request.host_with_port).to_json},


### PR DESCRIPTION
I haven't actually seen a problem related to editing, but it seems it could be theoretically problematic. I've made changes there as it's fairly safe.

Also, I've added a comment in `interactive_run_helper.rb` as this is a bigger problem. This interactive ID definitely doesn't seem to be unique for MwInteractive and ManagedInteractive. I couldn't easily fix it, as it's not that obvious to track all the places that use it. Ones I've found so far:
- click to play
- drawing tool snapshot

The problem is very unlikely to happen in production, so I'm not spending time on it for now. I've just added this comment and a story in the icebox: https://www.pivotaltracker.com/story/show/175098853
