### PR TITLE
Remove "Runtime" from Preview Menu

### DIFF
--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -88,13 +88,19 @@ module LightweightActivityHelper
       lara_runtime_url = preview_activity_path(activity)
       lara_runtime_te_url = preview_activity_path(activity, mode: "teacher-edition")
     end
-    {
-      'Select a runtime option...' => '',
-      'Activity Player' => activity_player_url,
-      'Activity Player Teacher Edition' => activity_player_te_url,
-      'LARA Runtime' => lara_runtime_url,
-      'LARA Runtime Teacher Edition' => lara_runtime_te_url
-    }
+
+    preview_options = {
+                       'Select an option...' => '', 
+                       'Activity Player' => activity_player_url, 
+                       'Activity Player Teacher Edition' => activity_player_te_url
+                      }
+
+    if activity.runtime != "Activity Player"
+      preview_options['LARA Runtime'] = lara_runtime_url
+      preview_options['LARA Runtime Teacher Edition'] = lara_runtime_te_url
+    end
+
+    return preview_options
   end
 
   def runtime_url(activity)

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -47,7 +47,8 @@
   %div.edit_interactive_page
     #preview-menu
       %label{for: "preview-options-select"}
-        Preview in:
+        %strong
+          Preview in:
       = select_tag :preview_options_select, options_for_select(activity_preview_options(@activity, @page)), {id: 'preview-options-select'}
     = form_for @page do |f|
       = f.select :layout, options_for_select(InteractivePage::LAYOUT_OPTIONS.map { |l| [l[:name], l[:class_val]] }, @page.layout), {},  { :onchange => 'this.form.submit();', :title => 'Page layout' }

--- a/app/views/lightweight_activities/_edit_header.html.haml
+++ b/app/views/lightweight_activities/_edit_header.html.haml
@@ -11,7 +11,8 @@
       = link_to "Convert", activity_player_conversion_url(@activity), :target => 'new'
   #preview-menu
     %label{for: "preview-options-select"}
-      Preview in:
+      %strong
+        Preview in:
     = select_tag :preview_options_select, options_for_select(activity_preview_options(@activity)), {id: 'preview-options-select'}
 
 - if show_publication_details

--- a/app/views/sequences/edit.html.haml
+++ b/app/views/sequences/edit.html.haml
@@ -18,7 +18,8 @@
     Edit sequence
   #preview-menu
     %label{for: "preview-options-select"}
-      Preview in:
+      %strong
+        Preview in:
     = select_tag :preview_options_select, options_for_select(sequence_preview_options(@sequence)), {id: 'preview-options-select'}
 
 = render :partial => "publications/publication_details", :locals =>{ :publication => @sequence}

--- a/spec/helpers/lightweight_activity_helper_spec.rb
+++ b/spec/helpers/lightweight_activity_helper_spec.rb
@@ -69,7 +69,7 @@ describe LightweightActivityHelper do
     describe "with an activity" do
       it "should return a list of preview options" do
         preview_options = helper.activity_preview_options(activity)
-        expect(preview_options["Select a runtime option..."]).to eq("")
+        expect(preview_options["Select an option..."]).to eq("")
       end
     end
   end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176906396

[#176906396]

* Remove "runtime" from Preview menu
* Bold "Preview in:" menu label
* Remove LARA preview options for Activity Player only activities