### PR TITLE
179822007 -- Fix layout updates

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,7 +195,7 @@ LightweightStandalone::Application.routes.draw do
       match 'get_portal_jwt(/:run_id)' => 'jwt#get_portal_jwt', :as => 'get_portal_jwt', :via => 'post'
       match 'get_interactive_list/:id' => 'interactive_pages#get_interactive_list', :as => 'get_interactive_list', :via => 'get'
 
-      # React authoring related routes. ()
+      # New Section (React) authoring routes:
       match 'get_page_sections/:id' => 'interactive_pages#get_sections', :as => 'get_page_sections', :via => 'get'
       # This will handle the delete case too ...
       match 'set_page_sections/:id' => 'interactive_pages#set_sections', :as => 'set_page_sections', :via => 'put'
@@ -203,6 +203,8 @@ LightweightStandalone::Application.routes.draw do
       match 'update_page_section/:id' => 'interactive_pages#update_section', :as => 'update_page_section', :via => 'post'
 
       match 'create_page_item/:id' => 'interactive_pages#create_page_item', :as => 'create_page_item', :via => 'post'
+      match 'delete_page_item/:id' => 'interactive_pages#delete_page_item', :as => 'delete_page_item', :via => 'post'
+
       match 'get_library_interactives_list' => 'interactive_pages#get_library_interactives_list', :as => 'get_library_interactives_list', :via => 'get'
 
       match 'get_pages/:activity_id' => 'interactive_pages#get_pages', :as => 'get_page_list', :via => 'get'

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -135,6 +135,7 @@ export type APISectionsUpdateF = (nextPage: IPage) => Promise<IPage>;
 export type APISectionUpdateF = (args: {pageId: PageId, changes: { section: Partial<ISection>}}) => Promise<IPage>;
 
 export type APIPageItemCreateF = (args: {pageId: PageId, newPageItem: ICreatePageItem}) => Promise<IPage>;
+export type APIPageItemDeleteF = (args: {pageId: PageId, pageItemId: ItemId}) => Promise<IPage>;
 
 /**
  * The implementation providing the API has to conform to this provider API
@@ -150,6 +151,7 @@ export interface IAuthoringAPIProvider {
   updateSection: APISectionUpdateF;
 
   createPageItem: APIPageItemCreateF;
+  deletePageItem: APIPageItemDeleteF;
 
   getAllEmbeddables: () => Promise<{allEmbeddables: ISectionItemType[]}>;
 }

--- a/lara-typescript/src/section-authoring/api/lara-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/lara-api-provider.ts
@@ -1,11 +1,12 @@
 import {
   IAuthoringAPIProvider,
-  IPage, PageId, ISection, ICreatePageItem,
+  IPage, PageId, ISection, ICreatePageItem, ItemId,
   APIPageGetF, APIPagesGetF,
   APIPageCreateF, APIPageDeleteF,
   APISectionCreateF, APISectionsUpdateF, APISectionUpdateF,
   APIPageItemCreateF,
-  ILibraryInteractiveResponse
+  ILibraryInteractiveResponse,
+  APIPageItemDeleteF
 } from "./api-types";
 
 const APIBase = "/api/v1";
@@ -25,6 +26,7 @@ export const getLaraAuthoringAPI =
   const createPageSectionUrl = (pageId: PageId) => `${prefix}/create_page_section/${pageId}.json`;
   const updateSectionUrl = (pageId: PageId) => `${prefix}/update_page_section/${pageId}.json`;
   const createPageItemUrl = (pageId: PageId) => `${prefix}/create_page_item/${pageId}.json`;
+  const deletePageItemUrl = (pageId: PageId) => `${prefix}/delete_page_item/${pageId}.json`;
   const libraryInteractivesUrl = `${prefix}/get_library_interactives_list.json`;
 
   interface ISendToLaraParams {
@@ -86,6 +88,12 @@ export const getLaraAuthoringAPI =
     return sendToLara({url: createPageItemUrl(args.pageId), method: "POST", body});
   };
 
+  const deletePageItem: APIPageItemDeleteF = (args: {pageId: PageId, pageItemId: ItemId}) => {
+    const { pageId, pageItemId } = args;
+    const body = { page_item_id: pageItemId };
+    return sendToLara({url: deletePageItemUrl(pageId), method: "POST", body});
+  };
+
   const getAllEmbeddables = () => {
     return sendToLara({url: libraryInteractivesUrl})
       .then( (json: ILibraryInteractiveResponse) => {
@@ -109,7 +117,8 @@ export const getLaraAuthoringAPI =
 
   return {
     getPages, getPage, createPage, deletePage,
-    createSection, updateSections, createPageItem, updateSection,
+    createSection, updateSections, updateSection,
+    createPageItem, deletePageItem,
     getAllEmbeddables
   };
 };

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -118,17 +118,17 @@ const deletePageItem: APIPageItemDeleteF = (args: {pageId: PageId, pageItemId: I
   const { pageId, pageItemId } = args;
   const page = pages.find(p => p.id === pageId);
   if (page) {
-    let replaceMentSection: ISection | null = null;
+    let replacementSection: ISection | null = null;
     page?.sections.forEach(s => {
       s.items?.forEach(i => {
         if (i.id === pageItemId) {
-          replaceMentSection = s;
+          replacementSection = s;
         }
       });
     });
 
-    if (replaceMentSection) {
-      (replaceMentSection as ISection).items = (replaceMentSection as ISection).items?.filter(i => i.id !== pageItemId);
+    if (replacementSection) {
+      (replacementSection as ISection).items = (replacementSection as ISection).items?.filter(i => i.id !== pageItemId);
     }
     return Promise.resolve(page);
   }

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -2,7 +2,8 @@
 import {
   IPage, PageId,
   APIPageGetF, APIPagesGetF,
-  IAuthoringAPIProvider, ISection, ICreatePageItem, ISectionItem, SectionColumns, ISectionItemType
+  IAuthoringAPIProvider, ISection, ICreatePageItem, ISectionItem, SectionColumns,
+  ISectionItemType, APIPageItemDeleteF, ItemId
 } from "./api-types";
 
 let pageCounter = 0;
@@ -113,6 +114,27 @@ const createPageItem = (args: {pageId: PageId, newPageItem: ICreatePageItem}) =>
   return Promise.reject(`cant find page ${pageId}`);
 };
 
+const deletePageItem: APIPageItemDeleteF = (args: {pageId: PageId, pageItemId: ItemId}) => {
+  const { pageId, pageItemId } = args;
+  const page = pages.find(p => p.id === pageId);
+  if (page) {
+    let replaceMentSection: ISection | null = null;
+    page?.sections.forEach(s => {
+      s.items?.forEach(i => {
+        if (i.id === pageItemId) {
+          replaceMentSection = s;
+        }
+      });
+    });
+
+    if (replaceMentSection) {
+      (replaceMentSection as ISection).items = (replaceMentSection as ISection).items?.filter(i => i.id !== pageItemId);
+    }
+    return Promise.resolve(page);
+  }
+  return Promise.reject(`cant find page ${pageId}`);
+};
+
 const getAllEmbeddables = () => {
   const allEmbeddables: ISectionItemType[] = [
     {id: "1", name: "Carousel", useCount: 1, dateAdded: 1630440496},
@@ -131,6 +153,7 @@ const getAllEmbeddables = () => {
 
 export const API: IAuthoringAPIProvider = {
   getPages, getPage, createPage, deletePage,
-  createSection, updateSections, createPageItem, updateSection,
+  createSection, updateSections, updateSection,
+  createPageItem, deletePageItem,
   getAllEmbeddables
 };

--- a/lara-typescript/src/section-authoring/api/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/use-api-provider.ts
@@ -2,7 +2,10 @@ import * as React from "react";
 import { useContext } from "react";
 import { useState } from "react";
 import {useMutation, useQuery, useQueryClient} from "react-query";
-import { IAuthoringAPIProvider, ICreatePageItem, IPage, ISection, ISectionItem, ISectionItemType, SectionColumns } from "./api-types";
+import {
+    IAuthoringAPIProvider, ICreatePageItem, IPage, ISection, ISectionItem,
+    ISectionItemType, ItemId, SectionColumns
+} from "./api-types";
 import { API as DEFAULT_API } from "./mock-api-provider";
 
 const PAGES_CACHE_KEY = "pages";
@@ -34,6 +37,17 @@ export const usePageAPI = () => {
     <IPage, Error, {pageId: string, newPageItem: ICreatePageItem}>
     (provider.createPageItem, mutationsOpts);
 
+  const deletePageItemMutation = useMutation
+    <IPage, Error, {pageId: string, pageItemId: ItemId}>
+    (provider.deletePageItem, mutationsOpts);
+
+  const deletePageItem = (pageItemId: ItemId) => {
+    if (getPages.data) {
+      const page = getPages.data[currentPageIndex];
+      deletePageItemMutation.mutate({pageId: page.id, pageItemId});
+    }
+  };
+
   const getAllEmbeddables = useQuery
     <{allEmbeddables: ISectionItemType[]}, Error>
     (SECTION_ITEM_TYPES_KEY, provider.getAllEmbeddables);
@@ -63,7 +77,7 @@ export const usePageAPI = () => {
   return {
     getPages, addPageMutation, deletePageMutation,
     addSectionMutation, updateSection, updateSections,
-    createPageItem,
+    createPageItem, deletePageItem,
     getAllEmbeddables, updateSectionItems
   };
 };

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -53,11 +53,6 @@ export interface ISectionProps extends ISection {
   copyFunction?: (id: string) => void;
 
   /**
-   * Optional function to delete the section (elsewhere)
-   */
-  updatePageItems?: (items: ISectionItem[], sectionId: string) => void;
-
-  /**
    * Function to move an item
    */
   moveItemFunction?: (id: string) => void;
@@ -82,7 +77,6 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
   items = [],
   collapsed: initCollapsed = false,
   title,
-  updatePageItems,
   moveItemFunction,
   draggableProvided,
   addPageItem
@@ -227,7 +221,6 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
         items={getColumnItems(columnValueForIndex(0))}
         moveFunction={handleMoveItem}
         sectionId={id}
-        updatePageItems={updatePageItems}
         />
       }
       {layout !== "Full Width" &&
@@ -240,7 +233,6 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
           items={getColumnItems(columnValueForIndex(1))}
           moveFunction={handleMoveItem}
           sectionId={id}
-          updatePageItems={updatePageItems}
         />
       }
     </div>

--- a/lara-typescript/src/section-authoring/components/section-column.tsx
+++ b/lara-typescript/src/section-authoring/components/section-column.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useState } from "react";
 import { SectionItem, ISectionItemProps} from "./section-item";
 import { absorbClickThen } from "../../shared/absorb-click";
-import { ICreatePageItem, ISection, ISectionItem, SectionColumns } from "../api/api-types";
+import { ICreatePageItem, ISection, ISectionItem, ItemId, SectionColumns } from "../api/api-types";
 import { DragDropContext, Droppable, Draggable, DropResult, DraggableProvided } from "react-beautiful-dnd";
 import { Add } from "../../shared/components/icons/add-icon";
 
@@ -51,11 +51,6 @@ export interface ISectionColumnProps {
    */
   sectionId: string;
 
-  /**
-   * Optional function to update section items
-   */
-  updatePageItems?: (items: ISectionItem[], sectionId: string) => void;
-
 }
 
 export const SectionColumn: React.FC<ISectionColumnProps> = ({
@@ -70,8 +65,7 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
   }: ISectionColumnProps) => {
 
   const api = usePageAPI();
-  const updateSectionItems = api.updateSectionItems;
-
+  const { deletePageItem, updateSectionItems} = api;
   const [showAddItem, setShowAddItem] = useState(false);
 
   const updateItemPositions = (sectionItems: ISectionItemProps[], sourceIndex: number, destinationIndex: number) => {
@@ -115,16 +109,6 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
     if (item) {
       addItem(column);
     }
-  };
-
-  const handleDeleteItem = (itemId: string) => {
-    const nextItems: ISectionItemProps[] = [];
-    items.forEach(i => {
-      if (i.id !== itemId) {
-        nextItems.push(i);
-      }
-    });
-    updateSectionItems({sectionId, newItems: nextItems, column});
   };
 
   const handleToggleShowAddItem = () => setShowAddItem((prev) => !prev);
@@ -176,7 +160,7 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
                               key={item.id}
                               moveFunction={handleMoveItem}
                               copyFunction={handleCopyItem}
-                              deleteFunction={handleDeleteItem}
+                              deleteFunction={deletePageItem}
                             />
                           </div>
                         )}

--- a/spec/controllers/api/v1/interactive_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/interactive_pages_controller_spec.rb
@@ -416,25 +416,19 @@ describe Api::V1::InteractivePagesController do
     end
 
     describe 'deleting items' do
-      let(:new_items) do
-        # There are three page_items, we just take the first two to post back
-        # This should result in the first one being deleted.
-        items.last(2).map { |i| { id: i.id, position: i.position, column: i.column } }
-      end
+      let(:item_to_delete) { items.last }
 
       let(:update_request) do
-        { id: page.id, section: { id: section.id, items: new_items } }
+        { id: page.id, page_item_id: item_to_delete.id }
       end
 
       describe 'success' do
         it 'deletes missing items not present in the items post request' do
-          xhr :post, 'update_section', update_request
+          xhr :post, 'delete_page_item', update_request
           expect(response.status).to eq(200)
           section.reload
           expect(section.page_items.length).to eq(2)
-          new_items.map { |i| i[:id] }.each do |included_id|
-            expect(section.page_items.map{ |i| i.id }).to include(included_id)
-          end
+          expect(section.page_items.map{ |i| i.id }).not_to include(item_to_delete.id)
         end
       end
 


### PR DESCRIPTION

There was a bug introduced by the work deleting pageItems.  In tracing that bug down, I decided it made a lot more sense to have an explicit route & controller for deleting pageItems.

This PR addresses that issue by creating a special route & controller.

It also stops the prop-drilling for the deletePageItem function.
