### PR TITLE
Background Images AP

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -138,10 +138,10 @@ class LightweightActivity < ActiveRecord::Base
                                         :editor_mode,
                                         :student_report_enabled,
                                         :show_submit_button,
-                                        :runtime ])
+                                        :runtime,
+                                        :background_image ])
     activity_json[:version] = 1
     activity_json[:theme_name] = self.theme ? self.theme.name : nil
-    activity_json[:background_image] = self.background_image ? self.background_image : nil
     activity_json[:project] = self.project ? self.project.export : nil
     activity_json[:pages] = []
     self.pages.each do |p|

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -169,7 +169,8 @@ class LightweightActivity < ActiveRecord::Base
       time_to_complete: activity_json_object[:time_to_complete],
       layout: activity_json_object[:layout],
       editor_mode: activity_json_object[:editor_mode],
-      runtime: activity_json_object[:runtime]
+      runtime: activity_json_object[:runtime],
+      background_image: activity_json_object[:background_image]
     }
 
   end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -18,7 +18,7 @@ class LightweightActivity < ActiveRecord::Base
   attr_accessible :name, :user_id, :pages, :related, :description,
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :theme_id, :project_id,
                   :portal_run_count, :layout, :editor_mode, :publication_hash, :copied_from_id,
-                  :student_report_enabled, :show_submit_button, :runtime, :project
+                  :student_report_enabled, :show_submit_button, :runtime, :project, :background_image
 
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
@@ -141,6 +141,7 @@ class LightweightActivity < ActiveRecord::Base
                                         :runtime ])
     activity_json[:version] = 1
     activity_json[:theme_name] = self.theme ? self.theme.name : nil
+    activity_json[:background_image] = self.background_image ? self.background_image : nil
     activity_json[:project] = self.project ? self.project.export : nil
     activity_json[:pages] = []
     self.pages.each do |p|

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -99,10 +99,10 @@ class Sequence < ActiveRecord::Base
                                         :logo,
                                         :display_title,
                                         :thumbnail_url,
-                                        :runtime
+                                        :runtime,
+                                        :background_image
     ])
     sequence_json[:project] = self.project ? self.project.export : nil
-    sequence_json[:background_image] = self.background_image ? self.background_image : nil
     sequence_json[:activities] = []
     self.lightweight_activities.each_with_index do |a,i|
       activity_hash = a.export

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -2,7 +2,7 @@ class Sequence < ActiveRecord::Base
 
   attr_accessible :description, :title, :theme_id, :project_id,
     :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash,
-    :runtime, :project
+    :runtime, :project, :background_image
 
   include Publishable # defines methods to publish to portals
   include PublicationStatus # defines publication status scopes and helpers
@@ -102,6 +102,7 @@ class Sequence < ActiveRecord::Base
                                         :runtime
     ])
     sequence_json[:project] = self.project ? self.project.export : nil
+    sequence_json[:background_image] = self.background_image ? self.background_image : nil
     sequence_json[:activities] = []
     self.lightweight_activities.each_with_index do |a,i|
       activity_hash = a.export

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -206,7 +206,8 @@ class Sequence < ActiveRecord::Base
       theme_id: sequence_json_object[:theme_id],
       thumbnail_url: sequence_json_object[:thumbnail_url],
       title: sequence_json_object[:title],
-      runtime: sequence_json_object[:runtime]
+      runtime: sequence_json_object[:runtime],
+      background_image: sequence_json_object[:background_image]
     }
 
   end

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -23,7 +23,7 @@
       .field
         = f.label :name, 'Activity Name'
         = f.text_field :name, :size => 80
-      .field
+      .field{:class => ("disabled" if @activity.runtime != 'LARA')}
         = f.label :theme_id, 'Theme'
         = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @activity.theme_id), { :include_blank => "None (inherit from sequence, project, or site default)" }
       .field{:class => ("disabled" if @activity.runtime != 'Activity Player')}

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -26,6 +26,10 @@
       .field
         = f.label :theme_id, 'Theme'
         = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @activity.theme_id), { :include_blank => "None (inherit from sequence, project, or site default)" }
+      .field{:class => ("disabled" if @activity.runtime != 'Activity Player')}
+        = f.label :background_image, 'Background Image URL'
+        = f.text_field :background_image
+        .hint (Specify the full URL of a background image file. NOTE: This value is only used by Activity Player. For LARA runtime, a background image can be specified in the theme.)
       - if current_user.is_admin
         .field
           = f.label :project_id, 'Project'

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -29,7 +29,7 @@
           [preview]
         .activity_thumbnail#thumbnail_preview
           %img
-    .field
+    .field{:class => ("disabled" if @sequence.runtime != 'LARA')}
       = f.label :theme_id, "Theme"
       = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @sequence.theme_id), { :include_blank => "None (inherit from project, or site default)" }
     .field{:class => ("disabled" if @sequence.runtime != 'Activity Player')}

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -32,6 +32,10 @@
     .field
       = f.label :theme_id, "Theme"
       = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @sequence.theme_id), { :include_blank => "None (inherit from project, or site default)" }
+    .field{:class => ("disabled" if @sequence.runtime != 'Activity Player')}
+      = f.label :background_image, 'Background Image URL'
+      = f.text_field :background_image
+      .hint (Specify the full URL of a background image file. NOTE: This value is only used by Activity Player. For LARA runtime, a background image can be specified in the theme.)
     .field
       = f.label :project_id, "Project"
       = f.select :project_id, options_from_collection_for_select(Project.all, 'id', 'title', @sequence.project_id), { :include_blank => true }

--- a/db/migrate/20210727180747_add_background_image_to_activities_and_sequences.rb
+++ b/db/migrate/20210727180747_add_background_image_to_activities_and_sequences.rb
@@ -1,0 +1,6 @@
+class AddBackgroundImageToActivitiesAndSequences < ActiveRecord::Migration
+  def change
+    add_column :lightweight_activities, :background_image, :string
+    add_column :sequences, :background_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20210604012146) do
+ActiveRecord::Schema.define(:version => 20210727180747) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -432,7 +432,9 @@ ActiveRecord::Schema.define(:version => 20210604012146) do
     t.boolean  "student_report_enabled",                 :default => true
     t.text     "last_report_service_hash"
     t.boolean  "show_submit_button",                     :default => true
+    t.boolean  "activity_player_only"
     t.string   "runtime",                                :default => "LARA"
+    t.string   "background_image"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -684,7 +686,9 @@ ActiveRecord::Schema.define(:version => 20210604012146) do
     t.string   "publication_hash",         :limit => 40
     t.string   "imported_activity_url"
     t.text     "last_report_service_hash"
+    t.boolean  "activity_player_only"
     t.string   "runtime",                                :default => "LARA"
+    t.string   "background_image"
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178990327

[#178990327]

These changes add a `background_image` property to activities and sequences. The value is only editable for resources set to use the Activity Player runtime environment. The value is included in resources' JSON for use by Activity Player in setting a background image for the resources' pages. 

Related Activity Player changes are at https://github.com/concord-consortium/activity-player/pull/260