### PR TITLE
Interactive API Client: fix empty string handling

### DIFF
--- a/lara-typescript/src/interactive-api-client/client.spec.ts
+++ b/lara-typescript/src/interactive-api-client/client.spec.ts
@@ -87,6 +87,22 @@ describe("Client", () => {
       expect(client.managedState.globalInteractiveState).toEqual({ globalState: true });
     });
 
+    it("handles init message and saves interactive, authored and global interactive states even if they're malformed JSONs or empty strings", () => {
+      const client = new Client();
+      mockedPhone.fakeServerMessage({
+        type: "initInteractive",
+        content: {
+          mode: "runtime",
+          interactiveState: "{ \"interactiveStat }",
+          authoredState: "",
+          globalInteractiveState: "{ \"global"
+        }
+      });
+      expect(client.managedState.interactiveState).toEqual("{ \"interactiveStat }");
+      expect(client.managedState.authoredState).toEqual("");
+      expect(client.managedState.globalInteractiveState).toEqual("{ \"global");
+    });
+
     it("automatically supports the getInteractiveState message", () => {
       const client = new Client();
       client.managedState.interactiveState = {test: 123};

--- a/lara-typescript/src/interactive-api-client/client.ts
+++ b/lara-typescript/src/interactive-api-client/client.ts
@@ -18,7 +18,13 @@ interface IListenerMap {
 }
 
 const parseJSONIfString = (data: any) => {
-  return typeof data === "string" ?  JSON.parse(data) : data;
+  // Note that we don't want to call JSON.parse for an empty string.
+  try {
+    return typeof data === "string" ? JSON.parse(data) : data;
+  } catch {
+    // If JSON string is malformed, it's an empty string, or not a JSON at all, return the original value.
+    return data;
+  }
 };
 
 const phoneInitialized = () => iframePhone.getIFrameEndpoint().getListenerNames().length > 0;

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/lara-typescript/src/plugin-api/package.json
+++ b/lara-typescript/src/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-plugin-api",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "LARA Plugin API",
   "types": "./index-bundle.d.ts",
   "repository": {

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -44467,7 +44467,14 @@ var interactive_api_client_1 = __webpack_require__(/*! ../interactive-api-client
 var in_frame_1 = __webpack_require__(/*! ./in-frame */ "./src/interactive-api-client/in-frame.ts");
 var managed_state_1 = __webpack_require__(/*! ./managed-state */ "./src/interactive-api-client/managed-state.ts");
 var parseJSONIfString = function (data) {
-    return typeof data === "string" ? JSON.parse(data) : data;
+    // Note that we don't want to call JSON.parse for an empty string.
+    try {
+        return typeof data === "string" ? JSON.parse(data) : data;
+    }
+    catch (_a) {
+        // If JSON string is malformed, it's an empty string, or not a JSON at all, return the original value.
+        return data;
+    }
 };
 var phoneInitialized = function () { return iframePhone.getIFrameEndpoint().getListenerNames().length > 0; };
 var clientInstance;


### PR DESCRIPTION
Some interactives don't define any authored state. In this case, an empty string was passed to JSON.parse and crashing interactive runtime. That's why Dan didn't see user state in Gravity interactive.