### PR TITLE
this escape wasn't really doing anything

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -355,7 +355,6 @@ class LightweightActivity < ActiveRecord::Base
     if preview
       query["preview"] = nil # adds 'preview' to query string as a valueless param
     end
-    query["activity"] = URI.escape(activity_api_url)
     uri.query = Rack::Utils.build_query(query)
     return uri.to_s
   end


### PR DESCRIPTION
build_query automatically escapes the values in the hash
URI.escape only escapes characters that aren't valid in a URI (as opposed to characters to avoid in a parameter)
so for example it will not escape `=`, `&`,  `?`, or `/`