### PR TITLE
Makes page nav behave similar to Activity Player

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -88,7 +88,7 @@ button, .btn-primary, span.edit_trigger, #modal .embeddable-save, #modal .close 
 }
 
 button.disabled, .btn-primary.disabled, span.edit_trigger.disabled {
-  background: #ccc !important;
+  background: #ccc;
 }
 
 .select_container {
@@ -535,7 +535,7 @@ div.summary {
     display: inline-block;
     list-style: none;
     margin: 0 0 0 15px;
-    
+
     a {
       color: #333;
       font-size: 12px;
@@ -569,7 +569,7 @@ ul.quiet_list {
     padding: 10px 5px;
     margin: 0;
     border-bottom: dashed 1px #ddd;
-    
+
 
     .action_menu {
       display: flex;

--- a/lara-typescript/src/shared/components/icons/completion-icon.tsx
+++ b/lara-typescript/src/shared/components/icons/completion-icon.tsx
@@ -6,6 +6,7 @@ const kDefaultWidth = "1em";
 export interface ICompletionProps {
   height?: string;
   width?: string;
+  className: string;
 }
 
 export const Completion = (props: ICompletionProps) => {

--- a/lara-typescript/src/shared/components/icons/home-icon.tsx
+++ b/lara-typescript/src/shared/components/icons/home-icon.tsx
@@ -6,6 +6,7 @@ const kDefaultWidth = "1em";
 export interface IHomeProps {
   height?: string;
   width?: string;
+  className?: string;
 }
 
 export const Home = (props: IHomeProps) => {


### PR DESCRIPTION
Limits the number of pages shown in page nav to 11 and scroll the numbers if there are more pages.
Removes the outline around nav arrows when disabled.
Still has the problem of home button not highlighting when user navigates to home button via previous arrow.