### PR TITLE
180087466 preview activities in activity player (3)

### DIFF
--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -284,7 +284,6 @@ class InteractivePage < ActiveRecord::Base
   end
 
   def export
-    helper = LaraSerializationHelper.new
     page_json = self.as_json(only: [:id,
                                     :name,
                                     :position,
@@ -300,11 +299,10 @@ class InteractivePage < ActiveRecord::Base
                                     :embeddable_display_mode,
                                     :additional_sections,
                                     :is_completion])
-    page_json[:embeddables] = []
+    page_json[:sections] = []
 
-    self.embeddables.each do |embed|
-      embeddable_hash = helper.export(embed)
-      page_json[:embeddables] << { embeddable: embeddable_hash, section: embed.page_section }
+    sections.each do |section|
+      page_json[:sections] << section.export
     end
 
     page_json

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -141,7 +141,7 @@ class LightweightActivity < ActiveRecord::Base
                                         :show_submit_button,
                                         :runtime,
                                         :background_image ])
-    activity_json[:version] = 1
+    activity_json[:version] = 2
     activity_json[:theme_name] = self.theme ? self.theme.name : nil
     activity_json[:project] = self.project ? self.project.export : nil
     activity_json[:pages] = []

--- a/app/models/page_item.rb
+++ b/app/models/page_item.rb
@@ -104,4 +104,11 @@ class PageItem < ActiveRecord::Base
     m = interactive_id.match(/^interactive_(.+)$/)
     m ? m[1] : nil
   end
+
+  def export(export_helper)
+    export_hash = export_helper.export(embeddable)
+    export_hash[:column] = column
+    export_hash[:position] = position
+    export_hash
+  end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -11,12 +11,12 @@ class Section < ActiveRecord::Base
   INTERACTIVE_BOX = 'interactive_box'
   ASSESSMENT_BLOCK = "assessment_block"
   DEFAULT_SECTION_TITLE = ASSESSMENT_BLOCK
-  LAYOUT_FULL_WIDTH="Full Width"
+  LAYOUT_FULL_WIDTH="full-width"
   LAYOUT_60_40="60-40"
   LAYOUT_40_60="40-60"
   LAYOUT_70_30="70-30"
-  LAYOUT_30_70="30_70"
-  LAYOUT_RESPONSIVE="Responsive"
+  LAYOUT_30_70="30-70"
+  LAYOUT_RESPONSIVE="responsive"
   LAYOUT_DFEAULT=LAYOUT_FULL_WIDTH
 
   LAYOUT_OPTIONS = [
@@ -57,6 +57,23 @@ class Section < ActiveRecord::Base
       position: position,
       interactive_page_id: interactive_page_id,
       can_collapse_small: can_collapse_small
+    }
+  end
+
+  def export
+    helper = LaraSerializationHelper.new
+    {
+      title: title,
+      is_hidden: !show,
+      layout: layout,
+      secondary_column_collapsible: can_collapse_small,
+      secondary_column_display_mode: "stacked", # TODO: FIXME
+      # embeddables: embeddables.map do |embed|
+      #   helper.export(embed)
+      # end
+      embeddables: page_items.map do |page_item|
+        page_item.export(helper)
+      end
     }
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -67,10 +67,7 @@ class Section < ActiveRecord::Base
       is_hidden: !show,
       layout: layout,
       secondary_column_collapsible: can_collapse_small,
-      secondary_column_display_mode: "stacked", # TODO: FIXME
-      # embeddables: embeddables.map do |embed|
-      #   helper.export(embed)
-      # end
+      secondary_column_display_mode: "stacked", # TODO: Add display mode
       embeddables: page_items.map do |page_item|
         page_item.export(helper)
       end

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -4,12 +4,12 @@ export type ItemId = string;
 export type RelativePosition = "before" | "after";
 
 export enum SectionLayouts {
-  LAYOUT_FULL_WIDTH = "Full Width",
+  LAYOUT_FULL_WIDTH = "full-width",
   LAYOUT_60_40 = "60-40",
   LAYOUT_40_60 = "40-60",
   LAYOUT_70_30 = "70-30",
   LAYOUT_30_70 = "30-70",
-  LAYOUT_RESPONSIVE = "Responsive",
+  LAYOUT_RESPONSIVE = "responsive",
 }
 
 export enum SectionColumns {

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -21,7 +21,10 @@ const layoutClassNames = {
 };
 
 const classNameForItem = (_layout: SectionLayouts, itemIndex: number) => {
-  const layout = _layout || defaultLayout;
+  // If the layout specified isn't valid, use the default layout:
+  const layout = Object.keys(layoutClassNames).indexOf(_layout) !== -1
+    ? _layout
+    : defaultLayout;
   const layouts = layoutClassNames[layout];
   const classNameIndex = itemIndex % layouts.length;
   return layoutClassNames[layout][classNameIndex];

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -222,7 +222,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
         sectionId={id}
         />
       }
-      {layout !== "Full Width" &&
+      {layout !== "full-width" &&
         <SectionColumn
           addItem={addItem}
           addPageItem={addPageItem}

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -52,7 +52,7 @@ export const SectionItemMoveDialog: React.FC = () => {
     const options: any = [{value: SectionColumns.PRIMARY}];
     if (selectedSectionId) {
       const section = getSections().find(s => s.id === selectedSectionId);
-      if (section?.layout !== "Full Width") {
+      if (section?.layout !== "full-width") {
         options.push({value: SectionColumns.SECONDARY});
       }
     }

--- a/spec/models/embeddable/external_script_spec.rb
+++ b/spec/models/embeddable/external_script_spec.rb
@@ -37,21 +37,26 @@ describe Embeddable::ExternalScript do
           expect(script.reload.page_section).to eql(Section::DEFAULT_SECTION_TITLE)
         end
         describe 'the page export' do
-          it "should include an ebmeddables section" do
-            expect(page.export).to include(:embeddables)
+          it "should include ebmeddables in each section" do
+            export_sections = page.export[:sections]
+            expect(export_sections.length).to be > 0
+            export_sections.each do |section|
+              expect(section).to include(:embeddables)
+            end
           end
         end
       end
 
       describe 'when the embeddable is added to the C-RATER section' do
         let(:section) { CRater::ARG_SECTION_NAME }
-        it "The section should be returned as CRater::ARG_SECTION_NAME" do
-          expect(script.reload.page_section).to eql(CRater::ARG_SECTION_NAME)
-        end
 
         describe 'the page export' do
-          it "should include an ebmeddables section" do
-            expect(page.export).to include(:embeddables)
+          it "should include a section named 'arg_block' with some ebmeddables" do
+            expect(page.export[:sections]).to include(hash_including(
+              {
+                title: CRater::ARG_SECTION_NAME,
+                embeddables: array_including(anything)
+              }))
           end
         end
       end

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -201,7 +201,8 @@ describe InteractivePage do
   describe '#export' do
     it 'returns json of an interactive page' do
       page_json = page.export.as_json
-      expect(page_json['embeddables'].length).to eq(page.embeddables.count)
+      puts page_json
+      expect(page_json['sections'][0]['embeddables'].length).to eq(page.embeddables.count)
       expect(page_json['is_hidden']).to eq(page.is_hidden)
       expect(page_json['is_completion']).to eq(page.is_completion)
       expect(page_json['id']).to eq(page.id)
@@ -222,9 +223,9 @@ describe InteractivePage do
         expect(interactive).not_to be_nil
         expect(labbook.interactive).not_to be_nil
         export_data = page.export.as_json
-        interactive_box_embeddables = export_data['embeddables'].select { |e| e['section'] == 'interactive_box' }
-        interactive_id = interactive_box_embeddables.first['embeddable']['ref_id']
-        labbook = export_data['embeddables'].select { |e| e['section'] == Section::DEFAULT_SECTION_TITLE }.last['embeddable']
+        interactive_box_embeddables = export_data['sections'][1]['embeddables']
+        interactive_id = interactive_box_embeddables.first['ref_id']
+        labbook = export_data['sections'][0]['embeddables'].find { |e| e["type"] == "Embeddable::Labbook"}
         expect(labbook).to match a_hash_including('interactive_ref_id' => interactive_id)
       end
     end

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -201,7 +201,6 @@ describe InteractivePage do
   describe '#export' do
     it 'returns json of an interactive page' do
       page_json = page.export.as_json
-      puts page_json
       expect(page_json['sections'][0]['embeddables'].length).to eq(page.embeddables.count)
       expect(page_json['is_hidden']).to eq(page.is_hidden)
       expect(page_json['is_completion']).to eq(page.is_completion)


### PR DESCRIPTION
## Enable previews in AP:

For [This PT story](https://www.pivotaltracker.com/story/show/180087466)

## Changes:
- Modifies the export format so that the AP player can read it.
- Changes the layout names for the sections to match what the AP expects.
- Updated the export test expectations


NB: 
- We will need to update all the sections on the lara-demo server to use the new section identifiers.
- We will need to change the Activity Player URL used on lara-demo


[#180087466]