### PR TITLE
Label for link target options

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -41,6 +41,11 @@ a:hover, a:active {
   color: #ea6d2f;
   text-decoration: underline;
 }
+a.btn {
+  background: #6fc5d8;
+  color: #fff;
+  text-decoration: none;
+}
 body {
   line-height: 1;
 }
@@ -72,7 +77,7 @@ button, .btn-primary, span.edit_trigger, #modal .embeddable-save, #modal .close 
   background: #6fc5d8;
   border: none;
   border-radius: 20px;
-  color: #fff !important;
+  color: #fff;
   cursor: pointer;
   display: inline-block;
   font-size: .9em;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177211486

[#177211486]

These changes fix a bug where the Target drop-down menu options and Cancel button in the rich text editor's Insert Link modal were essentially invisible.

Currently the Insert Link modal looks like this on production:
![image](https://user-images.githubusercontent.com/367459/111834913-a51f5f00-88ca-11eb-8054-caf1899315a1.png)

These changes will make it look like this:
![image](https://user-images.githubusercontent.com/367459/111834955-b36d7b00-88ca-11eb-93bf-2af47205573e.png)

