### PR TITLE
Implemented status flags for runs (#179923354)

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -1,12 +1,15 @@
 class Run < ActiveRecord::Base
 
+  # NOTE: additional status flags should use bitmask values (0x2, 0x4, etc) so that multiple flags can be set at the same time
+  SentToReportServiceStatusFlag = 0x1
+
   # Trigger whenever a portal update job needs to be re-run
   class PortalUpdateIncomplete < StandardError; end
   class InvalidJobState < StandardError; end
 
   attr_accessible :run_count, :user_id, :key, :activity, :user, :page_id,
   :remote_id, :remote_endpoint, :activity_id, :sequence_id, :context_id,
-  :class_info_url, :platform_id, :platform_user_id, :resource_link_id
+  :class_info_url, :platform_id, :platform_user_id, :resource_link_id, :status
 
   belongs_to :activity, :class_name => LightweightActivity
 
@@ -401,5 +404,15 @@ class Run < ActiveRecord::Base
 
   def lara_to_portal_secret_auth
     return 'Bearer %s' % Concord::AuthPortal.auth_token_for_url(self.remote_endpoint)
+  end
+
+  def set_status_flag(flag)
+    self.status = status | flag
+    self.save
+  end
+
+  def clear_status_flag(flag)
+    self.status = status & ~flag
+    self.save
   end
 end

--- a/app/services/submit_dirty_answers_job.rb
+++ b/app/services/submit_dirty_answers_job.rb
@@ -12,7 +12,12 @@ class SubmitDirtyAnswersJob < Struct.new(:run_id, :start_time)
       "num_answers: #{run.answers.count}, #{run.run_info_string}, " +
       "response: #{response.code} #{response.message} #{response.body}"
     )
-    run.abort_job_and_requeue(run.run_info_string) unless response.success?
+    if response.success?
+      run.set_status_flag(Run::SentToReportServiceStatusFlag)
+    else
+      run.clear_status_flag(Run::SentToReportServiceStatusFlag)
+      run.abort_job_and_requeue(run.run_info_string)
+    end
   end
 
   def perform

--- a/spec/libs/tasks/reporting_rake_spec.rb
+++ b/spec/libs/tasks/reporting_rake_spec.rb
@@ -38,7 +38,7 @@ describe "reporting:publish_anonymous_runs" do
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_SELF_URL").and_return("app.lara.docker")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_URL").and_return("http://foo.com")
     allow(ENV).to receive(:[]).with("REPORT_SERVICE_TOKEN").and_return("report_service_token")
-    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_ACTIVITY_ID").and_return(run.activity_id)
+    allow(ENV).to receive(:[]).with("REPORT_PUSH_RUN_START_DATE").and_return(nil)
   end
 
   it "sends a run to the report service, specifying `send_all_answers`" do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -732,4 +732,21 @@ describe Run do
       end
     end
   end
+
+  describe "status flags" do
+    it "constants are set" do
+      expect(Run::SentToReportServiceStatusFlag).to eq 1
+    end
+
+    it "can be set and cleared" do
+      expect(run.status).to eq 0
+      run.set_status_flag(Run::SentToReportServiceStatusFlag)
+      expect(run.status).to eq Run::SentToReportServiceStatusFlag
+      run.clear_status_flag(Run::SentToReportServiceStatusFlag)
+      expect(run.status).to eq 0
+
+      # NOTE: when/if other flags are added tests should be added to ensure only that flag is set and cleared
+      # and the other existing flags are kept as is
+    end
+  end
 end


### PR DESCRIPTION
- Flag is set when sent to report service succesfully
- Flag is cleared when NOT sent to report service succesfully
- Flag is queied in rake tasks to upload runs to the report service

Also replaced the REPORT_PUSH_RUN_ACTIVITY_ID with REPORT_PUSH_RUN_START_DATE in the anonymous run update rake task.