### PR TITLE
Add plugin id to activity export [#177461652]

### DIFF
--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -18,6 +18,7 @@ class Plugin < ActiveRecord::Base
 
   def to_hash
     {
+      id: id,
       description: description,
       author_data: author_data,
       approved_script_label: approved_script && approved_script.label,
@@ -42,6 +43,8 @@ class Plugin < ActiveRecord::Base
     # the approved_script_label is not found.  For now delete it from the hash so new doesn't try to load it directly
     # which will fail as it is a hash and not an instance of the class
     import_hash.delete(:approved_script)
+    # delete the id added to the to_hash method
+    import_hash.delete(:id)
     the_copy = self.new(import_hash)
     return the_copy
   end

--- a/spec/models/embeddable/embeddable_plugin_spec.rb
+++ b/spec/models/embeddable/embeddable_plugin_spec.rb
@@ -23,6 +23,7 @@ describe Embeddable::EmbeddablePlugin do
     it 'has saves interesting attributes' do
       expected = {
         plugin: {
+          id: plugin.id,
           description: plugin.description,
           author_data: plugin.author_data,
           approved_script_label: plugin.approved_script.label,

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -196,12 +196,23 @@ describe LightweightActivity do
 
   describe '#export' do
     let(:export) { activity.export }
+    let(:approved_script) { FactoryGirl.create(:approved_script) }
+    let(:plugins) do
+      FactoryGirl.create_list(:plugin, 2, approved_script: approved_script)
+    end
+
+    before :each do
+      plugins.each { |p| activity.plugins.push(p) }
+    end
+
     describe "the activity json" do
       it 'includes the activity pages' do
         expect(export[:pages].length).to eq(activity.pages.count)
       end
       it 'includes the plugins' do
         expect(export[:plugins].length).to eq(activity.plugins.count)
+        expect(export[:plugins][0][:id]).to eq(plugins[0].id)
+        expect(export[:plugins][1][:id]).to eq(plugins[1].id)
       end
     end
   end

--- a/spec/models/plugin_spec.rb
+++ b/spec/models/plugin_spec.rb
@@ -53,6 +53,7 @@ describe Plugin do
     it "should respond with serialized params" do
       expect(plugin.to_hash).to include(
         {
+          id: plugin.id,
           description: description,
           author_data: author_data,
           approved_script_label: approved_script.label,


### PR DESCRIPTION
This will allow us to store position independent plugin student data in the Activity Player.