### PR TITLE
ITSI Editing Updates

### DIFF
--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -10,7 +10,15 @@
     width: 100%
   }
   h1 {
-    margin-left: 0.5em;
+    margin: 0 1em;
+
+    &.title {
+      width: auto;
+
+      .buttons-menu {
+        font-size: .9rem;
+      }
+    }
   }
   a {
     color: #479492;

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -103,6 +103,16 @@ module LightweightActivityHelper
     return preview_options
   end
 
+  def itsi_preview_url(activity)
+    base_url = request.base_url
+    if activity.runtime == "Activity Player"
+      preview_activity_url = activity.activity_player_url(request.base_url, preview: true)
+    else
+      preview_activity_url = preview_activity_path(activity)
+    end
+    return preview_activity_url
+  end
+
   def runtime_url(activity)
     if activity.runtime == "Activity Player"
       view_activity_url = activity.activity_player_url(request.base_url, preview: true)

--- a/app/views/lightweight_activities/_edit_header.html.haml
+++ b/app/views/lightweight_activities/_edit_header.html.haml
@@ -9,11 +9,16 @@
   - if (can? :export, @activity) && ENV['CONVERSION_SCRIPT_URL'].present?
     %span.convert
       = link_to "Convert", activity_player_conversion_url(@activity), :target => 'new'
-  #preview-menu
-    %label{for: "preview-options-select"}
-      %strong
-        Preview in:
-    = select_tag :preview_options_select, options_for_select(activity_preview_options(@activity)), {id: 'preview-options-select'}
+  - if @editor_mode == LightweightActivity::ITSI_EDITOR_MODE
+    %div{class: "buttons-menu"}
+      %button{onclick: "window.open('#{itsi_preview_url(@activity)}', '_blank')"}
+        Preview
+  - else    
+    #preview-menu
+      %label{for: "preview-options-select"}
+        %strong
+          Preview in:
+      = select_tag :preview_options_select, options_for_select(activity_preview_options(@activity)), {id: 'preview-options-select'}
 
 - if show_publication_details
   = render :partial => "publications/publication_details", :locals =>{ :publication => @activity}

--- a/spec/helpers/lightweight_activity_helper_spec.rb
+++ b/spec/helpers/lightweight_activity_helper_spec.rb
@@ -74,6 +74,21 @@ describe LightweightActivityHelper do
     end
   end
 
+  describe "#itsi_preview_url" do
+  context "with an activity player runtime preview" do
+    it "returns an activity player url" do
+      url = "https://activity-player.concord.org/branch/master" +
+        "?activity=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Factivities%2F#{activity_player_activity.id}.json&preview"
+      expect(helper.itsi_preview_url(activity_player_activity)).to eq(url)
+    end
+  end
+  context "with a LARA runtime preview" do
+    it "returns a LARA url" do
+      expect(helper.itsi_preview_url(activity)).to eq("/activities/#{activity.id}/preview")
+    end
+  end
+end
+
   describe "#runtime_url" do
     context "with an activity player runtime" do
       it "returns an activity player url" do


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179359071

[#179359071]

These changes replace the "Preview in:" select menu in ITSI editing mode with a "Preview" button. Clicking the button will launch the appropriate URL depending on whether the activity is meant to be run in Activity Player or not. They also make sure the preview option is contained within the ITSI editor wrapper.