### PR TITLE
Use Portal Report instead of the summary page

### DIFF
--- a/.env-osx-sample
+++ b/.env-osx-sample
@@ -41,3 +41,6 @@ PORTAL_HOST=app.portal.docker
 REPORT_SERVICE_URL=https://us-central1-report-service-dev.cloudfunctions.net/api
 # Update to be the development token. This can be found in the Cloud Formation lara-ecs-staging stack parameters.
 #REPORT_SERVICE_TOKEN=
+
+# Report URL is used to generate student report links.
+# REPORT_URL=https://portal-report.concord.org/branch/master/index.html

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -27,11 +27,13 @@ module LightweightActivityHelper
 
   def runnable_summary_path(activity)
     report_link = ENV['REPORT_URL']
-    report_firebase_app = ENV['REPORT_SERVICE_URL'] && ENV['REPORT_SERVICE_URL'].match(/report-service-pro/) ? "report-service-pro" : "report-service-dev"
+    unless report_link
+      return nil
+    end
 
     uri = URI.parse(report_link)
     query = Rack::Utils.parse_query(uri.query)
-    query["firebase-app"] = report_firebase_app
+    query["firebase-app"] = ENV['REPORT_SERVICE_URL'] && ENV['REPORT_SERVICE_URL'].match(/report-service-pro/) ? "report-service-pro" : "report-service-dev"
     query["sourceKey"] = ReportService::Sender::source_key
 
     if !@run.user || !@run.class_info_url || !@run.platform_user_id || !@run.resource_link_id || !@run.platform_id

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -25,7 +25,7 @@ module LightweightActivityHelper
 
   def runnable_summary_path(activity)
     report_link = ENV['REPORT_URL']
-    report_firebase_app = ENV['REPORT_SERVICE_URL'].match(/report-service-pro/) ? "report-service-pro" : "report-service-dev"
+    report_firebase_app = ENV['REPORT_SERVICE_URL'] && ENV['REPORT_SERVICE_URL'].match(/report-service-pro/) ? "report-service-pro" : "report-service-dev"
     source_key = ENV['REPORT_SERVICE_TOOL_ID']
     result = ""
 

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -1,5 +1,5 @@
 module LightweightActivityHelper
-  include ReportService::Sender
+  # include ReportService::Sender
 
   def toggle_all(label='all', id_prefix='details_')
     link_to_function("show/hide #{label}", "$('div[id^=#{id_prefix}]').toggle();")
@@ -32,7 +32,7 @@ module LightweightActivityHelper
     uri = URI.parse(report_link)
     query = Rack::Utils.parse_query(uri.query)
     query["firebase-app"] = report_firebase_app
-    query["sourceKey"] = source_key # from ReportService::Sender
+    query["sourceKey"] = ReportService::Sender::source_key
 
     if !@run.user || !@run.class_info_url || !@run.platform_user_id || !@run.resource_link_id || !@run.platform_id
       # Anonymous run or a logged in user that didn't come from Portal (e.g. teacher running a preview).

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -32,35 +32,35 @@ module ReportService
 
   module Sender
 
-    def self_url
+    def self.self_url
       raise ReportService::NotConfigured.new unless ReportService::configured?
       ENV['REPORT_SERVICE_SELF_URL']
     end
 
-    def report_service_url
+    def self.report_service_url
       raise ReportService::NotConfigured.new unless ReportService::configured?
       ENV['REPORT_SERVICE_URL']
     end
 
-    def report_service_token
+    def self.report_service_token
       raise ReportService::NotConfigured.new unless ReportService::configured?
       ENV['REPORT_SERVICE_TOKEN']
     end
 
-    def tool_id
+    def self.tool_id
       if ENV['REPORT_SERVICE_TOOL_ID'].present?
         ENV['REPORT_SERVICE_TOOL_ID']
       else
-        self_url
+        self.self_url
       end
     end
 
-    def source_key
+    def self.source_key
       ReportService::make_source_key(tool_id)
     end
 
     def api_endpoint
-      "#{report_service_url}/#{api_method}"
+      "#{Sender::report_service_url}/#{api_method}"
     end
 
     def send()
@@ -69,7 +69,7 @@ module ReportService
         :body => to_json,
         :headers => {
           'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{report_service_token}"
+          'Authorization' => "Bearer #{Sender::report_service_token}"
         }
       )
     end

--- a/app/services/report_service/resource_sender.rb
+++ b/app/services/report_service/resource_sender.rb
@@ -13,13 +13,13 @@ module ReportService
     def initialize(resource, opts={})
       version = Version
       created = Time.now.utc.to_s
-      @payload = resource.serialize_for_report_service(self_url)
+      @payload = resource.serialize_for_report_service(Sender::self_url)
       type = @payload[:type]
       id = @payload[:id]
       @payload[:created] = created
       @payload[:version] = version
-      @payload[:source_key] = source_key
-      @payload[:tool_id] = tool_id
+      @payload[:source_key] = Sender::source_key
+      @payload[:tool_id] = Sender::tool_id
       @payload[:id] = ReportService::make_key(type, id)
     end
 

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -8,17 +8,17 @@ module ReportService
 
     def get_resource_url(run)
       if run.sequence_id
-        "#{self_url}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
+        "#{Sender::self_url}#{Rails.application.routes.url_helpers.sequence_path(run.sequence_id)}"
       else
-        "#{self_url}#{Rails.application.routes.url_helpers.activity_path(run.activity_id)}"
+        "#{Sender::self_url}#{Rails.application.routes.url_helpers.activity_path(run.activity_id)}"
       end
     end
 
     def add_meta_data(run, record)
       record[:version] = RunSender::Version
       record[:created] = Time.now.utc.to_s
-      record[:source_key] = source_key
-      record[:tool_id] = tool_id
+      record[:source_key] = Sender::source_key
+      record[:tool_id] = Sender::tool_id
       record[:tool_user_id] = run.user_id.to_s
       record[:platform_id] = run.platform_id
       record[:platform_user_id] = run.platform_user_id
@@ -64,7 +64,7 @@ module ReportService
     # +opts+:: _send_all_answers_ by default only send changed answers.
     def initialize(run, opts={ send_all_answers: false} )
       @send_all_answers = opts[:send_all_answers]
-      url = "#{self_url}#{Rails.application.routes.url_helpers.run_path(run)}"
+      url = "#{Sender::self_url}#{Rails.application.routes.url_helpers.run_path(run)}"
       @payload = {
         id: run.key,
         url: url,

--- a/app/views/interactive_pages/show.html.haml
+++ b/app/views/interactive_pages/show.html.haml
@@ -30,7 +30,7 @@
     .button-center
       - if @page.last_visible? && @page.lightweight_activity.student_report_enabled
         .submit.report
-          %a{ :href => runnable_summary_path(@page.lightweight_activity), :class => 'gen-report', :target => 'new' }
+          %a{ :href => runnable_summary_path(@page.lightweight_activity), :class => 'gen-report', :target => '_blank' }
             %input{ :class => 'button', :type => 'submit', :value => t("GENERATE_A_REPORT") }
     .button-right
       - if @page.last_visible? && next_activity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       REPORT_SERVICE_URL:
       REPORT_SERVICE_SELF_URL: "${LARA_PROTOCOL:-http}://${LARA_HOST:-app.lara.docker}"
       REPORT_SERVICE_TOOL_ID: "${LARA_HOST:-app.lara.docker}.${USER}"
+      REPORT_URL: "${REPORT_URL:-https://portal-report.concord.org/branch/master/index.html}"
       SECRET_TOKEN: b30c94c7-81b7-4f20-8df9-686b079a616a
       SHUTTERBUG_URI:
       # Enables logging to stdout instead of file.

--- a/spec/controllers/interactive_page_controller_spec.rb
+++ b/spec/controllers/interactive_page_controller_spec.rb
@@ -186,7 +186,6 @@ describe InteractivePagesController do
       get :show, :id => page1.id, :run_key => ar.key
 
       expect(response.body).to match /<div class='related-mod'>/
-      expect(response.body).to match /href='\/activities\/#{act.id}\/summary\/#{ar.key}'/
     end
 
     it 'does not show related content on pages other than the last page' do

--- a/spec/helpers/lightweight_activity_helper_spec.rb
+++ b/spec/helpers/lightweight_activity_helper_spec.rb
@@ -116,11 +116,11 @@ describe LightweightActivityHelper do
       it "returns Portal Report URL with runKey param" do
         expect(helper.runnable_summary_path(activity)).to eq(
           "https://portal-report.concord.org/branch/master/index.html?" +
-          "runKey=012345678901234567890123456789123456&" +
-          "activity=http://test.host/activities/23&" +
-          "resourceUrl=http://test.host/activities/23&" +
           "firebase-app=report-service-dev&" +
-          "sourceKey=authoring.test.concord.org"
+          "sourceKey=authoring.test.concord.org&" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
+          "resourceUrl=http%3A%2F%2Ftest.host%2Factivities%2F23"
         )
       end
     end
@@ -147,13 +147,13 @@ describe LightweightActivityHelper do
         puts helper.runnable_summary_path(activity)
         expect(helper.runnable_summary_path(activity)).to eq(
           "https://portal-report.concord.org/branch/master/index.html?" +
-          "class=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fclasses%2F123&" +
           "firebase-app=report-service-dev&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "class=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fclasses%2F123&" +
           "offering=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fofferings%2F321&" +
           "reportType=offering&" +
           "studentId=ABC&" +
-          "sourceKey=authoring.test.concord.org&" +
-          "auth-domain=https://test.portal.com"
+          "auth-domain=https%3A%2F%2Ftest.portal.com"
         )
       end
     end
@@ -166,11 +166,11 @@ describe LightweightActivityHelper do
       it "sets firebase-app to report-service-pro" do
         expect(helper.runnable_summary_path(activity)).to eq(
           "https://portal-report.concord.org/branch/master/index.html?" +
-          "runKey=012345678901234567890123456789123456&" +
-          "activity=http://test.host/activities/23&" +
-          "resourceUrl=http://test.host/activities/23&" +
           "firebase-app=report-service-pro&" +
-          "sourceKey=authoring.test.concord.org"
+          "sourceKey=authoring.test.concord.org&" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
+          "resourceUrl=http%3A%2F%2Ftest.host%2Factivities%2F23"
         )
       end
     end
@@ -183,11 +183,11 @@ describe LightweightActivityHelper do
       it "adds activityIndex param" do
         expect(helper.runnable_summary_path(activity)).to eq(
           "https://portal-report.concord.org/branch/master/index.html?" +
-          "runKey=012345678901234567890123456789123456&" +
-          "activity=http://test.host/sequences/1&" +
-          "resourceUrl=http://test.host/sequences/1&" +
           "firebase-app=report-service-dev&" +
           "sourceKey=authoring.test.concord.org&" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http%3A%2F%2Ftest.host%2Fsequences%2F1&" +
+          "resourceUrl=http%3A%2F%2Ftest.host%2Fsequences%2F1&" +
           "activityIndex=0"
         )
       end

--- a/spec/helpers/lightweight_activity_helper_spec.rb
+++ b/spec/helpers/lightweight_activity_helper_spec.rb
@@ -6,14 +6,14 @@ describe LightweightActivityHelper do
   let(:sequence)     { FactoryGirl.create(:sequence, id: 1, title: "Test Sequence", lightweight_activities: [activity])}
   let(:user)         { FactoryGirl.create(:user) }
   let(:sequence_run) { FactoryGirl.create(:sequence_run, sequence_id: sequence.id, user_id: user.id) }
-  let(:run)          { FactoryGirl.create(:run, {key: "012345678901234567890123456789123456", sequence_run: sequence_run, activity: activity, user: user})}
+  let(:run)          { FactoryGirl.create(:run, {key: "012345678901234567890123456789123456", sequence_run: sequence_run, activity: activity})}
   let(:sequence_path_with_run){ "/sequences/1/activities/23/012345678901234567890123456789123456" }
   let(:sequence_path){ "/sequences/1/activities/23" }
   let(:path_no_run)  { "/activities/23" }
 
-  subject { helper.runnable_activity_path(activity) }
-
   describe "#runnable_activity_path" do
+    subject { helper.runnable_activity_path(activity) }
+
     describe "with a sequence and sequence run" do
       it "should use the sequence with run path" do
         assign(:run, run)
@@ -75,19 +75,19 @@ describe LightweightActivityHelper do
   end
 
   describe "#itsi_preview_url" do
-  context "with an activity player runtime preview" do
-    it "returns an activity player url" do
-      url = "https://activity-player.concord.org/branch/master" +
-        "?activity=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Factivities%2F#{activity_player_activity.id}.json&preview"
-      expect(helper.itsi_preview_url(activity_player_activity)).to eq(url)
+    context "with an activity player runtime preview" do
+      it "returns an activity player url" do
+        url = "https://activity-player.concord.org/branch/master" +
+          "?activity=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Factivities%2F#{activity_player_activity.id}.json&preview"
+        expect(helper.itsi_preview_url(activity_player_activity)).to eq(url)
+      end
+    end
+    context "with a LARA runtime preview" do
+      it "returns a LARA url" do
+        expect(helper.itsi_preview_url(activity)).to eq("/activities/#{activity.id}/preview")
+      end
     end
   end
-  context "with a LARA runtime preview" do
-    it "returns a LARA url" do
-      expect(helper.itsi_preview_url(activity)).to eq("/activities/#{activity.id}/preview")
-    end
-  end
-end
 
   describe "#runtime_url" do
     context "with an activity player runtime" do
@@ -100,6 +100,96 @@ end
     context "with a LARA runtime" do
       it "returns a LARA url" do
         expect(helper.runtime_url(activity)).to eq("/activities/#{activity.id}")
+      end
+    end
+  end
+
+  describe "#runnable_summary_path" do
+    before(:each) do
+      assign(:run, run)
+      allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("https://us-central1-report-service-dev.cloudfunctions.net/api")
+      allow(ENV).to receive(:[]).with("REPORT_URL").and_return("https://portal-report.concord.org/branch/master/index.html")
+      allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return("authoring.test.concord.org")
+    end
+
+    describe "when the run is anonymous or doesn't include Portal info" do
+      it "returns Portal Report URL with runKey param" do
+        expect(helper.runnable_summary_path(activity)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http://test.host/activities/23&" +
+          "resourceUrl=http://test.host/activities/23&" +
+          "firebase-app=report-service-dev&" +
+          "sourceKey=authoring.test.concord.org"
+        )
+      end
+    end
+
+    describe "when the run has Portal info" do
+      let(:run_with_portal_info) do
+        FactoryGirl.create(:run, {
+          key: "012345678901234567890123456789123456",
+          sequence_run: sequence_run,
+          activity: activity,
+          user: user,
+          class_info_url: "https://test.portal.com/api/v1/classes/123",
+          platform_id: "https://test.portal.com",
+          platform_user_id: "ABC",
+          resource_link_id: "321"
+        })
+      end
+
+      before(:each) do
+        assign(:run, run_with_portal_info)
+      end
+
+      it "returns Portal Report URL with runKey param" do
+        puts helper.runnable_summary_path(activity)
+        expect(helper.runnable_summary_path(activity)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "class=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fclasses%2F123&" +
+          "firebase-app=report-service-dev&" +
+          "offering=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fofferings%2F321&" +
+          "reportType=offering&" +
+          "studentId=ABC&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "auth-domain=https://test.portal.com"
+        )
+      end
+    end
+
+    describe "when REPORT_SERVICE_URL points to production Report Service" do
+      before(:each) do
+        allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("https://us-central1-report-service-pro.cloudfunctions.net/api")
+      end
+
+      it "sets firebase-app to report-service-pro" do
+        expect(helper.runnable_summary_path(activity)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http://test.host/activities/23&" +
+          "resourceUrl=http://test.host/activities/23&" +
+          "firebase-app=report-service-pro&" +
+          "sourceKey=authoring.test.concord.org"
+        )
+      end
+    end
+
+    describe "when user is running a sequence" do
+      before(:each) do
+        assign(:sequence, sequence)
+      end
+
+      it "adds activityIndex param" do
+        expect(helper.runnable_summary_path(activity)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http://test.host/sequences/1&" +
+          "resourceUrl=http://test.host/sequences/1&" +
+          "firebase-app=report-service-dev&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "activityIndex=0"
+        )
       end
     end
   end


### PR DESCRIPTION
[#179499612]

The URL generation is partially based on AP code:
https://github.com/concord-consortium/activity-player/blob/master/src/utilities/report-utils.ts
I didn't hardcode the report URL, but added a new ENV variable instead.

Some URL params are encoded, some are not. I've followed AP pattern. I don't want to break Report assumptions about that. But maybe all the URLs should be encoded? 

Also, I'm adding `activityIndex` URL param when there's a sequence. The old LARA summary was always showing only one activity. Based on the places where these links are, I think this makes more sense. AP doesn't seem to do it, but not sure if it's intended or it's just missing.

I'll open a separate PR with the dead code removed (=> https://github.com/concord-consortium/lara/pull/764).