### PR TITLE
Publish interactives that pretend to be an image question to Portal and Report Service

### DIFF
--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -99,6 +99,13 @@ module BaseInteractive
         # This property is defined in IAuthoringMultipleChoiceMetadata:
         choices: (metadata[:choices] || []).map { |c| (c || {}).symbolize_keys.slice(:id, :content, :correct) }
       })
+    elsif type === "image_question"
+      result.merge!({
+        # This property is defined in IAuthoringImageQuestionMetadata.
+        # It can be confusing that drawing prompt == answer prompt. The property has been renamed while image question
+        # interactive was developed. It seems to make sense, as this prompt is rendered next to textarea.
+        drawing_prompt: metadata[:answerPrompt]
+      })
     end
 
     result

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -38,6 +38,7 @@ class InteractiveRunState < ActiveRecord::Base
     mapping = {
       "open_response_answer" => "open_response",
       "multiple_choice_answer" => "multiple_choice",
+      "image_question_answer" => "image_question",
       "interactive_state" => "iframe_interactive",
       "external_link" => "iframe_interactive"
     }
@@ -82,6 +83,7 @@ class InteractiveRunState < ActiveRecord::Base
       "interactive_state" => "interactive",
       "external_link" => "external_link",
       "open_response_answer" => "open_response",
+      "image_question_answer" => "image_question",
       "multiple_choice_answer" => "multiple_choice",
     }
     result[:type] = type_mapping[result[:type]]
@@ -95,6 +97,9 @@ class InteractiveRunState < ActiveRecord::Base
       result[:answer_ids] = result[:answer][:choice_ids]
       # multiple_choice_answer.rb also sends answer_texts.
       # This property is skipped here, as Portal doesn't use it anyway.
+    elsif result[:type] === "image_question"
+      result[:image_url] = result[:answer][:image_url]
+      result[:answer] = result[:answer][:text]
     end
 
     if (result[:type] === "interactive" || result[:type] === "external_link") && interactive.instance_of?(MwInteractive)
@@ -155,6 +160,13 @@ class InteractiveRunState < ActiveRecord::Base
       # answerText is defined in IRuntimeMetadataBase.
       # Use answer key to be compatible with current Report and Portal format.
       result[:answer] = metadata[:answerText]
+    when "image_question_answer"
+      # answerImageUrl is defined in IRuntimeImageQuestionMetadata.
+      # # Use answer key to be compatible with current Report service format.
+      result[:answer] = {
+        image_url: metadata[:answerImageUrl],
+        text: metadata[:answerText]
+      }
     when "external_link"
       result[:answer] = reporting_url
     when "interactive_state"

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -233,6 +233,22 @@ describe InteractiveRunState do
         end
       end
 
+      describe "when interactive run state pretends to be image question answer" do
+        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
+        let(:run_data) { JSON({answerType: "image_question_answer", answerText: "Test answer", answerImageUrl: "http://test.snapshot.com", submitted: true}) }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data) }
+
+        it "should overwrite type and provide supported fields to Portal" do
+          expect(subject).to include({
+            type: "image_question",
+            question_id: "mw_interactive_#{interactive.id.to_s}",
+            answer: "Test answer",
+            image_url: "http://test.snapshot.com",
+            is_final: true
+          })
+        end
+      end
+
       describe "when interactive run state pretends to be multiple choice answer" do
         let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
         let(:run_data) { JSON({answerType: "multiple_choice_answer", selectedChoiceIds: ["a", "b"], submitted: true}) }
@@ -303,6 +319,27 @@ describe InteractiveRunState do
             question_id: "mw_interactive_#{interactive.id.to_s}",
             question_type: "open_response",
             answer: "Test answer",
+            submitted: true
+          })
+        end
+      end
+
+      describe "when interactive run state pretends to be image question answer" do
+        let(:interactive) { FactoryGirl.create(:mw_interactive, enable_learner_state: true) }
+        let(:run_data) { JSON({answerType: "image_question_answer", answerText: "Test answer", answerImageUrl: "http://test.snapshot.com", submitted: true}) }
+        let(:interactive_run_state) { InteractiveRunState.create(run: run, interactive: interactive, raw_data: run_data) }
+
+        it "should overwrite type and provide supported fields to Report Service" do
+          expect(subject).to include({
+            type: "image_question_answer",
+            id: interactive_run_state.answer_id,
+            question_id: "mw_interactive_#{interactive.id.to_s}",
+            question_type: "image_question",
+            answer: {
+              text: "Test answer",
+              image_url: "http://test.snapshot.com"
+            },
+            answer_text: "Test answer",
             submitted: true
           })
         end

--- a/spec/support/shared_examples/base_interactive.rb
+++ b/spec/support/shared_examples/base_interactive.rb
@@ -45,6 +45,27 @@ shared_examples "a base interactive" do |model_factory|
       end
     end
 
+    describe "when interactive pretends to be image question" do
+      let (:authored_state) { JSON({questionType: "image_question", prompt: "Test prompt", answerPrompt: "answer prompt", required: true}) }
+      let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
+
+      it 'returns properties supported by Portal' do
+        expect(interactive.portal_hash).to include(
+          type: "image_question",
+          prompt: "Test prompt",
+          drawing_prompt: "answer prompt",
+          is_required: true,
+          id: interactive.embeddable_id,
+          name: interactive.name,
+          url: interactive.url,
+          native_width: interactive.native_width,
+          native_height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?,
+          show_in_featured_question_report: interactive.show_in_featured_question_report
+        )
+      end
+    end
+
     describe "when interactive pretends to be multiple choice question" do
       let (:authored_state) do JSON({
         questionType: "multiple_choice", prompt: "Test prompt", required: true,
@@ -89,12 +110,36 @@ shared_examples "a base interactive" do |model_factory|
       let (:authored_state) { JSON({questionType: "open_response", prompt: "Test prompt", required: true}) }
       let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
 
-      it 'returns properties supported by Portal' do
+      it 'returns properties supported by Report Service' do
         expect(interactive.report_service_hash).to include(
           # Open response props:
           type: 'open_response',
           id: interactive.embeddable_id,
           prompt: "Test prompt",
+          required: true,
+          show_in_featured_question_report: interactive.show_in_featured_question_report,
+          question_number: interactive.index_in_activity,
+          # Interactive props:
+          name: interactive.name,
+          url: interactive.url,
+          width: interactive.native_width,
+          height: interactive.native_height,
+          display_in_iframe: interactive.reportable_in_iframe?
+        )
+      end
+    end
+
+    describe "when interactive pretends to be image question" do
+      let (:authored_state) { JSON({questionType: "image_question", prompt: "Test prompt", answerPrompt: "answer prompt", required: true}) }
+      let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
+
+      it 'returns properties supported by Report Service' do
+        expect(interactive.report_service_hash).to include(
+          # IQ props:
+          type: 'image_question',
+          id: interactive.embeddable_id,
+          prompt: "Test prompt",
+          drawing_prompt: "answer prompt",
           required: true,
           show_in_featured_question_report: interactive.show_in_featured_question_report,
           question_number: interactive.index_in_activity,
@@ -115,9 +160,9 @@ shared_examples "a base interactive" do |model_factory|
       }) end
       let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state) }
 
-      it 'returns properties supported by Portal' do
+      it 'returns properties supported by Report Service' do
         expect(interactive.report_service_hash).to include(
-          # Open response props:
+          # MC props:
           type: 'multiple_choice',
           id: interactive.embeddable_id,
           prompt: "Test prompt",


### PR DESCRIPTION
There are two things that might be a bit confusing here:
- drawing prompt vs answer prompt - it seems that the author of the new interactive question named this property that way. It seems to make more sense, as it's placed next to the answer textarea. I left it that way, but now we have quite a few places where drawing_prompt == answer_prompt. I guess it's fine.
- This code can't be tested in practice right now. New Image Question interactive doesn't work in LARA. But unit tests were easy to add, as the related code is tested. I thought it makes sense to keep the implementation complete and don't have to think about which host (LARA, AP) does what transformations.

[#174824371]
[#174069081]