### PR TITLE
Added page id to activity export [#176197155]

### DIFF
--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -280,7 +280,8 @@ class InteractivePage < ActiveRecord::Base
 
   def export
     helper = LaraSerializationHelper.new
-    page_json = self.as_json(only: [:name,
+    page_json = self.as_json(only: [:id,
+                                    :name,
                                     :position,
                                     :layout,
                                     :is_hidden,

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -203,6 +203,7 @@ describe InteractivePage do
       expect(page_json['embeddables'].length).to eq(page.embeddables.count)
       expect(page_json['is_hidden']).to eq(page.is_hidden)
       expect(page_json['is_completion']).to eq(page.is_completion)
+      expect(page_json['id']).to eq(page.id)
     end
 
     describe "with a labbook" do


### PR DESCRIPTION
Used by this Activity Player PR to implement deep linking to a page via id (https://github.com/concord-consortium/activity-player/pull/97).  The Activity Player PR will gracefully degrade if this PR isn't yet merged/deployed.