### PR TITLE
switch sso client id localhost to authoring

### DIFF
--- a/docker/dev/docker-compose-portal-proxy.yml
+++ b/docker/dev/docker-compose-portal-proxy.yml
@@ -28,7 +28,7 @@ services:
     environment:
       CONCORD_CONFIGURED_PORTALS: LOCALHOST HAS_STAGING
       CONCORD_LOCALHOST_URL: ${PORTAL_PROTOCOL:-http}://${PORTAL_HOST:?Need to define PORTAL_HOST}/
-      CONCORD_LOCALHOST_CLIENT_ID: localhost
+      CONCORD_LOCALHOST_CLIENT_ID: authoring
       CONCORD_LOCALHOST_CLIENT_SECRET: 'unsecure local secret'
       # the code requires at least 2 portals configured this second one to has Staging
       # will not actually work


### PR DESCRIPTION
this is closer to what the name is on production,
and then the same client id can be be used for both local and cloud deployments

This is needed for these portal changes:
https://github.com/concord-consortium/rigse/pull/1086