### PR TITLE
Change to the  Mysql2Adaptor to modify SQL generated for ids

### DIFF
--- a/config/initializers/abstract_mysql_adapter.rb
+++ b/config/initializers/abstract_mysql_adapter.rb
@@ -1,0 +1,5 @@
+require 'active_record/connection_adapters/abstract_mysql_adapter'
+
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+end


### PR DESCRIPTION

# Change to the Mysql2Adaptor to modify SQL generated for ids

Based on this [slack discussion](https://concord-consortium.slack.com/archives/C0M5CM1RA/p1631638686130500?thread_ts=1631628873.128600&cid=C0M5CM1RA)

The migration should produce this SQL:

```
CREATE TABLE `sections` (`id` int(11) auto_increment PRIMARY KEY, `title` varchar(255), `show` tinyint(1), `layout` varchar(255), `position` int(11), `interactive_page_id` int(11), `can_collapse_small` tinyint(1), `created_at` datetime NOT NULL, `updated_at` datetime NOT NULL) ENGINE=InnoD
```