### PR TITLE
180351146 ping pong view changes

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::InteractivePagesController < API::APIController
 
     return error("Can't find activity for page") unless activity
 
-    position = params[:dest_index];
+    position = params[:dest_index]
 
     next_page = @interactive_page.duplicate
     next_page.lightweight_activity = activity

--- a/lara-typescript/src/section-authoring/components/page-nav-menu/page-copy-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/page-nav-menu/page-copy-dialog.tsx
@@ -44,7 +44,6 @@ export const PageCopyDialog: React.FC<IPageCopyDialogProps> = ({
 
   const handleCopyPage = () => {
     if (currentPageIndex != null && currentPageIndex > -1) {
-      const copiedPageId = pages[currentPageIndex].id;
       let destIndex = pages.findIndex(p => p.id === selectedOtherPageId);
       if (selectedPosition === RelativeLocation.After) {
         destIndex++;

--- a/lara-typescript/src/section-authoring/containers/user-interface-provider.tsx
+++ b/lara-typescript/src/section-authoring/containers/user-interface-provider.tsx
@@ -9,8 +9,18 @@ interface IUserInterface {
   editingItemId: string | false;
 }
 
+const getPageIdFromLocation = () => {
+  const pageIdRegex = /pages\/(\d+)\/edit/;
+  const currentLoc = window.location.toString();
+  const matchData = currentLoc.match(pageIdRegex);
+  if (matchData && matchData[1]) {
+    return matchData[1];
+  }
+  return null;
+};
+
 const defaultUI: IUserInterface = {
-  currentPageId: null,
+  currentPageId: getPageIdFromLocation(),
   movingItemId: false,
   movingSectionId: false,
   editingItemId: false


### PR DESCRIPTION
## Reduce visual ping-pong effect through fewer requests to the server.

We already explicitly invalidate the cache when we make changes. By default ReactQuery also
invalidates the cache whenever the page is focused or components re-mount. We would often request the list of pages several times in rapid succession.

### Some other general cleanup:
- Fix console error related to setting state in a render loop (page-provider -> user-interface-provider)
- remove unused var

PT Story: [🐞 180351146 ping pong view changes](https://www.pivotaltracker.com/story/show/180351146)