### PR TITLE
179783183 move section item with menu

### DIFF
--- a/lara-typescript/package-lock.json
+++ b/lara-typescript/package-lock.json
@@ -16719,10 +16719,9 @@
       "dev": true
     },
     "immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
-      "dev": true
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -22849,6 +22848,12 @@
             "slash": "^3.0.0"
           }
         },
+        "immer": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+          "dev": true
+        },
         "json5": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -27310,6 +27315,11 @@
       "requires": {
         "ts-essentials": "^2.0.3"
       }
+    },
+    "use-immer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.6.0.tgz",
+      "integrity": "sha512-dFGRfvWCqPDTOt/S431ETYTg6+uxbpb7A1pptufwXVzGJY3RlXr38+3wyLNpc6SbbmAKjWl6+EP6uW74fkEsXQ=="
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.1",

--- a/lara-typescript/package.json
+++ b/lara-typescript/package.json
@@ -140,18 +140,20 @@
     "@aws-sdk/s3-request-presigner": "^3.30.0",
     "@concord-consortium/interactive-api-host": "^0.3.0",
     "@concord-consortium/text-decorator": "^1.0.2",
+    "@concord-consortium/token-service": "^2.1.0",
     "@types/react-query": "^1.2.9",
     "classnames": "^2.3.1",
-    "@concord-consortium/token-service": "^2.1.0",
     "deep-freeze": "0.0.1",
     "dompurify": "^2.3.0",
     "eventemitter2": "^6.4.4",
     "html-react-parser": "^1.2.7",
     "iframe-phone": "^1.3.1",
+    "immer": "^9.0.6",
     "react-beautiful-dnd": "^13.1.0",
     "react-query": "^3.21.0",
     "react-select": "^3.2.0",
     "react-tabs": "^3.2.2",
+    "use-immer": "^0.6.0",
     "uuid": "^8.3.2"
   }
 }

--- a/lara-typescript/src/section-authoring/api/api-container.tsx
+++ b/lara-typescript/src/section-authoring/api/api-container.tsx
@@ -4,24 +4,29 @@ import { APIContext } from "./use-api-provider";
 import { IAuthoringAPIProvider } from "./api-types";
 import { API as mockProvider } from "./mock-api-provider";
 import { getLaraAuthoringAPI } from "./lara-api-provider";
-
+import { UserInterfaceContext, useUserInterface } from "./use-user-interface-context";
 export interface IAPIContainerProps {
   activityId?: string;
   host?: string;
 }
 
 export const APIContainer: React.FC<IAPIContainerProps> = (props) => {
-  const queryClient = new QueryClient();
   const {activityId, host} = props;
+  const queryClient = new QueryClient();
+  const ui = useUserInterface();
+
   let APIProvider: IAuthoringAPIProvider = mockProvider;
   if (activityId && host) {
     APIProvider = getLaraAuthoringAPI(activityId, host);
   }
+
   return (
-    <APIContext.Provider value={APIProvider}>
-    <QueryClientProvider client={queryClient}>
-      {props.children}
-    </QueryClientProvider>
-  </APIContext.Provider>
+    <UserInterfaceContext.Provider value={ui}>
+      <APIContext.Provider value={APIProvider}>
+        <QueryClientProvider client={queryClient}>
+          {props.children}
+        </QueryClientProvider>
+      </APIContext.Provider>
+    </UserInterfaceContext.Provider>
   );
 };

--- a/lara-typescript/src/section-authoring/api/use-user-interface-context.ts
+++ b/lara-typescript/src/section-authoring/api/use-user-interface-context.ts
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { useImmer } from "use-immer";
+
+interface IUserInterface {
+  currentPageIndex: number;
+  movingItemId: string | false;
+  movingSectionId: string | false;
+  editingItemId: string | false;
+}
+
+const defaultUI: IUserInterface = {
+  currentPageIndex: 0,
+  movingItemId: false,
+  movingSectionId: false,
+  editingItemId: false
+};
+
+interface IUIActions {
+  setMovingItemId: (id: false|string) => void;
+  setMovingSectionId: (id: false|string) => void;
+}
+
+interface IUIContext {
+  userInterface: IUserInterface;
+  actions: IUIActions;
+}
+
+const defaultContext: IUIContext = {
+  userInterface: defaultUI,
+  actions: {
+    // tslint:disable-next-line
+    setMovingItemId: (id) => console.log(id),
+    // tslint:disable-next-line
+    setMovingSectionId: (id) => console.log(id)
+  }
+};
+
+const UserInterfaceContext = React.createContext<IUIContext>(defaultContext);
+
+// 1: We define a context to be consumed from by subcomponents.
+// 2: We provide a hook for the wrapping component in api-container component
+// 3: This api-container component provides UI features via context.
+// Sample from consuming component:
+// `const { userInterface, actions }  = React.useContext(UserInterfaceContext);`
+
+const useUserInterface = (): IUIContext => {
+  const [userInterface, setUserInterface] = useImmer<IUserInterface>(defaultUI);
+
+  const setMovingItemId = (id: string| false) => {
+    setUserInterface( (draft) => { draft.movingItemId = id; });
+  };
+
+  const setMovingSectionId = (id: string| false) => {
+    setUserInterface( (draft) => { draft.movingSectionId = id; });
+  };
+
+  const actions = { setMovingItemId, setMovingSectionId };
+  return({userInterface, actions} );
+};
+
+export { UserInterfaceContext, useUserInterface };

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -4,6 +4,7 @@ import { GripLines } from "../../shared/components/icons/grip-lines";
 import { SectionColumn } from "./section-column";
 import { ICreatePageItem, ISection, ISectionItem, SectionColumns, SectionLayouts } from "../api/api-types";
 import { DraggableProvided } from "react-beautiful-dnd";
+import { UserInterfaceContext } from "../api/use-user-interface-context";
 
 import "./authoring-section.scss";
 
@@ -43,11 +44,6 @@ export interface ISectionProps extends ISection {
   deleteFunction?: (id: string) => void;
 
   /**
-   * Optional function to move the section
-   */
-  moveFunction?: (id: string) => void;
-
-  /**
    * Optional function to copy the section
    */
   copyFunction?: (id: string) => void;
@@ -71,7 +67,6 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
   id,
   updateFunction,
   deleteFunction,
-  moveFunction,
   copyFunction,
   layout: initLayout = defaultLayout,
   items = [],
@@ -82,6 +77,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
   addPageItem
   }: ISectionProps) => {
 
+  const { actions: {setMovingSectionId}} = React.useContext(UserInterfaceContext);
   const [layout, setLayout] = useState(initLayout);
   const [collapsed, setCollapsed] = useState(initCollapsed);
 
@@ -109,9 +105,8 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
   //   updateFunction?.({section: {id, items: nextItems}});
   // };
 
-  const handleMove = () => {
-    moveFunction?.(id);
-
+  const handleMoveSection = () => {
+    setMovingSectionId(id);
   };
 
   const handleCopy = () => {
@@ -206,7 +201,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
         <div className="menuEnd">
           <ul>
             <li><button onClick={toggleCollapse}>Collapse</button></li>
-            <li><button onClick={handleMove}>Move</button></li>
+            <li><button onClick={handleMoveSection}>Move</button></li>
             <li><button onClick={handleCopy}>Copy</button></li>
             <li><button onClick={handleDelete}>Delete</button></li>
           </ul>

--- a/lara-typescript/src/section-authoring/components/section-item.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { GripLines } from "../../shared/components/icons/grip-lines";
+import { UserInterfaceContext } from "../api/use-user-interface-context";
 
 import "./section-item.scss";
 
@@ -19,11 +20,6 @@ export interface ISectionItemProps {
    * Optional function to change the item
    */
   updateFunction?: (changes: {sectionItem: Partial<ISectionItemProps>}) => void;
-
-  /**
-   * Optional function to move the item
-   */
-  moveFunction?: (id: string) => void;
 
   /**
    * Optional function to copy the item
@@ -51,13 +47,14 @@ export interface ISectionItemProps {
  */
 export const SectionItem: React.FC<ISectionItemProps> = ({
   id,
-  moveFunction,
   copyFunction,
   deleteFunction,
   type,
   position,
   title
   }: ISectionItemProps) => {
+
+  const { userInterface: {movingItemId}, actions: {setMovingItemId}} = React.useContext(UserInterfaceContext);
 
   const renderTitle = () => (
     <>
@@ -74,7 +71,7 @@ export const SectionItem: React.FC<ISectionItemProps> = ({
   };
 
   const handleMove = () => {
-    moveFunction?.(id);
+    setMovingItemId(id);
   };
 
   const handleCopy = () => {

--- a/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
@@ -10,7 +10,6 @@ import { usePageAPI } from "../api/use-api-provider";
 import { UserInterfaceContext } from "../api/use-user-interface-context";
 
 export interface ISectionMoveDialogProps {
-  sectionId: string;
   sections: ISectionProps[];
   selectedPageId?: string;
   selectedPosition?: string;
@@ -18,7 +17,6 @@ export interface ISectionMoveDialogProps {
 }
 
 export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
-  sectionId,
   sections,
   selectedPageId = "0",
   selectedPosition = "after",
@@ -26,8 +24,9 @@ export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
   }: ISectionMoveDialogProps) => {
   const [selectedOtherSectionId, setSelectedOtherSectionId] = useState(initSelectedOtherSectionId);
 
-  const { moveSection } = usePageAPI();
-  const { userInterface, actions: {setMovingSectionId}} = React.useContext(UserInterfaceContext);
+  // TODO: We could remove sections from the property list too
+  const { moveSection, getSections } = usePageAPI();
+  const { userInterface: {movingSectionId}, actions: {setMovingSectionId}} = React.useContext(UserInterfaceContext);
 
   const handlePageChange = (change: React.ChangeEvent<HTMLSelectElement>) => {
     selectedPageId = change.target.value;
@@ -47,16 +46,18 @@ export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
   };
 
   const handleMoveSection = () => {
-    moveSection(sectionId, selectedPageId, selectedPosition as "before"|"after", selectedOtherSectionId);
+    if(movingSectionId) {
+      moveSection(movingSectionId, selectedPageId, selectedPosition as "before"|"after", selectedOtherSectionId);
+    }
     handleCloseDialog();
   };
 
   const sectionOptions = () => {
     let sectionsList: ISectionProps[] = [];
     if (selectedPageId) {
-      const selectedSection = sections.find(s => s.id === sectionId);
+      const selectedSection = sections.find(s => s.id === movingSectionId);
       if (selectedSection?.items) {
-        sectionsList = sections.filter(s => s.id !== sectionId);
+        sectionsList = sections.filter(s => s.id !== movingSectionId);
       }
     }
     if (sectionsList.length < 1) {
@@ -75,34 +76,37 @@ export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
     {classes: "move", clickHandler: handleMoveSection, disabled: false, svg: <Move height="16" width="16"/>, text: "Move"}
   ];
 
-  return (
-    <Modal title="Move this section to..."
-      visibility={true} width={600} closeFunction={handleCloseDialog}>
-      <div className="sectionMoveDialog">
-        <dl>
-          <dt className="col1">Page</dt>
-          <dd className="col1">
-            <select name="page" onChange={handlePageChange}>
-              <option value="1">1</option>
-            </select>
-          </dd>
-          <dt className="col2">Position</dt>
-          <dd className="col2">
-          <select name="position" onChange={handlePositionChange}>
-              <option value="after">After</option>
-              <option value="before">Before</option>
-            </select>
-          </dd>
-          <dt className="col3">Section</dt>
-          <dd className="col3">
-            <select name="otherItem" onChange={handleOtherSectionChange}>
-              <option value="">Select one...</option>
-              {sectionOptions()}
-            </select>
-          </dd>
-        </dl>
-        <ModalButtons buttons={modalButtons} />
-      </div>
-    </Modal>
-  );
+  if (movingSectionId) {
+    return (
+      <Modal title="Move this section to..."
+        visibility={true} width={600} closeFunction={handleCloseDialog}>
+        <div className="sectionMoveDialog">
+          <dl>
+            <dt className="col1">Page</dt>
+            <dd className="col1">
+              <select name="page" onChange={handlePageChange}>
+                <option value="1">1</option>
+              </select>
+            </dd>
+            <dt className="col2">Position</dt>
+            <dd className="col2">
+            <select name="position" onChange={handlePositionChange}>
+                <option value="after">After</option>
+                <option value="before">Before</option>
+              </select>
+            </dd>
+            <dt className="col3">Section</dt>
+            <dd className="col3">
+              <select name="otherItem" onChange={handleOtherSectionChange}>
+                <option value="">Select one...</option>
+                {sectionOptions()}
+              </select>
+            </dd>
+          </dl>
+          <ModalButtons buttons={modalButtons} />
+        </div>
+      </Modal>
+    );
+  }
+  return null;
 };

--- a/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
@@ -6,6 +6,8 @@ import { Close } from "../../shared/components/icons/close-icon";
 import { Move } from "../../shared/components/icons/move-icon";
 
 import "./section-move-dialog.scss";
+import { usePageAPI } from "../api/use-api-provider";
+import { UserInterfaceContext } from "../api/use-user-interface-context";
 
 export interface ISectionMoveDialogProps {
   sectionId: string;
@@ -13,13 +15,6 @@ export interface ISectionMoveDialogProps {
   selectedPageId?: string;
   selectedPosition?: string;
   selectedOtherSectionId?: string | undefined;
-  moveFunction: (
-    sectionId: string,
-    selectedPageId: string,
-    selectedPosition: string,
-    selectedOtherSectionId: string
-  ) => void;
-  closeDialogFunction: () => void;
 }
 
 export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
@@ -27,12 +22,12 @@ export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
   sections,
   selectedPageId = "0",
   selectedPosition = "after",
-  selectedOtherSectionId: initSelectedOtherSectionId = "0",
-  moveFunction,
-  closeDialogFunction
+  selectedOtherSectionId: initSelectedOtherSectionId = "0"
   }: ISectionMoveDialogProps) => {
   const [selectedOtherSectionId, setSelectedOtherSectionId] = useState(initSelectedOtherSectionId);
-  const [modalVisibility, setModalVisibility] = useState(true);
+
+  const { moveSection } = usePageAPI();
+  const { userInterface, actions: {setMovingSectionId}} = React.useContext(UserInterfaceContext);
 
   const handlePageChange = (change: React.ChangeEvent<HTMLSelectElement>) => {
     selectedPageId = change.target.value;
@@ -48,12 +43,12 @@ export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
   };
 
   const handleCloseDialog = () => {
-    closeDialogFunction();
+    setMovingSectionId(false);
   };
 
   const handleMoveSection = () => {
-    moveFunction(sectionId, selectedPageId, selectedPosition, selectedOtherSectionId);
-    closeDialogFunction();
+    moveSection(sectionId, selectedPageId, selectedPosition as "before"|"after", selectedOtherSectionId);
+    handleCloseDialog();
   };
 
   const sectionOptions = () => {
@@ -81,7 +76,8 @@ export const SectionMoveDialog: React.FC<ISectionMoveDialogProps> = ({
   ];
 
   return (
-    <Modal title="Move this section to..." visibility={modalVisibility} width={600}>
+    <Modal title="Move this section to..."
+      visibility={true} width={600} closeFunction={handleCloseDialog}>
       <div className="sectionMoveDialog">
         <dl>
           <dt className="col1">Page</dt>


### PR DESCRIPTION
@emcelroy -- This is a pretty big change that is underway.

The main thing I want to point out is that transient UI state is being centralized in `lara-typescript/src/section-authoring/api/use-user-interface-context.ts`

You can see the UI action being used here: 
``` 
    ...
    const { actions: {setMovingSectionId}} = React.useContext(UserInterfaceContext);
    ...
    const handleMoveSection = () => {
       setMovingSectionId(id);
    };

```

This is the same approach I think we should use for marking an item for editing, maybe using a `setEditingItemId` and checking that value to bring up the editing dialog box.  We will also have to set that after an item has been created. (TBD).

https://github.com/concord-consortium/lara/compare/new-sections...179783183-move-section-item-with-menu?expand=1#diff-034158d87db6f3522b91b12e3854d85d5700c60e4eabfdd611868a00b87b6a47R80