### PR TITLE
Fix section editing fonts are incorrect when viewed in LARA

### DIFF
--- a/lara-typescript/src/section-authoring/components/authoring-section.scss
+++ b/lara-typescript/src/section-authoring/components/authoring-section.scss
@@ -201,8 +201,10 @@ select {
     background: transparent;
     border: none;
     border-right: solid 1px white;
+    border-radius: 0;
     color: white;
     cursor: pointer;
+    font-family: var(--font-family);
     font-variant: small-caps;
     margin: 0;
     padding: 0 10px 0 0;

--- a/lara-typescript/src/section-authoring/components/section-item.scss
+++ b/lara-typescript/src/section-authoring/components/section-item.scss
@@ -33,8 +33,10 @@
     background: transparent;
     border: none;
     border-right: solid 1px white;
+    border-radius: 0;
     color: white;
     cursor: pointer;
+    font-family: var(--font-family);
     font-size: 11.5px;
     margin: 0;
     padding: 0 10px 0 0;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179677152

[#179677152]

As far as I could tell, the only issues with the fonts were the curved separators (actually a border issue) and some elements not having the right font family applied. The curved separators are fixed by setting `border-radius` to 0 for the header buttons. 