### PR TITLE
sketch of moving the listener inside of the client

### DIFF
--- a/lara-typescript/src/example-interactive/src/components/runtime.tsx
+++ b/lara-typescript/src/example-interactive/src/components/runtime.tsx
@@ -39,18 +39,7 @@ export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
       replace: msg.replace,
     };
 
-    const decoratedContentClickListener = {
-      type: "click",
-      listener: (evt: Event) => {
-        const wordElement = evt.srcElement as HTMLElement;
-        if (!wordElement) {
-          return;
-        }
-        const clickedWord = (wordElement.textContent || "").toLowerCase();
-        postDecoratedContentEvent({type: "click", text: clickedWord, bounds: wordElement.getBoundingClientRect()});
-      }
-    };
-    TextDecorator.decorateDOMClasses(domClasses, options, msg.wordClass, decoratedContentClickListener);
+    TextDecorator.decorateDOMClasses(domClasses, options, msg.wordClass, msg.eventListeners);
   });
 
   const handleSnapshotTargetChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/lara-typescript/src/interactive-api-client/client.ts
+++ b/lara-typescript/src/interactive-api-client/client.ts
@@ -134,7 +134,28 @@ export class Client {
   }
 
   public addDecorateContentListener(callback: ITextDecorationHandler) {
-    this.addListener("decorateContent", callback);
+    // Instead of `msg: any` here this should use a type defined in the api
+    // that type should also be used by the AP to verify it is sending the right kind of message
+    this.addListener("decorateContent", (msg: any) => {
+      callback({
+        words: msg.words,
+        replace: msg.replace,
+        wordClass: msg.wordClass,
+        eventlisteners: msg.eventListeners.map((eventListener) => {
+          return {
+            type: eventListener.type,
+            listener: (evt: Event) => {
+              const wordElement = evt.srcElement as HTMLElement;
+              if (!wordElement) {
+                return;
+              }
+              const clickedWord = (wordElement.textContent || "").toLowerCase();
+              postDecoratedContentEvent({type: eventListener.type, text: clickedWord, bounds: wordElement.getBoundingClientRect()});
+            }
+          }
+        })
+      });
+    });
   }
 
   public removeDecorateContentListener() {


### PR DESCRIPTION
this hasn't been compiled or tested it is just to illustrate a change that
should make it easier for interactive developers to use the client
and support decorating their content.

This might work without changing the AP PR. I think that will already be sending
the `eventListeners` array.
I'm guessing what is coming through postMessage right now is something like
{eventListeners: [{type: "click", listener: null}]}
since JSON.stringify seems to turn functions into null.