### PR TITLE
Final(?) attachments tweak: always set Content-Type when writing attachments

### DIFF
--- a/lara-typescript/src/interactive-api-client/api.spec.ts
+++ b/lara-typescript/src/interactive-api-client/api.spec.ts
@@ -451,7 +451,8 @@ describe("api", () => {
         resolvesTo: [undefined]
       });
       expect(fetchMock.mock.calls[0][0]).toBe(url);
-      expect(fetchMock.mock.calls[0][1]).toEqual({ method: "PUT", body: "foo" });
+      const fetchOptions = { method: "PUT", headers: { "Content-Type": "text/plain" }, body: "foo" };
+      expect(fetchMock.mock.calls[0][1]).toEqual(fetchOptions);
     });
 
     it("returns error when write attachment api fails", async () => {
@@ -476,7 +477,8 @@ describe("api", () => {
         rejectsWith: [new Error(kFetchError)]
       });
       expect(fetchMock.mock.calls[0][0]).toBe(response.url);
-      expect(fetchMock.mock.calls[0][1]).toEqual({ method: "PUT", body: "foo" });
+      const fetchOptions = { method: "PUT", headers: { "Content-Type": "text/plain" }, body: "foo" };
+      expect(fetchMock.mock.calls[0][1]).toEqual(fetchOptions);
     });
 
     const testReadAttachmentResponse = (others: ITestAttachmentResponse) =>

--- a/lara-typescript/src/interactive-api-client/api.ts
+++ b/lara-typescript/src/interactive-api-client/api.ts
@@ -396,12 +396,13 @@ type WriteAttachmentParams = Omit<IWriteAttachmentRequest, "requestId" | "operat
 export const writeAttachment = (params: WriteAttachmentParams): Promise<Response> => {
   return new Promise<Response>((resolve, reject) => {
     const client = getClient();
-    const { content, contentType, options = {}, ...others } = params;
+    const { content, options = {}, ...others } = params;
+    const { contentType = "text/plain" } = params;
     const request: IAttachmentUrlRequest = { ...others, operation: "write", requestId: client.getNextRequestId() };
     client.addListener("attachmentUrl", async (response: IAttachmentUrlResponse) => {
       if (response.url) {
         const headers: Record<string, string> = { ...(options.headers as Record<string, string>) };
-        headers["Content-Type"] = contentType || "text/plain";
+        headers["Content-Type"] = contentType;
         options.headers = headers;
         try {
           // resolves with the fetch Response object, so clients can check status

--- a/lara-typescript/src/interactive-api-client/api.ts
+++ b/lara-typescript/src/interactive-api-client/api.ts
@@ -396,14 +396,13 @@ type WriteAttachmentParams = Omit<IWriteAttachmentRequest, "requestId" | "operat
 export const writeAttachment = (params: WriteAttachmentParams): Promise<Response> => {
   return new Promise<Response>((resolve, reject) => {
     const client = getClient();
-    const { content, contentType, options, ...others } = params;
+    const { content, contentType, options = {}, ...others } = params;
     const request: IAttachmentUrlRequest = { ...others, operation: "write", requestId: client.getNextRequestId() };
     client.addListener("attachmentUrl", async (response: IAttachmentUrlResponse) => {
       if (response.url) {
-        const headers: Record<string, string> = { ...(params.options?.headers as Record<string, string>) };
-        if (params.contentType) {
-          headers["Content-Type"] = contentType || "text/plain";
-        }
+        const headers: Record<string, string> = { ...(options.headers as Record<string, string>) };
+        headers["Content-Type"] = contentType || "text/plain";
+        options.headers = headers;
         try {
           // resolves with the fetch Response object, so clients can check status
           resolve(await fetch(response.url, { ...options, method: "PUT", body: content }));

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -45776,37 +45776,35 @@ exports.getLibraryInteractiveList = getLibraryInteractiveList;
 var writeAttachment = function (params) {
     return new Promise(function (resolve, reject) {
         var client = client_1.getClient();
-        var content = params.content, contentType = params.contentType, options = params.options, others = __rest(params, ["content", "contentType", "options"]);
+        var content = params.content, contentType = params.contentType, _a = params.options, options = _a === void 0 ? {} : _a, others = __rest(params, ["content", "contentType", "options"]);
         var request = __assign(__assign({}, others), { operation: "write", requestId: client.getNextRequestId() });
         client.addListener("attachmentUrl", function (response) { return __awaiter(void 0, void 0, void 0, function () {
             var headers, _a, e_1;
-            var _b;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
+            return __generator(this, function (_b) {
+                switch (_b.label) {
                     case 0:
                         if (!response.url) return [3 /*break*/, 5];
-                        headers = __assign({}, (_b = params.options) === null || _b === void 0 ? void 0 : _b.headers);
-                        if (params.contentType) {
-                            headers["Content-Type"] = contentType || "text/plain";
-                        }
-                        _c.label = 1;
+                        headers = __assign({}, options.headers);
+                        headers["Content-Type"] = contentType || "text/plain";
+                        options.headers = headers;
+                        _b.label = 1;
                     case 1:
-                        _c.trys.push([1, 3, , 4]);
+                        _b.trys.push([1, 3, , 4]);
                         // resolves with the fetch Response object, so clients can check status
                         _a = resolve;
                         return [4 /*yield*/, fetch(response.url, __assign(__assign({}, options), { method: "PUT", body: content }))];
                     case 2:
                         // resolves with the fetch Response object, so clients can check status
-                        _a.apply(void 0, [_c.sent()]);
+                        _a.apply(void 0, [_b.sent()]);
                         return [3 /*break*/, 4];
                     case 3:
-                        e_1 = _c.sent();
+                        e_1 = _b.sent();
                         reject(e_1);
                         return [3 /*break*/, 4];
                     case 4: return [3 /*break*/, 6];
                     case 5:
                         reject(new Error(response.error || "error writing attachment"));
-                        _c.label = 6;
+                        _b.label = 6;
                     case 6: return [2 /*return*/];
                 }
             });

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -45776,7 +45776,8 @@ exports.getLibraryInteractiveList = getLibraryInteractiveList;
 var writeAttachment = function (params) {
     return new Promise(function (resolve, reject) {
         var client = client_1.getClient();
-        var content = params.content, contentType = params.contentType, _a = params.options, options = _a === void 0 ? {} : _a, others = __rest(params, ["content", "contentType", "options"]);
+        var content = params.content, _a = params.options, options = _a === void 0 ? {} : _a, others = __rest(params, ["content", "options"]);
+        var _b = params.contentType, contentType = _b === void 0 ? "text/plain" : _b;
         var request = __assign(__assign({}, others), { operation: "write", requestId: client.getNextRequestId() });
         client.addListener("attachmentUrl", function (response) { return __awaiter(void 0, void 0, void 0, function () {
             var headers, _a, e_1;
@@ -45785,7 +45786,7 @@ var writeAttachment = function (params) {
                     case 0:
                         if (!response.url) return [3 /*break*/, 5];
                         headers = __assign({}, options.headers);
-                        headers["Content-Type"] = contentType || "text/plain";
+                        headers["Content-Type"] = contentType;
                         options.headers = headers;
                         _b.label = 1;
                     case 1:


### PR DESCRIPTION
…rather than only when client passes a `contentType`