### PR TITLE
Interactive API: IDataset - make xAxisProp optional, release version 0.7.1

### DIFF
--- a/docs/interactive-api-client/interfaces/idataset.md
+++ b/docs/interactive-api-client/interfaces/idataset.md
@@ -19,7 +19,7 @@ Interface that can be used by interactives to export and consume datasets. For e
 * [rows](idataset.md#rows)
 * [type](idataset.md#type)
 * [version](idataset.md#version)
-* [xAxisProp](idataset.md#xaxisprop)
+* [xAxisProp](idataset.md#optional-xaxisprop)
 
 ## Properties
 
@@ -47,6 +47,6 @@ ___
 
 ___
 
-###  xAxisProp
+### `Optional` xAxisProp
 
-• **xAxisProp**: *string*
+• **xAxisProp**? : *undefined | string*

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/lara-typescript/src/interactive-api-client/types.ts
+++ b/lara-typescript/src/interactive-api-client/types.ts
@@ -416,8 +416,9 @@ export interface IDataset {
   type: "dataset";
   version: 1;
   properties: string[];
-  xAxisProp: string;
   rows: Array<Array<(number | string | null)>>;
+  // Row indices will be used when xAxisProp is undefined.
+  xAxisProp?: string;
 }
 
 /**


### PR DESCRIPTION
[#175787385]

When xAxisProp is undefined, row indices will be used by the graph interactive.