### PR TITLE
Adding a new rake task to create a lara admin user in dev environment only

### DIFF
--- a/lib/tasks/lightweight_tasks.rake
+++ b/lib/tasks/lightweight_tasks.rake
@@ -11,4 +11,18 @@ namespace :lightweight do
     end
   end
 
+  desc "Create an admin user, works only in development environment."
+  task :create_admin_user => :environment do
+    begin
+      raise SecurityError unless Rails.env == 'development'
+      u = User.create(
+        email: "dev_test_user@test.email",
+        password: "password",
+        is_admin: true
+      )
+    rescue SecurityError
+      puts "This script only runs in the development environment."
+    end
+  end
+
 end


### PR DESCRIPTION
This will help in importing activities into LARA when running the integration suite of portal-lara tests.