### PR TITLE
Interactive API: don't throw an error outside iframe

### DIFF
--- a/lara-typescript/src/interactive-api-client/client.spec.ts
+++ b/lara-typescript/src/interactive-api-client/client.spec.ts
@@ -23,10 +23,10 @@ describe("Client", () => {
       inIframe = false;
     });
 
-    it("throws an error", () => {
+    it("does not throw an error", () => {
       expect(() => {
         const c = new Client();
-      }).toThrowError();
+      }).not.toThrowError();
     });
   });
 

--- a/lara-typescript/src/interactive-api-client/client.ts
+++ b/lara-typescript/src/interactive-api-client/client.ts
@@ -41,7 +41,8 @@ export class Client {
 
   constructor() {
     if (!inIframe()) {
-      throw new Error("Interactive API is meant to be used in iframe");
+      // tslint:disable-next-line:no-console
+      console.warn("Interactive API is meant to be used in iframe");
     }
     if (phoneInitialized()) {
       throw new Error("IframePhone has been initialized previously. Only one Client instance is allowed.");

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -32798,7 +32798,8 @@ var Client = /** @class */ (function () {
             _this.post("supportedFeatures", newRequest);
         };
         if (!in_frame_1.inIframe()) {
-            throw new Error("Interactive API is meant to be used in iframe");
+            // tslint:disable-next-line:no-console
+            console.warn("Interactive API is meant to be used in iframe");
         }
         if (phoneInitialized()) {
             throw new Error("IframePhone has been initialized previously. Only one Client instance is allowed.");


### PR DESCRIPTION
[#176004704]

Old behavior wouldn't work for interactives that are meant to work both inside LARA and standalone.

Obviously, most of the features of LARA Interactive API aren't available outside LARA-like host, but interactive can use `useInteractiveState` as its state container and it works fine in both cases. And just call functions that are ignored if it's outside LARA, without having to have two separate code paths.

I've noticed that when I was working on CZI Gravity sim.