### PR TITLE
179739155 section numbering

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -240,7 +240,7 @@ class Api::V1::InteractivePagesController < API::APIController
         if linked_interactives.present?
           page_item.set_linked_interactives(JSON.parse(linked_interactives))
         end
-      end 
+      end
       if embeddable
         embeddable.update_attributes(data)
       end
@@ -355,6 +355,7 @@ class Api::V1::InteractivePagesController < API::APIController
     {
       id: section.id.to_s,
       layout: section.layout,
+      position: section.position,
       items: section.page_items.map { |pi| generate_item_json(pi) }
     }
   end
@@ -364,7 +365,8 @@ class Api::V1::InteractivePagesController < API::APIController
     {
       id: page.id.to_s,
       title: page.name,
-      sections: sections
+      sections: sections,
+      position: page.position
     }
   end
 

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -1,5 +1,5 @@
 import { findItemAddress, findItemByAddress } from "../util/finding-utils";
-import { updatePositions } from "../util/move-utils";
+import { setSectionPositions, updatePositions } from "../util/move-utils";
 import {
   IPage, PageId,
   APIPageGetF, APIPagesGetF, APIPageItemUpdateF,
@@ -170,6 +170,7 @@ export const updatePage = (id: PageId, changes: Partial<IPage>) => {
   if (indx > -1) {
     const nextPage = {... pages[indx], ...changes };
     pages[indx] = nextPage;
+    setSectionPositions(nextPage);
     return Promise.resolve({... nextPage});
   }
   return Promise.reject("Can't find that page");
@@ -179,6 +180,7 @@ const createSection = (id: PageId) => {
   const page = pages.find(p => p.id === id);
   if (page) {
     page.sections.push(makeNewSection());
+    setSectionPositions(page);
     return Promise.resolve(page);
   }
   return Promise.reject(`cant find page ${id}`);

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -65,6 +65,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
   updateFunction,
   layout: initLayout = defaultLayout,
   items = [],
+  position,
   collapsed: initCollapsed = false,
   title,
   moveItemFunction,
@@ -146,12 +147,12 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
 
   const addItem = (column: SectionColumns) => {
     const nextId = `section-${id}-item-${items.length}`;
-    const position = items.length + 1;
+    const itemPosition = items.length + 1;
     const newItem: ICreatePageItem = {
       // id: `${nextId}`,
       section_id: id,
       column,
-      position,
+      position: itemPosition,
       embeddable: "unknown",
       // title: `Item ${position} - ${Math.random().toString(36).substr(2, 9)}`
     };
@@ -176,6 +177,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
     return `edit-page-grid-container sectionContainer ${layoutClass}`;
   };
 
+  // console.log(id, items, title, position);
   return (
     <div className={sectionClassNames()}>
       <header className="sectionMenu full-row">
@@ -183,7 +185,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
           <span className="sectionDragHandle" {...draggableProvided?.dragHandleProps}>
             <GripLines  />
           </span>
-          <h3>{title}{id}</h3>
+          <h3>{title}{position}</h3>
           <label htmlFor="section_layout">Layout: </label>
           <select
             id="section_layout"

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -184,7 +184,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
           <span className="sectionDragHandle" {...draggableProvided?.dragHandleProps}>
             <GripLines  />
           </span>
-          <h3>{title}{position}</h3>
+          <h3>Section {position}{title ? " " + title : ""}</h3>
           <label htmlFor="section_layout">Layout: </label>
           <select
             id="section_layout"

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -177,7 +177,6 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
     return `edit-page-grid-container sectionContainer ${layoutClass}`;
   };
 
-  // console.log(id, items, title, position);
   return (
     <div className={sectionClassNames()}>
       <header className="sectionMenu full-row">

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -110,7 +110,7 @@ export const SectionItemMoveDialog: React.FC = () => {
                 <option value="">Select ...</option>
                 {
                   sections.map((s) => {
-                    return <option key={`section-option-${s.id}`} value={s.id}>{s.id}</option>;
+                    return <option key={`section-option-${s.id}`} value={s.id}>{s.position}</option>;
                     })
                 }
               </select>

--- a/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
@@ -10,7 +10,7 @@ import { ISectionDestination } from "../util/move-utils";
 import { useDestinationChooser } from "../hooks/use-destination-chooser";
 
 export const SectionMoveDialog: React.FC = () => {
-  const { userInterface: { movingSectionId }, actions: {setMovingSectionId}} = React.useContext(UserInterfaceContext);
+  const { userInterface: { movingSectionId }, actions: { setMovingSectionId }} = React.useContext(UserInterfaceContext);
   const { moveSection } = usePageAPI();
   const {
     sections, selectedSectionId,
@@ -42,9 +42,14 @@ export const SectionMoveDialog: React.FC = () => {
     }
     return sectionsList?.map((s) => (
       <option key={s.id} value={`${s.id}`}>
-        Section {`${s.id} ${s.title ? s.title : ""}`}
+        Section {`${s.position} ${s.title ? s.title : ""}`}
       </option>
     ));
+  };
+
+  const movingSectionPosition = () => {
+    const sectionToMove =  sections.find(s => s.id === movingSectionId);
+    return sectionToMove?.position;
   };
 
   const modalButtons = [
@@ -54,7 +59,7 @@ export const SectionMoveDialog: React.FC = () => {
 
   if (movingSectionId) {
     return (
-      <Modal title={`Move section ${movingSectionId} to...`}
+      <Modal title={`Move section ${movingSectionPosition()} to...`}
         visibility={true} width={600} closeFunction={handleCloseDialog}>
         <div className="sectionMoveDialog">
           <dl>

--- a/lara-typescript/src/section-authoring/hooks/use-destination-chooser.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-destination-chooser.ts
@@ -26,7 +26,7 @@ export const useDestinationChooser = () => {
       }
       setSections(foundPage?.sections || []);
     }
-  }, [selectedPageId]);
+  }, [selectedPageId, getPages]);
 
   React.useEffect( () => {
     if (currentPage && !validPage) {

--- a/lara-typescript/src/section-authoring/util/move-utils.tsx
+++ b/lara-typescript/src/section-authoring/util/move-utils.tsx
@@ -36,7 +36,7 @@ export const updatePositions = (items: Array<{position?: number}>) => {
   });
 };
 
-const setSectionPositions = (page: IPage)  => {
+export const setSectionPositions = (page: IPage)  => {
   updatePositions(page.sections);
   for (const section of page.sections) {
     updatePositions(section.items!);


### PR DESCRIPTION
Adds Section label to section authoring header.
Changes number shown in header to be position number from section id. Number updates to current position when sections are moved to current position.
Section move dialog shows position number in the dropdown instead of section ids. Fixes a bug where section list does not update when a section is added or deleted.
Item move dialog shows section position number in the section dropdown to move item to.