### PR TITLE
Integration: Switching section layouts (post-items added)

### DIFF
--- a/lara-typescript/src/section-authoring/util/change-layout-utils.tsx
+++ b/lara-typescript/src/section-authoring/util/change-layout-utils.tsx
@@ -26,6 +26,9 @@ export const changeLayout = (args: IChangeLayoutSignature) => {
     // All items get placed in secondary column.
     // Items from the former primary column are listed first.
     const primaryItems = section.items?.filter(i => i.column === SectionColumns.PRIMARY);
+    primaryItems?.forEach((item: ISectionItem, index: number) => {
+      item.position = index + 1;
+    });
     section.items?.forEach((item: ISectionItem, index: number) => {
       if (primaryItems && item.column === SectionColumns.SECONDARY) {
         item.position = item.position ? primaryItems.length + item.position : primaryItems.length + index + 1;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179594634

[#179594634]

The only change here is to ensure that items in the primary column are placed first when changing from a multi-column layout to full-width (single column). Otherwise, the layout switching functionality works as expected.