### PR TITLE
Deploy storybook

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
         working-directory: lara-typescript
-      - uses: concord-consortium/s3-deploy-action@add-more-flexibility
+      - uses: concord-consortium/s3-deploy-action@v1
         with:
           bucket: models-resources
           prefix: lara-storybook

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,22 @@
+name: Deploy Storybook
+
+on: push
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - name: Install Dependencies
+        run: npm ci
+      - uses: concord-consortium/s3-deploy-action@add-flexibility
+        with:
+          bucket: models-resources
+          prefix: lara-storybook
+          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          workingDirectory: lara-typescript
+          build: npm run build-storybook
+          folderToDeploy: storybook-static

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
       - name: Install Dependencies
         run: npm ci
+        working-directory: lara-typescript
       - uses: concord-consortium/s3-deploy-action@add-more-flexibility
         with:
           bucket: models-resources

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
       - name: Install Dependencies
         run: npm ci
-      - uses: concord-consortium/s3-deploy-action@add-flexibility
+      - uses: concord-consortium/s3-deploy-action@add-more-flexibility
         with:
           bucket: models-resources
           prefix: lara-storybook


### PR DESCRIPTION
This uses the s3-deploy-action to deploy storybook to models-resources:
https://github.com/concord-consortium/s3-deploy-action/pull/86

This LARA PR currently is using a branch of the s3-deploy-action code. I'm hoping I can get that s3-deploy-action branch merged shortly, and then I'll update this PR to refer to a tagged version of the s3-deploy-action code.