### PR TITLE
179007673 add labbook runtime metadata

### DIFF
--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -17,6 +17,7 @@
 * [IAuthoringImageQuestionMetadata](interfaces/iauthoringimagequestionmetadata.md)
 * [IAuthoringInitInteractive](interfaces/iauthoringinitinteractive.md)
 * [IAuthoringInteractiveMetadata](interfaces/iauthoringinteractivemetadata.md)
+* [IAuthoringLabbookMetadata](interfaces/iauthoringlabbookmetadata.md)
 * [IAuthoringMetadataBase](interfaces/iauthoringmetadatabase.md)
 * [IAuthoringMultipleChoiceChoiceMetadata](interfaces/iauthoringmultiplechoicechoicemetadata.md)
 * [IAuthoringMultipleChoiceMetadata](interfaces/iauthoringmultiplechoicemetadata.md)
@@ -64,6 +65,7 @@
 * [IRuntimeImageQuestionMetadata](interfaces/iruntimeimagequestionmetadata.md)
 * [IRuntimeInitInteractive](interfaces/iruntimeinitinteractive.md)
 * [IRuntimeInteractiveMetadata](interfaces/iruntimeinteractivemetadata.md)
+* [IRuntimeLabbookQuestionMetadata](interfaces/iruntimelabbookquestionmetadata.md)
 * [IRuntimeMetadataBase](interfaces/iruntimemetadatabase.md)
 * [IRuntimeMultipleChoiceMetadata](interfaces/iruntimemultiplechoicemetadata.md)
 * [IRuntimeOpenResponseMetadata](interfaces/iruntimeopenresponsemetadata.md)
@@ -203,7 +205,7 @@ ___
 
 ###  IAuthoringMetadata
 
-Ƭ **IAuthoringMetadata**: *[IAuthoringInteractiveMetadata](interfaces/iauthoringinteractivemetadata.md) | [IAuthoringOpenResponseMetadata](interfaces/iauthoringopenresponsemetadata.md) | [IAuthoringMultipleChoiceMetadata](interfaces/iauthoringmultiplechoicemetadata.md) | [IAuthoringImageQuestionMetadata](interfaces/iauthoringimagequestionmetadata.md)*
+Ƭ **IAuthoringMetadata**: *[IAuthoringInteractiveMetadata](interfaces/iauthoringinteractivemetadata.md) | [IAuthoringOpenResponseMetadata](interfaces/iauthoringopenresponsemetadata.md) | [IAuthoringMultipleChoiceMetadata](interfaces/iauthoringmultiplechoicemetadata.md) | [IAuthoringImageQuestionMetadata](interfaces/iauthoringimagequestionmetadata.md) | [IAuthoringLabbookMetadata](interfaces/iauthoringlabbookmetadata.md)*
 
 ___
 
@@ -255,7 +257,7 @@ ___
 
 ###  IRuntimeMetadata
 
-Ƭ **IRuntimeMetadata**: *[IRuntimeInteractiveMetadata](interfaces/iruntimeinteractivemetadata.md) | [IRuntimeOpenResponseMetadata](interfaces/iruntimeopenresponsemetadata.md) | [IRuntimeMultipleChoiceMetadata](interfaces/iruntimemultiplechoicemetadata.md) | [IRuntimeImageQuestionMetadata](interfaces/iruntimeimagequestionmetadata.md)*
+Ƭ **IRuntimeMetadata**: *[IRuntimeInteractiveMetadata](interfaces/iruntimeinteractivemetadata.md) | [IRuntimeOpenResponseMetadata](interfaces/iruntimeopenresponsemetadata.md) | [IRuntimeMultipleChoiceMetadata](interfaces/iruntimemultiplechoicemetadata.md) | [IRuntimeImageQuestionMetadata](interfaces/iruntimeimagequestionmetadata.md) | [IRuntimeLabbookQuestionMetadata](interfaces/iruntimelabbookquestionmetadata.md)*
 
 ___
 

--- a/docs/interactive-api-client/interfaces/iauthoringlabbookmetadata.md
+++ b/docs/interactive-api-client/interfaces/iauthoringlabbookmetadata.md
@@ -1,0 +1,60 @@
+[@concord-consortium/lara-interactive-api](../README.md) › [Globals](../globals.md) › [IAuthoringLabbookMetadata](iauthoringlabbookmetadata.md)
+
+# Interface: IAuthoringLabbookMetadata
+
+## Hierarchy
+
+* [IAuthoringMetadataBase](iauthoringmetadatabase.md)
+
+  ↳ **IAuthoringLabbookMetadata**
+
+## Index
+
+### Properties
+
+* [answerPrompt](iauthoringlabbookmetadata.md#optional-answerprompt)
+* [prompt](iauthoringlabbookmetadata.md#optional-prompt)
+* [questionSubType](iauthoringlabbookmetadata.md#optional-questionsubtype)
+* [questionType](iauthoringlabbookmetadata.md#questiontype)
+* [required](iauthoringlabbookmetadata.md#optional-required)
+
+## Properties
+
+### `Optional` answerPrompt
+
+• **answerPrompt**? : *undefined | string*
+
+___
+
+### `Optional` prompt
+
+• **prompt**? : *undefined | string*
+
+*Inherited from [IAuthoringMetadataBase](iauthoringmetadatabase.md).[prompt](iauthoringmetadatabase.md#optional-prompt)*
+
+___
+
+### `Optional` questionSubType
+
+• **questionSubType**? : *undefined | string*
+
+*Inherited from [IAuthoringMetadataBase](iauthoringmetadatabase.md).[questionSubType](iauthoringmetadatabase.md#optional-questionsubtype)*
+
+Interactive can optionally set questionSubType, so Teacher Report can display different icons
+or categorize interactives into subcategories.
+
+___
+
+###  questionType
+
+• **questionType**: *"labbook_question"*
+
+*Overrides [IAuthoringMetadataBase](iauthoringmetadatabase.md).[questionType](iauthoringmetadatabase.md#questiontype)*
+
+___
+
+### `Optional` required
+
+• **required**? : *undefined | false | true*
+
+*Inherited from [IAuthoringMetadataBase](iauthoringmetadatabase.md).[required](iauthoringmetadatabase.md#optional-required)*

--- a/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iauthoringmetadatabase.md
@@ -14,6 +14,8 @@
 
   ↳ [IAuthoringImageQuestionMetadata](iauthoringimagequestionmetadata.md)
 
+  ↳ [IAuthoringLabbookMetadata](iauthoringlabbookmetadata.md)
+
 ## Index
 
 ### Properties

--- a/docs/interactive-api-client/interfaces/iruntimelabbookquestionmetadata.md
+++ b/docs/interactive-api-client/interfaces/iruntimelabbookquestionmetadata.md
@@ -1,0 +1,51 @@
+[@concord-consortium/lara-interactive-api](../README.md) › [Globals](../globals.md) › [IRuntimeLabbookQuestionMetadata](iruntimelabbookquestionmetadata.md)
+
+# Interface: IRuntimeLabbookQuestionMetadata
+
+## Hierarchy
+
+* [IRuntimeMetadataBase](iruntimemetadatabase.md)
+
+  ↳ **IRuntimeLabbookQuestionMetadata**
+
+## Index
+
+### Properties
+
+* [answerImageUrl](iruntimelabbookquestionmetadata.md#optional-answerimageurl)
+* [answerText](iruntimelabbookquestionmetadata.md#optional-answertext)
+* [answerType](iruntimelabbookquestionmetadata.md#answertype)
+* [submitted](iruntimelabbookquestionmetadata.md#optional-submitted)
+
+## Properties
+
+### `Optional` answerImageUrl
+
+• **answerImageUrl**? : *undefined | string*
+
+___
+
+### `Optional` answerText
+
+• **answerText**? : *undefined | string*
+
+*Inherited from [IRuntimeMetadataBase](iruntimemetadatabase.md).[answerText](iruntimemetadatabase.md#optional-answertext)*
+
+answerText can be used by all the interactive types to display answer summary without having to load iframe
+with report view.
+
+___
+
+###  answerType
+
+• **answerType**: *"labbook_question_answer"*
+
+*Overrides [IRuntimeMetadataBase](iruntimemetadatabase.md).[answerType](iruntimemetadatabase.md#answertype)*
+
+___
+
+### `Optional` submitted
+
+• **submitted**? : *undefined | false | true*
+
+*Inherited from [IRuntimeMetadataBase](iruntimemetadatabase.md).[submitted](iruntimemetadatabase.md#optional-submitted)*

--- a/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
+++ b/docs/interactive-api-client/interfaces/iruntimemetadatabase.md
@@ -14,6 +14,8 @@
 
   ↳ [IRuntimeImageQuestionMetadata](iruntimeimagequestionmetadata.md)
 
+  ↳ [IRuntimeLabbookQuestionMetadata](iruntimelabbookquestionmetadata.md)
+
 ## Index
 
 ### Properties

--- a/lara-typescript/README.md
+++ b/lara-typescript/README.md
@@ -78,6 +78,7 @@ To facilitate testing local changes to the `lara-interactive-api` with existing 
 
 ```
 cd lara-typescript
+npm install  
 npm run lara-api:link     # creates a global symlink for clients to link to
 cd [the client you want to test (e.g. concord-consortium/question-interactives)]
 npm link @concord-consortium/lara-interactive-api

--- a/lara-typescript/package-lock.json
+++ b/lara-typescript/package-lock.json
@@ -2727,7 +2727,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4195,12 +4195,12 @@
       "dev": true
     },
     "cross-fetch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
-      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.5.tgz",
+      "integrity": "sha512-xqYAhQb4NhCJSRym03dwxpP1bYXpK3y7UN83Bo2WFi3x1Zmzn0SL/6xGoPr+gpt4WmNrgCCX3HPysvOwFOW36w==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.1.2",
+        "node-fetch": "2.6.1",
         "whatwg-fetch": "2.0.4"
       }
     },
@@ -8809,7 +8809,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -9936,9 +9936,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-gyp": {
@@ -12613,7 +12613,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {

--- a/lara-typescript/src/interactive-api-client/metadata-types.ts
+++ b/lara-typescript/src/interactive-api-client/metadata-types.ts
@@ -44,8 +44,16 @@ export interface IAuthoringImageQuestionMetadata extends IAuthoringMetadataBase 
   answerPrompt?: string;
 }
 
-export type IAuthoringMetadata = IAuthoringInteractiveMetadata | IAuthoringOpenResponseMetadata |
-  IAuthoringMultipleChoiceMetadata | IAuthoringImageQuestionMetadata;
+export interface IAuthoringLabbookMetadata extends IAuthoringMetadataBase {
+  questionType: "labbook_question";
+  answerPrompt?: string;
+}
+
+export type IAuthoringMetadata = IAuthoringInteractiveMetadata
+  | IAuthoringOpenResponseMetadata
+  | IAuthoringMultipleChoiceMetadata
+  | IAuthoringImageQuestionMetadata
+  | IAuthoringLabbookMetadata;
 
 // Runtime metadata:
 
@@ -81,5 +89,13 @@ export interface IRuntimeImageQuestionMetadata extends IRuntimeMetadataBase {
   answerImageUrl?: string;
 }
 
-export type IRuntimeMetadata = IRuntimeInteractiveMetadata | IRuntimeOpenResponseMetadata |
-  IRuntimeMultipleChoiceMetadata | IRuntimeImageQuestionMetadata;
+export interface IRuntimeLabbookQuestionMetadata extends IRuntimeMetadataBase {
+  answerType: "labbook_question_answer";
+  answerImageUrl?: string;
+}
+
+export type IRuntimeMetadata = IRuntimeInteractiveMetadata
+  | IRuntimeOpenResponseMetadata
+  | IRuntimeMultipleChoiceMetadata
+  | IRuntimeImageQuestionMetadata
+  | IRuntimeLabbookQuestionMetadata;


### PR DESCRIPTION
This simply adds metadata for Labbook Question runtime and authoring types, specifically the `question_type` and `answer_type` fields.

What I saw in the Question Interactives repo is that the implementation details of the interactives are kept in that repo, and extend the metadata types. So I followed that same pattern. 

Please let me know if I am supposed to do anything more than that here.