### PR TITLE
Interactive API: update hostFeatures, add getFirebaseJwt

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -28274,6 +28274,9 @@ var IFrameSaver = /** @class */ (function () {
                     dialog: false,
                     lightbox: true,
                     alert: true
+                },
+                getFirebaseJwt: {
+                    version: "1.0.0",
                 }
             },
             authoredState: this.authoredState,

--- a/docs/interactive-api-client/interfaces/idataset.md
+++ b/docs/interactive-api-client/interfaces/idataset.md
@@ -31,7 +31,7 @@ ___
 
 ###  rows
 
-• **rows**: *Array‹Array‹undefined | null | string | number››*
+• **rows**: *Array‹Array‹null | string | number››*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/ihostfeatures.md
+++ b/docs/interactive-api-client/interfaces/ihostfeatures.md
@@ -12,10 +12,17 @@
 
 ### Properties
 
-* [modal](ihostfeatures.md#modal)
+* [getFirebaseJwt](ihostfeatures.md#optional-getfirebasejwt)
+* [modal](ihostfeatures.md#optional-modal)
 
 ## Properties
 
-###  modal
+### `Optional` getFirebaseJwt
 
-• **modal**: *[IHostModalSupport](ihostmodalsupport.md)*
+• **getFirebaseJwt**? : *[IHostFeatureSupport](ihostfeaturesupport.md)*
+
+___
+
+### `Optional` modal
+
+• **modal**? : *[IHostModalSupport](ihostmodalsupport.md)*

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.7.0-pre.3",
+  "version": "0.7.0",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/lara-typescript/src/interactive-api-client/types.ts
+++ b/lara-typescript/src/interactive-api-client/types.ts
@@ -31,8 +31,9 @@ export interface IHostModalSupport extends IHostFeatureSupport {
   alert?: boolean;
 }
 
-export interface IHostFeatures extends Record<string, IHostFeatureSupport> {
-  modal: IHostModalSupport;
+export interface IHostFeatures extends Record<string, IHostFeatureSupport | undefined> {
+  modal?: IHostModalSupport;
+  getFirebaseJwt?: IHostFeatureSupport;
 }
 
 export interface IRuntimeInitInteractive<InteractiveState = {}, AuthoredState = {}, GlobalInteractiveState = {}>

--- a/lara-typescript/src/interactive-api-parent/iframe-saver.spec.ts
+++ b/lara-typescript/src/interactive-api-parent/iframe-saver.spec.ts
@@ -158,6 +158,9 @@ describe("IFrameSaver", () => {
               alert: true,
               lightbox: true,
               dialog: false
+            },
+            getFirebaseJwt: {
+              version: "1.0.0"
             }
           },
           authoredState: {test: 123},
@@ -202,6 +205,9 @@ describe("IFrameSaver", () => {
               alert: true,
               lightbox: true,
               dialog: false
+            },
+            getFirebaseJwt: {
+              version: "1.0.0"
             }
           },
           authoredState: {test: 123},

--- a/lara-typescript/src/interactive-api-parent/iframe-saver.ts
+++ b/lara-typescript/src/interactive-api-parent/iframe-saver.ts
@@ -390,6 +390,9 @@ export class IFrameSaver {
           dialog: false,
           lightbox: true,
           alert: true
+        },
+        getFirebaseJwt: {
+          version: "1.0.0",
         }
       },
       authoredState: this.authoredState,

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -32577,31 +32577,39 @@ exports.getAuthInfo = function () {
 };
 exports.getFirebaseJwt = function (firebaseApp) {
     return new Promise(function (resolve, reject) {
-        var listener = function (response) {
-            if (response.response_type === "ERROR") {
-                reject(response.message || "Error getting Firebase JWT");
-            }
-            else if (response.token) {
-                try {
-                    var claimsJson = atob(response.token.split(".")[1]);
-                    resolve({ token: response.token, claims: JSON.parse(claimsJson) });
-                }
-                catch (error) {
-                    reject("Unable to parse JWT Token");
-                }
+        exports.getInitInteractiveMessage().then(function (initMsg) {
+            var _a, _b;
+            if (initMsg && initMsg.mode === "runtime" && ((_b = (_a = initMsg.hostFeatures) === null || _a === void 0 ? void 0 : _a.getFirebaseJwt) === null || _b === void 0 ? void 0 : _b.version) === "1.0.0") {
+                var listener = function (response) {
+                    if (response.response_type === "ERROR") {
+                        reject(response.message || "Error getting Firebase JWT");
+                    }
+                    else if (response.token) {
+                        try {
+                            var claimsJson = atob(response.token.split(".")[1]);
+                            resolve({ token: response.token, claims: JSON.parse(claimsJson) });
+                        }
+                        catch (error) {
+                            reject("Unable to parse JWT Token");
+                        }
+                    }
+                    else {
+                        reject("Empty token");
+                    }
+                };
+                var client = client_1.getClient();
+                var requestId = client.getNextRequestId();
+                var request = {
+                    requestId: requestId,
+                    firebase_app: firebaseApp
+                };
+                client.addListener("firebaseJWT", listener, requestId);
+                client.post("getFirebaseJWT", { lol: 123 });
             }
             else {
-                reject("Empty token");
+                reject("getFirebaseJwt not supported by the host environment");
             }
-        };
-        var client = client_1.getClient();
-        var requestId = client.getNextRequestId();
-        var request = {
-            requestId: requestId,
-            firebase_app: firebaseApp
-        };
-        client.addListener("firebaseJWT", listener, requestId);
-        client.post("getFirebaseJWT", request);
+        });
     });
 };
 exports.log = function (action, data) {


### PR DESCRIPTION
[#175787385]

This PR adds `getFirebaseJwt` to `hostFeatures`. I've used a name that perfectly matches the client method name, so it's clear whether this method can be used or not.

Also, I've modified `client.getFirebaseJwt` to check `hostFeatures` before it's even executed. That way the interactive wouldn't have to do it itself. Client method will work or it will immediately fail. Interactive doesn't have to care about init message, `hostFeatures` properties, and know what hostFeature properties mean. This logic could be encapsulated in client methods instead. I think this might be much more usable in practice. Other methods could even check `hostFeatures` vs their arguments, e.g.`showModal` could check whether lightbox, dialog, or alert are actually supported (I haven't done it yet, as not sure if you like the approach). 

I've added a test that checks hostFeatures for `getFirebaseJwt`. There are more updates in spec file, as `testRequestResponse` was broken - it wasn't testing anything (missing async/await and Promise.all), plus it had some other problems. 