### PR TITLE
Fix item order bug after drag-and-drop.

### DIFF
--- a/lara-typescript/src/section-authoring/components/section-column.tsx
+++ b/lara-typescript/src/section-authoring/components/section-column.tsx
@@ -74,16 +74,20 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
 
   const [showAddItem, setShowAddItem] = useState(false);
 
-  const swapIndexes = (array: any[], a: number, b: number) => {
-    const aItem = array[a];
-    const bItem = array[b];
-    const aPos = aItem.position;
-    const bPos = bItem.position;
-    aItem.position = bPos;
-    bItem.position = aPos;
-    array[b] = aItem;
-    array[a] = bItem;
-    return [...array];
+  const updateItemPositions = (sectionItems: ISectionItemProps[], sourceIndex: number, destinationIndex: number) => {
+    const itemToMove = sectionItems[sourceIndex];
+    const otherItem = sectionItems[destinationIndex];
+    itemToMove.position = otherItem.position;
+    sectionItems.splice(sourceIndex, 1);
+    sectionItems.splice(destinationIndex, 0, itemToMove);
+    let itemsCount = 0;
+    sectionItems.forEach((i, index) => {
+      itemsCount++;
+      if (index > destinationIndex) {
+        i.position = itemsCount;
+      }
+    });
+    return [...sectionItems];
   };
 
   const onDragEnd = (e: DropResult) => {
@@ -97,7 +101,7 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
       return;
     }
     if (e.destination && e.destination.index !== e.source.index) {
-      nextItems = swapIndexes(items, e.source.index, e.destination.index);
+      nextItems = updateItemPositions(items, e.source.index, e.destination.index);
       updateSectionItems({sectionId, newItems: nextItems, column });
     }
   };


### PR DESCRIPTION
[#179239933]

@knowuh This fixes the ordering problem you discovered by replacing `swapIndexes` with a new `updateItemPositions` method. The latter has some similar code to `handleMoveItem` in the AuthoringPage component. So I suspect it's something we'll want to refactor and combine with that somehow, but it seems like for the time being this is good enough. Please let me know if you think otherwise, though.