### PR TITLE
180250615 pages have unique urls

### DIFF
--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -62,7 +62,11 @@
     });
 
     $(document).ready(function() {
-      var params = {host: window.location.origin, activityId: "#{@activity.id}"};
+      var params = {
+        host: window.location.origin,
+        activityId: "#{@activity.id}",
+        id: "#{@page.id}"
+      };
       var element;
       console.log(params);
       var container = $("#sections-container")[0];

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -16,8 +16,9 @@
       %li
         \/
         = @page.name
-
-= render :partial => "publications/publication_failures", :locals =>{ :publication => @activity}
+-# 2021-11-15 NP stopped rendering the publication partial. It was chatty (polling) and ugly
+-# TODO: TBD: Do we need to update publication status?
+-# = render :partial => "publications/publication_failures", :locals =>{ :publication => @activity}
 
 .activity-name= @activity.name
 

--- a/lara-typescript/src/section-authoring/components/query-bound-page.tsx
+++ b/lara-typescript/src/section-authoring/components/query-bound-page.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { APIContainer } from "../containers/api-container";
 import { AuthoringPageUsingAPI, IPageProps } from "./authoring-page";
 
-interface IQueryBoundPage extends IPageProps {
+export interface IQueryBoundPage extends IPageProps {
   host?: string;
   activityId?: string;
 }
@@ -10,8 +10,9 @@ interface IQueryBoundPage extends IPageProps {
 export const QueryBoundPage = (props: IQueryBoundPage) => {
   const host = props.host || "https://app.lara.docker";
   const activityId = props.activityId || "55";
+  const pageId = props.id;
   return (
-    <APIContainer activityId={activityId} host={host}>
+    <APIContainer activityId={activityId} host={host} pageId={pageId}>
       <AuthoringPageUsingAPI />
     </APIContainer>
   );

--- a/lara-typescript/src/section-authoring/components/query-bound-page.tsx
+++ b/lara-typescript/src/section-authoring/components/query-bound-page.tsx
@@ -12,7 +12,7 @@ export const QueryBoundPage = (props: IQueryBoundPage) => {
   const activityId = props.activityId || "55";
   const pageId = props.id;
   return (
-    <APIContainer activityId={activityId} host={host} pageId={pageId}>
+    <APIContainer activityId={activityId} host={host}>
       <AuthoringPageUsingAPI />
     </APIContainer>
   );

--- a/lara-typescript/src/section-authoring/containers/api-container.tsx
+++ b/lara-typescript/src/section-authoring/containers/api-container.tsx
@@ -10,17 +10,12 @@ import { ReactQueryDevtools } from "react-query/devtools";
 export interface IAPIContainerProps {
   activityId?: string;
   host?: string;
-  pageId?: string;
 }
 
 export const APIContainer: React.FC<IAPIContainerProps> = (props) => {
-  const {activityId, host, pageId} = props;
+  const {activityId, host} = props;
   const queryClient = new QueryClient();
   const ui = React.useContext(UserInterfaceContext);
-  const {actions} = ui;
-  if (pageId) {
-    actions.setCurrentPageId(pageId);
-  }
   let APIProvider: IAuthoringAPIProvider = mockProvider;
   if (activityId && host) {
     APIProvider = getLaraAuthoringAPI(activityId, host);

--- a/lara-typescript/src/section-authoring/containers/api-container.tsx
+++ b/lara-typescript/src/section-authoring/containers/api-container.tsx
@@ -10,13 +10,17 @@ import { ReactQueryDevtools } from "react-query/devtools";
 export interface IAPIContainerProps {
   activityId?: string;
   host?: string;
+  pageId?: string;
 }
 
 export const APIContainer: React.FC<IAPIContainerProps> = (props) => {
-  const {activityId, host} = props;
+  const {activityId, host, pageId} = props;
   const queryClient = new QueryClient();
   const ui = React.useContext(UserInterfaceContext);
-
+  const {actions} = ui;
+  if (pageId) {
+    actions.setCurrentPageId(pageId);
+  }
   let APIProvider: IAuthoringAPIProvider = mockProvider;
   if (activityId && host) {
     APIProvider = getLaraAuthoringAPI(activityId, host);

--- a/lara-typescript/src/section-authoring/containers/user-interface-provider.tsx
+++ b/lara-typescript/src/section-authoring/containers/user-interface-provider.tsx
@@ -65,6 +65,11 @@ const UserInterfaceProvider: React.FC = ({children}) => {
   };
 
   const setCurrentPageId = (id: string) => {
+    const url = window.location.toString();
+    const nextUrl = url.replace(/\/pages\/\d+\//, `/pages/${id}/`);
+    const title = `edit page ${id}`;
+    const data = {title};
+    window.history.pushState(data, `edit page ${id}`, nextUrl);
     setUserInterface( (draft) => {draft.currentPageId = id; });
   };
 

--- a/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
@@ -32,11 +32,25 @@ export const usePageAPI = () => {
 
   const getPages = useQuery<IPage[], Error>(PAGES_CACHE_KEY, provider.getPages);
 
+  const getPageIdFromLocation = () => {
+    const pageIdRegex = /pages\/(\d+)\/edit/;
+    const currentLoc = window.location.toString();
+    const matchData = currentLoc.match(pageIdRegex);
+    if (matchData && matchData[1]) {
+      return matchData[1];
+    }
+    return null;
+  };
+
   const getPage =  () => {
     const pages = getPages.data;
     if (pages && pages.length > -1) {
       if (userInterface.currentPageId == null) {
-        actions.setCurrentPageId(getPages.data[0].id);
+        // Look for the pageId in the URL in the address bar
+        // if its not there, fallback to the first page
+        const fromLocation = getPageIdFromLocation();
+        const pageId = fromLocation ? fromLocation :  getPages.data[0].id;
+        actions.setCurrentPageId(pageId);
       }
       return getPages.data.find( (p: IPage) => p.id === userInterface.currentPageId);
     }

--- a/lara-typescript/src/section-authoring/index.tsx
+++ b/lara-typescript/src/section-authoring/index.tsx
@@ -1,14 +1,12 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { QueryClient, QueryClientProvider } from "react-query";
 import { AuthoringSection, ISectionProps } from "./components/authoring-section";
-import { IPageProps } from "./components/authoring-page";
-import { QueryBoundPage } from "./components/query-bound-page";
+import { QueryBoundPage, IQueryBoundPage } from "./components/query-bound-page";
 const renderAuthoringSection = (root: HTMLElement, props: ISectionProps) => {
   return ReactDOM.render(<AuthoringSection {...props} />, root);
 };
 
-const renderAuthoringPage = (root: HTMLElement, props: IPageProps) => {
+const renderAuthoringPage = (root: HTMLElement, props: IQueryBoundPage) => {
   const App = <QueryBoundPage {...props} />;
   return ReactDOM.render(App, root);
 };


### PR DESCRIPTION
When editing pages in the new-sections React SPA, update the location to reflect the page currently being edited.

Also: When launching the editor from LARA start on the correct page based on the url of the edit link clicked from the activity page.

**Note**  Publication status polling was disabled in this PR too. It's not clear whether we are going to need portal publication. For the moment I have taken it out completely because it was slowing things down and cluttering up the console log.

One other unrelated fix: The wrong interface was being used for `QueryBoundPage` in `renderAuthoringPage`.