### PR TITLE
180167095 fix rack-secure_samesite_cookies Gem install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,4 +117,4 @@ gem "spreadsheet", "~> 1.0"
 gem "nokogiri", ">= 1.8.5"
 gem "rack-cors","~> 0.4.1", :require => 'rack/cors'
 gem "test-unit", "~> 3.0"
-gem 'rack-secure_samesite_cookies', {:git => 'git://github.com/concord-consortium/secure-samesite-cookies', :tag => 'v1.0.2'}
+gem 'rack-secure_samesite_cookies', {:git => 'https://github.com/concord-consortium/secure-samesite-cookies.git', :tag => 'v1.0.2'}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,18 +15,18 @@ GIT
       railties
 
 GIT
-  remote: git://github.com/concord-consortium/secure-samesite-cookies
+  remote: git://github.com/lostapathy/yaml_db.git
+  revision: 98e9a5dca43e3fedd3268c76a73af40d1bdf1dfd
+  specs:
+    yaml_db (0.2.2)
+
+GIT
+  remote: https://github.com/concord-consortium/secure-samesite-cookies.git
   revision: da3078b1f2d1ac9c4c62b5cd7cd4c1fce1eb6dd1
   tag: v1.0.2
   specs:
     rack-secure_samesite_cookies (1.0.2)
       rack (>= 1.4.7)
-
-GIT
-  remote: git://github.com/lostapathy/yaml_db.git
-  revision: 98e9a5dca43e3fedd3268c76a73af40d1bdf1dfd
-  specs:
-    yaml_db (0.2.2)
 
 GIT
   remote: https://github.com/intridea/omniauth-oauth2.git


### PR DESCRIPTION

Change from `git` to `https` for installing `rack-secure_samesite_cookies`


see: https://github.blog/2021-09-01-improving-git-protocol-security-github/