### PR TITLE
Large interactive prompts caused issue when publishing to the portal

### DIFF
--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -50,7 +50,7 @@ module BaseInteractive
 
     # If name is not available, but prompt is, this should make Portal details report a bit more readable.
     unless result[:name].present?
-      result[:name] = result[:prompt]
+      result[:name] = BaseInteractive.clean_value(result[:prompt]).truncate(200)
     end
 
     # Open response and multiple choice properties are the same as in report_service_hash and/or properties mapped above.
@@ -153,6 +153,14 @@ module BaseInteractive
     if page_item
       self.linked_interactive = page_item.embeddable
     end
+  end
+
+  def self.clean_value(value)
+    value.class == String ? clean_text(value) : value
+  end
+
+  def self.clean_text(text)
+    Nokogiri::HTML(text).inner_text
   end
 
 end

--- a/spec/support/shared_examples/base_interactive.rb
+++ b/spec/support/shared_examples/base_interactive.rb
@@ -91,6 +91,17 @@ shared_examples "a base interactive" do |model_factory|
     end
   end
 
+  describe "#portal_hash" do
+    let (:authored_state) { JSON({questionType: "image_question", prompt: "<p>Lorem <strong>ipsum dolor sit amet</strong>, consectetur<br /> adipiscing elit. Duis porttitor tincidunt ante. Pellentesque suscipit sollicitudin condimentum. Vivamus gravida aliquam fringilla. Nunc pretium, urna eget accumsan interdum, turpis ante iaculis nisl, a condimentum nisl odio a ipsum. Aliquam erat volutpat. Nulla facilisi. Pellentesque ultrices rutrum est. Cras nec felis in orci porttitor iaculis in vel lectus. Nam aliquam mi sem, quis viverra ligula consequat at. Aliquam dictum eros felis, sit amet fermentum odio sagittis nec. Sed pretium dignissim commodo.</p>", answerPrompt: "answer prompt", required: true}) }
+    let (:interactive) { FactoryGirl.create(model_factory, authored_state: authored_state, name: nil) }
+
+    it 'handles complex prompts' do
+      expect(interactive.portal_hash).to include(
+        name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis porttitor tincidunt ante. Pellentesque suscipit sollicitudin condimentum. Vivamus gravida aliquam fringilla. Nunc pretium, urna eget ac..."
+      )
+    end
+  end
+
   describe "#report_service_hash" do
     it 'returns properties supported by Report Service' do
       expect(interactive.report_service_hash).to include(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176215104

[#176215104]

* Truncate and sanitize prompt content when it is used to replace empty name value on publication.
* Add related spec test.