### PR TITLE
add preview_urls to the report-structure

### DIFF
--- a/app/controllers/api/v1/lightweight_activities_controller.rb
+++ b/app/controllers/api/v1/lightweight_activities_controller.rb
@@ -12,4 +12,12 @@ class Api::V1::LightweightActivitiesController < API::APIController
     lightweight_activity_json = activity.export.to_json
     render json: lightweight_activity_json
   end
+
+  # GET /api/v1/activities/1/reeport_structure.json
+  def report_structure
+    activity = LightweightActivity.find(params[:id])
+    self_url = "#{request.protocol}#{request.host_with_port}"
+    json = activity.serialize_for_report_service(self_url).to_json
+    render json: json
+  end
 end

--- a/app/controllers/api/v1/sequences_controller.rb
+++ b/app/controllers/api/v1/sequences_controller.rb
@@ -12,4 +12,12 @@ class Api::V1::SequencesController < API::APIController
     sequence_json = sequence.export
     render json: sequence_json
   end
+
+  # GET /api/v1/sequences/1/reeport_structure.json
+  def report_structure
+    sequence = Sequence.find(params[:id])
+    self_url = "#{request.protocol}#{request.host_with_port}"
+    json = sequence.serialize_for_report_service(self_url).to_json
+    render json: json
+  end
 end

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -59,21 +59,6 @@ module LightweightActivityHelper
     end
   end
 
-  def activity_player_url(activity, mode="")
-    activity_api_url = "#{api_v1_activity_url(activity.id)}.json"
-    uri = URI.parse(ENV["ACTIVITY_PLAYER_URL"])
-    query = Rack::Utils.parse_query(uri.query)
-    query["activity"] = URI.escape(activity_api_url)
-    query["preview"] = nil # adds 'preview' to query string as a valueless param
-    query["mode"] = mode
-    uri.query = Rack::Utils.build_query(query)
-    return uri.to_s
-  end
-
-  def activity_player_page_url(activity, page, mode="")
-    return  "#{activity_player_url(activity, mode)}&page=#{page.position}"
-  end
-
   def activity_player_conversion_url(activity)
     if @sequence
       lara_resource = "#{api_v1_activity_url(@sequence.id)}.json"
@@ -92,14 +77,14 @@ module LightweightActivityHelper
   end
 
   def activity_preview_options(activity, page=nil)
+    base_url = request.base_url
+
+    activity_player_url = activity.activity_player_url(base_url, page: page)
+    activity_player_te_url = activity.activity_player_url(base_url, page: page, mode: "teacher-edition")
     if page
-      activity_player_url = activity_player_page_url(activity, page)
-      activity_player_te_url = activity_player_page_url(activity, page, "teacher-edition")
       lara_runtime_url = preview_activity_page_path(activity, page)
       lara_runtime_te_url = preview_activity_page_path(activity, page, mode: "teacher-edition")
     else
-      activity_player_url = activity_player_url(activity)
-      activity_player_te_url = activity_player_url(activity, "teacher-edition")
       lara_runtime_url = preview_activity_path(activity)
       lara_runtime_te_url = preview_activity_path(activity, mode: "teacher-edition")
     end
@@ -114,7 +99,7 @@ module LightweightActivityHelper
 
   def runtime_url(activity)
     if activity.runtime == "Activity Player"
-      view_activity_url = activity.activity_player_url(request.protocol, request.host_with_port, true)
+      view_activity_url = activity.activity_player_url(request.base_url, preview: true)
     else
       view_activity_url = activity_path(activity)
     end

--- a/app/helpers/sequence_helper.rb
+++ b/app/helpers/sequence_helper.rb
@@ -1,20 +1,16 @@
 module SequenceHelper
-  def activity_player_sequence_url(sequence, mode="")
-    sequence_api_url = "#{api_v1_sequence_url(sequence.id)}.json"
-    return  "#{ENV['ACTIVITY_PLAYER_URL']}/?sequence=#{CGI.escape(sequence_api_url)}&preview&mode=#{mode}"
-  end
-
   def sequence_preview_options(activity)
+    base_url = request.base_url
     {
       'Select a runtime option...' => '',
-      'Activity Player' => activity_player_sequence_url(@sequence),
-      'Activity Player Teacher Edition' => activity_player_sequence_url(@sequence, "teacher-edition")
+      'Activity Player' => @sequence.activity_player_sequence_url(base_url, preview: true),
+      'Activity Player Teacher Edition' => @sequence.activity_player_sequence_url(base_url, preview: true, mode: "teacher-edition")
     }
   end
 
   def sequence_runtime_url(sequence)
     if sequence.runtime == "Activity Player"
-      view_sequence_url = sequence.activity_player_sequence_url(request.host_with_port, true)
+      view_sequence_url = sequence.activity_player_sequence_url(request.base_url, preview: true)
     else
       view_sequence_url = sequence_path(sequence)
     end

--- a/app/helpers/sequence_helper.rb
+++ b/app/helpers/sequence_helper.rb
@@ -14,7 +14,7 @@ module SequenceHelper
 
   def sequence_runtime_url(sequence)
     if sequence.runtime == "Activity Player"
-      view_sequence_url = sequence.activity_player_sequence_url(request.protocol, request.host_with_port, true)
+      view_sequence_url = sequence.activity_player_sequence_url(request.host_with_port, true)
     else
       view_sequence_url = sequence_path(sequence)
     end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -359,7 +359,7 @@ class LightweightActivity < ActiveRecord::Base
     api_url = "#{host}#{Rails.application.routes.url_helpers.api_v1_activity_path(self)}.json"
     uri = URI.parse(ENV["ACTIVITY_PLAYER_URL"])
     query = Rack::Utils.parse_query(uri.query)
-    query["activity"] = URI.escape(api_url)
+    query["activity"] = api_url
     if page != nil
       query["page"] = "page_#{page.id}"
     end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -170,25 +170,28 @@ class Sequence < ActiveRecord::Base
       url: local_url
     }
     if self.runtime == "Activity Player"
-      data[:preview_url] = self.activity_player_sequence_url(host, true)
+      data[:preview_url] = self.activity_player_sequence_url(host, preview: true)
     end
 
     # FIXME: the urls and preview_urls in these activities do not include the
     # the sequence, so links in the report to the activities or activity pages
-    # will not show the activity or page in the context of a sequence 
+    # will not show the activity or page in the context of a sequence
     # see https://www.pivotaltracker.com/story/show/177122631
     data[:children] = self.activities.map { |a| a.serialize_for_report_service(host) }
     data
   end
 
-  def activity_player_sequence_url(host, preview)
+  def activity_player_sequence_url(host, preview: false, mode: nil)
     sequence_api_url = "#{host}#{Rails.application.routes.url_helpers.api_v1_sequence_path(self)}.json"
     uri = URI.parse(ENV["ACTIVITY_PLAYER_URL"])
     query = Rack::Utils.parse_query(uri.query)
     if preview
       query["preview"] = nil # adds 'preview' to query string as a valueless param
     end
-    query["sequence"] = URI.escape(sequence_api_url)
+    if mode
+      query["mode"] = mode
+    end
+    query["sequence"] = sequence_api_url
     uri.query = Rack::Utils.build_query(query)
     return uri.to_s
   end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -127,7 +127,7 @@ class Sequence < ActiveRecord::Base
       run_url = local_url
       source_type = "LARA"
       append_auth_token = false
-      tool_id = ""  
+      tool_id = ""
     end
 
     {
@@ -169,12 +169,20 @@ class Sequence < ActiveRecord::Base
       name: self.title,
       url: local_url
     }
+    if self.runtime == "Activity Player"
+      data[:preview_url] = self.activity_player_sequence_url(host, true)
+    end
+
+    # FIXME: the urls and preview_urls in these activities do not include the
+    # the sequence, so links in the report to the activities or activity pages
+    # will not show the activity or page in the context of a sequence 
+    # see https://www.pivotaltracker.com/story/show/177122631
     data[:children] = self.activities.map { |a| a.serialize_for_report_service(host) }
     data
   end
 
-  def activity_player_sequence_url(protocol, host, preview)
-    sequence_api_url = "#{Rails.application.routes.url_helpers.api_v1_sequence_url(id: self.id, protocol: protocol, host: host)}.json"
+  def activity_player_sequence_url(host, preview)
+    sequence_api_url = "#{host}#{Rails.application.routes.url_helpers.api_v1_sequence_path(self)}.json"
     uri = URI.parse(ENV["ACTIVITY_PLAYER_URL"])
     query = Rack::Utils.parse_query(uri.query)
     if preview

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -185,13 +185,13 @@ class Sequence < ActiveRecord::Base
     sequence_api_url = "#{host}#{Rails.application.routes.url_helpers.api_v1_sequence_path(self)}.json"
     uri = URI.parse(ENV["ACTIVITY_PLAYER_URL"])
     query = Rack::Utils.parse_query(uri.query)
+    query["sequence"] = sequence_api_url
     if preview
       query["preview"] = nil # adds 'preview' to query string as a valueless param
     end
     if mode
       query["mode"] = mode
     end
-    query["sequence"] = sequence_api_url
     uri.query = Rack::Utils.build_query(query)
     return uri.to_s
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,8 +175,16 @@ LightweightStandalone::Application.routes.draw do
         match 'report' =>  "question_trackers#report", via: ['get','post', 'put'], defaults: { format: 'json' }
       end
 
-      resources :activities, :controller => 'lightweight_activities', only: [:show, :destroy]
-      resources :sequences, :controller => 'sequences', only: [:show, :destroy]
+      resources :activities, :controller => 'lightweight_activities', only: [:show, :destroy] do
+        member do
+          get :report_structure
+        end
+      end
+      resources :sequences, :controller => 'sequences', only: [:show, :destroy] do
+        member do
+          get :report_structure
+        end
+      end
 
       match 'import' => 'import#import', :via => 'post'
 

--- a/spec/controllers/api/v1/lighweight_activity_controller_spec.rb
+++ b/spec/controllers/api/v1/lighweight_activity_controller_spec.rb
@@ -25,6 +25,25 @@ describe Api::V1::LightweightActivitiesController do
     end
   end
 
+  describe "#report_structure" do
+    it 'recognizes and generates #report_structure' do
+      expect({:get => "api/v1/activities/1/report_structure.json"}).to route_to(
+        :controller => 'api/v1/lightweight_activities',
+        :action => 'report_structure',
+        :id => "1",
+        :format => "json"
+      )
+    end
+
+    it "when user is anonymous, shows an the json sent to the report structure" do
+
+      get :report_structure, :id => activity.id, :format => :json
+      expect(response.status).to eq(200)
+      # json_response = JSON.parse(response.body)
+      # expect(json_response["token"]).to eq('fake-token')
+    end
+  end
+
   describe "#destroy" do
     def expect_success_for(user)
       if user

--- a/spec/controllers/api/v1/sequences_controller_spec.rb
+++ b/spec/controllers/api/v1/sequences_controller_spec.rb
@@ -7,22 +7,41 @@ describe Api::V1::SequencesController do
   let (:sequence) { FactoryGirl.create(:sequence, user: author1, :title => 'Test Sequence') }
 
   describe "#show" do
-  it 'recognizes and generates #show' do
-    expect({:get => "api/v1/sequences/1.json"}).to route_to(
-      :controller => 'api/v1/sequences',
-      :action => 'show',
-      :id => "1",
-      :format => "json"
-    )
+    it 'recognizes and generates #show' do
+      expect({:get => "api/v1/sequences/1.json"}).to route_to(
+        :controller => 'api/v1/sequences',
+        :action => 'show',
+        :id => "1",
+        :format => "json"
+      )
+    end
+
+    it "when user is anonymous, shows a sequence's json" do
+      get :show, :id => sequence.id, :format => :json
+      expect(response.status).to eq(200)
+      json_response = JSON.parse(response.body)
+      expect(json_response["title"]).to eq('Test Sequence')
+    end
   end
 
-  it "when user is anonymous, shows a sequence's json" do
-    get :show, :id => sequence.id, :format => :json
-    expect(response.status).to eq(200)
-    json_response = JSON.parse(response.body)
-    expect(json_response["title"]).to eq('Test Sequence')
+  describe "#report_structure" do
+    it 'recognizes and generates #report_structure' do
+      expect({:get => "api/v1/sequences/1/report_structure.json"}).to route_to(
+        :controller => 'api/v1/sequences',
+        :action => 'report_structure',
+        :id => "1",
+        :format => "json"
+      )
+    end
+
+    it "when user is anonymous, shows an the json sent to the report structure" do
+
+      get :report_structure, :id => sequence.id, :format => :json
+      expect(response.status).to eq(200)
+      # json_response = JSON.parse(response.body)
+      # expect(json_response["token"]).to eq('fake-token')
+    end
   end
-end
 
   describe "#destroy" do
     def expect_success_for(user)

--- a/spec/helpers/lightweight_activity_helper_spec.rb
+++ b/spec/helpers/lightweight_activity_helper_spec.rb
@@ -40,7 +40,7 @@ describe LightweightActivityHelper do
       @template = "https://lara.fake/api/activities/3.json"
       allow(ENV).to receive(:[]).with("CONVERSION_SCRIPT_URL").and_return("https://test.fake?lara_root=#{@lara_root}&template=#{@template}")
     end
-    describe "with an activity" do 
+    describe "with an activity" do
       it "should return a URI containing the required params" do
         conversion_url = activity_player_conversion_url(activity)
         uri = URI.parse(conversion_url)
@@ -51,7 +51,7 @@ describe LightweightActivityHelper do
         expect(query["resource_name"]).to eq("Test Activity")
       end
     end
-    describe "with a sequence" do 
+    describe "with a sequence" do
       it "should return a URI containing the required params" do
         conversion_url = activity_player_conversion_url(sequence)
         uri = URI.parse(conversion_url)
@@ -64,33 +64,10 @@ describe LightweightActivityHelper do
     end
   end
 
-  describe "#activity_player_url" do
-    describe "with an activity" do 
-      it "should return a URI containing the required param" do
-        activity_player_url = activity_player_url(activity)
-        activity_api_url = api_v1_activity_url(activity.id)
-        uri = URI.parse(activity_player_url)
-        query = Rack::Utils.parse_query(uri.query)
-        expect(query["activity"]).to eq("#{activity_api_url}.json")
-        expect(query["mode"]).to eq("")
-      end
-    end
-    describe "with an activity and teacher mode enabled" do 
-      it "should return a URI containing the required params" do
-        activity_player_url = activity_player_url(activity, "teacher-edition")
-        activity_api_url = api_v1_activity_url(activity.id)
-        uri = URI.parse(activity_player_url)
-        query = Rack::Utils.parse_query(uri.query)
-        expect(query["activity"]).to eq("#{activity_api_url}.json")
-        expect(query["mode"]).to eq("teacher-edition")
-      end
-    end
-  end
-
   describe "#activity_preview_options" do
     describe "with an activity" do
       it "should return a list of preview options" do
-        preview_options = activity_preview_options(activity)
+        preview_options = helper.activity_preview_options(activity)
         expect(preview_options["Select a runtime option..."]).to eq("")
       end
     end

--- a/spec/helpers/lightweight_activity_helper_spec.rb
+++ b/spec/helpers/lightweight_activity_helper_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe LightweightActivityHelper do
   let(:activity)     { FactoryGirl.create(:activity, id: 23, name: "Test Activity") }
+  let(:activity_player_activity)     { FactoryGirl.create(:activity, id: 23, name: "Test Activity", runtime: "Activity Player") }
   let(:sequence)     { FactoryGirl.create(:sequence, id: 1, title: "Test Sequence", lightweight_activities: [activity])}
   let(:user)         { FactoryGirl.create(:user) }
   let(:sequence_run) { FactoryGirl.create(:sequence_run, sequence_id: sequence.id, user_id: user.id) }
@@ -69,6 +70,21 @@ describe LightweightActivityHelper do
       it "should return a list of preview options" do
         preview_options = helper.activity_preview_options(activity)
         expect(preview_options["Select a runtime option..."]).to eq("")
+      end
+    end
+  end
+
+  describe "#runtime_url" do
+    context "with an activity player runtime" do
+      it "returns an activity player url" do
+        url = "https://activity-player.concord.org/branch/master" +
+          "?activity=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Factivities%2F#{activity_player_activity.id}.json&preview"
+        expect(helper.runtime_url(activity_player_activity)).to eq(url)
+      end
+    end
+    context "with a LARA runtime" do
+      it "returns a LARA url" do
+        expect(helper.runtime_url(activity)).to eq("/activities/#{activity.id}")
       end
     end
   end

--- a/spec/helpers/sequence_helper_spec.rb
+++ b/spec/helpers/sequence_helper_spec.rb
@@ -8,31 +8,8 @@ describe SequenceHelper do
     describe "with an activity" do
       it "should return a list of preview options" do
         @sequence = sequence
-        preview_options = sequence_preview_options(activity)
+        preview_options = helper.sequence_preview_options(activity)
         expect(preview_options["Select a runtime option..."]).to eq("")
-      end
-    end
-  end
-
-  describe "#activity_player_sequence_url" do
-    describe "with an activity" do 
-      it "should return a URI containing the required param" do
-        activity_player_sequence_url = activity_player_sequence_url(sequence)
-        sequence_api_url = api_v1_sequence_url(sequence.id)
-        uri = URI.parse(activity_player_sequence_url)
-        query = Rack::Utils.parse_query(uri.query)
-        expect(query["sequence"]).to eq("#{sequence_api_url}.json")
-        expect(query["mode"]).to eq("")
-      end
-    end
-    describe "with an activity and teacher mode enabled" do 
-      it "should return a URI containing the required params" do
-        activity_player_sequence_url = activity_player_sequence_url(sequence, "teacher-edition")
-        sequence_api_url = api_v1_sequence_url(sequence.id)
-        uri = URI.parse(activity_player_sequence_url)
-        query = Rack::Utils.parse_query(uri.query)
-        expect(query["sequence"]).to eq("#{sequence_api_url}.json")
-        expect(query["mode"]).to eq("teacher-edition")
       end
     end
   end

--- a/spec/helpers/sequence_helper_spec.rb
+++ b/spec/helpers/sequence_helper_spec.rb
@@ -3,6 +3,8 @@ require "spec_helper"
 describe SequenceHelper do
   let(:activity)     { FactoryGirl.create(:activity, id: 23, name: "Test Activity") }
   let(:sequence)     { FactoryGirl.create(:sequence, id: 1, title: "Test Sequence", lightweight_activities: [activity])}
+  let(:activity_player_sequence) { FactoryGirl.create(:sequence, id: 1, title: "Test Sequence",
+    runtime: "Activity Player", lightweight_activities: [activity])}
 
   describe "#sequence_preview_options" do
     describe "with an activity" do
@@ -13,4 +15,20 @@ describe SequenceHelper do
       end
     end
   end
+
+  describe "#sequence_runtime_url" do
+    context "with an activity player runtime" do
+      it "returns an activity player url" do
+        url = "https://activity-player.concord.org/branch/master" +
+          "?sequence=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Fsequences%2F#{activity_player_sequence.id}.json&preview"
+        expect(helper.sequence_runtime_url(activity_player_sequence)).to eq(url)
+      end
+    end
+    context "with a LARA runtime" do
+      it "returns a LARA url" do
+        expect(helper.sequence_runtime_url(sequence)).to eq("/sequences/#{sequence.id}")
+      end
+    end
+  end
+
 end

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -234,7 +234,7 @@ describe Sequence do
     it 'returns a hash for a simple sequence with a preview_url when sequence has an activity player runtime that can be consumed by the report service' do
       sequence.runtime = "Activity Player"
       ap_hash = simple_report_service_hash
-      ap_hash[:preview_url] = "https://activity-player.concord.org/branch/master?preview&sequence=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Fsequences%2F#{sequence.id}.json"
+      ap_hash[:preview_url] = "https://activity-player.concord.org/branch/master?sequence=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Fsequences%2F#{sequence.id}.json&preview"
       expect(sequence.serialize_for_report_service('http://test.host')).to eq(simple_report_service_hash)
     end
 

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -368,4 +368,30 @@ describe Sequence do
     end
   end
 
+  describe "#activity_player_sequence_url" do
+    let(:base_url) { "http://test.host" }
+    describe "with an activity" do
+      it "should return a URI containing the required param" do
+        activity_player_sequence_url = sequence.activity_player_sequence_url(base_url, preview: true)
+        uri = URI.parse(activity_player_sequence_url)
+        query = Rack::Utils.parse_query(uri.query)
+        expect(query["sequence"]).to eq("http://test.host/api/v1/sequences/#{sequence.id}.json")
+        expect(query).to have_key("preview")
+        expect(query["preview"]).to be_nil
+        expect(query).to_not have_key("mode")
+      end
+    end
+    describe "with an activity and teacher mode enabled" do
+      it "should return a URI containing the required params" do
+        activity_player_sequence_url = sequence.activity_player_sequence_url(base_url, preview: true, mode:"teacher-edition")
+        uri = URI.parse(activity_player_sequence_url)
+        query = Rack::Utils.parse_query(uri.query)
+        expect(query["sequence"]).to eq("http://test.host/api/v1/sequences/#{sequence.id}.json")
+        expect(query).to have_key("preview")
+        expect(query["preview"]).to be_nil
+        expect(query["mode"]).to eq("teacher-edition")
+      end
+    end
+  end
+
 end

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -231,6 +231,13 @@ describe Sequence do
       expect(sequence.serialize_for_report_service('http://test.host')).to eq(simple_report_service_hash)
     end
 
+    it 'returns a hash for a simple sequence with a preview_url when sequence has an activity player runtime that can be consumed by the report service' do
+      sequence.runtime = "Activity Player"
+      ap_hash = simple_report_service_hash
+      ap_hash[:preview_url] = "https://activity-player.concord.org/branch/master?preview&sequence=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Fsequences%2F#{sequence.id}.json"
+      expect(sequence.serialize_for_report_service('http://test.host')).to eq(simple_report_service_hash)
+    end
+
     it 'returns a hash for a sequence with activities that can be consumed by the report service' do
       expect(sequence_with_activities.serialize_for_report_service("http://test.host")).to eq(complex_report_service_hash)
     end


### PR DESCRIPTION
this also returns the urls of pages back to being LARA urls
the portal-report will need to be updated to check for this preview_url and use that
if it exist.
without this change the portal-report page preview links will be broken

Additionally this adds a new route and action so it is easier to see what an activity or sequence will send to the report-service. For example: https://app.lara.docker/api/v1/activities/10/report_structure

It also removes `URI.escape` which probably wasn't doing what was expected.
build_query automatically escapes the values in the hash
URI.escape only escapes characters that aren't valid in a URI (as opposed to characters to avoid in a parameter)
so for example it would not escape =, &, ?, or /