### PR TITLE
179783183 move section items between pages

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -48,6 +48,7 @@ class Api::V1::InteractivePagesController < API::APIController
   end
 
   def set_sections
+    authorize! :update, @interactive_page
     param_sections = params['sections'] || [] # array of [{:id,:layout}]
     old_sections = @interactive_page.sections
     # Put them in the correct order:

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -17,7 +17,7 @@ export enum SectionColumns {
   SECONDARY =  "secondary"
 }
 export interface ISectionItem {
-  column?: SectionColumns;
+  column: SectionColumns;
   data?: any;
   id: ItemId;
   position?: number;

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -1,4 +1,4 @@
-import { findSectionAddress } from "../util/finding-utils";
+import { findItemAddress } from "../util/finding-utils";
 import {
   IPage, PageId,
   APIPageGetF, APIPagesGetF, APIPageItemUpdateF,
@@ -189,7 +189,7 @@ const copySection = (args: {pageId: PageId, sectionId: SectionId}) => {
   if (!page) {
     return Promise.reject(`can't find page: ${pageId}`);
   }
-  const address = findSectionAddress(pages, sectionId);
+  const address = findItemAddress({pages, sectionId});
 
   // updates position, assumes the array is in the right order.
   const reorderSection = (sections: ISection[]) => {

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -220,7 +220,7 @@ export const AuthoringPage: React.FC<IPageProps> = ({
         />
       }
       <SectionMoveDialog sections={sections} />
-      <SectionItemMoveDialog sections={sections} />
+      <SectionItemMoveDialog />
       <ItemEditDialog />
     </>
   );

--- a/lara-typescript/src/section-authoring/components/section-column.tsx
+++ b/lara-typescript/src/section-authoring/components/section-column.tsx
@@ -39,7 +39,7 @@ export interface ISectionColumnProps {
   /*
    * List of all items in the column
    */
-  items: ISection[];
+  items: ISectionItem[];
 
   /**
    * Function to move an item
@@ -75,7 +75,7 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
   const { deletePageItem, updateSectionItems} = api;
   const [showAddItem, setShowAddItem] = useState(false);
 
-  const updateItemPositions = (sectionItems: ISectionItemProps[], sourceIndex: number, destinationIndex: number) => {
+  const updateItemPositions = (sectionItems: ISectionItem[], sourceIndex: number, destinationIndex: number) => {
     const itemToMove = sectionItems[sourceIndex];
     const otherItem = sectionItems[destinationIndex];
     itemToMove.position = otherItem.position;
@@ -95,7 +95,7 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
     if (!e.destination) {
       return;
     }
-    let nextItems: ISectionItemProps[] = [];
+    let nextItems: ISectionItem[] = [];
     if (e.source.droppableId !== e.destination.droppableId) {
       // items[e.source.index].section_col = items[e.source.index].section_col === 0 ? 1 : 0;
       // disallow cross column reordering for now

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -29,7 +29,6 @@ export const SectionItemMoveDialog: React.FC<ISectionItemMoveDialogProps> = () =
   };
 
   const handleSectionChange = (change: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(change.target.value);
     setSelectedSectionId(change.target.value);
   };
 

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -16,7 +16,7 @@ export interface ISectionItemMoveDialogProps {
 export const SectionItemMoveDialog: React.FC<ISectionItemMoveDialogProps> = () => {
   const [selectedPageId, setSelectedPageId] = useState("0");
   const [selectedSectionId, setSelectedSectionId] = useState("");
-  const [selectedColumn, setSelectedColumn] = useState("");
+  const [selectedColumn, setSelectedColumn] = useState(SectionColumns.PRIMARY);
   const [selectedPosition, setSelectedPosition] = useState(RelativeLocation.After);
   const [selectedOtherItemId, setSelectedOtherItemId] = useState("");
   const [modalVisibility, setModalVisibility] = useState(true);
@@ -55,6 +55,7 @@ export const SectionItemMoveDialog: React.FC<ISectionItemMoveDialogProps> = () =
         destSectionId: selectedSectionId,
         destItemId: selectedOtherItemId,
         relativeLocation: selectedPosition,
+        destColumn: selectedColumn as SectionColumns
       });
     }
     handleCloseDialog();
@@ -80,7 +81,9 @@ export const SectionItemMoveDialog: React.FC<ISectionItemMoveDialogProps> = () =
     if (selectedSectionId) {
       const selectedSection = getSections().find(s => s.id === selectedSectionId);
       if (selectedSection?.items) {
-        itemsList = selectedSection.items.filter(i => i.id !== movingItemId);
+        itemsList = selectedSection.items
+          .filter(i => i.column === selectedColumn)
+          .filter(i => i.id !== movingItemId);
       }
     }
     if (itemsList.length < 1) {

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -114,6 +114,7 @@ export const SectionItemMoveDialog: React.FC<ISectionItemMoveDialogProps> = () =
             <dt className="col2">Section</dt>
             <dd className="col2">
               <select name="section" onChange={handleSectionChange}>
+                <option value="">Select ...</option>
                 {getSections().map((s) => {
                     return <option key={`section-option-${s.id}`} value={s.id}>{s.id}</option>;
                   })}

--- a/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
@@ -173,7 +173,6 @@ export const usePageAPI = () => {
   };
 
   const moveItem = (itemId: string, destination: IItemDestination) => {
-    debugger
     if (currentPage) {
       const changes = _moveItem({itemId, destination, pages: getPages.data || []});
       if (changes) {

--- a/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
@@ -174,9 +174,13 @@ export const usePageAPI = () => {
 
   const moveItem = (itemId: string, destination: IItemDestination) => {
     if (currentPage) {
-      const changes = _moveItem({itemId, destination, pages: getPages.data || []});
-      if (changes) {
-        updateSectionsMutation.mutate({...changes[0]});
+      const updatedSections = _moveItem({itemId, destination, pages: getPages.data || []});
+      for (const updatedSection of updatedSections) {
+        if (updatedSection.items) {
+          const changes = {section: updatedSection, sectionId: updatedSection.id};
+          updateSection.mutate({pageId: currentPage.id, changes});
+          updateSectionItems({sectionId: updatedSection.id, newItems: updatedSection.items});
+        }
       }
     }
     else {

--- a/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { useContext } from "react";
-import { moveSection  as _moveSection, ISectionDestination} from "../util/move-utils";
+import {
+  moveSection  as _moveSection,
+  moveItem  as _moveItem,
+  ISectionDestination,
+  IItemDestination
+} from "../util/move-utils";
 
 import {useMutation, useQuery, useQueryClient} from "react-query";
 import {
@@ -166,46 +171,18 @@ export const usePageAPI = () => {
       updateSections(update);
     }
   };
-  const moveItem = (
-    itemId: string,
-    selectedSectionId: string,
-    selectedColumn: SectionColumns,
-    selectedPosition: string,
-    selectedOtherItemId: string
-    ) => {
-    const items = getItems();
-    const itemIndex = items.findIndex(i => i.id === itemId);
-    const item = items[itemIndex];
-    const otherItemIndex = items.findIndex(i => (i.id === selectedOtherItemId));
-    const otherItem = items[otherItemIndex];
-    const targetSection = getSection(selectedSectionId);
-    item.column = selectedColumn;
-    item.position = otherItem && otherItem.position
-                      ? selectedPosition === "after"
-                        ? otherItem.position + 1
-                        : otherItem.position
-                      : 1;
-    const newIndex = otherItemIndex
-                       ? selectedPosition === "after"
-                         ? otherItemIndex + 1
-                         : otherItemIndex
-                       : 0;
-    const updatedItems = targetSection?.items;
-    updatedItems?.splice(itemIndex, 1);
-    updatedItems?.splice(newIndex, 0, item);
-    let sectionItemsCount = 0;
-    updatedItems?.forEach((i, index) => {
-      sectionItemsCount++;
-      if (index > newIndex) {
-        updatedItems[index].position = sectionItemsCount;
+
+  const moveItem = (itemId: string, destination: IItemDestination) => {
+    debugger
+    if (currentPage) {
+      const changes = _moveItem({itemId, destination, pages: getPages.data || []});
+      if (changes) {
+        updateSectionsMutation.mutate({...changes[0]});
       }
-    });
-    // setItems(updatedItems);
-    if (targetSection) {
-      targetSection.items = updatedItems;
-      if (updateSectionItems && updatedItems) {
-        updateSectionItems({sectionId: selectedSectionId, newItems: updatedItems});
-      }
+    }
+    else {
+      // tslint:disable-next-line
+      console.error("no page specified, cant invoke method.");
     }
   };
 

--- a/lara-typescript/src/section-authoring/util/finding-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/finding-utils.spec.ts
@@ -1,22 +1,56 @@
 import { IPage, ISection, ISectionItem } from "../api/api-types";
-import { findSectionAddress, findSection, findSectionByAddress, ISectionAddress, findPage } from "./finding-utils";
+import { findSection, findSectionByAddress,
+  ISectionAddress, findPage, findItemAddress } from "./finding-utils";
 import { makePages } from "./spec-helper";
 
 const samplePages = makePages(3);
 
-describe("findSectionAddress", () => {
-  it ("finds sections that exist, and returns index", () => {
-    expect(findSectionAddress(samplePages, "section0")).toEqual({pageIndex: 0, sectionIndex: 0});
-    expect(findSectionAddress(samplePages, "section1")).toEqual({pageIndex: 0, sectionIndex: 1});
-    expect(findSectionAddress(samplePages, "section2")).toEqual({pageIndex: 0, sectionIndex: 2});
-    expect(findSectionAddress(samplePages, "section3")).toEqual({pageIndex: 1, sectionIndex: 0});
-    expect(findSectionAddress(samplePages, "section8")).toEqual({pageIndex: 2, sectionIndex: 2});
+const nullResults = { pageIndex: null, sectionIndex: null, itemIndex: null, column: null };
+
+describe("get a Sections nested address", () => {
+  it ("finds sections that exist, and returns nested index", () => {
+    expect(findItemAddress({pages: samplePages, sectionId: "section0"}))
+      .toMatchObject({pageIndex: 0, sectionIndex: 0});
+
+    expect(findItemAddress({pages: samplePages, sectionId: "section1"}))
+      .toMatchObject({pageIndex: 0, sectionIndex: 1});
+    expect(findItemAddress({pages: samplePages, sectionId: "section2"}))
+      .toMatchObject({pageIndex: 0, sectionIndex: 2});
+    expect(findItemAddress({pages: samplePages, sectionId: "section3"}))
+      .toMatchObject({pageIndex: 1, sectionIndex: 0});
+    expect(findItemAddress({pages: samplePages, sectionId: "section8"}))
+      .toMatchObject({pageIndex: 2, sectionIndex: 2});
   });
 
   it ("returns null for sections that can't be found", () => {
-    const nullResults = {pageIndex: null, sectionIndex: null};
-    expect(findSectionAddress(samplePages, "Vorgon poetry")).toEqual(nullResults);
+    expect(findItemAddress({pages: samplePages, sectionId: "Vorgon poetry"}))
+      .toEqual(nullResults);
   });
+
+  describe("get an items nested address", () => {
+    it("finds the nested index for items that exist", () => {
+      expect(findItemAddress({pages: samplePages, itemId: "item1"}))
+        .toMatchObject({pageIndex: 0, sectionIndex: 0});
+      expect(findItemAddress({pages: samplePages, itemId: "item3"}))
+        .toMatchObject({pageIndex: 0, sectionIndex: 1});
+      expect(findItemAddress({pages: samplePages, itemId: "item9"}))
+        .toMatchObject({pageIndex: 1, sectionIndex: 0});
+    });
+    it("finds the nested index for items that exist", () => {
+      expect(findItemAddress({pages: samplePages, itemId: "item1"}))
+        .toMatchObject({pageIndex: 0, sectionIndex: 0});
+      expect(findItemAddress({pages: samplePages, itemId: "item3"}))
+        .toMatchObject({pageIndex: 0, sectionIndex: 1});
+      expect(findItemAddress({pages: samplePages, itemId: "item9"}))
+        .toMatchObject({pageIndex: 1, sectionIndex: 0});
+    });
+
+    it("returns null index for items that do not exist", () => {
+      expect(findItemAddress({pages: samplePages, itemId: "Vorgon poetry"}))
+        .toEqual(nullResults);
+    });
+  });
+
 });
 
 describe("findSection", () => {

--- a/lara-typescript/src/section-authoring/util/finding-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/finding-utils.spec.ts
@@ -1,11 +1,12 @@
 import { IPage, ISection, ISectionItem } from "../api/api-types";
+import { SectionColumn } from "../components/section-column";
 import { findSection, findSectionByAddress,
   ISectionAddress, findPage, findItemAddress } from "./finding-utils";
 import { makePages } from "./spec-helper";
 
 const samplePages = makePages(3);
 
-const nullResults = { pageIndex: null, sectionIndex: null, itemIndex: null, column: null };
+const nullResults = { pageIndex: null, sectionIndex: null, itemIndex: null };
 
 describe("get a Sections nested address", () => {
   it ("finds sections that exist, and returns nested index", () => {
@@ -24,7 +25,7 @@ describe("get a Sections nested address", () => {
 
   it ("returns null for sections that can't be found", () => {
     expect(findItemAddress({pages: samplePages, sectionId: "Vorgon poetry"}))
-      .toEqual(nullResults);
+      .toMatchObject(nullResults);
   });
 
   describe("get an items nested address", () => {
@@ -47,7 +48,7 @@ describe("get a Sections nested address", () => {
 
     it("returns null index for items that do not exist", () => {
       expect(findItemAddress({pages: samplePages, itemId: "Vorgon poetry"}))
-        .toEqual(nullResults);
+        .toMatchObject(nullResults);
     });
   });
 

--- a/lara-typescript/src/section-authoring/util/finding-utils.ts
+++ b/lara-typescript/src/section-authoring/util/finding-utils.ts
@@ -1,8 +1,13 @@
-import { IPage, SectionId, ISection, PageId } from "../api/api-types";
+import { IPage, SectionId, ISection, PageId, ItemId } from "../api/api-types";
 
 export interface ISectionAddress {
   pageIndex: number|null;
   sectionIndex: number|null;
+}
+
+export interface IItemAddress extends ISectionAddress {
+  column: string; // TODO: Lookup this type
+
 }
 
 // memoize me, invalidate on pages[]
@@ -44,3 +49,7 @@ export const findSectionAddress = (pages: IPage[], sectionId: SectionId): ISecti
   }
   return {pageIndex: null, sectionIndex: null};
 };
+
+export const findItemAddress = (sectionID: SectionId, itemId: ItemId): IItemAddress => {
+
+}

--- a/lara-typescript/src/section-authoring/util/finding-utils.ts
+++ b/lara-typescript/src/section-authoring/util/finding-utils.ts
@@ -6,7 +6,7 @@ export interface ISectionAddress {
 }
 
 export interface IItemAddress extends ISectionAddress {
-  column: SectionColumns | null;
+  column: SectionColumns;
   itemIndex: number|null;
 }
 
@@ -55,7 +55,7 @@ export const findItemAddress = (args: IAddressQuery): IItemAddress => {
   let sectionIndex = null;
   let pageIndex = null;
   let itemIndex = null;
-  let column = null;
+  let column = SectionColumns.PRIMARY;
 
   pageIndex = 0;
   for (const page of pages) {
@@ -79,5 +79,5 @@ export const findItemAddress = (args: IAddressQuery): IItemAddress => {
     }
     pageIndex++;
   }
-  return {pageIndex: null, sectionIndex: null, itemIndex: null, column: null};
+  return {pageIndex: null, sectionIndex: null, itemIndex: null, column};
 };

--- a/lara-typescript/src/section-authoring/util/move-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/move-utils.spec.ts
@@ -1,3 +1,4 @@
+import { SectionColumns } from "../api/api-types";
 import { moveSection, ISectionDestination, RelativeLocation, moveItem, IItemDestination } from "./move-utils";
 import { makePages } from "./spec-helper";
 
@@ -139,7 +140,8 @@ describe("moveItem", () => {
       const destination: IItemDestination = {
         destPageId: pages[0].id,
         relativeLocation: RelativeLocation.After,
-        destSectionId: "section3"
+        destSectionId: "section3",
+        destColumn: SectionColumns.PRIMARY
       };
       const itemId = "bogus";
 
@@ -156,7 +158,8 @@ describe("moveItem", () => {
         destPageId: "page0",
         relativeLocation: RelativeLocation.After,
         destSectionId: "section0",
-        destItemId: "item2"
+        destItemId: "item2",
+        destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
 
@@ -171,7 +174,8 @@ describe("moveItem", () => {
         destPageId: pages[0].id,
         relativeLocation: RelativeLocation.Before,
         destSectionId: "section0",
-        destItemId: "item0"
+        destItemId: "item0",
+        destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item9";
       const changedSections = moveItem({ destination, pages, itemId });
@@ -185,6 +189,7 @@ describe("moveItem", () => {
         destPageId: "page1",
         relativeLocation: RelativeLocation.Before,
         destSectionId: "section3",
+        destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
       const changedSections = moveItem({ destination, pages, itemId });
@@ -198,6 +203,7 @@ describe("moveItem", () => {
         destPageId: "page2",
         relativeLocation: RelativeLocation.Before,
         destSectionId: "section8",
+        destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
       const changedSections = moveItem({ destination, pages, itemId });
@@ -211,6 +217,7 @@ describe("moveItem", () => {
         destPageId: "page0",
         relativeLocation: RelativeLocation.Before,
         destSectionId: "section2",
+        destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
       const changedSections = moveItem({ destination, pages, itemId });
@@ -225,6 +232,7 @@ describe("moveItem", () => {
         destPageId: "page0",
         relativeLocation: RelativeLocation.Before,
         destSectionId: "section2",
+        destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
       const changedSections = moveItem({ destination, pages, itemId });

--- a/lara-typescript/src/section-authoring/util/move-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/move-utils.spec.ts
@@ -1,6 +1,14 @@
 import { moveSection, ISectionDestination, RelativeLocation, moveItem, IItemDestination } from "./move-utils";
 import { makePages } from "./spec-helper";
 
+const verifyPositions = (items: Array<{position?: number, id: string}>):boolean => {
+  let counter = 1;
+  for (const item of items) {
+    if (item.position !== counter++) { return false; }
+  }
+  return true;
+};
+
 describe("moveSection", () => {
 
   describe("Failing scenarios" , () => {
@@ -183,6 +191,49 @@ describe("moveItem", () => {
       const changedPages = moveItem({ destination, pages, itemId });
       expect(changedPages.length).toEqual(2);
       expect(changedPages[1].sections[0].items!.map(i => i.id)).toEqual(["item9", "item10", "item11", "item0" ]);
+    });
+
+    it("can move an item backward from the first section to the last not specifying item destination", () => {
+      const pages = makePages(3);
+      const destination: IItemDestination = {
+        destPageId: "page2",
+        relativeLocation: RelativeLocation.Before,
+        destSectionId: "section8",
+      };
+      const itemId = "item0";
+      const changedPages = moveItem({ destination, pages, itemId });
+      expect(changedPages.length).toEqual(2);
+      expect(changedPages[1].sections[2].items!.map(i => i.id)).toEqual(["item24", "item25", "item26", "item0" ]);
+    });
+
+    it("can move an item backward from the first section on a page the last not specifying item destination", () => {
+      const pages = makePages(3);
+      const destination: IItemDestination = {
+        destPageId: "page0",
+        relativeLocation: RelativeLocation.Before,
+        destSectionId: "section2",
+      };
+      const itemId = "item0";
+      const changedPages = moveItem({ destination, pages, itemId });
+      expect(changedPages.length).toEqual(1);
+      expect(changedPages[0].sections[2].items!.map(i => i.id)).toEqual(["item6", "item7", "item8", "item0" ]);
+    });
+
+    it("will update the position attributes of the sections and items that moved", () => {
+      const pages = makePages(3);
+      const destination: IItemDestination = {
+        destPageId: "page0",
+        relativeLocation: RelativeLocation.Before,
+        destSectionId: "section2",
+      };
+      const itemId = "item0";
+      const changedPages = moveItem({ destination, pages, itemId });
+      for (const page of changedPages) {
+        verifyPositions(page.sections);
+        for(const section of page.sections) {
+          verifyPositions(section.items!);
+        }
+      }
     });
   });
 });

--- a/lara-typescript/src/section-authoring/util/move-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/move-utils.spec.ts
@@ -1,6 +1,4 @@
-import { IPage, ISection, ISectionItem } from "../api/api-types";
-import { findSectionAddress, findSection, findSectionByAddress } from "./finding-utils";
-import { moveSection, ISectionDestination, RelativeLocation } from "./move-utils";
+import { moveSection, ISectionDestination, RelativeLocation, moveItem, IItemDestination } from "./move-utils";
 import { makePages } from "./spec-helper";
 
 describe("moveSection", () => {
@@ -124,4 +122,67 @@ describe("moveSection", () => {
   });
 
   // TODO:  Tests asserting position of Sections.
+});
+
+describe("moveItem", () => {
+
+  describe("Failing scenarios" , () => {
+    it ("it can't move non-existent item", () => {
+      const pages = makePages(3);
+      const destination: IItemDestination = {
+        destPageId: pages[0].id,
+        relativeLocation: RelativeLocation.After,
+        destSectionId: "section3"
+      };
+      const itemId = "bogus";
+
+      // Move failed:
+      expect(moveItem({ destination, pages, itemId })).toEqual([]);
+    });
+  });
+
+  describe("moving items within the same section", () => {
+
+    it ("it can move the first item in the section to the end of the section", () => {
+      const pages = makePages(3);
+      const destination: IItemDestination = {
+        destPageId: "page0",
+        relativeLocation: RelativeLocation.After,
+        destSectionId: "section0",
+        destItemId: "item2"
+      };
+      const itemId = "item0";
+
+      const changedPages = moveItem({ destination, pages, itemId });
+      expect(changedPages.length).toEqual(1);
+      expect(changedPages[0].sections[0].items!.map(i => i.id)).toEqual(["item1", "item2", "item0" ]);
+    });
+
+    it("can move an item forward from one page to another", () => {
+      const pages = makePages(3);
+      const destination: IItemDestination = {
+        destPageId: pages[0].id,
+        relativeLocation: RelativeLocation.Before,
+        destSectionId: "section0",
+        destItemId: "item0"
+      };
+      const itemId = "item9";
+      const changedPages = moveItem({ destination, pages, itemId });
+      expect(changedPages.length).toEqual(2);
+      expect(changedPages[1].sections[0].items!.map(i => i.id)).toEqual(["item9", "item0", "item1", "item2" ]);
+    });
+
+    it("can move an item backward from one page to another, not specifying item destination", () => {
+      const pages = makePages(3);
+      const destination: IItemDestination = {
+        destPageId: "page1",
+        relativeLocation: RelativeLocation.Before,
+        destSectionId: "section3",
+      };
+      const itemId = "item0";
+      const changedPages = moveItem({ destination, pages, itemId });
+      expect(changedPages.length).toEqual(2);
+      expect(changedPages[1].sections[0].items!.map(i => i.id)).toEqual(["item9", "item10", "item11", "item0" ]);
+    });
+  });
 });

--- a/lara-typescript/src/section-authoring/util/move-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/move-utils.spec.ts
@@ -1,7 +1,7 @@
 import { moveSection, ISectionDestination, RelativeLocation, moveItem, IItemDestination } from "./move-utils";
 import { makePages } from "./spec-helper";
 
-const verifyPositions = (items: Array<{position?: number, id: string}>):boolean => {
+const verifyPositions = (items: Array<{position?: number, id: string}>): boolean => {
   let counter = 1;
   for (const item of items) {
     if (item.position !== counter++) { return false; }
@@ -230,7 +230,7 @@ describe("moveItem", () => {
       const changedPages = moveItem({ destination, pages, itemId });
       for (const page of changedPages) {
         verifyPositions(page.sections);
-        for(const section of page.sections) {
+        for (const section of page.sections) {
           verifyPositions(section.items!);
         }
       }

--- a/lara-typescript/src/section-authoring/util/move-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/move-utils.spec.ts
@@ -36,7 +36,6 @@ describe("moveSection", () => {
         destSectionId: "bogus" // not specifying a page...
       };
       const sectionId = "section0";
-
       const changedPages = moveSection({ destination, pages, sectionId });
       expect(changedPages.length).toEqual(1);
       expect(changedPages[0].sections.map(s => s.id)).toEqual(["section1", "section2", "section0" ]);
@@ -161,9 +160,9 @@ describe("moveItem", () => {
       };
       const itemId = "item0";
 
-      const changedPages = moveItem({ destination, pages, itemId });
-      expect(changedPages.length).toEqual(1);
-      expect(changedPages[0].sections[0].items!.map(i => i.id)).toEqual(["item1", "item2", "item0" ]);
+      const changedSections = moveItem({ destination, pages, itemId });
+      expect(changedSections.length).toEqual(1);
+      expect(changedSections[0].items!.map(i => i.id)).toEqual(["item1", "item2", "item0" ]);
     });
 
     it("can move an item forward from one page to another", () => {
@@ -175,9 +174,9 @@ describe("moveItem", () => {
         destItemId: "item0"
       };
       const itemId = "item9";
-      const changedPages = moveItem({ destination, pages, itemId });
-      expect(changedPages.length).toEqual(2);
-      expect(changedPages[1].sections[0].items!.map(i => i.id)).toEqual(["item9", "item0", "item1", "item2" ]);
+      const changedSections = moveItem({ destination, pages, itemId });
+      expect(changedSections.length).toEqual(2);
+      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item9", "item0", "item1", "item2" ]);
     });
 
     it("can move an item backward from one page to another, not specifying item destination", () => {
@@ -188,9 +187,9 @@ describe("moveItem", () => {
         destSectionId: "section3",
       };
       const itemId = "item0";
-      const changedPages = moveItem({ destination, pages, itemId });
-      expect(changedPages.length).toEqual(2);
-      expect(changedPages[1].sections[0].items!.map(i => i.id)).toEqual(["item9", "item10", "item11", "item0" ]);
+      const changedSections = moveItem({ destination, pages, itemId });
+      expect(changedSections.length).toEqual(2);
+      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item9", "item10", "item11", "item0" ]);
     });
 
     it("can move an item backward from the first section to the last not specifying item destination", () => {
@@ -201,12 +200,12 @@ describe("moveItem", () => {
         destSectionId: "section8",
       };
       const itemId = "item0";
-      const changedPages = moveItem({ destination, pages, itemId });
-      expect(changedPages.length).toEqual(2);
-      expect(changedPages[1].sections[2].items!.map(i => i.id)).toEqual(["item24", "item25", "item26", "item0" ]);
+      const changedSections = moveItem({ destination, pages, itemId });
+      expect(changedSections.length).toEqual(2);
+      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item24", "item25", "item26", "item0" ]);
     });
 
-    it("can move an item backward from the first section on a page the last not specifying item destination", () => {
+    it("can move an item backward from the first section on a page to the last not specifying item destination", () => {
       const pages = makePages(3);
       const destination: IItemDestination = {
         destPageId: "page0",
@@ -214,9 +213,10 @@ describe("moveItem", () => {
         destSectionId: "section2",
       };
       const itemId = "item0";
-      const changedPages = moveItem({ destination, pages, itemId });
-      expect(changedPages.length).toEqual(1);
-      expect(changedPages[0].sections[2].items!.map(i => i.id)).toEqual(["item6", "item7", "item8", "item0" ]);
+      const changedSections = moveItem({ destination, pages, itemId });
+      expect(changedSections.length).toEqual(2);
+      expect(changedSections[0].items!.map(i => i.id)).toEqual(["item1", "item2" ]);
+      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item6", "item7", "item8", "item0" ]);
     });
 
     it("will update the position attributes of the sections and items that moved", () => {
@@ -227,12 +227,9 @@ describe("moveItem", () => {
         destSectionId: "section2",
       };
       const itemId = "item0";
-      const changedPages = moveItem({ destination, pages, itemId });
-      for (const page of changedPages) {
-        verifyPositions(page.sections);
-        for (const section of page.sections) {
-          verifyPositions(section.items!);
-        }
+      const changedSections = moveItem({ destination, pages, itemId });
+      for (const section of changedSections) {
+        verifyPositions(section.items!);
       }
     });
   });

--- a/lara-typescript/src/section-authoring/util/move-utils.tsx
+++ b/lara-typescript/src/section-authoring/util/move-utils.tsx
@@ -71,11 +71,11 @@ export const moveSection = (args: IMoveSectionSignature): IPage[] => {
     return error(`can't find destination ${destination}`);
   }
 
-  // If no section is specified, insert at the end
+  // If no section is specified, insert it at the end
   if (destAddress.sectionIndex == null) {
     destAddress.sectionIndex = (pages[destAddress.pageIndex].sections.length) || 0;
   }
-  // Otherwise, optionally add one if we are inserting after.
+  // Otherwise, optionally add one to the index if we are inserting after.
   else {
     // Adjust destination index by relative location:
     if (relativeLocation === RelativeLocation.After) {
@@ -96,7 +96,7 @@ export const moveSection = (args: IMoveSectionSignature): IPage[] => {
     sections: sourcePage.sections.filter(s => s.id !== sourceSection.id)
   };
 
-  // If we are adding the section to the same section we are removing it from:
+  // If we are adding the section to the same page we are removing it from:
   if (sourceAddress.pageIndex === destAddress.pageIndex) {
     nextSourcePage.sections.splice(destAddress.sectionIndex, 0, sourceSection);
     return [ setSectionPositions(nextSourcePage) ];

--- a/lara-typescript/src/section-authoring/util/move-utils.tsx
+++ b/lara-typescript/src/section-authoring/util/move-utils.tsx
@@ -1,4 +1,4 @@
-import { IPage, ISection, PageId, SectionId, ItemId, ISectionItem} from "../api/api-types";
+import { IPage, ISection, PageId, SectionId, ItemId, ISectionItem, SectionColumns} from "../api/api-types";
 import { findSection, findItemAddress, IAddressQuery, findItemByAddress, findSectionByAddress } from "./finding-utils";
 
 export enum RelativeLocation {
@@ -20,6 +20,7 @@ export interface IMoveSectionSignature {
 
 export interface IItemDestination extends ISectionDestination {
   destSectionId: SectionId;
+  destColumn: SectionColumns;
   destItemId?: ItemId;
 }
 
@@ -125,6 +126,8 @@ export const moveItem = (args: IMoveItemSignature): ISection[] => {
     return error(`can't find itemId ${itemId}`);
   }
 
+  // Set the items column:
+  sourceItem.column = destination.destColumn;
   // We must have a destination section:
   if (destAddress.sectionIndex == null || destAddress.pageIndex == null) {
     return error(`can't find destination ${destination}`);
@@ -148,9 +151,7 @@ export const moveItem = (args: IMoveItemSignature): ISection[] => {
   // At this point we should have indexes for everything...
   // 1. remove the item from the source section items
   // 2. add the item back into the dest section items
-  // 3. update the sections and pages
-  const sourcePage = pages[sourceAddress.pageIndex];
-  const destPage = pages[destAddress.pageIndex];
+  // 3. update the sections
   const sourceSection = findSectionByAddress(pages, sourceAddress);
   const destSection = findSectionByAddress(pages, destAddress);
   if (destSection == null || sourceSection == null) {

--- a/lara-typescript/src/section-authoring/util/move-utils.tsx
+++ b/lara-typescript/src/section-authoring/util/move-utils.tsx
@@ -109,7 +109,7 @@ export const moveSection = (args: IMoveSectionSignature): IPage[] => {
   return [setSectionPositions(nextSourcePage), setSectionPositions(nextDestPage)];
 };
 
-export const moveItem = (args: IMoveItemSignature): IPage[] => {
+export const moveItem = (args: IMoveItemSignature): ISection[] => {
   const { itemId, destination,  pages } = args;
   const { relativeLocation } = destination;
   const sourceAddress = findItemAddress({ pages, itemId});
@@ -166,13 +166,12 @@ export const moveItem = (args: IMoveItemSignature): IPage[] => {
       (sourceAddress.sectionIndex === destAddress.sectionIndex)
    ) {
     sourceSection.items.splice(destAddress.itemIndex, 0, sourceItem);
+    updatePositions(sourceSection.items);
     // Just return the one page that changed:
-    return [ setSectionPositions(sourcePage) ];
+    return [ sourceSection ];
   }
 
   destSection.items!.splice(destAddress.itemIndex, 0, sourceItem);
-  if (sourcePage.id === destPage.id) {
-    return [setSectionPositions(destPage)];
-  }
-  return [setSectionPositions(sourcePage), setSectionPositions(destPage)];
+  updatePositions(destSection?.items || []);
+  return [sourceSection, destSection];
 };

--- a/lara-typescript/src/section-authoring/util/move-utils.tsx
+++ b/lara-typescript/src/section-authoring/util/move-utils.tsx
@@ -170,7 +170,6 @@ export const moveItem = (args: IMoveItemSignature): IPage[] => {
     return [ setSectionPositions(sourcePage) ];
   }
 
-
   destSection.items!.splice(destAddress.itemIndex, 0, sourceItem);
   if (sourcePage.id === destPage.id) {
     return [setSectionPositions(destPage)];

--- a/lara-typescript/src/section-authoring/util/move-utils.tsx
+++ b/lara-typescript/src/section-authoring/util/move-utils.tsx
@@ -1,4 +1,4 @@
-import { IPage, ISection, PageId, SectionId } from "../api/api-types";
+import { IPage, ISection, PageId, SectionId, ItemId, ISectionItem} from "../api/api-types";
 import { findSection, findSectionAddress } from "./finding-utils";
 
 export enum RelativeLocation {
@@ -18,8 +18,17 @@ export interface IMoveSectionSignature {
   pages: IPage[];
 }
 
+export interface IItemDestination extends ISectionDestination {
+  destSectionId: SectionId;
+  destItemId?: ItemId;
+}
+
+const updatePositions = (items: ISection[] | ISectionItem[] ) => {
+  items.forEach ( (item, index) => { item.position = index + 1; });
+};
+
 const setSectionPositions = (page: IPage)  => {
-  page.sections = page.sections.map( (s, i) => ({ ...s, position: i}) );
+  updatePositions(page.sections);
   return page;
 };
 

--- a/lara-typescript/src/section-authoring/util/spec-helper.ts
+++ b/lara-typescript/src/section-authoring/util/spec-helper.ts
@@ -1,4 +1,4 @@
-import { ISectionItem, ISection, IPage } from "../api/api-types";
+import { ISectionItem, ISection, IPage, SectionColumns } from "../api/api-types";
 import { collect } from "./array-util";
 
 let pageCounter = 0;
@@ -6,7 +6,10 @@ let sectionCounter = 0;
 let itemCounter = 0;
 
 const makeItems = (count: number): ISectionItem[] => {
-  return collect<ISectionItem>(count, () => ({ id: `item${itemCounter++}` }));
+  return collect<ISectionItem>(count, () => ({
+    id: `item${itemCounter++}`,
+    column: SectionColumns.SECONDARY
+  }));
 };
 
 const makeSections = (count: number): ISection[] => {

--- a/spec/controllers/api/v1/interactive_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/interactive_pages_controller_spec.rb
@@ -533,6 +533,28 @@ end
           new_id_order = section.page_items.map(& :id)
           expect(new_id_order).to eql(old_id_order.reverse)
         end
+
+        it 'will add new items' do
+          extra_item = FactoryGirl.create(:page_item, { column: PageItem::COLUMN_PRIMARY })
+          items << extra_item
+          expect(section.page_items.length).to eql(3)
+          update_request = { id: page.id, section: { id: section.id, items: items.map(&:attributes) } }
+          xhr :post, 'update_section', update_request
+          expect(response.status).to eq(200)
+          section.reload
+          expect(section.page_items.length).to eql(4)
+        end
+
+        it 'will delete missing items' do
+          new_items = items[0, 2].map { |i| { id: i.id, column: i.column } }
+          expect(section.page_items.length).to eql(3)
+          update_request = { id: page.id, section: { id: section.id, items: new_items } }
+          xhr :post, 'update_section', update_request
+          expect(response.status).to eq(200)
+          section.reload
+          expect(section.page_items.length).to eql(2)
+        end
+
       end
 
       describe 'failures' do


### PR DESCRIPTION
## Move sections using dropdown section-item-move-dialog. ##

This lets an author move an item to a different page / section / column.
![2021-10-28 16 53 13](https://user-images.githubusercontent.com/22908/139334563-e9c0c189-32a8-4a29-89fa-694aa1a81583.gif)


