### PR TITLE
Fix assets compilation (transform regexp named capture groups)

### DIFF
--- a/lara-typescript/package-lock.json
+++ b/lara-typescript/package-lock.json
@@ -53,11 +53,11 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.25.0.tgz",
-      "integrity": "sha512-uEVKqKkPVz6atbCxCNJY5O7V+ieSK8crUswXo8/WePyEbGEgxJ4t9x/WG4lV8kBjelmvQHDR4GqfJmb5Sh9xSg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.29.0.tgz",
+      "integrity": "sha512-MLeexxMs06WkPKuA/ltOCA3TV+vN1WQjEhojNtylQzz/AJDDq4z/7nmIf4lJKM7h1PDuD4XHLPfbxNuv75mu6A==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -69,9 +69,9 @@
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.23.0.tgz",
-      "integrity": "sha512-gmJhCuXrKOOumppviE4K30NvsIQIqqxbGDNptrJrMYBO0qXCbK8/BypZ/hS/oT3loDzlSIxG2z5GDL/va9lbFw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.29.0.tgz",
+      "integrity": "sha512-s24ycAMo8rY60gGw9aH29QhpPJKD9M/0oCZ1cf9IZj1u2e896Q4Q/wknwfanaWS7thF5AcTdjNMfvny9QVJJBA==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -84,11 +84,11 @@
       }
     },
     "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.23.0.tgz",
-      "integrity": "sha512-Ya5f8Ntv0EyZw+AHkpV6n6qqHzpCDNlkX50uj/dwFCMmPiHFWsWMvd0Qu04Y7miycJINEatRrJ5V8r/uVvZIDg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.29.0.tgz",
+      "integrity": "sha512-m/zLdRz5AR5y8NblhYEXmoAAIQkad73D7tIkT1PvgPoC0wmSurBsbDCx2NYNi8CF5nRJjofq0MNduU0al/o8yg==",
       "requires": {
-        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -100,54 +100,54 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.27.0.tgz",
-      "integrity": "sha512-Ut6RlmJ20mtKonslaaeLvMYGmoYDdxR5GlIABg1Ppc+tKQl4xnaxIJIPcya9N2KmK69+4OcBn00UWAPKh//bJQ==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.30.0.tgz",
+      "integrity": "sha512-prp5MSs+ysS9XRb/BrH1eG/Az2nmxl2A6vbQ147nvuy/cAIMWPoDRwSlOXhD57i5EfAvAoJjSooEh1dfcvna+Q==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/client-sts": "3.27.0",
-        "@aws-sdk/config-resolver": "3.27.0",
-        "@aws-sdk/credential-provider-node": "3.27.0",
-        "@aws-sdk/eventstream-serde-browser": "3.25.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.25.0",
-        "@aws-sdk/eventstream-serde-node": "3.25.0",
-        "@aws-sdk/fetch-http-handler": "3.25.0",
-        "@aws-sdk/hash-blob-browser": "3.25.0",
-        "@aws-sdk/hash-node": "3.25.0",
-        "@aws-sdk/hash-stream-node": "3.25.0",
-        "@aws-sdk/invalid-dependency": "3.25.0",
-        "@aws-sdk/md5-js": "3.25.0",
-        "@aws-sdk/middleware-apply-body-checksum": "3.25.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.27.0",
-        "@aws-sdk/middleware-content-length": "3.25.0",
-        "@aws-sdk/middleware-expect-continue": "3.25.0",
-        "@aws-sdk/middleware-host-header": "3.25.0",
-        "@aws-sdk/middleware-location-constraint": "3.25.0",
-        "@aws-sdk/middleware-logger": "3.25.0",
-        "@aws-sdk/middleware-retry": "3.27.0",
-        "@aws-sdk/middleware-sdk-s3": "3.25.0",
-        "@aws-sdk/middleware-serde": "3.25.0",
-        "@aws-sdk/middleware-signing": "3.27.0",
-        "@aws-sdk/middleware-ssec": "3.25.0",
-        "@aws-sdk/middleware-stack": "3.25.0",
-        "@aws-sdk/middleware-user-agent": "3.25.0",
-        "@aws-sdk/node-config-provider": "3.27.0",
-        "@aws-sdk/node-http-handler": "3.25.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/smithy-client": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/url-parser": "3.25.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "@aws-sdk/util-base64-node": "3.23.0",
-        "@aws-sdk/util-body-length-browser": "3.23.0",
-        "@aws-sdk/util-body-length-node": "3.23.0",
-        "@aws-sdk/util-user-agent-browser": "3.25.0",
-        "@aws-sdk/util-user-agent-node": "3.27.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
-        "@aws-sdk/util-waiter": "3.25.0",
-        "@aws-sdk/xml-builder": "3.23.0",
+        "@aws-sdk/client-sts": "3.30.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.30.0",
+        "@aws-sdk/eventstream-serde-browser": "3.29.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.29.0",
+        "@aws-sdk/eventstream-serde-node": "3.29.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-blob-browser": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/hash-stream-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/md5-js": "3.29.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.29.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.30.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-expect-continue": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-location-constraint": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-sdk-s3": "3.30.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-ssec": "3.29.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
+        "@aws-sdk/util-waiter": "3.29.0",
+        "@aws-sdk/xml-builder": "3.29.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
@@ -161,37 +161,37 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.27.0.tgz",
-      "integrity": "sha512-/Op+OaQgcAG/FyyqJc2NVfIJWEd1cTWIl8gBWSTUugrhhd5rMnAtg3u5ds/tYUimVQJv03z4bDjbI0Rnv/t6XQ==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.30.0.tgz",
+      "integrity": "sha512-Ctt9CXV8ElFBs05oXGjOIYhJ/aTJZsGEX+dsRP7C3D/oswE/z+Uo7rS7sGkiLo4GOroeqSFduMYRcZtl6gvzyw==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "3.27.0",
-        "@aws-sdk/fetch-http-handler": "3.25.0",
-        "@aws-sdk/hash-node": "3.25.0",
-        "@aws-sdk/invalid-dependency": "3.25.0",
-        "@aws-sdk/middleware-content-length": "3.25.0",
-        "@aws-sdk/middleware-host-header": "3.25.0",
-        "@aws-sdk/middleware-logger": "3.25.0",
-        "@aws-sdk/middleware-retry": "3.27.0",
-        "@aws-sdk/middleware-serde": "3.25.0",
-        "@aws-sdk/middleware-stack": "3.25.0",
-        "@aws-sdk/middleware-user-agent": "3.25.0",
-        "@aws-sdk/node-config-provider": "3.27.0",
-        "@aws-sdk/node-http-handler": "3.25.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/smithy-client": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/url-parser": "3.25.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "@aws-sdk/util-base64-node": "3.23.0",
-        "@aws-sdk/util-body-length-browser": "3.23.0",
-        "@aws-sdk/util-body-length-node": "3.23.0",
-        "@aws-sdk/util-user-agent-browser": "3.25.0",
-        "@aws-sdk/util-user-agent-node": "3.27.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -203,40 +203,40 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.27.0.tgz",
-      "integrity": "sha512-QagsjULn6eacR/IL9d/nky17jUcqnbeShrHGrAyOhAXtehG3g2kkFcGbFy30iNw8gl1LteZL9dslpPFdWIEI1A==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.30.0.tgz",
+      "integrity": "sha512-iJm5XlAcgLiRO3lHbAuVkjT8FpueJsCBZQOmjP7JVk9D8DUTV1NdMQOoqY9iuOZsuY5q8725teIqKL9SmZJqfA==",
       "requires": {
         "@aws-crypto/sha256-browser": "^1.0.0",
         "@aws-crypto/sha256-js": "^1.0.0",
-        "@aws-sdk/config-resolver": "3.27.0",
-        "@aws-sdk/credential-provider-node": "3.27.0",
-        "@aws-sdk/fetch-http-handler": "3.25.0",
-        "@aws-sdk/hash-node": "3.25.0",
-        "@aws-sdk/invalid-dependency": "3.25.0",
-        "@aws-sdk/middleware-content-length": "3.25.0",
-        "@aws-sdk/middleware-host-header": "3.25.0",
-        "@aws-sdk/middleware-logger": "3.25.0",
-        "@aws-sdk/middleware-retry": "3.27.0",
-        "@aws-sdk/middleware-sdk-sts": "3.27.0",
-        "@aws-sdk/middleware-serde": "3.25.0",
-        "@aws-sdk/middleware-signing": "3.27.0",
-        "@aws-sdk/middleware-stack": "3.25.0",
-        "@aws-sdk/middleware-user-agent": "3.25.0",
-        "@aws-sdk/node-config-provider": "3.27.0",
-        "@aws-sdk/node-http-handler": "3.25.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/smithy-client": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/url-parser": "3.25.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
-        "@aws-sdk/util-base64-node": "3.23.0",
-        "@aws-sdk/util-body-length-browser": "3.23.0",
-        "@aws-sdk/util-body-length-node": "3.23.0",
-        "@aws-sdk/util-user-agent-browser": "3.25.0",
-        "@aws-sdk/util-user-agent-node": "3.27.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/config-resolver": "3.30.0",
+        "@aws-sdk/credential-provider-node": "3.30.0",
+        "@aws-sdk/fetch-http-handler": "3.29.0",
+        "@aws-sdk/hash-node": "3.29.0",
+        "@aws-sdk/invalid-dependency": "3.29.0",
+        "@aws-sdk/middleware-content-length": "3.29.0",
+        "@aws-sdk/middleware-host-header": "3.29.0",
+        "@aws-sdk/middleware-logger": "3.29.0",
+        "@aws-sdk/middleware-retry": "3.29.0",
+        "@aws-sdk/middleware-sdk-sts": "3.30.0",
+        "@aws-sdk/middleware-serde": "3.29.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/middleware-user-agent": "3.29.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/node-http-handler": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/smithy-client": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
+        "@aws-sdk/util-base64-node": "3.29.0",
+        "@aws-sdk/util-body-length-browser": "3.29.0",
+        "@aws-sdk/util-body-length-node": "3.29.0",
+        "@aws-sdk/util-user-agent-browser": "3.29.0",
+        "@aws-sdk/util-user-agent-node": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
         "tslib": "^2.3.0"
@@ -250,12 +250,12 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.27.0.tgz",
-      "integrity": "sha512-gc7dfBzdmUHJamMjOc0bzAkIm3VUIK9kbLQSy0+nfjT641+AYvXO3qpjR6ywvutsbKhBg5kyGn/4QhyRxg61OQ==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.30.0.tgz",
+      "integrity": "sha512-1qb8WB2uiH2O1UYc98adfmQX3/Rxh1bwU1VW2FxEfCGBTT6wi+Ic1nVTdVy+2gd3usCeIim5mEs8REXgvjLENQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -267,12 +267,12 @@
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.27.0.tgz",
-      "integrity": "sha512-IbPdlYl0A5GcpuT394cJceexxo0tzUzC7jIUxqL8gNbB/MIXC5ZlkeX9Z7bYloNb8SXk7GumXyQTsK1CchUvQA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.29.0.tgz",
+      "integrity": "sha512-FUhdZODjkUeTFNfH7EnqN9piQwBR1gg+8NUJt6Rn7G4rj5lN2n2ryAatowIlzIB+/oWDvpPj+yMIE+XGjQrMhg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -284,14 +284,14 @@
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.27.0.tgz",
-      "integrity": "sha512-rhzlEvxiB7ecpVDl3NkjP1vPmqs+HHmqNXrK4efOYshwIbu+/h3xPePQMBOQ0AGezYn3k/iumoXXysVhVqtwUA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.29.0.tgz",
+      "integrity": "sha512-sjyJrJoLhP2ekx+Z3m5g+/YIWYtuKII9eXuTTwRhzBKTpqv0WQm1ilISdNcz691JueF5jHQs4bP6FWk55RUWEg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.27.0",
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/url-parser": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/url-parser": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -303,18 +303,18 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.27.0.tgz",
-      "integrity": "sha512-jvWUDz6nFqUvjmPRebwf1mWsOZ+inmZNQxz20DC/ROCRfGF1y8Yqf7KgCJy8MQOlDdTA4lPS+w6OJ0J/OOGbPg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.30.0.tgz",
+      "integrity": "sha512-EEg3x60sAPO8xQc/tm631pk5yxOMOoiw2fsE0ojBeF8X78pYKT6sE2Uz0aj8/d8RtqqA3lsXr4O0txtdYbRokg==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.27.0",
-        "@aws-sdk/credential-provider-imds": "3.27.0",
-        "@aws-sdk/credential-provider-sso": "3.27.0",
-        "@aws-sdk/credential-provider-web-identity": "3.27.0",
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-credentials": "3.23.0",
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.30.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -326,20 +326,20 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.27.0.tgz",
-      "integrity": "sha512-GfCDX/AA7EJKyVGmNnh3wngWfEWFkuNJyend6FLN+81s3kUpXTkILuZCwQrD9AyjBYR2ksv0t929nW2fBUGT9Q==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.30.0.tgz",
+      "integrity": "sha512-mT1ImT8nvo062Yf4WE5xZoEl2Wz4lkkA1oewOjvmNUi/AfBkf0YgIK6+XtoC06O2VWqXUhYv7N357/CzGP2I+w==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.27.0",
-        "@aws-sdk/credential-provider-imds": "3.27.0",
-        "@aws-sdk/credential-provider-ini": "3.27.0",
-        "@aws-sdk/credential-provider-process": "3.27.0",
-        "@aws-sdk/credential-provider-sso": "3.27.0",
-        "@aws-sdk/credential-provider-web-identity": "3.27.0",
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-credentials": "3.23.0",
+        "@aws-sdk/credential-provider-env": "3.29.0",
+        "@aws-sdk/credential-provider-imds": "3.29.0",
+        "@aws-sdk/credential-provider-ini": "3.30.0",
+        "@aws-sdk/credential-provider-process": "3.29.0",
+        "@aws-sdk/credential-provider-sso": "3.30.0",
+        "@aws-sdk/credential-provider-web-identity": "3.29.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -351,14 +351,14 @@
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.27.0.tgz",
-      "integrity": "sha512-F9pqKKnd5+fwoldVQJX9uLbDyPyIDnCpZGbiTw6BZANZM1qhjoEn7rNE5g2h0tkeq4dWMA9bANKMR4j3YhTpXw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.29.0.tgz",
+      "integrity": "sha512-1dMq84uGh3zcu+/bGohibWYMSxcrjwaIAc4dBU/3+rkNzPPdRA83hzYS34EizQ61JQHnM3z/xX9SLMeaNRKaSA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-credentials": "3.23.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -370,15 +370,15 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.27.0.tgz",
-      "integrity": "sha512-yXyy+/FYFtpnRmPBiw5rxwSQBj1pcI0R+z77EA8a8+tozZPjsIri+xBsU62DtIlv/2yVb/goPgw+w2vg0L4NFw==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.30.0.tgz",
+      "integrity": "sha512-zZ9T7QLGxOHryDTEEojtpZbDtI3Xu5tSNDvAIg7AzCIE75cRbcc8X9bXD2RUFRZTYDCVg2sSHHOcki1uIonOzA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.27.0",
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-credentials": "3.23.0",
+        "@aws-sdk/client-sso": "3.30.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-credentials": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -390,12 +390,12 @@
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.27.0.tgz",
-      "integrity": "sha512-FYvDzB4UqmJjY+ZZoIAPM1EFK9/RdNn1VT5xvDcebQe7xKOVUG1tZbOA4rVZ3MUcxfyRqp7Ou/AhIWu/9RSt2Q==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.29.0.tgz",
+      "integrity": "sha512-TwICG9y/iw08urlCymroQfRRJY++4JZwdhR0/2ycU+/Cgac6u4MfZsB1qD+u9+Q39/TqSz6QwtNhKLNdf0N23A==",
       "requires": {
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -407,13 +407,13 @@
       }
     },
     "@aws-sdk/eventstream-marshaller": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.25.0.tgz",
-      "integrity": "sha512-gUZIIxupgCIGyspiIV6bEplSRWnhAR9MkyrCJbHhbs4GjWIYlFqp7W0+Y7HY1tIeeXCUf0O8KE3paUMszKPXtg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.29.0.tgz",
+      "integrity": "sha512-yRcWAVSPEcZ8l/iYTJHdo3/aAEsrbY1X3M7N0eQbF/awAXTtrbZ0Fg213xWWgdydP1+TdFv13GeluqhKq/oBBg==",
       "requires": {
         "@aws-crypto/crc32": "^1.0.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-hex-encoding": "3.23.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -425,13 +425,13 @@
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.25.0.tgz",
-      "integrity": "sha512-QJF08OIZiufoBPPoVcRwBPvZIpKMSZpISZfpCHcY1GaTpMIzz35N7Nkd10JGpfzpUO9oFcgcmm2q3XHo1XJyyw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.29.0.tgz",
+      "integrity": "sha512-rzy5caqRjuRXpcbWRC6fGNm4/wt53noYz2Y5Adko+x4X9fSmOBkS+6BCo2I1wQ/RlLyhh+9jrC/ySnD/6Gsd7g==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.25.0",
-        "@aws-sdk/eventstream-serde-universal": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/eventstream-marshaller": "3.29.0",
+        "@aws-sdk/eventstream-serde-universal": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -443,11 +443,11 @@
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.25.0.tgz",
-      "integrity": "sha512-Fb4VS3waKNzc6pK6tQBmWM+JmCNQJYNG/QBfb8y4AoJOZ+I7yX0Qgo90drh8IiUcIKDeprUFjSi/cGIa/KHIsg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.29.0.tgz",
+      "integrity": "sha512-q286hf5EJXcJy6NKeAvPReajGsqELRlV48Wz2Q6hG3n2FTRYO6JQC4pi/YrabnK+oeLZ3UZFye4Ph8BTL5/xnw==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -459,13 +459,13 @@
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.25.0.tgz",
-      "integrity": "sha512-gPs+6w0zXf+p0PuOxxmpAlCvP/7E7+8oAar8Ys27exnLXNgqJJK1k5hMBSrfR9GLVti3EhJ1M9x5Seg1SN0/SA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.29.0.tgz",
+      "integrity": "sha512-859ZHD2FyBSEV4RpYl562i/ddcxNAHcrEsKJE430MNiNuiG324/RE/vIIOb5rleHZI+a62yfU1b/BjUrgVc6IQ==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.25.0",
-        "@aws-sdk/eventstream-serde-universal": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/eventstream-marshaller": "3.29.0",
+        "@aws-sdk/eventstream-serde-universal": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -477,12 +477,12 @@
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.25.0.tgz",
-      "integrity": "sha512-NgsQk5dXg7NlRDEKGRUdiAx7WESQGD1jEhXitklL3/PHRZ7Y9BJugEFlBvKpU7tiHZBcomTbl/gE2o6i2op/jA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.29.0.tgz",
+      "integrity": "sha512-GOXf5s1mKf0aCtl+Um4kDDPrwZa1A9jx7vZ/cHSCc3mb/W/Nqn/CP0mMw4r3YCOkHLdil4TqoQ70/1/kHsq9YQ==",
       "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/eventstream-marshaller": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -494,14 +494,14 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.25.0.tgz",
-      "integrity": "sha512-792kkbfSRBdiFb7Q2cDJts9MKxzAwuQSwUIwRKAOMazU8HkKbKnXXAFSsK3T7VasOFOh7O7YEGN0q9UgEw1q+g==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.29.0.tgz",
+      "integrity": "sha512-rx+YlHFYzgGsCZMEvJBUdRsqfMGW4RY6J3USQvz63a32jVlMC3Kw9xINaXGhCEmOlUlzdeeIMQOZW5VxavLnjQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/querystring-builder": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-base64-browser": "3.23.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-base64-browser": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -513,13 +513,13 @@
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.25.0.tgz",
-      "integrity": "sha512-dsvV/nkW8v9wIotd3xJn3TQ8AxVLl56H82WkGkHcfw61csRxj3eSUNv0apUBopCcQPK8OK4l2nHAg08r0+LWXg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.29.0.tgz",
+      "integrity": "sha512-8nD1A0w7aPQ0Mzij7+X95GwapMm2MfrN6bLa1iCn5PNdQ5Zn+tK70NUL/s9X6KaEQi3Lh7S0xGN9paEZ5o4+sg==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.23.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.23.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/chunked-blob-reader": "3.29.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -531,12 +531,12 @@
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.25.0.tgz",
-      "integrity": "sha512-qRn6iqG9VLt8D29SBABcbauDLn92ssMjtpyVApiOhDYyFm2VA2avomOHD6y2PRBMwM5FMQAygZbpA2HIN2F96w==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.29.0.tgz",
+      "integrity": "sha512-iANkXAGNgUSX17GjyTdrFRE357AmAgnIsuyKhuaK8vi4SPPxHYCyXOdxtUx5TjkzW4bUym3cRJS8zeirayTEHA==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-buffer-from": "3.23.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-buffer-from": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -548,11 +548,11 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.25.0.tgz",
-      "integrity": "sha512-pzScUO9pPEEHQ5YQk1sl1bPlU2tt0OCblxUwboZJ9mRgNnWwkMWxe7Mec5IfyMWVUcbIznUHn7qRYEvJQ9JXmw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.29.0.tgz",
+      "integrity": "sha512-2ha+yzpJCoR23NoCfP/9OMBF5jgg76xAQo14/ItRWLnn0np7eRTGM+OFnNuAfvDRbzM4UcJoGDbUreAhaoSOBQ==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -564,11 +564,11 @@
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.25.0.tgz",
-      "integrity": "sha512-ZBXjBAF2JSiO/wGBa1oaXsd1q5YG3diS8TfIUMXeQoe9O66R5LGoGOQeAbB/JjlwFot6DZfAcfocvl6CtWwqkw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.29.0.tgz",
+      "integrity": "sha512-0TyZZbPs5SWCF2tT1DXccK5SUx7/bDJCVojgBuW3QRJn9ta3US/u5l7w8k6jwWFU3CQhLAWuG0TD7FhATiM2HQ==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -580,9 +580,9 @@
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.23.0.tgz",
-      "integrity": "sha512-XN20/scFthok0lCbjtinW77CoIBoar8cbOzmu+HkYTnBBpJrF6Ai5g9sgglO8r+X+OLn4PrDrTP+BxdpNuIh9g==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.29.0.tgz",
+      "integrity": "sha512-QqIhHGp2qTfDlW7uNh/T4kcyAU2TfxHA29cppQusuTJjploAXXMzvBdmxjFH1ZvPbKs0Rd7owQ0YnC9Lnq+Nzg==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -595,13 +595,13 @@
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.25.0.tgz",
-      "integrity": "sha512-97MtL1VF3JCkyJJnwi8LcXpqItnH1VtgoqtVqmaASYp5GXnlsnA1WDnB0754ufPHlssS1aBj/gkLzMZ0Htw/Rg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.29.0.tgz",
+      "integrity": "sha512-6wsT7zM9qEIbf+FI1QzKXG1o1z91u3zF6tPiXtdopVOs2m2I0emG2c1cEzqFwqB4HhiaR6PejBhn/tDxfc7oNw==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-utf8-browser": "3.23.0",
-        "@aws-sdk/util-utf8-node": "3.23.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-utf8-browser": "3.29.0",
+        "@aws-sdk/util-utf8-node": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -613,13 +613,13 @@
       }
     },
     "@aws-sdk/middleware-apply-body-checksum": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.25.0.tgz",
-      "integrity": "sha512-162qFG7eap4vDKuKrpXWQYE4tbIETNrpTQX6jrPgqostOy1O0Nc5Bn1COIoOMgeMVnkOAZV7qV1J/XAYGz32Yw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.29.0.tgz",
+      "integrity": "sha512-csHiQKvxSJWxQx7lbla3Wgs+lWuNQ/DEFid5SxBZBhsqKz5FPBJr6kMPWIopmIL/vCxrYhMaS4ARloQBUkLoyQ==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.23.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -631,13 +631,13 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.27.0.tgz",
-      "integrity": "sha512-kwKkWE2bjQ/DcSBatRUjuF671+gy3Gv1TgivyLC0H0f+g7HXxead7jXOBoQ4aYIC7SuG5EwqxkmFrLXwJozr5A==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.30.0.tgz",
+      "integrity": "sha512-WlPeUGEhuuTKtpRH6pDgBjX7uoAXaCv4FatK06R6tRBp7oSFiq3az0AUrNE5u45BOT6sj7Yl7C96WLcvHfG4gA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-arn-parser": "3.23.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-arn-parser": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -649,12 +649,12 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.25.0.tgz",
-      "integrity": "sha512-uOXus0MmZi/mucRIr5yfwM1vDhYG66CujNfnhyEaq5f4kcDA1Q5qPWSn9dkQPV9JWTZK3WTuYiOPSgtmlAYTAg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.29.0.tgz",
+      "integrity": "sha512-g+tOOXQXqKG84XwFrJexZa2iTuYJce9jnjHV4vyfXwVuKrwuf+ZFguPZ4hzEd40vDo5aLM49JtF/OcO4plCneg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -666,13 +666,13 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.25.0.tgz",
-      "integrity": "sha512-o3euv8NIO0zlHML81krtfs4TrF5gZwoxBYtY+6tRHXlgutsHe1yfg1wrhWnJNbJg1QhPwXxbMNfYX7MM83D8Ng==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.29.0.tgz",
+      "integrity": "sha512-5SzOhxF1rO2ajlMkLYklTD9XnAcsDxKfAyRZeHCH5pYVdskjWphpJ61IS+/rWv+1L0qDsxYum7Ig50R853c4Cw==",
       "requires": {
-        "@aws-sdk/middleware-header-default": "3.25.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/middleware-header-default": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -684,12 +684,12 @@
       }
     },
     "@aws-sdk/middleware-header-default": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.25.0.tgz",
-      "integrity": "sha512-xkFfZcctPL0VTxmEKITf6/MSDv/8rY+8uA9OMt/YZqfbg0RfeqR2+R1xlDNDxeHeK/v+g5gTNIYTQLM8L2unNA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.29.0.tgz",
+      "integrity": "sha512-DoTQvcmqhgTcPdkJi1+To/esmURd0HGaP3oUoIYxnoWK+hC1zJmq9hb+0oi1wdXX79l5iz2DkjH3sm547rJIuQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -701,12 +701,12 @@
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.25.0.tgz",
-      "integrity": "sha512-xKD/CfsUS3ul2VaQ3IgIUXgA7jU2/Guo/DUhYKrLZTOxm0nuvsIFw0RqSCtRBCLptE5Qi+unkc1LcFDbfqrRbg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.29.0.tgz",
+      "integrity": "sha512-aBifr86Owrhvy29cvZD17JzdoTtKMxzdjCkMA7ckNP+9Lg7kLI/6ws1yZ6BJlmcOnKxtNSnkvunGmJy8BU8EWQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -718,11 +718,11 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.25.0.tgz",
-      "integrity": "sha512-diwmJ+MRQrq3H9VH+8CNAT4dImf2j3CLewlMrUEY+HsJN9xl2mtU6GQaluQg60iw6FjurLUKKGTTZCul4PGkIQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.29.0.tgz",
+      "integrity": "sha512-c7aOFU7AEzLXTIen5VIBm45KrRHLVuHewIpotwApFFSpLjxroPogsT0MSFyGDR9cHLl5QCiJ777Zu6L2x6819A==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -734,11 +734,11 @@
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.25.0.tgz",
-      "integrity": "sha512-M1F7BlAsDKoEM8hBaU2pHlLSM40rzzgtZ6jFNhfmTwGcjxe1N7JXCH5QPa7aI8wnJq2RoIRHVfVsUH4GwvOZnA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.29.0.tgz",
+      "integrity": "sha512-0rLvuTvfaMWNb7+FApXAH0111FEp/AfG3fO7QkyVrXmHlTrNIJozilhkd0FwEMcQqqM9UK5lPLXwloH9Rkp9vw==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -750,13 +750,13 @@
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.27.0.tgz",
-      "integrity": "sha512-H57NP27qOxgbPRwCFkBYtAJylhAOWKSv3/TsCpDNnrb3Z0pqKUQH9mLC8hRGTRplkA7SDGfiuf9bsoNhZ3HFwQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.29.0.tgz",
+      "integrity": "sha512-yRQ48UIGPmK3/jWMJ2LC4trltFevMDEXyvtT6knwDnwXxmuwv7K6udk6TnGaUU5TlLVI1XdRQHaZY7xZH1KbGw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/service-error-classification": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/service-error-classification": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       },
@@ -769,13 +769,13 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.25.0.tgz",
-      "integrity": "sha512-Y1P6JnpAdj7p5Q43aSLSuYBCc3hKpZ/mrqFSGN8VFXl7Tzo7tYfjpd9SVRxNGJK7O7tDAUsPNmuGqBrdA2tj8w==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.30.0.tgz",
+      "integrity": "sha512-ZyDz7reDqHYbYCftpsjmn7HpwQDSBSEb5PcXawF1/SnK2X4toTsWx0jZHmlYo7Xti/rE4Gfgx69dt/ACDO33BA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-arn-parser": "3.23.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-arn-parser": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -787,15 +787,15 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.27.0.tgz",
-      "integrity": "sha512-4geCMczCujTz4GWSrwKhxEW9rYikp5NrLcIpHI0NjthQQfa8T4/D1WSsSnW3JNmQcMgQXeC9h8jTn0dOE4EhUw==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.30.0.tgz",
+      "integrity": "sha512-TZQQ0LA/rjYNgV+DbU0KvyHZaNhihrWf4IeJeKoez1vpvQmU58G5zAm0+rVHbzazJaOQuHYKKdPttOPxl/JAAg==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.27.0",
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/signature-v4": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/middleware-signing": "3.30.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -807,11 +807,11 @@
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.25.0.tgz",
-      "integrity": "sha512-065Kugo8yXzBkcVAxctxFCHKlHcINnaQRsJ8ifvgc+UOEgvTG9+LfGWDwfdgarW9CkF7RkCoZOyaqFsO+HJWsg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.29.0.tgz",
+      "integrity": "sha512-jN6zuaXg3k9HiWJZjBROiVJEdFaZrMikhyVdqYTT3hR+i08M/9UgVuX84HP/dALChZazOn9MPhvPWGvxrMOr9A==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -823,14 +823,14 @@
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.27.0.tgz",
-      "integrity": "sha512-eOXwKOFuCIGAW3wZO9Cyh+z7swZYTq8BiBDjwWu6u0UBb5B/zMiq1z1LDa88iZY200O3Zip8+6RZV7LLd3XH+Q==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.30.0.tgz",
+      "integrity": "sha512-T/zGCijEGODmpbS/HlwnxT0Bn69FhZpBrVAjfofLUFzHteJ5Ab2q7AEt1dOdi3GrtTGStdwbfiZVeTxMKIjaTw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/signature-v4": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -842,11 +842,11 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.25.0.tgz",
-      "integrity": "sha512-bnrHb8oddW+vDexbNzZtpfshshKru+skcmq3dyXlL8LB/NlJsMiQJE8xoGbq5odTLiflIgaDBt527m5q58i+fg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.29.0.tgz",
+      "integrity": "sha512-XJC00iN3sqJ5ZH05VpP/bimRHfS1aWGs5/Vuz4swdyKGwez725ZBfof0lg6LSnP4G+me6ZqwsbUxHkdrupcWAA==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -858,9 +858,9 @@
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.25.0.tgz",
-      "integrity": "sha512-s2VgdsasOVKHY3/SIGsw9AeZMMsdcIbBGWim9n5IO3j8C8y54EdRLVCEja8ePvMDZKIzuummwatYPHaUrnqPtQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.29.0.tgz",
+      "integrity": "sha512-S6Jt108uxs/PEoLAgGow9SdMKWXhlg0EGgY77Z4pNPQDrBYoca2kwWeTsyTpgBXSsyV0z0WZB4TJK5/doGv6CA==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -873,12 +873,12 @@
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.25.0.tgz",
-      "integrity": "sha512-HXd/Qknq8Cp7fzJYU7jDDpN7ReJ3arUrnt+dAPNaDDrhmrBbCZp+24UXN6X6DAj0JICRoRuF/l7KxjwdF5FShw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.29.0.tgz",
+      "integrity": "sha512-AVbn9QEbqBgScaD3cxLv7/yi9Up10vYKy/AWIwgTrW0LxOuy9+Za2hdk5eZRP/QpqS/Ibz2/CqcmK1GQ/03kmg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -890,13 +890,13 @@
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.27.0.tgz",
-      "integrity": "sha512-5jeCLV7NI/ouQCMGDnGbxpCBhGirksXY55uvAaeysMxzjJLmPDwOZUD1gMhfYe8lxvktwhAndOdPQofWwTFUoQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.29.0.tgz",
+      "integrity": "sha512-ANRnPz4IT4FiSAc+9p0HqGSjL+cdzB2E68BFmbbGin0fZwhflX1BksjuUEibw8Emf8jvhvbUxdtAIUWctTYxOA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.27.0",
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/property-provider": "3.29.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -908,14 +908,14 @@
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.25.0.tgz",
-      "integrity": "sha512-zVeAM/bXewZiuMtcUZI/xGDID6knkzOv73ueVkzUbP0Ki8bfao7diR3hMbIt5Fy/r8cAVjJce9v6zFqo4sr1WA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.29.0.tgz",
+      "integrity": "sha512-FnPdoK0hmEr2JO/g7MVE3oeC2TvMpoRDQqUnDrn9C1bzRzgzhHqGVyaiRmc1HECMKjPFYVn02NCzY4qx56K0Ag==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.25.0",
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/querystring-builder": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -927,11 +927,11 @@
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.27.0.tgz",
-      "integrity": "sha512-8vovVNldgJwCpUfehdwUPwvzfUPB7TEW/tcTgrkLQW/cpEULbRrymtiZrzSkBLspNw2iU5d3FpQxE61s1ou0UA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.29.0.tgz",
+      "integrity": "sha512-N2fd3H4mGGE51PgmMbEzBGSNwcyPkEgMxgfZsrQUaFh+CE5uuelOAL70Yzr4IZ4yZJvf1F9e8drtCuUcHnSUEw==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -943,11 +943,11 @@
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.25.0.tgz",
-      "integrity": "sha512-4Jebt5G8uIFa+HZO7KOgOtA66E/CXysQekiV5dfAsU8ca+rX5PB6qhpWZ2unX/l6He+oDQ0zMoW70JkNiP4/4w==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.29.0.tgz",
+      "integrity": "sha512-OIeJ7ukfgGkaIL0/NNM5sxIlfxtOqQN+KoaQ89YeLBlJPVoKnptAw+eWjjLwxLs+r/SbyZHXbBawP+sbzq0mSQ==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -959,12 +959,12 @@
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.25.0.tgz",
-      "integrity": "sha512-o/R3/viOxjWckI+kepkxJSL7fIdg1hHYOW/rOpo9HbXS0CJrHVnB8vlBb+Xwl1IFyY2gg+5YZTjiufcgpgRBkw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.29.0.tgz",
+      "integrity": "sha512-htrHPmwGfWxl/Mt0JpR63NmlDtmwMJTjvLVrdbxBBXfjiyB8023lEFfyMSDHzD6fegQcw/rOwaliQNAuaVNnXQ==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-uri-escape": "3.23.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -976,11 +976,11 @@
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.25.0.tgz",
-      "integrity": "sha512-FCNyaOLFLVS5j43MhVA7/VJUDX0t/9RyNTNulHgzFjj6ffsgqcY0uwUq1RO3QCL4asl56zOrLVJgK+Z7wMbvFg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.29.0.tgz",
+      "integrity": "sha512-v22PBXafAHw+wMaSGbq4B9wEsSYV2e0nZgGHZBNML3HPDiAYJqsQHiYEbiz8nzkmoayU0wrVFZ/XfKNXXcXGbw==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -992,16 +992,16 @@
       }
     },
     "@aws-sdk/s3-request-presigner": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.27.0.tgz",
-      "integrity": "sha512-uDohpVXEdqsrR8+8ILZ/KkECk+RH78LGyaGdEVTK0f/zlcKeEyCTi/wPwbrm72qThDgBztlHnG2ZR97zShg/AA==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.30.0.tgz",
+      "integrity": "sha512-V6Bktzjf0cONf2fB8iMl4zfzpZQKzch+ZxY2YM4yKyfMxWyhtWY6GrZqjdk6LYoQEqs3TakJzoOL5RJF2ox+UA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.25.0",
-        "@aws-sdk/signature-v4": "3.25.0",
-        "@aws-sdk/smithy-client": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-create-request": "3.27.0",
-        "@aws-sdk/util-format-url": "3.25.0",
+        "@aws-sdk/protocol-http": "3.29.0",
+        "@aws-sdk/signature-v4": "3.30.0",
+        "@aws-sdk/smithy-client": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-create-request": "3.30.0",
+        "@aws-sdk/util-format-url": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1013,14 +1013,14 @@
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.25.0.tgz",
-      "integrity": "sha512-66FfIab87LnnHtOLrGrVOht9Pw6lE8appyOpBdtoeoU5DP7ARSWuDdsYmKdGdRCWvn/RaVFbSYua9k0M1WsGqg=="
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.29.0.tgz",
+      "integrity": "sha512-VqOjXXTLTGbifzg3Fg2g/Ac6W3uzC3llPZjm/b0goM17KLWMGU7JKiem2l+CFyN4sxkver7InNlIUJCJAPB6+Q=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.23.0.tgz",
-      "integrity": "sha512-YUp46l6E3dLKHp1cKMkZI4slTjsVc/Lm7nPCTVc3oQvZ1MvC99N/jMCmZ7X5YYofuAUSdc9eJ8sYiF2BnUww9g==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.29.0.tgz",
+      "integrity": "sha512-x4Chk4+iMiYaxcomZjdg7IwU1mQhJ7iPl/3RrIqCShPIOZDwwH4vLl6Fw0bniOZiHK30JQ1wlAgLxzVP0JMHTw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1033,14 +1033,14 @@
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.25.0.tgz",
-      "integrity": "sha512-6KDRRz9XVrj9RxrBLC6dzfnb2TDl3CjIzcNpLdRuKFgzEEdwV+5D+EZuAQU3MuHG5pWTIwG72k/dmCbJ2MDPUQ==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.30.0.tgz",
+      "integrity": "sha512-uBvut8RrhXGunTDYuJMALlV8IaFHyZHPzadhrqx12QJT+LQevSB4CR2WXZknz0JZ4HcFvpaJqbiionLobwVEuQ==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.23.0",
-        "@aws-sdk/types": "3.25.0",
-        "@aws-sdk/util-hex-encoding": "3.23.0",
-        "@aws-sdk/util-uri-escape": "3.23.0",
+        "@aws-sdk/is-array-buffer": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
+        "@aws-sdk/util-hex-encoding": "3.29.0",
+        "@aws-sdk/util-uri-escape": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1052,12 +1052,12 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.27.0.tgz",
-      "integrity": "sha512-PpsSDUsRqw8HGuXv+AR2UzhVUJz4APM7K6Br8TTDPKvDwQtXkT5GROXRyAwU+htPcOHq006lS5EiF343y0HRvg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.30.0.tgz",
+      "integrity": "sha512-Kokc3OHDY0T5ppjeMnsJEaxOBvonzNvYSQrCEvPbj9yUCLHvEWw4g6USQDfzqyofCwwhuFKFS6hS/bbiW6cXvQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1069,17 +1069,17 @@
       }
     },
     "@aws-sdk/types": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.25.0.tgz",
-      "integrity": "sha512-vS0+cTKwj6CujlR07HmeEBxzWPWSrdmZMYnxn/QC9KW9dFu0lsyCGSCqWsFluI6GI0flsnYYWNkP5y4bfD9tqg=="
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.29.0.tgz",
+      "integrity": "sha512-8ilWQU5ZTdiRfblmmjl38+6JZKKM8EqA5Sbn8djgDLShCLeVJ2TsL2guzNi+WHcL7BHdv1pI/NNmTcgRUo6yOw=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.25.0.tgz",
-      "integrity": "sha512-qZ3Vq0NjHsE7Qq6R5NVRswIAsiyYjCDnAV+/Vt4jU/K0V3mGumiasiJyRyblW4Da8R6kfcJk0mHSMFRJfoHh8Q==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.29.0.tgz",
+      "integrity": "sha512-385f+g4xeRym2S4bzF+Nc0MB8addAlCSb5hIUJu1JKH6FwFLrNRuixeaelGLyWr77xv25P0ruyXQAFf2ISxzKw==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/querystring-parser": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1091,9 +1091,9 @@
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.23.0.tgz",
-      "integrity": "sha512-J3+/wnC21kbb3UAHo7x31aCZxzIa7GBijt6Q7nad/j2aF38EZtE3SI0aZpD8250Vi+9zsZ4672QDUeSZ5BR5kg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.29.0.tgz",
+      "integrity": "sha512-NK4xAU7EGp0H4oYIICAJL49BzGvezkWD6rQdfJpXrPoqXviXXDq0nmFEoP9k4PsT+mDBEFiuvXhQlrHhBPVx5g==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1106,9 +1106,9 @@
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.23.0.tgz",
-      "integrity": "sha512-xlI/qw+uhLJWa3k0mRtRHQ42v5QzsMFEUXScredQMfJ/34qzXyocsG6OHPOTV1I8WSANrxnHR5m1Ae3iU6JuVw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.29.0.tgz",
+      "integrity": "sha512-yMgn5vZ7laVO/497iPDjTdmia3sDdFBDq6k42EZxVTpkUcd8JS2nWJ+9ePuIMwqOgPjhhkOOXiidrbZaUQ+L6Q==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1121,11 +1121,11 @@
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.23.0.tgz",
-      "integrity": "sha512-Kf8JIAUtjrPcD5CJzrig2B5CtegWswUNpW4zBarww/UJhHlp8WzKlCxxA+yNS1ghT0ZMjrRvxPabKDGpkyUfmQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.29.0.tgz",
+      "integrity": "sha512-4pRwjQ6+yS7SQm+yK3pchrsmGPEuoR2YiNsBG0LVNecQmnxWUbOhaEWIxXKTnAzs9bAt7AWEbLzsW8/cN/yTNw==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.23.0",
+        "@aws-sdk/util-buffer-from": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1137,9 +1137,9 @@
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.23.0.tgz",
-      "integrity": "sha512-Bi6u/5omQbOBSB5BxqVvaPgVplLRjhhSuqK3XAukbeBPh7lcibIBdy7YvbhQyl4i8Hb2QjFnqqfzA0lNBe5eiw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.29.0.tgz",
+      "integrity": "sha512-cKSwlDlZkcxuhSdoiq1TxleaBvveEgKA2Yo4TYP4DKVPHZuYZtbFv8r1driml1SaIKXg4GQpe+pJit3mxDRxAg==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1152,9 +1152,9 @@
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.23.0.tgz",
-      "integrity": "sha512-8kSczloA78mikPaJ742SU9Wpwfcz3HOruoXiP/pOy69UZEsMe4P7zTZI1bo8BAp7j6IFUPCXth9E3UAtkbz+CQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.29.0.tgz",
+      "integrity": "sha512-8rG65GMpsjVFd9jhx5y/dhwbJVIKq0OqwNRK+GoIVDo0KKaGtjNbCVHYYDjpwIuksZumiqvlC0E3AUcXn7p1rQ==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1167,11 +1167,11 @@
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.23.0.tgz",
-      "integrity": "sha512-axXy1FvEOM1uECgMPmyHF1S3Hd7JI+BerhhcAlGig0bbqUsZVQUNL9yhOsWreA+nf1v08Ucj8P2SHPCT9Hvpgg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.29.0.tgz",
+      "integrity": "sha512-4ODxK5y/yONgsuc9SAzZ0j/v0IQkJVCRApziF4Q8NiZ1z9050nZ08rgTEhrTbWgLmDju4SDvJhn/nUNTrsLhug==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.23.0",
+        "@aws-sdk/is-array-buffer": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1183,13 +1183,13 @@
       }
     },
     "@aws-sdk/util-create-request": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.27.0.tgz",
-      "integrity": "sha512-XQy+kZmvrFptKssc0MjxDBBjWe2ykhtajv/od5qPMjUmAuWX3Mb0OX/A6HM5cgLUrUOdrOjzjT0cy8xRI5hBEA==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.30.0.tgz",
+      "integrity": "sha512-7kSXMcxfaDsrk0keAFP3Gnx9bly0mHeeXBASah2K3k+oSgpw5VLO5OJrw9YnAjt2gZ05W6FlduaSqgBDEQHSbQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.25.0",
-        "@aws-sdk/smithy-client": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/middleware-stack": "3.29.0",
+        "@aws-sdk/smithy-client": "3.30.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1201,11 +1201,11 @@
       }
     },
     "@aws-sdk/util-credentials": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.23.0.tgz",
-      "integrity": "sha512-6TDGZnFa0kZr+vSsWXXMfWt347jbMGKtzGnBxbrmiQgZMijz9s/wLYxsjglZ+CyqI/QrSMOTtqy6mEgJxdnGWQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.29.0.tgz",
+      "integrity": "sha512-xCWQizP5d6SwbwB2HmxpDqu0WYY7/E7pNrZ+7tSMrJxZlT8Zsd+lFaO23JVFMEBqjjBnpLBr+XkNZgOpD1BYwA==",
       "requires": {
-        "@aws-sdk/shared-ini-file-loader": "3.23.0",
+        "@aws-sdk/shared-ini-file-loader": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1217,12 +1217,12 @@
       }
     },
     "@aws-sdk/util-format-url": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.25.0.tgz",
-      "integrity": "sha512-/qtyFO36k/ZHgDbu4UM/Xtnfd/SsRZHKBDkzoVvNe932Bc6rXW+3DqJaI5EjOnrUHINWZB4LQ203rSxXsNCgPQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.29.0.tgz",
+      "integrity": "sha512-RrCSVlfWRuDB7oVtECqSgwrMK69z75Ettq9niaCz2CAVnJlvWTnknybX+M/l1TDBKeLKM3C7k6jFv+J+twByFg==",
       "requires": {
-        "@aws-sdk/querystring-builder": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/querystring-builder": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1234,9 +1234,9 @@
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.23.0.tgz",
-      "integrity": "sha512-RFDCwNrJMmmPSMVRadxRNePqTXGwtL9s4844x44D0bbGg1TdC42rrg0PRKYkxFL7wd1FbibVQOzciZAvzF+Z+w==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.29.0.tgz",
+      "integrity": "sha512-YZ9fhJ2HKnnPL+8M9/YMFo4906Cvh1NaVOZT61joPM5Vv1rSYXdD1/tvn2qNjVhAJAGFWdBsIqZWw43km5DNpw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1249,9 +1249,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.23.0.tgz",
-      "integrity": "sha512-mM8kWW7SWIxCshkNllpYqCQi5SzwJ+sv5nURhtquOB5/H3qGqZm0V5lUE3qpE1AYmqKwk6qbGUy1woFn1T5nrw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.29.0.tgz",
+      "integrity": "sha512-gvcbl9UdTOvuCCzgbtTTsKnL1l/cnT/CFl0f6ZCQ6qubUTRCuL/aK8DvgWa1n9p/ddCiVKPLmHu/L1xtX4gc0A==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1264,9 +1264,9 @@
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.23.0.tgz",
-      "integrity": "sha512-SvQx2E/FDlI5vLT67wwn/k1j2R/G58tYj4Te6GNgEwPGL43X2+7c0+d/WTgndMaRvxSBHZMUTxBYh1HOeU7loA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.29.0.tgz",
+      "integrity": "sha512-js834TiNTdwIZOxmGSCPiLETUoc2JslY07D6A+yLNI/kZmmTHa0tKCyPxMqo7LBb+iU9ymky2LLJuDGp6aZNHw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1279,11 +1279,11 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.25.0.tgz",
-      "integrity": "sha512-qGqiWfs49NRmQVXPsBXgMRVkjDZocicU0V2wak98e0t7TOI+KmP8hnwsTkE6c4KwhsFOOUhAzjn5zk3kOwi6tQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.29.0.tgz",
+      "integrity": "sha512-se9WLQS3H36u8FUA3/DfnzH3LU77QBRpJN4FmQtcQHR3A5mR2tRty+eOrvIf2R4QtveMWXrQbvScTrca7ZFZug==",
       "requires": {
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/types": "3.29.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.0"
       },
@@ -1296,12 +1296,12 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.27.0.tgz",
-      "integrity": "sha512-jigZzAuhEnaLFeYEDGKQq8tas8OsT6qI7WAm/UnCXqtLhdnIu7u1yPhXk+TjI7SSn4Z6zP6Oh1qtFxzhpPmdoQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.29.0.tgz",
+      "integrity": "sha512-atyjuDnD1WtIR1sZzcCJcD0JyYKGZ6bYqAhh/apaiPs0LoTyaFGYN8K7wSr3gL8PqD9YYNKfiNiPU3AbY6pW5A==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.27.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/node-config-provider": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1313,9 +1313,9 @@
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.23.0.tgz",
-      "integrity": "sha512-fSB95AKnvCnAbCd7o0xLbErfAgD9wnLCaEu23AgfGAiaG3nFF8Z2+wtjebU/9Z4RI9d/x83Ho/yguRnJdkMsPA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.29.0.tgz",
+      "integrity": "sha512-ZIHbBYByMq5vadQ1SZOQTHVtrkGAFiuypATYF5ST8YB3j7XKvflv+fiBX2xQ8xpqb28noEg6dNPnvqkQQ1n/aw==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1328,11 +1328,11 @@
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.23.0.tgz",
-      "integrity": "sha512-yao8+8okyfCxRvxZe3GBdO7lJnQEBf3P6rDgleOQD/0DZmMjOQGXCvDd42oagE2TegXhkUnJfVOZU2GqdoR0hg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.29.0.tgz",
+      "integrity": "sha512-CIZPDnSvtfv7MeHM/hA1fHXcXJR2f7ULjw4nXsX/BLaKGKf/O6IhOXPt1ecUIpGeUrCgPCqxkDjmThUCa87Bcg==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.23.0",
+        "@aws-sdk/util-buffer-from": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1344,12 +1344,12 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.25.0.tgz",
-      "integrity": "sha512-rhJ7Q2fcPD8y4H0qNEpaspkSUya0OaNcVrca9wCZKs7jWnropPzrQ+e2MH7fWJ/8jgcBV890+Txr4fWkD4J01g==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.29.0.tgz",
+      "integrity": "sha512-9qNsX+yRpX8xE0eW9qHZCy7W6+MFkYFR10umSPVl9gc5p+RViQwS0D2wVYmQblrqGK6VpK+wAb3faFf6KaDesg==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.25.0",
-        "@aws-sdk/types": "3.25.0",
+        "@aws-sdk/abort-controller": "3.29.0",
+        "@aws-sdk/types": "3.29.0",
         "tslib": "^2.3.0"
       },
       "dependencies": {
@@ -1361,9 +1361,9 @@
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.23.0.tgz",
-      "integrity": "sha512-5LEGdhQIJtGTwg4dIYyNtpz5QvPcQoxsqJygmj+VB8KLd+mWorH1IOpiL74z0infeK9N+ZFUUPKIzPJa9xLPqw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.29.0.tgz",
+      "integrity": "sha512-lixmZNupjRsfAxCZh3CshqWSxKJEAPcuPiKhUlW9DhfoIc+YTD9U5G2fzY9LBd7ugDo4N7H5sU3Oa1iYLp2ZDg==",
       "requires": {
         "tslib": "^2.3.0"
       },
@@ -1384,26 +1384,26 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.6",
-        "@babel/parser": "^7.14.6",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -1421,10 +1421,59 @@
             "@babel/highlight": "^7.14.5"
           }
         },
+        "@babel/generator": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+          "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
         "@babel/highlight": {
@@ -1438,13 +1487,47 @@
             "js-tokens": "^4.0.0"
           }
         },
-        "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+        "@babel/parser": {
+          "version": "7.15.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.5.tgz",
+          "integrity": "sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -1456,6 +1539,18 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
         },
         "json5": {
           "version": "2.2.0",
@@ -1515,13 +1610,40 @@
         }
       }
     },
-    "@babel/helper-compilation-targets": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-      "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+      "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/types": "^7.15.4"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
@@ -1533,6 +1655,16 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.5.tgz",
+      "integrity": "sha512-TLawwqpOErY2HhWbGJ2nZT5wSkR192QpN+nBg1THfBfftrlvOh+WbhrxXCH4q4xJ9Gl16BGPR/48JA+Ryiho/A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "regexpu-core": "^4.7.1"
       }
     },
     "@babel/helper-function-name": {
@@ -1619,27 +1751,27 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -1670,70 +1802,200 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-      "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+      "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.14.5",
-        "@babel/helper-simple-access": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
-        "@babel/helper-module-imports": {
+        "@babel/code-frame": {
           "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-          "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+          "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
-        "@babel/types": {
+        "@babel/highlight": {
           "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.5.tgz",
+          "integrity": "sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -1746,57 +2008,187 @@
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-      "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.14.5",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
+        "@babel/code-frame": {
           "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+          "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
-        "@babel/types": {
+        "@babel/highlight": {
           "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.5.tgz",
+          "integrity": "sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-      "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
         "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         }
@@ -1841,31 +2233,161 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
+        "@babel/code-frame": {
           "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+          "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
           "dev": true
         },
-        "@babel/types": {
+        "@babel/highlight": {
           "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.15.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.5.tgz",
+          "integrity": "sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -2000,6 +2522,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.9.tgz",
+      "integrity": "sha512-l666wCVYO75mlAtGFfyFwnWmIXQm3kSH0C3IRnJqWcZbWkoihyAdDhFm2ZWaxWTqvBvhVFfJjMRQ0ez4oN1yYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5"
       }
     },
     "@babel/runtime": {
@@ -4264,6 +4795,112 @@
         }
       }
     },
+    "babel-loader": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
+      "integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^3.3.1",
+        "loader-utils": "^1.4.0",
+        "make-dir": "^3.1.0",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "find-cache-dir": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+          "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -4741,16 +5378,24 @@
       }
     },
     "browserslist": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
+      "integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001219",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.723",
+        "caniuse-lite": "^1.0.30001254",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.830",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.71"
+        "node-releases": "^1.1.75"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+          "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+          "dev": true
+        }
       }
     },
     "bs-logger": {
@@ -4901,9 +5546,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001245",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-      "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+      "version": "1.0.30001255",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
+      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
       "dev": true
     },
     "caseless": {
@@ -6125,9 +6770,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.776",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.776.tgz",
-      "integrity": "sha512-V0w7eFSBoFPpdw4xexjVPZ770UDZIevSwkkj4W97XbE3IsCsTRFpa7/yXGZ88EOQAUEA09JMMsWK0xsw0kRAYw==",
+      "version": "1.3.833",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.833.tgz",
+      "integrity": "sha512-h+9aVaUHjyunLqtCjJF2jrJ73tYcJqo2cCGKtVAXH9WmnBsb8hiChRQ0P1uXjdxR6Wcfxibephy41c1YlZA/pA==",
       "dev": true
     },
     "elliptic": {
@@ -11426,9 +12071,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
     },
     "node-sass": {
@@ -12844,6 +13489,21 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
@@ -12866,6 +13526,43 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexpu-core": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.9.tgz",
+      "integrity": "sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
@@ -14871,9 +15568,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uglify-js": {
@@ -14890,6 +15587,34 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+      "dev": true
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
     "union-value": {

--- a/lara-typescript/package.json
+++ b/lara-typescript/package.json
@@ -78,6 +78,8 @@
   },
   "homepage": "https://github.com/concord-consortium/lara/tree/master/lara-typescript#readme",
   "devDependencies": {
+    "@babel/core": "^7.15.5",
+    "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
     "@testing-library/react": "^12.0.0",
     "@testing-library/react-hooks": "^7.0.1",
     "@types/deep-freeze": "^0.1.2",
@@ -91,6 +93,7 @@
     "@types/react-tabs": "^2.3.3",
     "@types/uuid": "^8.3.1",
     "babel-core": "^6.26.3",
+    "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^6.4.1",
     "cpx": "^1.5.0",
     "css-loader": "^5.2.7",
@@ -120,13 +123,13 @@
     "tslint-react-hooks": "^2.2.2",
     "typedoc": "0.17.0-3",
     "typedoc-plugin-markdown": "^2.4.2",
-    "typescript": "^4.3.5",
+    "typescript": "^4.4.2",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.27.0",
-    "@aws-sdk/s3-request-presigner": "^3.27.0",
+    "@aws-sdk/client-s3": "^3.30.0",
+    "@aws-sdk/s3-request-presigner": "^3.30.0",
     "@concord-consortium/interactive-api-host": "^0.3.0",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@concord-consortium/token-service": "^2.1.0",

--- a/lara-typescript/webpack.config.js
+++ b/lara-typescript/webpack.config.js
@@ -36,11 +36,30 @@ module.exports = (env, argv) => {
             {
               loader: 'tslint-loader'
             }
-          ]
+          ],
+          exclude: /node_modules/
         },
         {
           test: /\.tsx?$/,
-          loader: 'ts-loader'
+          loader: 'ts-loader',
+          exclude: /node_modules/
+        },
+        // PJ 9/9/2021: Why is Babel necessary if there's TS loader and tsconfig specifies ES5 target?
+        // TS doesn't transform regexp named capture groups added in ES2018. This breaks Rails assets compilation.
+        // Uglifier that is not able to parse the updated regexp format. Note that this loader is applied both to our
+        // own code and node_modules. The problematic regexp is in AWS S3 Client.
+        // See: https://github.com/microsoft/TypeScript/issues/36132
+        {
+          test: /\.(t|j)sx?$/,
+          enforce: 'post',
+          use: [
+            {
+              loader: 'babel-loader',
+              options: {
+                plugins: ['@babel/plugin-transform-named-capturing-groups-regex']
+              }
+            }
+          ]
         },
         {
           test: /\.s?css$/,

--- a/public/example-interactive/index.js
+++ b/public/example-interactive/index.js
@@ -44842,14 +44842,14 @@ var authoring_1 = __webpack_require__(/*! ./authoring */ "./src/example-interact
 var report_1 = __webpack_require__(/*! ./report */ "./src/example-interactive/src/components/report.tsx");
 var runtime_1 = __webpack_require__(/*! ./runtime */ "./src/example-interactive/src/components/runtime.tsx");
 var AppComponent = function (props) {
-    var initMessage = interactive_api_client_1.useInitMessage();
+    var initMessage = (0, interactive_api_client_1.useInitMessage)();
     // TODO: this should really be moved into a client hook file so it can be reused
     useEffect(function () {
         if (initMessage) {
             var body_1 = document.getElementsByTagName("BODY")[0];
             var updateHeight_1 = function () {
                 if (body_1 && body_1.clientHeight) {
-                    interactive_api_client_1.setHeight(body_1.clientHeight);
+                    (0, interactive_api_client_1.setHeight)(body_1.clientHeight);
                 }
             };
             var observer_1 = new resize_observer_polyfill_1.default(function () { return updateHeight_1(); });
@@ -44861,7 +44861,7 @@ var AppComponent = function (props) {
     }, [initMessage]);
     useEffect(function () {
         if (initMessage) {
-            interactive_api_client_1.setSupportedFeatures({
+            (0, interactive_api_client_1.setSupportedFeatures)({
                 authoredState: true,
                 interactiveState: true
             });
@@ -44937,8 +44937,8 @@ var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var client = __webpack_require__(/*! ../../../../interactive-api-client */ "./src/interactive-api-client/index.ts");
 var GetInteractiveListComponent = function (_a) {
     var setError = _a.setError, setOutput = _a.setOutput;
-    var scopeRef = react_1.useRef(null);
-    var supportsSnapshotsRef = react_1.useRef(null);
+    var scopeRef = (0, react_1.useRef)(null);
+    var supportsSnapshotsRef = (0, react_1.useRef)(null);
     var handleCall = function () { return __awaiter(void 0, void 0, void 0, function () {
         var scope, supportsSnapshotsValue, supportsSnapshots, _a, err_1;
         var _b, _c;
@@ -45038,8 +45038,8 @@ var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var client = __webpack_require__(/*! ../../../../interactive-api-client */ "./src/interactive-api-client/index.ts");
 var SetLinkedInteractivesComponent = function (_a) {
     var setError = _a.setError, setOutput = _a.setOutput;
-    var linkedInteractivesRef = react_1.useRef(null);
-    var linkedStateRef = react_1.useRef(null);
+    var linkedInteractivesRef = (0, react_1.useRef)(null);
+    var linkedStateRef = (0, react_1.useRef)(null);
     var handleCall = function () { return __awaiter(void 0, void 0, void 0, function () {
         var linkedInteractives, linkedInteractivesValue, linkedState, linkedStateValue;
         var _a, _b;
@@ -45105,10 +45105,10 @@ var get_interactive_list_1 = __webpack_require__(/*! ./authoring-apis/get-intera
 var set_linked_interactives_1 = __webpack_require__(/*! ./authoring-apis/set-linked-interactives */ "./src/example-interactive/src/components/authoring-apis/set-linked-interactives.tsx");
 var AuthoringComponent = function (_a) {
     var initMessage = _a.initMessage;
-    var _b = react_1.useState("getInteractiveList"), selectedAuthoringApi = _b[0], setSelectedAuthoringApi = _b[1];
-    var _c = react_1.useState(), authoringApiError = _c[0], setAuthoringApiError = _c[1];
-    var _d = react_1.useState(), authoringApiOutput = _d[0], setAuthoringApiOutput = _d[1];
-    var _e = interactive_api_client_1.useAuthoredState(), authoredState = _e.authoredState, setAuthoredState = _e.setAuthoredState;
+    var _b = (0, react_1.useState)("getInteractiveList"), selectedAuthoringApi = _b[0], setSelectedAuthoringApi = _b[1];
+    var _c = (0, react_1.useState)(), authoringApiError = _c[0], setAuthoringApiError = _c[1];
+    var _d = (0, react_1.useState)(), authoringApiOutput = _d[0], setAuthoringApiOutput = _d[1];
+    var _e = (0, interactive_api_client_1.useAuthoredState)(), authoredState = _e.authoredState, setAuthoredState = _e.setAuthoredState;
     var handleClearAuthoringApiError = function () { return setAuthoringApiError(undefined); };
     var handleClearAuthoringApiOutput = function () { return setAuthoringApiOutput(undefined); };
     var handleAuthoringApiChange = function (e) {
@@ -45191,10 +45191,14 @@ exports.ReportComponent = ReportComponent;
 
 "use strict";
 
-var __spreadArray = (this && this.__spreadArray) || function (to, from) {
-    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
-        to[j] = from[i];
-    return to;
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.RuntimeComponent = void 0;
@@ -45209,10 +45213,10 @@ var RuntimeComponent = function (_a) {
     var _c = useState("interactive_123"), snapshotSourceId = _c[0], setSnapshotSourceId = _c[1];
     var _d = useState(), snapshotUrl = _d[0], setSnapshotUrl = _d[1];
     var authoredState = initMessage.authoredState;
-    var _e = use_glossary_decoration_1.useGlossaryDecoration(), decorateOptions = _e[0], decorateClassName = _e[1];
+    var _e = (0, use_glossary_decoration_1.useGlossaryDecoration)(), decorateOptions = _e[0], decorateClassName = _e[1];
     useEffect(function () {
         if (authoredState === null || authoredState === void 0 ? void 0 : authoredState.firebaseApp) {
-            interactive_api_client_1.getFirebaseJwt(authoredState.firebaseApp)
+            (0, interactive_api_client_1.getFirebaseJwt)(authoredState.firebaseApp)
                 .then(function (response) {
                 setRawFirebaseJWT(response.token);
             })
@@ -45222,15 +45226,15 @@ var RuntimeComponent = function (_a) {
         }
     }, [authoredState]);
     var _f = useState([]), customMessages = _f[0], setCustomMessages = _f[1];
-    interactive_api_client_1.useCustomMessages(function (msg) {
-        setCustomMessages(function (messages) { return __spreadArray(__spreadArray([], messages), [msg]); });
+    (0, interactive_api_client_1.useCustomMessages)(function (msg) {
+        setCustomMessages(function (messages) { return __spreadArray(__spreadArray([], messages, true), [msg], false); });
     }, { "*": true });
     var handleSnapshotTargetChange = function (event) {
         setSnapshotSourceId(event.target.value);
     };
     var handleTakeSnapshot = function () {
         setSnapshotUrl("");
-        interactive_api_client_1.getInteractiveSnapshot({ interactiveItemId: snapshotSourceId }).then(function (response) {
+        (0, interactive_api_client_1.getInteractiveSnapshot)({ interactiveItemId: snapshotSourceId }).then(function (response) {
             if (response.success) {
                 setSnapshotUrl(response.snapshotUrl);
             }
@@ -45309,7 +45313,7 @@ exports.renderHTML = void 0;
 var DOMPurify = __webpack_require__(/*! dompurify */ "./node_modules/dompurify/dist/purify.js");
 var html_react_parser_1 = __webpack_require__(/*! html-react-parser */ "./node_modules/html-react-parser/index.mjs");
 function renderHTML(html) {
-    return html_react_parser_1.default(DOMPurify.sanitize(html || ""));
+    return (0, html_react_parser_1.default)(DOMPurify.sanitize(html || ""));
 }
 exports.renderHTML = renderHTML;
 
@@ -45333,19 +45337,19 @@ var text_decorator_1 = __webpack_require__(/*! @concord-consortium/text-decorato
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var kClassName = "text-decorate";
 var useGlossaryDecoration = function () {
-    var _a = react_1.useState({ words: [], replace: "" }), options = _a[0], setOptions = _a[1];
-    var _b = react_1.useState(), listeners = _b[0], setListeners = _b[1];
-    interactive_api_client_1.useDecorateContent(function (msg) {
+    var _a = (0, react_1.useState)({ words: [], replace: "" }), options = _a[0], setOptions = _a[1];
+    var _b = (0, react_1.useState)(), listeners = _b[0], setListeners = _b[1];
+    (0, interactive_api_client_1.useDecorateContent)(function (msg) {
         var msgOptions = {
             words: msg.words,
-            replace: render_html_1.renderHTML(msg.replace),
+            replace: (0, render_html_1.renderHTML)(msg.replace),
         };
         setOptions(msgOptions);
         setListeners(msg.eventListeners);
     });
-    react_1.useEffect(function () {
-        listeners && text_decorator_1.addEventListeners(kClassName, listeners);
-        return function () { return listeners && text_decorator_1.removeEventListeners(kClassName, listeners); };
+    (0, react_1.useEffect)(function () {
+        listeners && (0, text_decorator_1.addEventListeners)(kClassName, listeners);
+        return function () { return listeners && (0, text_decorator_1.removeEventListeners)(kClassName, listeners); };
     });
     return [options, kClassName];
 };
@@ -45429,7 +45433,7 @@ var THROW_NOT_IMPLEMENTED_YET = function (method) {
     throw new Error(method + " is not yet implemented in the client!");
 };
 var getInitInteractiveMessage = function () {
-    var client = client_1.getClient();
+    var client = (0, client_1.getClient)();
     return new Promise(function (resolve) {
         if (client.managedState.initMessage) {
             resolve(client.managedState.initMessage);
@@ -45441,11 +45445,11 @@ var getInitInteractiveMessage = function () {
 };
 exports.getInitInteractiveMessage = getInitInteractiveMessage;
 var getMode = function () {
-    return exports.getInitInteractiveMessage().then(function (initInteractiveMessage) { return initInteractiveMessage === null || initInteractiveMessage === void 0 ? void 0 : initInteractiveMessage.mode; });
+    return (0, exports.getInitInteractiveMessage)().then(function (initInteractiveMessage) { return initInteractiveMessage === null || initInteractiveMessage === void 0 ? void 0 : initInteractiveMessage.mode; });
 };
 exports.getMode = getMode;
 var getInteractiveState = function () {
-    return client_1.getClient().managedState.interactiveState;
+    return (0, client_1.getClient)().managedState.interactiveState;
 };
 exports.getInteractiveState = getInteractiveState;
 var setInteractiveStateTimeoutId;
@@ -45469,7 +45473,7 @@ exports.setInteractiveStateTimeout = 2000; // ms
  * ```
  */
 var setInteractiveState = function (newInteractiveState) {
-    var client = client_1.getClient();
+    var client = (0, client_1.getClient)();
     client.managedState.interactiveState = newInteractiveState;
     window.clearTimeout(setInteractiveStateTimeoutId);
     delayedInteractiveStateUpdate = function () {
@@ -45495,7 +45499,7 @@ var flushStateUpdates = function () {
 };
 exports.flushStateUpdates = flushStateUpdates;
 var getAuthoredState = function () {
-    return client_1.getClient().managedState.authoredState;
+    return (0, client_1.getClient)().managedState.authoredState;
 };
 exports.getAuthoredState = getAuthoredState;
 /**
@@ -45516,13 +45520,13 @@ exports.getAuthoredState = getAuthoredState;
  * ```
  */
 var setAuthoredState = function (newAuthoredState) {
-    var client = client_1.getClient();
+    var client = (0, client_1.getClient)();
     client.managedState.authoredState = newAuthoredState;
     client.post("authoredState", newAuthoredState);
 };
 exports.setAuthoredState = setAuthoredState;
 var getGlobalInteractiveState = function () {
-    return client_1.getClient().managedState.globalInteractiveState;
+    return (0, client_1.getClient)().managedState.globalInteractiveState;
 };
 exports.getGlobalInteractiveState = getGlobalInteractiveState;
 /**
@@ -45543,25 +45547,25 @@ exports.getGlobalInteractiveState = getGlobalInteractiveState;
  * ```
  */
 var setGlobalInteractiveState = function (newGlobalState) {
-    var client = client_1.getClient();
+    var client = (0, client_1.getClient)();
     client.managedState.globalInteractiveState = newGlobalState;
     client.post("interactiveStateGlobal", newGlobalState);
 };
 exports.setGlobalInteractiveState = setGlobalInteractiveState;
 var addCustomMessageListener = function (callback, handles) {
-    client_1.getClient().addCustomMessageListener(callback, handles);
+    (0, client_1.getClient)().addCustomMessageListener(callback, handles);
 };
 exports.addCustomMessageListener = addCustomMessageListener;
 var removeCustomMessageListener = function () {
-    client_1.getClient().removeCustomMessageListener();
+    (0, client_1.getClient)().removeCustomMessageListener();
 };
 exports.removeCustomMessageListener = removeCustomMessageListener;
 var addDecorateContentListener = function (callback) {
-    client_1.getClient().addDecorateContentListener(callback);
+    (0, client_1.getClient)().addDecorateContentListener(callback);
 };
 exports.addDecorateContentListener = addDecorateContentListener;
 var removeDecorateContentListener = function () {
-    client_1.getClient().removeDecorateContentListener();
+    (0, client_1.getClient)().removeDecorateContentListener();
 };
 exports.removeDecorateContentListener = removeDecorateContentListener;
 var setSupportedFeatures = function (features) {
@@ -45569,15 +45573,15 @@ var setSupportedFeatures = function (features) {
         apiVersion: 1,
         features: features
     };
-    client_1.getClient().setSupportedFeatures(request);
+    (0, client_1.getClient)().setSupportedFeatures(request);
 };
 exports.setSupportedFeatures = setSupportedFeatures;
 var setHeight = function (height) {
-    client_1.getClient().post("height", height);
+    (0, client_1.getClient)().post("height", height);
 };
 exports.setHeight = setHeight;
 var postDecoratedContentEvent = function (msg) {
-    client_1.getClient().post("decoratedContentEvent", msg);
+    (0, client_1.getClient)().post("decoratedContentEvent", msg);
 };
 exports.postDecoratedContentEvent = postDecoratedContentEvent;
 /*
@@ -45585,11 +45589,11 @@ exports.postDecoratedContentEvent = postDecoratedContentEvent;
  */
 var setHint = function (hint) {
     var request = { text: hint };
-    client_1.getClient().post("hint", request);
+    (0, client_1.getClient)().post("hint", request);
 };
 exports.setHint = setHint;
 var setNavigation = function (options) {
-    client_1.getClient().post("navigation", options);
+    (0, client_1.getClient)().post("navigation", options);
 };
 exports.setNavigation = setNavigation;
 var getAuthInfo = function () {
@@ -45597,7 +45601,7 @@ var getAuthInfo = function () {
         var listener = function (authInfo) {
             resolve(authInfo);
         };
-        var client = client_1.getClient();
+        var client = (0, client_1.getClient)();
         var requestId = client.getNextRequestId();
         var request = {
             requestId: requestId
@@ -45609,7 +45613,7 @@ var getAuthInfo = function () {
 exports.getAuthInfo = getAuthInfo;
 var getFirebaseJwt = function (firebaseApp) {
     return new Promise(function (resolve, reject) {
-        exports.getInitInteractiveMessage().then(function (initMsg) {
+        (0, exports.getInitInteractiveMessage)().then(function (initMsg) {
             var _a, _b;
             if (((_b = (_a = initMsg === null || initMsg === void 0 ? void 0 : initMsg.hostFeatures) === null || _a === void 0 ? void 0 : _a.getFirebaseJwt) === null || _b === void 0 ? void 0 : _b.version) === "1.0.0") {
                 var listener = function (response) {
@@ -45629,7 +45633,7 @@ var getFirebaseJwt = function (firebaseApp) {
                         reject("Empty token");
                     }
                 };
-                var client = client_1.getClient();
+                var client = (0, client_1.getClient)();
                 var requestId = client.getNextRequestId();
                 var request = {
                     requestId: requestId,
@@ -45646,42 +45650,42 @@ var getFirebaseJwt = function (firebaseApp) {
 };
 exports.getFirebaseJwt = getFirebaseJwt;
 var log = function (action, data) {
-    client_1.getClient().post("log", { action: action, data: data });
+    (0, client_1.getClient)().post("log", { action: action, data: data });
 };
 exports.log = log;
 // tslint:disable-next-line:max-line-length
 var addInteractiveStateListener = function (listener) {
-    client_1.getClient().managedState.on("interactiveStateUpdated", listener);
+    (0, client_1.getClient)().managedState.on("interactiveStateUpdated", listener);
 };
 exports.addInteractiveStateListener = addInteractiveStateListener;
 // tslint:disable-next-line:max-line-length
 var removeInteractiveStateListener = function (listener) {
-    client_1.getClient().managedState.off("interactiveStateUpdated", listener);
+    (0, client_1.getClient)().managedState.off("interactiveStateUpdated", listener);
 };
 exports.removeInteractiveStateListener = removeInteractiveStateListener;
 var addAuthoredStateListener = function (listener) {
-    client_1.getClient().managedState.on("authoredStateUpdated", listener);
+    (0, client_1.getClient)().managedState.on("authoredStateUpdated", listener);
 };
 exports.addAuthoredStateListener = addAuthoredStateListener;
 var removeAuthoredStateListener = function (listener) {
-    client_1.getClient().managedState.off("authoredStateUpdated", listener);
+    (0, client_1.getClient)().managedState.off("authoredStateUpdated", listener);
 };
 exports.removeAuthoredStateListener = removeAuthoredStateListener;
 // tslint:disable-next-line:max-line-length
 var addGlobalInteractiveStateListener = function (listener) {
-    client_1.getClient().managedState.on("globalInteractiveStateUpdated", listener);
+    (0, client_1.getClient)().managedState.on("globalInteractiveStateUpdated", listener);
 };
 exports.addGlobalInteractiveStateListener = addGlobalInteractiveStateListener;
 // tslint:disable-next-line:max-line-length
 var removeGlobalInteractiveStateListener = function (listener) {
-    client_1.getClient().managedState.off("globalInteractiveStateUpdated", listener);
+    (0, client_1.getClient)().managedState.off("globalInteractiveStateUpdated", listener);
 };
 exports.removeGlobalInteractiveStateListener = removeGlobalInteractiveStateListener;
 // Mapping between external listener and internal listener, so it's possible to remove linkedInteractiveState listeners.
 var _linkedInteractiveStateListeners = new Map();
 var addLinkedInteractiveStateListener = function (listener, options) {
-    var client = client_1.getClient();
-    var listenerId = uuid_1.v4();
+    var client = (0, client_1.getClient)();
+    var listenerId = (0, uuid_1.v4)();
     var internalListener = function (response) {
         if (response.listenerId === listenerId) {
             listener(response.interactiveState);
@@ -45699,7 +45703,7 @@ var addLinkedInteractiveStateListener = function (listener, options) {
 };
 exports.addLinkedInteractiveStateListener = addLinkedInteractiveStateListener;
 var removeLinkedInteractiveStateListener = function (listener) {
-    var client = client_1.getClient();
+    var client = (0, client_1.getClient)();
     if (_linkedInteractiveStateListeners.has(listener)) {
         var _a = _linkedInteractiveStateListeners.get(listener), internalListener = _a.internalListener, listenerId = _a.listenerId;
         // Remove local message handler. Theoretically it's not necessary if host implementation is correct
@@ -45720,23 +45724,23 @@ exports.removeLinkedInteractiveStateListener = removeLinkedInteractiveStateListe
 var showModal = function (options) {
     // Opening modal usually means reloading interactive. It's necessary to make sure that the state is up to date
     // before it happens.
-    exports.flushStateUpdates();
-    client_1.getClient().post("showModal", options);
+    (0, exports.flushStateUpdates)();
+    (0, client_1.getClient)().post("showModal", options);
 };
 exports.showModal = showModal;
 var closeModal = function (options) {
     // Opening modal usually means reloading interactive. It's necessary to make sure that the state is up to date
     // before it happens.
-    exports.flushStateUpdates();
-    client_1.getClient().post("closeModal", options);
+    (0, exports.flushStateUpdates)();
+    (0, client_1.getClient)().post("closeModal", options);
 };
 exports.closeModal = closeModal;
 var getInteractiveList = function (options) {
     return new Promise(function (resolve, reject) {
-        return exports.getMode()
+        return (0, exports.getMode)()
             .then(function (mode) {
             if (mode === "authoring") {
-                var client = client_1.getClient();
+                var client = (0, client_1.getClient)();
                 var requestId = client.getNextRequestId();
                 var request = __assign({ requestId: requestId }, options);
                 client.addListener("interactiveList", resolve, requestId);
@@ -45750,7 +45754,7 @@ var getInteractiveList = function (options) {
 };
 exports.getInteractiveList = getInteractiveList;
 var setLinkedInteractives = function (options) {
-    client_1.getClient().post("setLinkedInteractives", options);
+    (0, client_1.getClient)().post("setLinkedInteractives", options);
 };
 exports.setLinkedInteractives = setLinkedInteractives;
 var getInteractiveSnapshot = function (options) {
@@ -45758,7 +45762,7 @@ var getInteractiveSnapshot = function (options) {
         var listener = function (snapshotResponse) {
             resolve(snapshotResponse);
         };
-        var client = client_1.getClient();
+        var client = (0, client_1.getClient)();
         var requestId = client.getNextRequestId();
         var request = __assign({ requestId: requestId }, options);
         client.addListener("interactiveSnapshot", listener, requestId);
@@ -45775,7 +45779,7 @@ var getLibraryInteractiveList = function (options) {
 exports.getLibraryInteractiveList = getLibraryInteractiveList;
 var writeAttachment = function (params) {
     return new Promise(function (resolve, reject) {
-        var client = client_1.getClient();
+        var client = (0, client_1.getClient)();
         var content = params.content, _a = params.options, options = _a === void 0 ? {} : _a, others = __rest(params, ["content", "options"]);
         var _b = params.contentType, contentType = _b === void 0 ? "text/plain" : _b;
         var request = __assign(__assign({}, others), { operation: "write", requestId: client.getNextRequestId() });
@@ -45817,7 +45821,7 @@ exports.writeAttachment = writeAttachment;
 var readAttachment = function (name) {
     return new Promise(function (resolve, reject) {
         // set up response listener
-        var client = client_1.getClient();
+        var client = (0, client_1.getClient)();
         var request = { name: name, operation: "read", requestId: client.getNextRequestId() };
         client.addListener("attachmentUrl", function (response) { return __awaiter(void 0, void 0, void 0, function () {
             var _a, e_2;
@@ -45856,7 +45860,7 @@ exports.readAttachment = readAttachment;
 var getAttachmentUrl = function (name, contentType, expiresIn) {
     return new Promise(function (resolve, reject) {
         // set up response listener
-        var client = client_1.getClient();
+        var client = (0, client_1.getClient)();
         var requestId = client.getNextRequestId();
         var request = { name: name, operation: "read", contentType: contentType, expiresIn: expiresIn, requestId: requestId };
         client.addListener("attachmentUrl", function (response) { return __awaiter(void 0, void 0, void 0, function () {
@@ -45955,7 +45959,7 @@ var Client = /** @class */ (function () {
             }
             _this.post("supportedFeatures", newRequest);
         };
-        if (!in_frame_1.inIframe()) {
+        if (!(0, in_frame_1.inIframe)()) {
             // tslint:disable-next-line:no-console
             console.warn("Interactive API is meant to be used in iframe");
         }
@@ -46054,7 +46058,7 @@ var Client = /** @class */ (function () {
                                 return;
                             }
                             var clickedWord = (wordElement.textContent || "").toLowerCase();
-                            interactive_api_client_1.postDecoratedContentEvent({ type: listener.type,
+                            (0, interactive_api_client_1.postDecoratedContentEvent)({ type: listener.type,
                                 text: clickedWord,
                                 bounds: wordElement.getBoundingClientRect() });
                         }
@@ -46158,8 +46162,8 @@ var handleUpdate = function (newStateOrUpdateFunc, prevState) {
     }
 };
 var useInteractiveState = function () {
-    var _a = react_1.useState(null), interactiveState = _a[0], setInteractiveState = _a[1];
-    react_1.useEffect(function () {
+    var _a = (0, react_1.useState)(null), interactiveState = _a[0], setInteractiveState = _a[1];
+    (0, react_1.useEffect)(function () {
         setInteractiveState(client.getInteractiveState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to interactive state, this hook will receive these changes.
@@ -46181,8 +46185,8 @@ var useInteractiveState = function () {
 };
 exports.useInteractiveState = useInteractiveState;
 var useAuthoredState = function () {
-    var _a = react_1.useState(null), authoredState = _a[0], setAuthoredState = _a[1];
-    react_1.useEffect(function () {
+    var _a = (0, react_1.useState)(null), authoredState = _a[0], setAuthoredState = _a[1];
+    (0, react_1.useEffect)(function () {
         // Note that we need to update authoredState exactly in this moment, right before setting up event listeners.
         // It can't be done above using initial useState value. There's a little delay between initial render and calling
         // useEffect. If client's authoredState gets updated before the listener is added, this hook will have outdated
@@ -46211,8 +46215,8 @@ var useAuthoredState = function () {
 };
 exports.useAuthoredState = useAuthoredState;
 var useGlobalInteractiveState = function () {
-    var _a = react_1.useState(null), globalInteractiveState = _a[0], setGlobalInteractiveState = _a[1];
-    react_1.useEffect(function () {
+    var _a = (0, react_1.useState)(null), globalInteractiveState = _a[0], setGlobalInteractiveState = _a[1];
+    (0, react_1.useEffect)(function () {
         setGlobalInteractiveState(client.getGlobalInteractiveState());
         // Setup client event listeners. They will ensure that another instance of this hook (or anything else
         // using client directly) makes changes to global interactive state, this hook will receive these changes.
@@ -46236,8 +46240,8 @@ var useGlobalInteractiveState = function () {
 exports.useGlobalInteractiveState = useGlobalInteractiveState;
 // tslint:disable-next-line:max-line-length
 var useInitMessage = function () {
-    var _a = react_1.useState(null), initMessage = _a[0], setInitMessage = _a[1];
-    react_1.useEffect(function () {
+    var _a = (0, react_1.useState)(null), initMessage = _a[0], setInitMessage = _a[1];
+    (0, react_1.useEffect)(function () {
         // useEffect callback can't be async.
         (function () { return __awaiter(void 0, void 0, void 0, function () {
             var initMsg;
@@ -46256,14 +46260,14 @@ var useInitMessage = function () {
 };
 exports.useInitMessage = useInitMessage;
 var useCustomMessages = function (callback, handles) {
-    react_1.useEffect(function () {
+    (0, react_1.useEffect)(function () {
         client.addCustomMessageListener(callback, handles);
         return function () { return client.removeCustomMessageListener(); };
     }, []);
 };
 exports.useCustomMessages = useCustomMessages;
 var useDecorateContent = function (callback) {
-    react_1.useEffect(function () {
+    (0, react_1.useEffect)(function () {
         client.addDecorateContentListener(callback);
         return function () { return client.removeDecorateContentListener(); };
     }, []);


### PR DESCRIPTION
I didn't find a cleaner solution than this. babel-preset-env includes this plugin, but I tried to use it alone. Hopefully, one day TS compiler will do something similar, or we don't need to use Rails assets compilation. 