### PR TITLE
Add external_report_url to InteractiveRunState JSON, update Plugin API to use it as reporting_url

### DIFF
--- a/app/assets/javascripts/lara-typescript.js
+++ b/app/assets/javascripts/lara-typescript.js
@@ -44760,7 +44760,13 @@ var getReportingUrl = function (interactiveStateUrl, interactiveStatePromise) {
       var rawJSON = JSON.parse(interactiveState.raw_data);
 
       if (rawJSON && rawJSON.lara_options && rawJSON.lara_options.reporting_url) {
+        // Interactive has its own reporting_url
         return rawJSON.lara_options.reporting_url;
+      } // Use a generic Portal Report URL
+
+
+      if (interactiveState.external_report_url) {
+        return interactiveState.external_report_url;
       }
 
       return null;

--- a/app/controllers/api/v1/interactive_run_states_controller.rb
+++ b/app/controllers/api/v1/interactive_run_states_controller.rb
@@ -6,9 +6,9 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
 
   def show
     begin
-      authorize! :show, @run
+      authorize! :show, @interactive_run_state
 
-      render :json => @run.to_runtime_json(request.protocol, request.host_with_port)
+      render :json => @interactive_run_state.to_runtime_json(request.protocol, request.host_with_port)
     rescue CanCan::AccessDenied
       authorization_error("get")
     end
@@ -16,20 +16,20 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
 
   def update
     begin
-      authorize! :update, @run
-      @run.touch # update timestamp even if no data is provided
+      authorize! :update, @interactive_run_state
+      @interactive_run_state.touch # update timestamp even if no data is provided
       if params.has_key?('raw_data')
         # Handle 'null' value, so interactive can reset / clear its state if necessary.
-        @run.raw_data = params['raw_data'] == 'null' ? nil : params['raw_data']
+        @interactive_run_state.raw_data = params['raw_data'] == 'null' ? nil : params['raw_data']
       end
       if params.has_key?('learner_url')
-        @run.learner_url = params['learner_url']
+        @interactive_run_state.learner_url = params['learner_url']
       end
       if params.has_key?('metadata')
-        @run.metadata = params['metadata']
+        @interactive_run_state.metadata = params['metadata']
       end
-      if @run.save
-        render :json => @run.to_runtime_json(request.protocol, request.host_with_port)
+      if @interactive_run_state.save
+        render :json => @interactive_run_state.to_runtime_json(request.protocol, request.host_with_port)
       else
         render :json => { :success => false }
       end
@@ -41,7 +41,7 @@ class Api::V1::InteractiveRunStatesController < ApplicationController
   private
 
   def set_interactive_run
-    @run = InteractiveRunState.find_by_key!(params['key'])
+    @interactive_run_state = InteractiveRunState.find_by_key!(params['key'])
   end
 
   def authorization_error(action)

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -26,39 +26,7 @@ module LightweightActivityHelper
   end
 
   def runnable_summary_path(activity)
-    report_link = ENV['REPORT_URL']
-    unless report_link
-      return nil
-    end
-
-    uri = URI.parse(report_link)
-    query = Rack::Utils.parse_query(uri.query)
-    query["firebase-app"] = ENV['REPORT_SERVICE_URL'] && ENV['REPORT_SERVICE_URL'].match(/report-service-pro/) ? "report-service-pro" : "report-service-dev"
-    query["sourceKey"] = ReportService::Sender::source_key
-
-    if !@run.user || !@run.class_info_url || !@run.platform_user_id || !@run.resource_link_id || !@run.platform_id
-      # Anonymous run or a logged in user that didn't come from Portal (e.g. teacher running a preview).
-      resource_url = @sequence ? sequence_url(@sequence) : activity_url(activity)
-
-      query["runKey"] = @run.key
-      query["activity"] = resource_url
-      query["resourceUrl"] = resource_url
-    else
-      offering_url = "#{@run.class_info_url.split("/classes")[0]}/offerings/#{@run.resource_link_id}"
-
-      query["class"] = @run.class_info_url
-      query["offering"] = offering_url
-      query["reportType"] = "offering"
-      query["studentId"] = @run.platform_user_id
-      query["auth-domain"] = @run.platform_id
-    end
-
-    if @sequence
-      query["activityIndex"] = @sequence.activities.index(activity)
-    end
-
-    uri.query = Rack::Utils.build_query(query)
-    uri.to_s
+    ReportService::report_url(@run, activity, @sequence)
   end
 
   def runnable_single_page_activity_path(activity, opts={})

--- a/app/models/interactive_run_state.rb
+++ b/app/models/interactive_run_state.rb
@@ -288,14 +288,15 @@ class InteractiveRunState < ActiveRecord::Base
         page_name: page && page.name,
         activity_name: activity && activity.name,
         created_at: created_at,
-        updated_at: updated_at
+        updated_at: updated_at,
+        # User activity run (not to confuse with InteractiveStateRun which could be called just InteractiveState)
+        external_report_url: ReportService::report_url(run, interactive.activity, nil, interactive)
     }
     if include_linked_states
       hash[:has_linked_interactive] = has_linked_interactive
       hash[:linked_state] = linked_state
       hash[:all_linked_states] = all_linked_states(protocol, host)
     end
-
     hash
   end
 

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -29,6 +29,52 @@ module ReportService
     ENV['REPORT_SERVICE_SELF_URL'].present?
   end
 
+  # Helper that generates activity report for given run and activity. When interactive is also provided, it limits
+  # report to a single interactive.
+  def self.report_url(run, activity, sequence = nil, interactive = nil)
+    if !run || !activity
+      return nil
+    end
+
+    report_link = ENV['REPORT_URL']
+    self_url = ENV['REPORT_SERVICE_SELF_URL']
+    if !report_link || !self_url
+      return nil
+    end
+
+    uri = URI.parse(report_link)
+    query = Rack::Utils.parse_query(uri.query)
+    query["firebase-app"] = ENV['REPORT_SERVICE_URL'] && ENV['REPORT_SERVICE_URL'].match(/report-service-pro/) ? "report-service-pro" : "report-service-dev"
+    query["sourceKey"] = ReportService::Sender::source_key
+
+    if !run.user || !run.class_info_url || !run.platform_user_id || !run.resource_link_id || !run.platform_id
+      # Anonymous run or a logged in user that didn't come from Portal (e.g. teacher running a preview).
+      resource_url = self_url + (sequence ? Rails.application.routes.url_helpers.sequence_path(sequence) : Rails.application.routes.url_helpers.activity_path(activity))
+
+      query["runKey"] = run.key
+      query["activity"] = resource_url
+      query["resourceUrl"] = resource_url
+    else
+      offering_url = "#{run.class_info_url.split("/classes")[0]}/offerings/#{run.resource_link_id}"
+
+      query["class"] = run.class_info_url
+      query["offering"] = offering_url
+      query["reportType"] = "offering"
+      query["studentId"] = run.platform_user_id
+      query["auth-domain"] = run.platform_id
+    end
+
+    if sequence
+      query["activityIndex"] = sequence.activities.index(activity)
+    end
+
+    if interactive
+      query["iframeQuestionId"] = interactive.embeddable_id
+    end
+
+    uri.query = Rack::Utils.build_query(query)
+    uri.to_s
+  end
 
   module Sender
 

--- a/docs/lara-plugin-api/interfaces/iinteractivestate.md
+++ b/docs/lara-plugin-api/interfaces/iinteractivestate.md
@@ -11,6 +11,7 @@
 ### Properties
 
 * [activity_name](iinteractivestate.md#activity_name)
+* [external_report_url](iinteractivestate.md#external_report_url)
 * [id](iinteractivestate.md#id)
 * [interactive_name](iinteractivestate.md#interactive_name)
 * [interactive_state_url](iinteractivestate.md#interactive_state_url)
@@ -22,6 +23,12 @@
 ###  activity_name
 
 • **activity_name**: *string*
+
+___
+
+###  external_report_url
+
+• **external_report_url**: *string*
 
 ___
 

--- a/lara-typescript/src/plugin-api/types.ts
+++ b/lara-typescript/src/plugin-api/types.ts
@@ -188,4 +188,5 @@ export interface IInteractiveState {
   interactive_name: string;
   interactive_state_url: string;
   activity_name: string;
+  external_report_url: string;
 }

--- a/lara-typescript/src/plugins/embeddable-runtime-context.ts
+++ b/lara-typescript/src/plugins/embeddable-runtime-context.ts
@@ -26,7 +26,12 @@ const getReportingUrl = (
     try {
       const rawJSON = JSON.parse(interactiveState.raw_data);
       if (rawJSON && rawJSON.lara_options && rawJSON.lara_options.reporting_url) {
+        // Interactive has its own reporting_url
         return rawJSON.lara_options.reporting_url;
+      }
+      // Use a generic Portal Report URL
+      if (interactiveState.external_report_url) {
+        return interactiveState.external_report_url;
       }
       return null;
     }

--- a/spec/controllers/lightweight_activity_controller_spec.rb
+++ b/spec/controllers/lightweight_activity_controller_spec.rb
@@ -263,6 +263,7 @@ describe LightweightActivitiesController do
   describe "#summary" do
       before(:each) do
         allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("http://test.host")
         allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("https://us-central1-report-service-dev.cloudfunctions.net/api")
         allow(ENV).to receive(:[]).with("REPORT_URL").and_return("https://portal-report.concord.org/branch/master/index.html")
         allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return("authoring.test.concord.org")

--- a/spec/helpers/lightweight_activity_helper_spec.rb
+++ b/spec/helpers/lightweight_activity_helper_spec.rb
@@ -107,89 +107,20 @@ describe LightweightActivityHelper do
   describe "#runnable_summary_path" do
     before(:each) do
       assign(:run, run)
-      allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("https://us-central1-report-service-dev.cloudfunctions.net/api")
-      allow(ENV).to receive(:[]).with("REPORT_URL").and_return("https://portal-report.concord.org/branch/master/index.html")
-      allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return("authoring.test.concord.org")
     end
 
-    describe "when the run is anonymous or doesn't include Portal info" do
-      it "returns Portal Report URL with runKey param" do
-        expect(helper.runnable_summary_path(activity)).to eq(
-          "https://portal-report.concord.org/branch/master/index.html?" +
-          "firebase-app=report-service-dev&" +
-          "sourceKey=authoring.test.concord.org&" +
-          "runKey=012345678901234567890123456789123456&" +
-          "activity=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
-          "resourceUrl=http%3A%2F%2Ftest.host%2Factivities%2F23"
-        )
-      end
-    end
-
-    describe "when the run has Portal info" do
-      let(:run_with_portal_info) do
-        FactoryGirl.create(:run, {
-          key: "012345678901234567890123456789123456",
-          sequence_run: sequence_run,
-          activity: activity,
-          user: user,
-          class_info_url: "https://test.portal.com/api/v1/classes/123",
-          platform_id: "https://test.portal.com",
-          platform_user_id: "ABC",
-          resource_link_id: "321"
-        })
-      end
-
-      before(:each) do
-        assign(:run, run_with_portal_info)
-      end
-
-      it "returns Portal Report URL with runKey param" do
-        puts helper.runnable_summary_path(activity)
-        expect(helper.runnable_summary_path(activity)).to eq(
-          "https://portal-report.concord.org/branch/master/index.html?" +
-          "firebase-app=report-service-dev&" +
-          "sourceKey=authoring.test.concord.org&" +
-          "class=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fclasses%2F123&" +
-          "offering=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fofferings%2F321&" +
-          "reportType=offering&" +
-          "studentId=ABC&" +
-          "auth-domain=https%3A%2F%2Ftest.portal.com"
-        )
-      end
-    end
-
-    describe "when REPORT_SERVICE_URL points to production Report Service" do
-      before(:each) do
-        allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("https://us-central1-report-service-pro.cloudfunctions.net/api")
-      end
-
-      it "sets firebase-app to report-service-pro" do
-        expect(helper.runnable_summary_path(activity)).to eq(
-          "https://portal-report.concord.org/branch/master/index.html?" +
-          "firebase-app=report-service-pro&" +
-          "sourceKey=authoring.test.concord.org&" +
-          "runKey=012345678901234567890123456789123456&" +
-          "activity=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
-          "resourceUrl=http%3A%2F%2Ftest.host%2Factivities%2F23"
-        )
+    describe "when user is running an activity" do
+      it "calls ReportService::report_url with the current run, activity, and no sequence" do
+        expect(ReportService).to receive(:report_url).with(run, activity, nil)
+        helper.runnable_summary_path(activity)
       end
     end
 
     describe "when user is running a sequence" do
-      before(:each) do
+      it "calls ReportService::report_url with the current run, activity, and sequence" do
         assign(:sequence, sequence)
-      end
-
-      it "adds activityIndex param" do
-        expect(helper.runnable_summary_path(activity)).to eq(
-          "https://portal-report.concord.org/branch/master/index.html?" +
-          "firebase-app=report-service-dev&" +
-          "sourceKey=authoring.test.concord.org&" +
-          "runKey=012345678901234567890123456789123456&" +
-          "activity=http%3A%2F%2Ftest.host%2Fsequences%2F1&" +
-          "resourceUrl=http%3A%2F%2Ftest.host%2Fsequences%2F1&" +
-          "activityIndex=0"
-        )
+        expect(ReportService).to receive(:report_url).with(run, activity, sequence)
+        helper.runnable_summary_path(activity)
       end
     end
   end

--- a/spec/models/interactive_run_state_spec.rb
+++ b/spec/models/interactive_run_state_spec.rb
@@ -3,10 +3,14 @@ require 'spec_helper'
 def make(thing); end
 
 describe InteractiveRunState do
-  let(:activity)        { FactoryGirl.create(:activity)       }
+  let(:activity)        { FactoryGirl.create(:activity_with_page) }
   let(:interactive)     { FactoryGirl.create(:mw_interactive) }
-  let(:user)            { FactoryGirl.create(:user)           }
+  let(:user)            { FactoryGirl.create(:user) }
   let(:run)             { FactoryGirl.create(:run, {activity: activity, user: user})}
+
+  before(:each) do
+    activity.pages.first.add_embeddable(interactive)
+  end
 
   describe 'class methods' do
     describe "InteractiveRunState#generate_key" do
@@ -58,6 +62,13 @@ describe InteractiveRunState do
 
       it "should have a run_remote_endpoint" do
         expect(result_hash).to have_key "run_remote_endpoint"
+      end
+
+      describe "when interactive run state has a run" do
+        it "should have a external_report_url" do
+          expect(ReportService).to receive(:report_url).and_return("https://test.report/123")
+          expect(result_hash["external_report_url"]).to eq("https://test.report/123")
+        end
       end
 
       describe "when the interactive run state has no linked interactive" do

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe ReportService do
+  let(:user)         { FactoryGirl.create(:user) }
+  let(:activity)     { FactoryGirl.create(:activity, id: 23, name: "Test Activity") }
+  let(:sequence)     { FactoryGirl.create(:sequence, id: 1, title: "Test Sequence", lightweight_activities: [activity])}
+  let(:run)          { FactoryGirl.create(:run, {key: "012345678901234567890123456789123456", activity: activity})}
+
+  describe "#report_url" do
+    before(:each) do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("http://test.host")
+      allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("https://us-central1-report-service-dev.cloudfunctions.net/api")
+      allow(ENV).to receive(:[]).with("REPORT_URL").and_return("https://portal-report.concord.org/branch/master/index.html")
+      allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOOL_ID").and_return("authoring.test.concord.org")
+    end
+
+    describe "when the run is anonymous or doesn't include Portal info" do
+      it "returns Portal Report URL with runKey param" do
+        expect(ReportService::report_url(run, activity)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "firebase-app=report-service-dev&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
+          "resourceUrl=http%3A%2F%2Ftest.host%2Factivities%2F23"
+        )
+      end
+    end
+
+    describe "when the run has Portal info" do
+      let(:run_with_portal_info) do
+        FactoryGirl.create(:run, {
+          key: "012345678901234567890123456789123456",
+          activity: activity,
+          user: user,
+          class_info_url: "https://test.portal.com/api/v1/classes/123",
+          platform_id: "https://test.portal.com",
+          platform_user_id: "ABC",
+          resource_link_id: "321"
+        })
+      end
+
+      it "returns Portal Report URL with runKey param" do
+        expect(ReportService::report_url(run_with_portal_info, activity)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "firebase-app=report-service-dev&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "class=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fclasses%2F123&" +
+          "offering=https%3A%2F%2Ftest.portal.com%2Fapi%2Fv1%2Fofferings%2F321&" +
+          "reportType=offering&" +
+          "studentId=ABC&" +
+          "auth-domain=https%3A%2F%2Ftest.portal.com"
+        )
+      end
+    end
+
+    describe "when REPORT_SERVICE_URL points to production Report Service" do
+      before(:each) do
+        allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("https://us-central1-report-service-pro.cloudfunctions.net/api")
+      end
+
+      it "sets firebase-app to report-service-pro" do
+        expect(ReportService::report_url(run, activity)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "firebase-app=report-service-pro&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
+          "resourceUrl=http%3A%2F%2Ftest.host%2Factivities%2F23"
+        )
+      end
+    end
+
+    describe "when sequence is provided" do
+      it "adds activityIndex param" do
+        expect(ReportService::report_url(run, activity, sequence)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "firebase-app=report-service-dev&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http%3A%2F%2Ftest.host%2Fsequences%2F1&" +
+          "resourceUrl=http%3A%2F%2Ftest.host%2Fsequences%2F1&" +
+          "activityIndex=0"
+        )
+      end
+    end
+
+    describe "when interactive is provided" do
+      let(:mw_interactive) { FactoryGirl.create(:mw_interactive, id: 123) }
+
+      it "adds iframeQuestionId param" do
+        expect(ReportService::report_url(run, activity, nil, mw_interactive)).to eq(
+          "https://portal-report.concord.org/branch/master/index.html?" +
+          "firebase-app=report-service-dev&" +
+          "sourceKey=authoring.test.concord.org&" +
+          "runKey=012345678901234567890123456789123456&" +
+          "activity=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
+          "resourceUrl=http%3A%2F%2Ftest.host%2Factivities%2F23&" +
+          "iframeQuestionId=mw_interactive_123"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
[#179466138]

I've moved Portal Report links generation to `ReportService` module, as it seems like a logical place and let me share this logic easily. However, that forced me to use REPORT_SERVICE_SELF_URL to construct activity or sequence URLs (this module doesn't have access to helpers that are available in the controller/helper context). But this should be fine, right?
I've reorganized tests a bit not to duplicate them too much (use stubs instead).

