### PR TITLE
support activity player page links in the report service

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -289,11 +289,16 @@ class LightweightActivity < ActiveRecord::Base
         questions.push(embeddable.report_service_hash) if embeddable.respond_to?(:report_service_hash)
         # Otherwise we don't support this embeddable type right now.
       end
+      if self.runtime == "Activity Player"
+        page_url = serialized_ap_url(host, page)
+      else
+        page_url = "#{host}#{Rails.application.routes.url_helpers.page_path(page)}"
+      end
       pages.push({
         id: "page_" + page.id.to_s,
         type: "page",
         name: page.name,
-        url: "#{host}#{Rails.application.routes.url_helpers.page_path(page)}",
+        url: page_url,
         children: questions
       })
     end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -600,7 +600,6 @@ describe LightweightActivity do
         expect(pages.length).to eql(2)
         expect(pages[0][:type]).to eql('page')
         expect(pages[0][:name]).to eql('page 1')
-        # https://activity-player.concord.org/branch/master?activity=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Factivities%2F885.json&page=page_550
         expect(pages[0][:url]).to match page_url_pattern
         expect(pages[1][:type]).to eql('page')
         expect(pages[1][:name]).to eql('page 2')

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -592,6 +592,20 @@ describe LightweightActivity do
         expect(pages[1][:name]).to eql('page 2')
         expect(pages[1][:url]).to match /http:\/\/test.host\/pages\/\d+/
       end
+
+      it 'sets the page url for the activity player runtime' do
+        activity.runtime = "Activity Player"
+        pages = activity.serialize_for_report_service('http://test.host')[:children][0][:children]
+        page_url_pattern = /https:\/\/activity-player.concord.org\/.*&page=page_\d+/
+        expect(pages.length).to eql(2)
+        expect(pages[0][:type]).to eql('page')
+        expect(pages[0][:name]).to eql('page 1')
+        # https://activity-player.concord.org/branch/master?activity=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Factivities%2F885.json&page=page_550
+        expect(pages[0][:url]).to match page_url_pattern
+        expect(pages[1][:type]).to eql('page')
+        expect(pages[1][:name]).to eql('page 2')
+        expect(pages[0][:url]).to match page_url_pattern
+      end
     end
 
     describe 'pages section with hidden embeddables & reportable interactives' do


### PR DESCRIPTION
@dougmartin did the original work on this in this PR: https://github.com/concord-consortium/lara/pull/667
But that missed the key bit bit of updating the data going to the report-service.

[#176197155]