### PR TITLE
Add ID to activity export method.

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -127,7 +127,8 @@ class LightweightActivity < ActiveRecord::Base
   end
 
   def export
-    activity_json = self.as_json(only: [:name,
+    activity_json = self.as_json(only: [:id,
+                                        :name,
                                         :related,
                                         :description,
                                         :time_to_complete,


### PR DESCRIPTION
Related PT Story: https://www.pivotaltracker.com/story/show/178131977

[#178131977]

Adding the activity ID to activity exports will make it possible for the Activity Player to identify an activity within a sequence when the activity ID is included as a param in the Activity Player sequence's URL.