### PR TITLE
handle saving managed and mw interactive updating from ITSI form

### DIFF
--- a/app/controllers/interactive_controller.rb
+++ b/app/controllers/interactive_controller.rb
@@ -38,6 +38,9 @@ class InteractiveController < ApplicationController
     if params[:page_id]
       @page = InteractivePage.find(params[:page_id], :include => :lightweight_activity)
       @activity = @page.lightweight_activity
+    elsif @interactive
+      @page = @interactive.page
+      @activity = @interactive.activity
     end
   end
 

--- a/app/controllers/interactive_controller.rb
+++ b/app/controllers/interactive_controller.rb
@@ -23,22 +23,9 @@ class InteractiveController < ApplicationController
     end
   end
 
-  def toggle_visibility
-    new_val = !@interactive.is_hidden
-    @interactive.update_attributes!(is_hidden: new_val)
-    if request.xhr?
-      render json: {is_hidden: new_val}
-    else
-      redirect_to :back
-    end
-  end
-
   protected
   def set_page
-    if params[:page_id]
-      @page = InteractivePage.find(params[:page_id], :include => :lightweight_activity)
-      @activity = @page.lightweight_activity
-    elsif @interactive
+    if @interactive
       @page = @interactive.page
       @activity = @interactive.activity
     end

--- a/app/views/image_interactives/edit.html.haml
+++ b/app/views/image_interactives/edit.html.haml
@@ -1,4 +1,4 @@
-- form_url = defined?(@page) ? page_image_interactive_path(@page, @interactive) : image_interactive_path(@interactive)
+- form_url = image_interactive_path(@interactive)
 = form_for @interactive, :url => form_url do |f|
   = f.error_messages
   =# f.hidden_field 'investigation_id', :value =>@activity.investigation.id # LightweightActivities currently don't belong_to Investigations

--- a/app/views/managed_interactives/edit.html.haml
+++ b/app/views/managed_interactives/edit.html.haml
@@ -1,4 +1,4 @@
-- form_url = defined?(@page) ? page_managed_interactive_path(@page, @interactive) : managed_interactive_path(@interactive)
+- form_url = managed_interactive_path(@interactive)
 .managed-interactive-edit-id
   Interactive ID:
   %span.managed-interactve-id=@interactive.interactive_item_id

--- a/app/views/mw_interactives/edit.html.haml
+++ b/app/views/mw_interactives/edit.html.haml
@@ -1,4 +1,4 @@
-- form_url = defined?(@page) ? page_mw_interactive_path(@page, @interactive) : mw_interactive_path(@interactive)
+- form_url = mw_interactive_path(@interactive)
 .mw-interactive-edit-id
   Interactive ID:
   %span.mw-interactve-id=@interactive.interactive_item_id

--- a/app/views/video_interactives/edit.html.haml
+++ b/app/views/video_interactives/edit.html.haml
@@ -1,4 +1,4 @@
-- form_url = defined?(@page) ? page_video_interactive_path(@page, @interactive) : video_interactive_path(@interactive)
+- form_url = video_interactive_path(@interactive)
 = nested_form_for @interactive, :url => form_url do |f|
   = f.error_messages
   = field_set_tag 'Poster URL' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,26 +129,6 @@ LightweightStandalone::Application.routes.draw do
   end
 
   resources :pages, :controller => 'interactive_pages', :constraints => { :id => /\d+/ }, :except => :create do
-    resources :mw_interactives, :controller => 'mw_interactives', :constraints => { :id => /\d+/ }, :except => :show do
-      member do
-        post 'toggle_visibility'
-      end
-    end
-    resources :managed_interactives, :controller => 'managed_interactives', :constraints => { :id => /\d+/ }, :except => :show do
-      member do
-        post 'toggle_visibility'
-      end
-    end
-    resources :image_interactives, :constraints => { :id => /\d+/ }, :except => :show do
-      member do
-        post 'toggle_visibility'
-      end
-    end
-    resources :video_interactives, :constraints => { :id => /\d+/ }, :except => :show do
-      member do
-        post 'toggle_visibility'
-      end
-    end
     member do
       get 'preview'
     end

--- a/spec/controllers/image_interactives_controller_spec.rb
+++ b/spec/controllers/image_interactives_controller_spec.rb
@@ -6,6 +6,10 @@ describe ImageInteractivesController do
   let (:page) { activity.pages.first }
   let (:int) { FactoryGirl.create(:image_interactive, :url => 'http://mw.concord.org/modeler/_assets/img/cc-logo-1.png') }
 
+  before(:each) {
+    page.add_embeddable(int)
+  }
+
   describe 'show' do
     it 'is not routable' do
       begin
@@ -38,7 +42,7 @@ describe ImageInteractivesController do
 
           expect(response.headers['Content-Type']).to match /text\/json/
           value_hash = JSON.parse(response.body)
-          expect(value_hash['html']).to match %r[<form[^>]+action=\"/pages\/#{page.id}\/image_interactives\/#{int.id}\"[^<]+method=\"post]
+          expect(value_hash['html']).to match %r[<form[^>]+action=\"\/image_interactives\/#{int.id}\"[^<]+method=\"post]
         end
       end
 

--- a/spec/controllers/managed_interactives_controller_spec.rb
+++ b/spec/controllers/managed_interactives_controller_spec.rb
@@ -10,6 +10,10 @@ describe ManagedInteractivesController do
   let (:page) { activity.pages.first }
   let (:int) { FactoryGirl.create(:managed_interactive, :name => 'Test Managed Interactive', :url_fragment => '/interactive') }
 
+  before(:each) {
+    page.add_embeddable(int)
+  }
+
   describe 'edit' do
     it 'shows a form with values of the Managed Interactive filled in' do
       get :edit, :id => int.id
@@ -22,7 +26,7 @@ describe ManagedInteractivesController do
 
       expect(response.headers['Content-Type']).to match /text\/json/
       value_hash = JSON.parse(response.body)
-      expect(value_hash['html']).to match %r[<form[^>]+action=\"/pages\/#{page.id}\/managed_interactives\/#{int.id}\"[^<]+method=\"post]
+      expect(value_hash['html']).to match %r[<form[^>]+action=\"\/managed_interactives\/#{int.id}\"[^<]+method=\"post]
     end
   end
 

--- a/spec/controllers/mw_interactives_controller_spec.rb
+++ b/spec/controllers/mw_interactives_controller_spec.rb
@@ -10,6 +10,10 @@ describe MwInteractivesController do
   let (:page) { activity.pages.first }
   let (:int) { FactoryGirl.create(:mw_interactive, :name => 'Test Interactive') }
 
+  before(:each) {
+    page.add_embeddable(int)
+  }
+
   describe 'edit' do
     it 'shows a form which renders the React-based MW Interactive editor' do
       get :edit, :id => int.id
@@ -22,7 +26,7 @@ describe MwInteractivesController do
 
       expect(response.headers['Content-Type']).to match /text\/json/
       value_hash = JSON.parse(response.body)
-      expect(value_hash['html']).to match %r[<form[^>]+action=\"/pages\/#{page.id}\/mw_interactives\/#{int.id}\"[^<]+method=\"post]
+      expect(value_hash['html']).to match %r[<form[^>]+action=\"\/mw_interactives\/#{int.id}\"[^<]+method=\"post]
     end
   end
 

--- a/spec/controllers/video_interactives_controller_spec.rb
+++ b/spec/controllers/video_interactives_controller_spec.rb
@@ -6,6 +6,10 @@ describe VideoInteractivesController do
   let (:page) { activity.pages.first }
   let (:int) { FactoryGirl.create(:video_interactive, :poster_url => 'http://example.com/poster.png') }
 
+  before(:each) {
+    page.add_embeddable(int)
+  }
+
   describe 'show' do
     it 'is not routable' do
       begin
@@ -37,7 +41,7 @@ describe VideoInteractivesController do
 
           expect(response.headers['Content-Type']).to match /text\/json/
           value_hash = JSON.parse(response.body)
-          expect(value_hash['html']).to match %r[<form[^>]+action=\"/pages\/#{page.id}\/video_interactives\/#{int.id}\"[^<]+method=\"post]
+          expect(value_hash['html']).to match %r[<form[^>]+action=\"\/video_interactives\/#{int.id}\"[^<]+method=\"post]
         end
       end
 


### PR DESCRIPTION
On the ITSI form there is no page, so there is no page_id parameter
So when changing an interactive in ITSI authoring you see an error message
about "save failed".

I initially took the conservative approach of continuing to use the page_id when it is available. But this broke some tests, so then I just decided to make the full change. This simplifies the routes, and makes the interactives behave more like the other embeddables. 

Note: if there is a way for an interactive to be created and not added to the page, then this approach will fail. However I could not find any code that does that.

This PR also removes some dead code: `toggle_visibility`.
That action on the interactive controllers was not being used anywhere.

Instead the edit form was calling `/hideshow_page_item/[id]`. This route calls the action `interactive_pages#toggle_hideshow_page_item` 
