### PR TITLE
use new docker-rails-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.13
-
-# update apt libraries
-RUN apt-get update
+FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.25
 
 # install nginx
 RUN apt-get install -qq -y nginx

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.13
+FROM concordconsortium/docker-rails-base-private:ruby-2.3.7-rails-3.2.22.25
 
 #
 # Install wait-for-it to support docker-volume-sync


### PR DESCRIPTION
this fixes an issue with the https root certificates
it also bumps the version of rails being used slightly,
and upgrades all of the linux libraries

Here are the changes to the docker-rails-base:
https://github.com/concord-consortium/docker-rails-base/commit/783eb11625433df07570a944812ed832979653f1

I put the changes in docker-rails-base instead of the LARA image itself, so that the upgrade of the linux libraries doesn't slow down every build of the LARA image. 