### PR TITLE
#176708540 Modify publish_runs rake task

### DIFF
--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -71,8 +71,14 @@ namespace :reporting do
 
   desc "publish runs to report service"
   task :publish_runs => :environment do
-    # limit this to portal runs for now
-    runs = Run.where('remote_endpoint is not null')
+    # limit this to portal runs by default:
+    where_query = 'remote_endpoint is not null'
+    # Or specify remote endpoint substring to match:
+    env_value = ENV["REPORT_PUSH_RUN_SELECT_REMOTE"]
+    if env_value && env_value.size > 0
+      where_query = "remote_endpoint like '%#{env_value}%'"
+    end
+    runs = Run.where(where_query)
     opts = { send_all_answers: true }
     send_all_resources(runs, ReportService::RunSender, opts)
   end

--- a/spec/libs/tasks/reporting_rake_spec.rb
+++ b/spec/libs/tasks/reporting_rake_spec.rb
@@ -15,6 +15,7 @@ describe "reporting:publish_runs" do
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("app.lara.docker")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("http://foo.com")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return("report_service_token")
+    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_SELECT_REMOTE").and_return(nil)
   end
 
   it "sends a run to the report service, specifying `send_all_answers`" do


### PR DESCRIPTION
This task was updated so it only publishes runs that match specific remote_endpoints. It should speed things up.

If the value for `REPORT_PUSH_RUN_SELECT_REMOTE` is set in the environment, the task will find runs
that match that value.