### PR TITLE
Prevent warning message from overlapping Preview button

### DIFF
--- a/app/assets/stylesheets/components/itsi_authoring.scss
+++ b/app/assets/stylesheets/components/itsi_authoring.scss
@@ -13,6 +13,7 @@
     margin: 0 1em;
 
     &.title {
+      overflow: hidden;
       width: auto;
 
       .buttons-menu {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179367834

[#179367834]

This change is a follow up to changes already made for the above story and  will prevent warning messages about activity usage from overlapping the Preview button on the ITSI editing form.