### PR TITLE
Send answers from anonymous users to the report service [#179623345]

### DIFF
--- a/app/models/embeddable/answer.rb
+++ b/app/models/embeddable/answer.rb
@@ -59,7 +59,7 @@ module Embeddable::Answer
   def send_to_portal
     if run
       mark_dirty
-      run.queue_for_portal(self)
+      run.queue_for_portal
     end
   end
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -259,7 +259,7 @@ class Run < ActiveRecord::Base
   def queue_for_portal
     # Don't check remote_endpoint so we can allow anonymous runs to be enqueued and sent to the report service.
     # The submit_dirty_answers will enqueue a job that will eventually call #send_to_portal which will drop
-    # it on the floor silenty but will then continue and send the answer to the report service.
+    # it on the floor silently but will then continue and send the answer to the report service.
     return false if answers.empty?
     if dirty?
       # no-op: only queue one time

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -257,7 +257,9 @@ class Run < ActiveRecord::Base
   end
 
   def queue_for_portal(answer)
-    return false if remote_endpoint.nil? || remote_endpoint.blank?
+    # Don't check remote_endpoint so we can allow anonymous runs to be enqueued and sent to the report service.
+    # The submit_dirty_answers will enqueue a job that will eventually call #send_to_portal which will drop
+    # it on the floor silenty but will then continue and send the answer to the report service.
     return false if answers.nil?
     if dirty?
       # no-op: only queue one time

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -256,11 +256,11 @@ class Run < ActiveRecord::Base
     is_success
   end
 
-  def queue_for_portal(answer)
+  def queue_for_portal
     # Don't check remote_endpoint so we can allow anonymous runs to be enqueued and sent to the report service.
     # The submit_dirty_answers will enqueue a job that will eventually call #send_to_portal which will drop
     # it on the floor silenty but will then continue and send the answer to the report service.
-    return false if answers.nil?
+    return false if answers.empty?
     if dirty?
       # no-op: only queue one time
     else

--- a/app/services/report_service/run_sender.rb
+++ b/app/services/report_service/run_sender.rb
@@ -21,7 +21,7 @@ module ReportService
       record[:tool_id] = Sender::tool_id
       record[:tool_user_id] = run.user_id.to_s
       record[:platform_id] = run.platform_id
-      record[:platform_user_id] = run.platform_user_id
+      record[:platform_user_id] = run.platform_user_id || run.key  # fallback to run.key for anonymous users
       record[:resource_link_id] = run.resource_link_id
       record[:context_id] = run.context_id
       record[:resource_url] = get_resource_url(run)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -463,7 +463,7 @@ ActiveRecord::Schema.define(:version => 20210903171847) do
     t.datetime "updated_at",   :null => false
   end
 
-  add_index "linked_page_items", ["primary_id", "secondary_id", "label"], :name => "index_linked_page_items_unique", :unique => true
+  add_index "linked_page_items", ["primary_id", "label"], :name => "index_linked_page_items_unique", :unique => true
   add_index "linked_page_items", ["primary_id"], :name => "index_linked_page_items_primary"
   add_index "linked_page_items", ["secondary_id"], :name => "index_linked_page_items_secondary"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -463,7 +463,7 @@ ActiveRecord::Schema.define(:version => 20210903171847) do
     t.datetime "updated_at",   :null => false
   end
 
-  add_index "linked_page_items", ["primary_id", "label"], :name => "index_linked_page_items_unique", :unique => true
+  add_index "linked_page_items", ["primary_id", "secondary_id", "label"], :name => "index_linked_page_items_unique", :unique => true
   add_index "linked_page_items", ["primary_id"], :name => "index_linked_page_items_primary"
   add_index "linked_page_items", ["secondary_id"], :name => "index_linked_page_items_secondary"
 

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -86,13 +86,9 @@ namespace :reporting do
   desc "publish anonymous runs to report service"
   task :publish_anonymous_runs => :environment do
     runs = Run.where('remote_endpoint is null')
-    env_value = ENV["REPORT_PUSH_RUN_MIN_ID"]
+    env_value = ENV["REPORT_PUSH_RUN_ACTIVITY_ID"]
     if env_value && env_value.present?
-      runs = runs.where("id >= #{env_value.to_i}")
-    end
-    env_value = ENV["REPORT_PUSH_RUN_MAX_ID"]
-    if env_value && env_value.present?
-      runs = runs.where("id <= #{env_value.to_i}")
+      runs = runs.where(activity_id: env_value)
     end
     opts = { send_all_answers: true }
     send_all_resources(runs, ReportService::RunSender, opts)

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -85,7 +85,6 @@ namespace :reporting do
 
   desc "publish anonymous runs to report service"
   task :publish_anonymous_runs => :environment do
-    ActiveRecord::Base.logger = Logger.new(STDOUT)
     runs = Run.where('remote_endpoint is null')
     opts = { send_all_answers: true }
     send_all_resources(runs, ReportService::RunSender, opts)

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -69,8 +69,8 @@ namespace :reporting do
     send_all_resources(Sequence, ReportService::ResourceSender)
   end
 
-  desc "publish runs to report service"
-  task :publish_runs => :environment do
+  desc "publish student runs to report service"
+  task :publish_student_runs => :environment do
     # limit this to portal runs by default:
     where_query = 'remote_endpoint is not null'
     # Or specify remote endpoint substring to match:
@@ -79,6 +79,22 @@ namespace :reporting do
       where_query = "remote_endpoint like '%#{env_value}%'"
     end
     runs = Run.where(where_query)
+    opts = { send_all_answers: true }
+    send_all_resources(runs, ReportService::RunSender, opts)
+  end
+
+  desc "publish anonymous runs to report service"
+  task :publish_anonymous_runs => :environment do
+    runs = Run.where('remote_endpoint is null')
+    # allow caller do specify the limit and offset of the query
+    limit_env_value = ENV["REPORT_PUSH_RUN_LIMIT"]
+    if limit_env_value && limit_env_value.size > 0
+      runs = runs.limit(limit_env_value.to_i)
+    end
+    offset_env_value = ENV["REPORT_PUSH_RUN_OFFSET"]
+    if offset_env_value && offset_env_value.size > 0
+      runs = runs.offset(offset_env_value.to_i)
+    end
     opts = { send_all_answers: true }
     send_all_resources(runs, ReportService::RunSender, opts)
   end

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -85,16 +85,8 @@ namespace :reporting do
 
   desc "publish anonymous runs to report service"
   task :publish_anonymous_runs => :environment do
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
     runs = Run.where('remote_endpoint is null')
-    # allow caller do specify the limit and offset of the query
-    limit_env_value = ENV["REPORT_PUSH_RUN_LIMIT"]
-    if limit_env_value && limit_env_value.size > 0
-      runs = runs.limit(limit_env_value.to_i)
-    end
-    offset_env_value = ENV["REPORT_PUSH_RUN_OFFSET"]
-    if offset_env_value && offset_env_value.size > 0
-      runs = runs.offset(offset_env_value.to_i)
-    end
     opts = { send_all_answers: true }
     send_all_resources(runs, ReportService::RunSender, opts)
   end

--- a/spec/libs/tasks/reporting_rake_spec.rb
+++ b/spec/libs/tasks/reporting_rake_spec.rb
@@ -38,8 +38,7 @@ describe "reporting:publish_anonymous_runs" do
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("app.lara.docker")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("http://foo.com")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return("report_service_token")
-    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_MIN_ID").and_return(run.id)
-    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_MAX_ID").and_return(run.id)
+    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_ACTIVITY_ID").and_return(run.activity_id)
   end
 
   it "sends a run to the report service, specifying `send_all_answers`" do

--- a/spec/libs/tasks/reporting_rake_spec.rb
+++ b/spec/libs/tasks/reporting_rake_spec.rb
@@ -1,7 +1,7 @@
 # spec/lib/tasks/reporting_rake_spec.rb
 require 'spec_helper'
 
-describe "reporting:publish_runs" do
+describe "reporting:publish_student_runs" do
   include_context "rake"
   let(:run) do
     Run.create( {
@@ -23,8 +23,30 @@ describe "reporting:publish_runs" do
     expect(ReportService::RunSender).to receive(:new).with(run, expected_options)
     subject.invoke
   end
-
 end
+
+describe "reporting:publish_anonymous_runs" do
+  include_context "rake"
+  let(:run) do
+    Run.create({
+      user_id: 1,
+      activity_id: 1
+    })
+  end
+
+  before(:each) do
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("app.lara.docker")
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("http://foo.com")
+    allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return("report_service_token")
+  end
+
+  it "sends a run to the report service, specifying `send_all_answers`" do
+    expected_options = {:send_all_answers=>true}
+    expect(ReportService::RunSender).to receive(:new).with(run, expected_options)
+    subject.invoke
+  end
+end
+
 
 describe  "reporting:import_clazz_info" do
   include_context "rake"

--- a/spec/libs/tasks/reporting_rake_spec.rb
+++ b/spec/libs/tasks/reporting_rake_spec.rb
@@ -38,6 +38,8 @@ describe "reporting:publish_anonymous_runs" do
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("app.lara.docker")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("http://foo.com")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return("report_service_token")
+    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_MIN_ID").and_return(run.id)
+    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_MAX_ID").and_return(run.id)
   end
 
   it "sends a run to the report service, specifying `send_all_answers`" do

--- a/spec/support/shared_examples/answer.rb
+++ b/spec/support/shared_examples/answer.rb
@@ -33,7 +33,7 @@ shared_examples "an answer" do
     describe "with a run" do
       it "should call run.send_to_portal(self, nil)" do
         allow(answer).to receive_messages(:run => run)
-        expect(run).to receive(:queue_for_portal).with(answer)
+        expect(run).to receive(:queue_for_portal)
         answer.send_to_portal
         expect(answer).to be_dirty
       end
@@ -41,7 +41,7 @@ shared_examples "an answer" do
 
     describe "with out a run" do
       it "wont call run.send_to_portal(self)" do
-        expect(run).not_to receive(:queue_for_portal).with(answer)
+        expect(run).not_to receive(:queue_for_portal)
         answer.send_to_portal
       end
     end


### PR DESCRIPTION
- Removed check for remote_endpoint from run.rb@queue_for_portal
- Removed unused answer parameter from run.rb@queue_for_portal
- Added missing run_spec.rb spec tests
- Fixed existing test by disabling delayed jobs around the rub_spec.rb dirty_answers test
- Added fallback to run.key for platform_user_id
- Added (untested) rake task to publish anonymous runs to the report service