### PR TITLE
180087466 -- Add preview links to activity player

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -2312,3 +2312,68 @@ select {
     .nav-pages .page-button svg {
       fill: var(--teal); }
 
+@font-face {
+  font-family: 'Lato-Light';
+  font-style: normal;
+  font-weight: 100;
+  src: local("Lato Light"), local("Lato-Light"), url(//fonts.googleapis.com/css?family=Lato:100) format("woff"); }
+
+@font-face {
+  font-family: 'Lato-Regular';
+  font-style: normal;
+  font-weight: 400;
+  src: local("Lato Regular"), local("Lato-Regular"), url(//themes.googleusercontent.com/static/fonts/lato/v6/qIIYRU-oROkIk8vfvxw6QvesZW2xOQ-xsNqO47m55DA.woff) format("woff"); }
+
+@font-face {
+  font-family: 'Lato-Bold';
+  font-style: normal;
+  font-weight: 700;
+  src: local("Lato Bold"), local("Lato-Bold"), url(//themes.googleusercontent.com/static/fonts/lato/v6/qdgUG4U09HnJwhYI-uK18wLUuEpTyoUstqEm5AMlJo4.woff) format("woff"); }
+
+:root {
+  --font-family-bold: Lato-Bold, helvetica, verdana, sans-serif;
+  --font-family-default: Lato-Regular, helvetica, verdana, sans-serif;
+  --font-family-light: Lato-Light, helvetica, verdana, sans-serif;
+  --font-color-default: #313131;
+  --dark-teal: #016082;
+  --teal: #0592af;
+  --lt-teal: #93d5e4;
+  --ltr-teal: #cdebf2;
+  --ltst-teal: #e2f4f8;
+  --gold: #ffc320;
+  --lt-orange: #ffe6d0;
+  --orange: #ea6d2f;
+  --dark-gray: #3f3f3f;
+  --med-gray: #979797;
+  --lt-gray: hsl(0, 0%, 90%);
+  --ltr-gray: hsl(0, 0%, 95%); }
+
+.preview-links {
+  color: var(--font-color-default);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  font-family: var(--font-family-default);
+  font-size: 12pt;
+  font-weight: bold;
+  margin-left: 1em;
+  margin-bottom: 1em;
+  position: relative; }
+  .preview-links a {
+    color: var(--orange);
+    margin: 0px 5px; }
+    .preview-links a:hover {
+      fill: var(--teal); }
+  .preview-links span {
+    display: flex;
+    margin: 0px 5px; }
+  .preview-links svg {
+    color: var(--orange);
+    fill: var(--orange);
+    font-size: 1.3em; }
+  .preview-links .disabled {
+    color: var(--dark-gray); }
+    .preview-links .disabled svg {
+      fill: var(--dark-gray); }
+

--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -1542,6 +1542,71 @@ select {
   --lt-gray: hsl(0, 0%, 90%);
   --ltr-gray: hsl(0, 0%, 95%); }
 
+.preview-links {
+  color: var(--font-color-default);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  font-family: var(--font-family-default);
+  font-size: 12pt;
+  font-weight: bold;
+  margin-left: 1em;
+  margin-bottom: 1em;
+  position: relative; }
+  .preview-links a {
+    color: var(--orange);
+    margin: 0px 5px; }
+    .preview-links a:hover {
+      fill: var(--teal); }
+  .preview-links span {
+    display: flex;
+    margin: 0px 5px; }
+  .preview-links svg {
+    color: var(--orange);
+    fill: var(--orange);
+    font-size: 1.3em; }
+  .preview-links .disabled {
+    color: var(--dark-gray); }
+    .preview-links .disabled svg {
+      fill: var(--dark-gray); }
+
+@font-face {
+  font-family: 'Lato-Light';
+  font-style: normal;
+  font-weight: 100;
+  src: local("Lato Light"), local("Lato-Light"), url(//fonts.googleapis.com/css?family=Lato:100) format("woff"); }
+
+@font-face {
+  font-family: 'Lato-Regular';
+  font-style: normal;
+  font-weight: 400;
+  src: local("Lato Regular"), local("Lato-Regular"), url(//themes.googleusercontent.com/static/fonts/lato/v6/qIIYRU-oROkIk8vfvxw6QvesZW2xOQ-xsNqO47m55DA.woff) format("woff"); }
+
+@font-face {
+  font-family: 'Lato-Bold';
+  font-style: normal;
+  font-weight: 700;
+  src: local("Lato Bold"), local("Lato-Bold"), url(//themes.googleusercontent.com/static/fonts/lato/v6/qdgUG4U09HnJwhYI-uK18wLUuEpTyoUstqEm5AMlJo4.woff) format("woff"); }
+
+:root {
+  --font-family-bold: Lato-Bold, helvetica, verdana, sans-serif;
+  --font-family-default: Lato-Regular, helvetica, verdana, sans-serif;
+  --font-family-light: Lato-Light, helvetica, verdana, sans-serif;
+  --font-color-default: #313131;
+  --dark-teal: #016082;
+  --teal: #0592af;
+  --lt-teal: #93d5e4;
+  --ltr-teal: #cdebf2;
+  --ltst-teal: #e2f4f8;
+  --gold: #ffc320;
+  --lt-orange: #ffe6d0;
+  --orange: #ea6d2f;
+  --dark-gray: #3f3f3f;
+  --med-gray: #979797;
+  --lt-gray: hsl(0, 0%, 90%);
+  --ltr-gray: hsl(0, 0%, 95%); }
+
 .pageSettingsDialog input[type="text"] {
   border: solid 1.5px var(--med-gray);
   border-radius: 4px;
@@ -2311,69 +2376,4 @@ select {
       fill: var(--orange); }
     .nav-pages .page-button svg {
       fill: var(--teal); }
-
-@font-face {
-  font-family: 'Lato-Light';
-  font-style: normal;
-  font-weight: 100;
-  src: local("Lato Light"), local("Lato-Light"), url(//fonts.googleapis.com/css?family=Lato:100) format("woff"); }
-
-@font-face {
-  font-family: 'Lato-Regular';
-  font-style: normal;
-  font-weight: 400;
-  src: local("Lato Regular"), local("Lato-Regular"), url(//themes.googleusercontent.com/static/fonts/lato/v6/qIIYRU-oROkIk8vfvxw6QvesZW2xOQ-xsNqO47m55DA.woff) format("woff"); }
-
-@font-face {
-  font-family: 'Lato-Bold';
-  font-style: normal;
-  font-weight: 700;
-  src: local("Lato Bold"), local("Lato-Bold"), url(//themes.googleusercontent.com/static/fonts/lato/v6/qdgUG4U09HnJwhYI-uK18wLUuEpTyoUstqEm5AMlJo4.woff) format("woff"); }
-
-:root {
-  --font-family-bold: Lato-Bold, helvetica, verdana, sans-serif;
-  --font-family-default: Lato-Regular, helvetica, verdana, sans-serif;
-  --font-family-light: Lato-Light, helvetica, verdana, sans-serif;
-  --font-color-default: #313131;
-  --dark-teal: #016082;
-  --teal: #0592af;
-  --lt-teal: #93d5e4;
-  --ltr-teal: #cdebf2;
-  --ltst-teal: #e2f4f8;
-  --gold: #ffc320;
-  --lt-orange: #ffe6d0;
-  --orange: #ea6d2f;
-  --dark-gray: #3f3f3f;
-  --med-gray: #979797;
-  --lt-gray: hsl(0, 0%, 90%);
-  --ltr-gray: hsl(0, 0%, 95%); }
-
-.preview-links {
-  color: var(--font-color-default);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  font-family: var(--font-family-default);
-  font-size: 12pt;
-  font-weight: bold;
-  margin-left: 1em;
-  margin-bottom: 1em;
-  position: relative; }
-  .preview-links a {
-    color: var(--orange);
-    margin: 0px 5px; }
-    .preview-links a:hover {
-      fill: var(--teal); }
-  .preview-links span {
-    display: flex;
-    margin: 0px 5px; }
-  .preview-links svg {
-    color: var(--orange);
-    fill: var(--orange);
-    font-size: 1.3em; }
-  .preview-links .disabled {
-    color: var(--dark-gray); }
-    .preview-links .disabled svg {
-      fill: var(--dark-gray); }
 

--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -13,6 +13,19 @@ class Api::V1::InteractivePagesController < API::APIController
     render_page_sections_json
   end
 
+  def get_preview_url
+    page = @interactive_page
+    activity = page.lightweight_activity
+    base_url = request.base_url
+    activity_player_url = activity.activity_player_url(base_url, page: page)
+    activity_player_te_url = activity.activity_player_url(base_url, page: page, mode: "teacher-edition")
+    render json: {
+      'Select an option...' => '',
+      'Activity Player' => activity_player_url,
+      'Activity Player Teacher Edition' => activity_player_te_url
+    }
+  end
+
   # This is identical to get_sections. Why use different names?
   # Because it expresses the intent. Its possible we will want to return
   # different responses for each in the future.

--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -16,14 +16,7 @@ class Api::V1::InteractivePagesController < API::APIController
   def get_preview_url
     page = @interactive_page
     activity = page.lightweight_activity
-    base_url = request.base_url
-    activity_player_url = activity.activity_player_url(base_url, page: page)
-    activity_player_te_url = activity.activity_player_url(base_url, page: page, mode: "teacher-edition")
-    render json: {
-      'Select an option...' => '',
-      'Activity Player' => activity_player_url,
-      'Activity Player Teacher Edition' => activity_player_te_url
-    }
+    render json: view_context.activity_preview_options(activity, page)
   end
 
   # This is identical to get_sections. Why use different names?

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -88,12 +88,6 @@ module LightweightActivityHelper
                        'Activity Player' => activity_player_url,
                        'Activity Player Teacher Edition' => activity_player_te_url
                       }
-
-    if activity.runtime != "Activity Player"
-      preview_options['LARA Runtime'] = lara_runtime_url
-      preview_options['LARA Runtime Teacher Edition'] = lara_runtime_te_url
-    end
-
     return preview_options
   end
 

--- a/app/views/lightweight_activities/_edit_header.html.haml
+++ b/app/views/lightweight_activities/_edit_header.html.haml
@@ -25,3 +25,14 @@
 - if @activity.active_runs > 0
   %p.active-runs
     = "This activity has been used by #{pluralize(@activity.active_runs, "learner")}. Editing may cause problems with results data."
+
+
+:javascript
+  $(document).ready(function() {
+    var params = { host: window.location.origin };
+    var container = $("#preview-menu")[0];
+    LARA.SectionAuthoring.renderPreviewLinks(
+      container,
+      { previewLinks: #{activity_preview_options(@activity).to_json}
+    });
+  });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,7 +215,8 @@ LightweightStandalone::Application.routes.draw do
       match 'delete_page/:id' => 'interactive_pages#delete_page', as: 'delete_page', :via => 'post'
       match 'create_page/:activity_id' => 'interactive_pages#create_page', :as => 'create_page', :via => 'post'
       match 'copy_page/:id' => 'interactive_pages#copy_page', :as => 'copy_page', :via => 'post'
-
+      match 'get_preview_url/:id' => 'interactive_pages#get_preview_url', :as => 'get_preview_url', :via => 'get'
+      
       match 'plugin_learner_states/:plugin_id/:run_id' =>
         'plugin_learner_states#load', as: 'show_plugin_learner_state', via: 'get'
       match 'plugin_plugin_learner_state/:plugin_id/:run_id' =>

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -253,7 +253,7 @@ export type APIPageItemCreateF = (args: {pageId: PageId, newPageItem: ICreatePag
 export type APIPageItemDeleteF = (args: {pageId: PageId, pageItemId: ItemId}) => Promise<IPage>;
 export type APIPageItemUpdateF = (args: {pageId: PageId, sectionItem: ISectionItem}) => Promise<ISectionItem>;
 export type APIPageItemCopyF = (args: {pageId: PageId, sectionItemId: ItemId}) => Promise<ISectionItem>;
-
+export type APIGetPreviewOptionsF = (args: {pageId: PageId | null}) => Promise<Record<string, string>|null>;
 /**
  * The implementation providing the API has to conform to this provider API
  */
@@ -276,6 +276,7 @@ export interface IAuthoringAPIProvider {
 
   getLibraryInteractives: () => Promise<{libraryInteractives: ILibraryInteractive[]}>;
   getAllEmbeddables: () => Promise<{allEmbeddables: ISectionItemType[]}>;
+  getPreviewOptions: APIGetPreviewOptionsF;
 
   getPortals: () => Promise<{portals: IPortal[]}>;
 

--- a/lara-typescript/src/section-authoring/api/lara-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/lara-api-provider.ts
@@ -1,3 +1,4 @@
+import { current } from "immer";
 import { stringify } from "uuid";
 import { camelToSnakeCaseKeys } from "../../shared/convert-keys";
 import {
@@ -48,6 +49,7 @@ export const getLaraAuthoringAPI =
   const updatePageItemUrl = (pageId: PageId) => `${prefix}/update_page_item/${pageId}.json`;
   const deletePageItemUrl = (pageId: PageId) => `${prefix}/delete_page_item/${pageId}.json`;
   const copyPageItemUrl = (pageId: PageId) => `${prefix}/copy_page_item/${pageId}.json`;
+  const getPreviewUrl = (pageId: PageId) => `${prefix}/get_preview_url/${pageId}.json`;
   const libraryInteractivesUrl = `${prefix}/get_library_interactives_list.json`;
   const portalsURL = `${prefix}/get_portal_list.json`;
 
@@ -194,11 +196,19 @@ export const getLaraAuthoringAPI =
       });
   };
 
+  const getPreviewOptions = (args: {pageId: PageId}) => {
+    const { pageId } = args;
+    if (pageId) {
+      return sendToLara({url: getPreviewUrl(args.pageId)});
+    }
+    return Promise.resolve(null);
+  };
+
   return {
     getPages, getPage, createPage, deletePage, copyPage,
     createSection, updateSections, updateSection, copySection,
     createPageItem, updatePageItem, deletePageItem, copyPageItem,
-    getAllEmbeddables, getLibraryInteractives, getPortals,
+    getAllEmbeddables, getLibraryInteractives, getPortals, getPreviewOptions,
     pathToTinyMCE: "/assets/tinymce.js", pathToTinyMCECSS: "/assets/tinymce-content.css"
   };
 };

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -22,6 +22,14 @@ let pages: IPage[] = [
   }
 ];
 
+const getPreviewOptions = (args: {pageId: PageId}): Promise<Record<string, string>> => {
+  return Promise.resolve({
+    "Select an option...": "",
+    "Fake Activity Player": "https://activity-player.concord.org/branch/master",
+    "Fake Activity Player Teachers": "https://activity-player.concord.org/branch/master"
+  });
+};
+
 const makeNewSection = (): ISection => {
   const section: ISection = {
     id: `${++sectionCounter}`,
@@ -558,5 +566,6 @@ export const API: IAuthoringAPIProvider = {
   createSection, updateSections, updateSection, copySection,
   createPageItem, updatePageItem, deletePageItem, copyPageItem,
   getAllEmbeddables, getLibraryInteractives, getPortals,
+  getPreviewOptions,
   pathToTinyMCE: "https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.10.0/tinymce.min.js", pathToTinyMCECSS: undefined
 };

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -14,6 +14,7 @@ import "./authoring-page.scss";
 import { usePageAPI } from "../hooks/use-api-provider";
 import { UserInterfaceContext} from "../containers/user-interface-provider";
 import { PageNavContainer } from "../containers/page-nav-container";
+import { PreviewLinksContainer } from "../containers/preview-links-container";
 
 export interface IPageProps extends IPage {
 
@@ -152,10 +153,6 @@ export const AuthoringPage: React.FC<IPageProps> = ({
     }
   };
 
-  const handleEditItem = () => {
-    return;
-  };
-
   const handleCloseDialog = () => {
     setShowSettings(false);
     setItemToEdit(undefined);
@@ -167,6 +164,7 @@ export const AuthoringPage: React.FC<IPageProps> = ({
   return (
     <>
       <PageNavContainer />
+      <PreviewLinksContainer />
       <header className="editPageHeader">
         <h2>Page: {displayTitle}</h2>
         <button onClick={pageSettingsClickHandler}><Cog height="16" width="16" /> Page Settings</button>

--- a/lara-typescript/src/section-authoring/components/preview-links.scss
+++ b/lara-typescript/src/section-authoring/components/preview-links.scss
@@ -1,0 +1,40 @@
+@import "../../vars.scss";
+
+.preview-links {
+  color: var(--font-color-default);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  font-family: var(--font-family-default);
+  font-size: 12pt;
+  font-weight: bold;
+  margin-left: 1em;
+  margin-bottom: 1em;
+  position: relative;
+    a {
+      color: var(--orange);
+      margin: 0px 5px;
+      &:hover {
+        fill: var(--teal);
+      }
+    }
+
+    span {
+      display: flex;
+      margin: 0px 5px;
+    }
+
+    svg {
+      color: var(--orange);
+      fill: var(--orange);
+      font-size: 1.3em;
+    }
+
+    .disabled {
+      color: var(--dark-gray);
+      svg {
+        fill: var(--dark-gray);
+      }
+    }
+}

--- a/lara-typescript/src/section-authoring/components/preview-links.tsx
+++ b/lara-typescript/src/section-authoring/components/preview-links.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { useState } from "react";
+import {ExternalLink } from "../../shared/components/icons/external-link-icon";
+
+import "./preview-links.scss";
+
+export interface IPreviewLinksProps {
+  previewLinks: Record<string, string> | null;
+}
+
+export const PreviewLinks: React.FC<IPreviewLinksProps> =
+  (props: IPreviewLinksProps) => {
+
+  const { previewLinks } = props;
+  const [ previewLink, setPreviewLink] = useState<string|false>(false);
+
+  const handleLinkSelect = (evt: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = evt.currentTarget.value;
+    if (value && value.length > 0) {
+      setPreviewLink(value);
+    }
+    else {
+      setPreviewLink(false);
+    }
+  };
+
+  const renderPreviewOptions = () => {
+    if (previewLinks) {
+      return (
+        <span className="links-list" >
+          <select onChange={handleLinkSelect}>
+            { Object.keys(previewLinks).map(label => {
+              return (
+                  <option key={label} value={previewLinks[label]} >
+                    {label}
+                  </option>
+                );
+              })
+            }
+          </select>
+          { previewLink
+            ? <a href={previewLink} target="_blank"><ExternalLink/></a>
+            : <span className="disabled"><ExternalLink/></span>
+          }
+        </span>
+      );
+    }
+    return (
+        <span className="not-available">No preview link available</span>
+    );
+  };
+
+  return (
+    <>
+      <div className="preview-links">
+        <span>Preview in:</span>
+        {renderPreviewOptions()}
+      </div>
+    </>
+  );
+};

--- a/lara-typescript/src/section-authoring/components/preview-links.tsx
+++ b/lara-typescript/src/section-authoring/components/preview-links.tsx
@@ -51,11 +51,9 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
   };
 
   return (
-    <>
       <div className="preview-links">
         <span>Preview in:</span>
         {renderPreviewOptions()}
       </div>
-    </>
   );
 };

--- a/lara-typescript/src/section-authoring/containers/preview-links-container.tsx
+++ b/lara-typescript/src/section-authoring/containers/preview-links-container.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+import { IPreviewLinksProps, PreviewLinks } from "../components/preview-links";
+import { usePageAPI } from "../hooks/use-api-provider";
+
+export const PreviewLinksContainer: React.FC = () => {
+  const {getPreviewOptions } = usePageAPI();
+  const previewLinks = getPreviewOptions.data || null;
+  const props: IPreviewLinksProps = { previewLinks };
+  return <PreviewLinks {...props} />;
+};

--- a/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
@@ -21,6 +21,7 @@ const PAGES_CACHE_KEY = "pages";
 const SECTION_ITEM_TYPES_KEY = "SectionItemTypes";
 const LIBRARY_INTERACTIVES_KEY = "LibraryInteractives";
 const PORTAL_KEY = "Portal";
+const LAUNCH_URLS_KEY = "LaunchUrls";
 
 // Use this in a parent component to setup API context:
 // <APIProviderContext.Provider value={someAPIProvider} />
@@ -37,6 +38,15 @@ export const usePageAPI = () => {
   (PAGES_CACHE_KEY, provider.getPages, {
     refetchOnWindowFocus: false,
     staleTime: 1000 * 60 * 5,
+    refetchOnMount: false
+  });
+
+  const getPreviewOptions =
+    useQuery<Record<string, string>|null, Error>
+  ([LAUNCH_URLS_KEY, userInterface.currentPageId],
+    () => provider.getPreviewOptions({pageId: userInterface.currentPageId}), {
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
     refetchOnMount: false
   });
 
@@ -261,6 +271,7 @@ export const usePageAPI = () => {
     addPageItem, createPageItem, updatePageItem, deletePageItem, copyPageItem,
     updateSectionItems, moveItem, getItems, getPortals,
     getAllEmbeddables, getLibraryInteractives, currentPage, deleteSectionFunction,
+    getPreviewOptions,
     pathToTinyMCE: provider.pathToTinyMCE, pathToTinyMCECSS: provider.pathToTinyMCECSS
   };
 };

--- a/lara-typescript/src/section-authoring/index.tsx
+++ b/lara-typescript/src/section-authoring/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { AuthoringSection, ISectionProps } from "./components/authoring-section";
+import { IPreviewLinksProps, PreviewLinks } from "./components/preview-links";
 import { QueryBoundPage, IQueryBoundPage } from "./components/query-bound-page";
 
 const renderAuthoringSection = (root: HTMLElement, props: ISectionProps) => {
@@ -12,7 +13,12 @@ const renderAuthoringPage = (root: HTMLElement, props: IQueryBoundPage) => {
   return ReactDOM.render(App, root);
 };
 
+const renderPreviewLinks = (root: HTMLElement, props: IPreviewLinksProps) => {
+  return ReactDOM.render(<PreviewLinks {...props} />, root);
+};
+
 export {
   renderAuthoringSection,
-  renderAuthoringPage
+  renderAuthoringPage,
+  renderPreviewLinks
 };

--- a/lara-typescript/src/shared/components/icons/external-link-icon.tsx
+++ b/lara-typescript/src/shared/components/icons/external-link-icon.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+
+const kDefaultHeight = "1em";
+const kDefaultWidth = "1em";
+
+export interface IExternLinkProps {
+  height?: string;
+  width?: string;
+}
+
+export const ExternalLink = (props: IExternLinkProps) => {
+  const height = props.height ? props.height : kDefaultHeight;
+  const width = props.width ? props.width : kDefaultWidth;
+
+  return(
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 512 512"
+      data-icon="up-right-from-square"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+    <path
+      fill="currentColor"
+      d="M384 320c-17.67 0-32 14.33-32 32v96H64V160h96c17.67 0 32-14.32 32-32s-14.33-32-32-32L64 96c-35.35 0-64 28.65-64 64V448c0 35.34 28.65 64 64 64h288c35.35 0 64-28.66 64-64v-96C416 334.3 401.7 320 384 320zM488 0H352c-12.94 0-24.62 7.797-29.56 19.75c-4.969 11.97-2.219 25.72 6.938 34.88L370.8 96L169.4 297.4c-12.5 12.5-12.5 32.75 0 45.25C175.6 348.9 183.8 352 192 352s16.38-3.125 22.62-9.375L416 141.3l41.38 41.38c9.156 9.141 22.88 11.84 34.88 6.938C504.2 184.6 512 172.9 512 160V24C512 10.74 501.3 0 488 0z"/>
+  </svg>
+  );
+};

--- a/lara-typescript/src/stories/preview-link.stories.tsx
+++ b/lara-typescript/src/stories/preview-link.stories.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { PreviewLinks, IPreviewLinksProps } from "../section-authoring/components/preview-links";
+
+export default {
+  title: "Preview Links",
+  component: PreviewLinks,
+} as ComponentMeta<typeof PreviewLinks>;
+
+const Template: ComponentStory<typeof PreviewLinks> = (args: IPreviewLinksProps) =>  {
+  return (<PreviewLinks {...args} />);
+};
+
+export const PageHeaderStory = Template.bind({});
+
+PageHeaderStory.args = {
+  "Select an option...": "",
+  "Fake Activity Player": "https://activity-player.concord.org/branch/master",
+  "Fake Activity Player Teachers": "https://activity-player.concord.org/branch/master"
+};


### PR DESCRIPTION
## 180087466 -- Add preview links to activity player

[PT Story 180087466](https://www.pivotaltracker.com/story/show/180087466)

### NOTES: 
- In order to test this completely, it will have to be deployed to https://lara-demo.concordqa.org/
- Any testing LARA host will also have to set an `.env` var: `ACTIVITY_PLAYER_URL=https://activity-player.concord.org/branch/new-sections/` 
- In development mode (and story book) the links will be populated, but the report service won't likely be able to talk with the developers LARA instance. 
- There is a small bug in storybook that the first page is not set, and so the preview links wont work until some navigation has happened. This should be a simple thing to fix.
- More design work and CSS work is needed.
- Rails controller test needed.

