### PR TITLE
Allow admins to migrate interactives

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -572,6 +572,13 @@ div.summary {
       &:hover {
         color: #ea6d2f;
       }
+      &.disabled {
+        cursor: default;
+        opacity: .5;
+        &:hover {
+          color: #333;
+        }
+      }
     }
   }
 }

--- a/app/controllers/library_interactives_controller.rb
+++ b/app/controllers/library_interactives_controller.rb
@@ -61,6 +61,11 @@ class LibraryInteractivesController < ApplicationController
     end
   end
 
+  # GET /library_interactives/1/migrate
+  def migrate
+    @library_interactive = LibraryInteractive.find(params[:id]) 
+  end
+
   # DELETE /library_interactives/1
   # DELETE /library_interactives/1.json
   def destroy

--- a/app/controllers/library_interactives_controller.rb
+++ b/app/controllers/library_interactives_controller.rb
@@ -62,8 +62,29 @@ class LibraryInteractivesController < ApplicationController
   end
 
   # GET /library_interactives/1/migrate
+  # POST /library_interactives/1/migrate
   def migrate
     @library_interactive = LibraryInteractive.find(params[:id]) 
+    
+    if params[:new_library_interactive_id]
+      @mi_count = 0
+      ManagedInteractive.where("library_interactive_id = #{params[:id]}").find_each do |mi|
+        mi.library_interactive_id = params[:new_library_interactive_id]
+        mi.save
+        @mi_count += 1
+      end
+
+      if @mi_count > 0
+        @notice = 'All embeddables that used the library interactive have been updated to use the new version.'
+      else
+        @notice = 'No embeddables currently use the older version of that library interactive.'
+      end
+
+      respond_to do |format|
+        format.html { redirect_to library_interactives_url, notice: @notice }
+        format.json { head :no_content }
+      end
+    end
   end
 
   # DELETE /library_interactives/1

--- a/app/controllers/managed_interactives_controller.rb
+++ b/app/controllers/managed_interactives_controller.rb
@@ -1,26 +1,7 @@
 require_dependency "application_controller"
 
 class ManagedInteractivesController < InteractiveController
-  before_filter :set_interactive, :except => [:create, :new, :set_library_interactive]
-  before_filter :can_manage, :only => :set_library_interactive
-
-  def set_library_interactive
-    @current_library_interactive_id = params[:current_library_interactive_id]
-    @new_library_interactive_id = params[:new_library_interactive_id]
-    @managed_interactives = ManagedInteractive.where(library_interactive_id: @current_library_interactive_id).all
-    if @managed_interactives.length > 0
-      @managed_interactives.each do |mi|
-        mi.update_attribute(:library_interactive_id, @new_library_interactive_id)
-      end
-      @notice = 'All embeddables that used the library interactive have been updated to use the new version.'
-    else
-      @notice = 'No embeddables currently use the old version of that library interactive.'
-    end
-    respond_to do |format|
-      format.html { redirect_to library_interactives_url, notice: @notice }
-      format.json { head :no_content }
-    end
-  end
+  before_filter :set_interactive, :except => [:new, :create]
 
   private
 
@@ -31,10 +12,6 @@ class ManagedInteractivesController < InteractiveController
 
   def get_interactive_params
     @input_params = params[:managed_interactive]
-  end
-
-  def can_manage
-    authorize! :manage, LibraryInteractive
   end
 end
 

--- a/app/controllers/managed_interactives_controller.rb
+++ b/app/controllers/managed_interactives_controller.rb
@@ -1,7 +1,26 @@
 require_dependency "application_controller"
 
 class ManagedInteractivesController < InteractiveController
-  before_filter :set_interactive, :except => [:new, :create]
+  before_filter :set_interactive, :except => [:create, :new, :set_library_interactive]
+  before_filter :can_manage, :only => :set_library_interactive
+
+  def set_library_interactive
+    @current_library_interactive_id = params[:current_library_interactive_id]
+    @new_library_interactive_id = params[:new_library_interactive_id]
+    @managed_interactives = ManagedInteractive.where(library_interactive_id: @current_library_interactive_id).all
+    if @managed_interactives.length > 0
+      @managed_interactives.each do |mi|
+        mi.update_attribute(:library_interactive_id, @new_library_interactive_id)
+      end
+      @notice = 'All embeddables that used the library interactive have been updated to use the new version.'
+    else
+      @notice = 'No embeddables currently use the old version of that library interactive.'
+    end
+    respond_to do |format|
+      format.html { redirect_to library_interactives_url, notice: @notice }
+      format.json { head :no_content }
+    end
+  end
 
   private
 
@@ -12,6 +31,10 @@ class ManagedInteractivesController < InteractiveController
 
   def get_interactive_params
     @input_params = params[:managed_interactive]
+  end
+
+  def can_manage
+    authorize! :manage, LibraryInteractive
   end
 end
 

--- a/app/helpers/library_interactive_helper.rb
+++ b/app/helpers/library_interactive_helper.rb
@@ -1,0 +1,13 @@
+module LibraryInteractiveHelper
+  def migrate_library_interactive_options(current_library_interactive)
+    migration_options = {
+                         'Select a library interactive...' => ''
+                        }
+    LibraryInteractive.all.each do |li|
+      if li.id != current_library_interactive.id
+        migration_options["#{li.id} - #{li.name}"] = li.id
+      end
+    end
+    return migration_options
+  end
+end

--- a/app/views/library_interactives/index.html.haml
+++ b/app/views/library_interactives/index.html.haml
@@ -28,6 +28,7 @@
         %div.action_menu_header_right.themes
           %ul.menu
             %li.edit= link_to "Edit", edit_library_interactive_path(library_interactive) if can? :update, library_interactive
+            %li.edit= link_to "Migrate", migrate_library_interactive_path(library_interactive) if can? :update, library_interactive
             %li.delete= link_to 'Delete', library_interactive_path(library_interactive), method: :delete, data: { confirm: 'Are you sure?' } if can? :update, library_interactive
       %div.tiny
         %p

--- a/app/views/library_interactives/index.html.haml
+++ b/app/views/library_interactives/index.html.haml
@@ -28,7 +28,10 @@
         %div.action_menu_header_right.themes
           %ul.menu
             %li.edit= link_to "Edit", edit_library_interactive_path(library_interactive) if can? :update, library_interactive
-            %li.edit= link_to "Migrate", migrate_library_interactive_path(library_interactive) if can? :update, library_interactive
+            - if library_interactive.use_count > 0
+              %li.migrate= link_to "Migrate", migrate_library_interactive_path(library_interactive) if can? :update, library_interactive
+            - else 
+              %li.migrate= link_to "Migrate", "javascript:alert('No embeddables currently use this library interactive.')", :class => 'disabled' if can? :update, library_interactive
             %li.delete= link_to 'Delete', library_interactive_path(library_interactive), method: :delete, data: { confirm: 'Are you sure?' } if can? :update, library_interactive
       %div.tiny
         %p

--- a/app/views/library_interactives/migrate.html.haml
+++ b/app/views/library_interactives/migrate.html.haml
@@ -13,10 +13,9 @@
       %li= "/ Migrate #{@library_interactive.name}"
 
 %h1.title= "Migrate #{@library_interactive.name}"
-= form_for @library_interactive, :url => managed_interactives_set_library_interactive_path, :html => {:class => "styled-admin-form"} do |f|
+= form_for @library_interactive, :url => migrate_library_interactive_path, :html => {:class => "styled-admin-form"} do |f|
   %div{:class => "option_group"}
     = f.label :new_library_interactive_id, "Select a new version of #{@library_interactive.name} to migrate to."
     %br
     = select_tag :new_library_interactive_id, options_for_select(migrate_library_interactive_options(@library_interactive)), {id: 'migrate-options-select'}
-    = hidden_field_tag 'current_library_interactive_id', @library_interactive.id
     = f.submit "Migrate", :style => "margin-left:10px"

--- a/app/views/library_interactives/migrate.html.haml
+++ b/app/views/library_interactives/migrate.html.haml
@@ -1,0 +1,22 @@
+= content_for :session do
+  #session
+    = render :partial => 'shared/session'
+= content_for :title do
+  = "Migrate #{@library_interactive.name}"
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li
+        \/
+        = link_to 'All Library Iinteractives', library_interactives_path
+      %li= "/ Migrate #{@library_interactive.name}"
+
+%h1.title= "Migrate #{@library_interactive.name}"
+= form_for @library_interactive, :url => managed_interactives_set_library_interactive_path, :html => {:class => "styled-admin-form"} do |f|
+  %div{:class => "option_group"}
+    = f.label :new_library_interactive_id, "Select a new version of #{@library_interactive.name} to migrate to."
+    %br
+    = select_tag :new_library_interactive_id, options_for_select(migrate_library_interactive_options(@library_interactive)), {id: 'migrate-options-select'}
+    = hidden_field_tag 'current_library_interactive_id', @library_interactive.id
+    = f.submit "Migrate", :style => "margin-left:10px"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 LightweightStandalone::Application.routes.draw do
 
-  resources :library_interactives, :except => [:show]
+  resources :library_interactives, :except => [:show] do
+    member do
+      get :migrate
+    end
+  end
 
   resources :approved_scripts
 
@@ -213,6 +217,8 @@ LightweightStandalone::Application.routes.draw do
       match 'plugins/:plugin_id/author_data' => 'plugins#save_author_data', as: 'update_plugin_author_data', via: 'put'
     end
   end
+
+  match '/managed_interactives/set_library_interactive' => 'managed_interactives#set_library_interactive', via: 'put'
 
   match "/publications/show_status/:publishable_type/:publishable_id"=> 'publications#show_status', :as => 'publication_show_status'
   match "/publications/autopublishing_status/:publishable_type/:publishable_id"=> 'publications#autopublishing_status', :as => 'publication_autopublishing_status'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ LightweightStandalone::Application.routes.draw do
   resources :library_interactives, :except => [:show] do
     member do
       get :migrate
+      put :migrate
     end
   end
 
@@ -217,8 +218,6 @@ LightweightStandalone::Application.routes.draw do
       match 'plugins/:plugin_id/author_data' => 'plugins#save_author_data', as: 'update_plugin_author_data', via: 'put'
     end
   end
-
-  match '/managed_interactives/set_library_interactive' => 'managed_interactives#set_library_interactive', via: 'put'
 
   match "/publications/show_status/:publishable_type/:publishable_id"=> 'publications#show_status', :as => 'publication_show_status'
   match "/publications/autopublishing_status/:publishable_type/:publishable_id"=> 'publications#autopublishing_status', :as => 'publication_autopublishing_status'

--- a/spec/controllers/library_interactives_controller_spec.rb
+++ b/spec/controllers/library_interactives_controller_spec.rb
@@ -111,6 +111,23 @@ describe LibraryInteractivesController do
       end
     end
 
+    describe "GET #migrate" do
+      it "returns a success response" do
+        library_interactive = LibraryInteractive.create! valid_attributes
+        get :migrate, {:id => library_interactive.to_param, :library_interactive => valid_attributes}
+        expect(response).to be_successful
+      end
+    end
+
+    describe "PUT #migrate" do
+      it "changes all references to one library_interactive to another specified library_interactive and redirects to the library_interactive index" do
+        library_interactive1 = LibraryInteractive.create! valid_attributes
+        library_interactive2 = LibraryInteractive.create! valid_attributes
+        put :update, {:id => library_interactive1.to_param, :new_library_interactive_id => library_interactive2.to_param}
+        expect(response).to redirect_to(library_interactives_url)
+      end
+    end
+
     describe "DELETE #destroy" do
       it "destroys the requested library_interactive" do
         library_interactive = LibraryInteractive.create! valid_attributes
@@ -172,6 +189,24 @@ describe LibraryInteractivesController do
         it "returns a failure response" do
           library_interactive = LibraryInteractive.create! valid_attributes
           put :update, {:id => library_interactive.to_param, :library_interactive => {:name => "new name"}}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      describe "GET #migrate" do
+        it "returns a failure response for HTML requests" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          get :migrate, {:id => library_interactive.to_param}
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(403)
+        end
+      end
+
+      describe "PUT #migrate" do
+        it "returns a failure response" do
+          library_interactive = LibraryInteractive.create! valid_attributes
+          get :migrate, {:id => library_interactive.to_param}
           expect(response).not_to be_successful
           expect(response).to have_http_status(403)
         end

--- a/spec/controllers/library_interactives_controller_spec.rb
+++ b/spec/controllers/library_interactives_controller_spec.rb
@@ -123,7 +123,7 @@ describe LibraryInteractivesController do
       it "changes all references to one library_interactive to another specified library_interactive and redirects to the library_interactive index" do
         library_interactive1 = LibraryInteractive.create! valid_attributes
         library_interactive2 = LibraryInteractive.create! valid_attributes
-        put :update, {:id => library_interactive1.to_param, :new_library_interactive_id => library_interactive2.to_param}
+        put :migrate, {:id => library_interactive1.to_param, :new_library_interactive_id => library_interactive2.to_param}
         expect(response).to redirect_to(library_interactives_url)
       end
     end
@@ -205,8 +205,9 @@ describe LibraryInteractivesController do
 
       describe "PUT #migrate" do
         it "returns a failure response" do
-          library_interactive = LibraryInteractive.create! valid_attributes
-          get :migrate, {:id => library_interactive.to_param}
+          library_interactive1 = LibraryInteractive.create! valid_attributes
+          library_interactive2 = LibraryInteractive.create! valid_attributes
+          put :migrate, {:id => library_interactive1.to_param, :new_library_interactive_id => library_interactive2.to_param}
           expect(response).not_to be_successful
           expect(response).to have_http_status(403)
         end

--- a/spec/controllers/library_interactives_controller_spec.rb
+++ b/spec/controllers/library_interactives_controller_spec.rb
@@ -120,10 +120,20 @@ describe LibraryInteractivesController do
     end
 
     describe "PUT #migrate" do
-      it "changes all references to one library_interactive to another specified library_interactive and redirects to the library_interactive index" do
+      it "changes all references to one library_interactive to another library_interactive and redirects to the library_interactive index" do
         library_interactive1 = LibraryInteractive.create! valid_attributes
         library_interactive2 = LibraryInteractive.create! valid_attributes
         managed_interactive = FactoryGirl.create(:managed_interactive, :library_interactive => library_interactive1)
+        put :migrate, {:id => library_interactive1.to_param, :new_library_interactive_id => library_interactive2.to_param}
+        managed_interactive.reload
+        expect(response).to redirect_to(library_interactives_url)
+        expect(managed_interactive.library_interactive_id).to eq(library_interactive2.id)
+      end
+
+      it "changes nothing and redirects to the library_interactive index when the library interactive specified for migration is not used by any managed interactives" do
+        library_interactive1 = LibraryInteractive.create! valid_attributes
+        library_interactive2 = LibraryInteractive.create! valid_attributes
+        managed_interactive = FactoryGirl.create(:managed_interactive, :library_interactive => library_interactive2)
         put :migrate, {:id => library_interactive1.to_param, :new_library_interactive_id => library_interactive2.to_param}
         managed_interactive.reload
         expect(response).to redirect_to(library_interactives_url)

--- a/spec/controllers/library_interactives_controller_spec.rb
+++ b/spec/controllers/library_interactives_controller_spec.rb
@@ -123,8 +123,11 @@ describe LibraryInteractivesController do
       it "changes all references to one library_interactive to another specified library_interactive and redirects to the library_interactive index" do
         library_interactive1 = LibraryInteractive.create! valid_attributes
         library_interactive2 = LibraryInteractive.create! valid_attributes
+        managed_interactive = FactoryGirl.create(:managed_interactive, :library_interactive => library_interactive1)
         put :migrate, {:id => library_interactive1.to_param, :new_library_interactive_id => library_interactive2.to_param}
+        managed_interactive.reload
         expect(response).to redirect_to(library_interactives_url)
+        expect(managed_interactive.library_interactive_id).to eq(library_interactive2.id)
       end
     end
 

--- a/spec/helpers/library_interactive_helper_spec.rb
+++ b/spec/helpers/library_interactive_helper_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe LibraryInteractiveHelper do
+  let (:library_interactive1) { FactoryGirl.create(:library_interactive,
+       :name => 'Test Library Interactive 1',
+       :base_url => 'http://foo.com/',
+       :thumbnail_url => nil
+      ) }
+  let (:library_interactive2) { FactoryGirl.create(:library_interactive,
+       :name => 'Test Library Interactive 2',
+       :base_url => 'http://bar.com/',
+       :thumbnail_url => nil
+      ) }
+
+  describe "#migrate_library_interactive_options" do
+    it "should return a hash of library interactives that are not the library interactive to be migrated" do
+      li1_key = "#{library_interactive1.id} - #{library_interactive1.name}"
+      li2_key = "#{library_interactive2.id} - #{library_interactive2.name}"
+      options = helper.migrate_library_interactive_options(library_interactive1)
+
+      expect(options).not_to have_key(li1_key)
+      expect(options).to have_key(li2_key)
+    end
+  end
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178060576

[#178060576]

These changes provide an option to migrate library interactives used by questions in existing activities from one version to another.