### PR TITLE
Fix inconsistent edit menus for sequences and activities

### DIFF
--- a/app/assets/stylesheets/activity-sequences.scss
+++ b/app/assets/stylesheets/activity-sequences.scss
@@ -50,14 +50,13 @@ footer.sequence_run {
 #activities ul.menu li.delete form {
   display: inline;
   input[type="submit"] {
+    background: transparent;
     border: none;
     cursor: pointer;
     font: inherit;
-    background: transparent url(/assets/icons/delete.png) 0 0 no-repeat;
-    background-size: 16px;
     color: #333;
     height: 16px;
-    padding-left: 18px;
+    padding-left: 16px;
   }
 }
 .activities {

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -1175,14 +1175,13 @@ body.admin.edit {
 #activities ul.menu li.delete form {
   display: inline;
   input[type="submit"] {
+    background: transparent;
     border: none;
     cursor: pointer;
     font: inherit;
-    background: transparent url(/assets/icons/delete.png) 0 0 no-repeat;
-    background-size: 16px;
     color: #333;
     height: 16px;
-    padding-left: 18px;
+    padding-left: 16px;
   }
 }
 

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -7,7 +7,7 @@ class LightweightActivitiesController < ApplicationController
     portal_launchable = (action_name == 'show' && params[:sequence_id].blank?)
     set_run_key(portal_launchable: portal_launchable)
   }
-  before_filter :set_sequence, :only   => [:summary, :show, :single_page]
+  before_filter :set_sequence, :only   => [:summary, :show, :single_page, :preview]
 
   before_filter :enable_js_logger, :only => [:summary, :show, :preview, :single_page]
 

--- a/app/views/sequences/_activity_list.html.haml
+++ b/app/views/sequences/_activity_list.html.haml
@@ -8,7 +8,7 @@
           = truncate(activity.name_with_id, :length => 20, :omission => "…")
           %ul.menu
             %li.edit= link_to "Edit", edit_activity_path(activity) if can? :update, activity
-            %li.run= link_to "Run", activity_path(activity)
+            %li.run= link_to "Preview", sequence_path(@sequence) + activity_path(activity)
             %li.delete
               = form_tag remove_activity_sequence_path(@sequence) do
                 = hidden_field_tag :activity_id, activity.id

--- a/app/views/sequences/_activity_list.html.haml
+++ b/app/views/sequences/_activity_list.html.haml
@@ -8,7 +8,7 @@
           = truncate(activity.name_with_id, :length => 20, :omission => "…")
           %ul.menu
             %li.edit= link_to "Edit", edit_activity_path(activity) if can? :update, activity
-            %li.run= link_to "Preview", sequence_path(@sequence) + activity_path(activity)
+            %li.run= link_to "Preview", preview_sequence_activity_path(activity, sequence_id: @sequence.id)
             %li.delete
               = form_tag remove_activity_sequence_path(@sequence) do
                 = hidden_field_tag :activity_id, activity.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,11 @@ LightweightStandalone::Application.routes.draw do
       # TODO: dpeprecate this Dashboard route
       get :dashboard_toc, to: redirect(path: "/api/v1/dashboard_toc/sequences/%{id}")
     end
-    resources :activities, :controller => 'lightweight_activities', :constraints => { :id => /\d+/, :sequence_id => /\d+/ }, :only => [:show, :summary]
+    resources :activities, :controller => 'lightweight_activities', :constraints => { :id => /\d+/, :sequence_id => /\d+/ }, :only => [:show, :summary] do
+      member do
+        get :preview
+      end
+    end
   end
 
   namespace :embeddable do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/175995433

[#175995433]

* Change "Run" to "Preview" on sequence edit page
* Change run/preview URL to point to activity within sequence
* Remove trashcan icon from "Remove" link on sequence edit page