### PR TITLE
179597784 completion page

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -91,8 +91,11 @@ class Api::V1::InteractivePagesController < API::APIController
         name: page_params['name'],
         is_completion: page_params['isCompletion'],
         is_hidden: page_params['isHidden'],
-        position: page_params['position']
       })
+
+      if page_params['isCompletion']
+        @interactive_page.move_to_bottom
+      end
     end
     @interactive_page.save!
     pages = activity.reload.pages.map do |page|

--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -59,7 +59,15 @@ class Api::V1::InteractivePagesController < API::APIController
     authorize! :update, activity
     return error("Can't find activity #{params[:activity_id]}") unless activity
     activity.pages.create()
+    last_idx = activity.pages.length - 1
+    prev_last_idx = activity.pages.length - 2
+    if activity.pages[prev_last_idx].is_completion
+      activity.pages[prev_last_idx].position = last_idx
+      activity.pages[prev_last_idx].move_lower
+    end
+
     pages = activity.reload.pages.map do |page|
+      page.reload
       generate_page_json page
     end
     render :json => pages

--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -82,7 +82,8 @@ class Api::V1::InteractivePagesController < API::APIController
       @interactive_page.update_attributes({
         name: page_params['name'],
         is_completion: page_params['isCompletion'],
-        is_hidden: page_params['isHidden']
+        is_hidden: page_params['isHidden'],
+        position: page_params['position']
       })
     end
     @interactive_page.save!

--- a/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
+++ b/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
@@ -12,6 +12,7 @@ export interface IPageSettingsDialogProps {
   hasArgBlock?: boolean;
   hasStudentSidebar?: boolean;
   hasTESidebar?: boolean;
+  disableCompletionPageSetting?: boolean;
   updateSettingsFunction: (
     updatedTitle: string | undefined,
     updatedIsCompletion: boolean,
@@ -30,6 +31,7 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
   hasArgBlock = false,
   hasStudentSidebar = false,
   hasTESidebar = false,
+  disableCompletionPageSetting,
   updateSettingsFunction,
   closeDialogFunction
   }: IPageSettingsDialogProps) => {
@@ -111,10 +113,12 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
               onChange={handleIsHiddenChange}
             />
           </dd>
-          <dt className="input3">
-            <label htmlFor="isCompletion">Page is a completion/summary page</label>
+          <dt className={`input3 ${disableCompletionPageSetting ? "disabled" : ""}`}>
+            <label htmlFor="isCompletion">
+              Page is a completion/summary page (An activity can only have one completion page)
+            </label>
           </dt>
-          <dd className="input3">
+          <dd className={`input3 ${disableCompletionPageSetting ? "disabled" : ""}`}>
             <input
               type="checkbox"
               id="isCompletion"

--- a/lara-typescript/src/section-authoring/api/lara-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/lara-api-provider.ts
@@ -90,14 +90,27 @@ export const getLaraAuthoringAPI =
     return sendToLara({url: createPageUrl, method: "POST"});
   };
 
-  const updatePage: APIPageUpdateF = (args: {pageId: PageId, changes: Partial<IPage>}) => {
+  const updatePage: APIPageUpdateF = async (args: {pageId: PageId, changes: Partial<IPage>}) => {
     const {pageId, changes} = args;
-    const data = { id: pageId,
-                   page: { id: pageId,
-                           name: changes.name,
-                           isCompletion: changes.isCompletion,
-                           isHidden: changes.isHidden } };
-    return sendToLara({url: updatePageUrl(pageId), method: "PUT", body: data});
+    const pages = await getPages();
+    const indx = pages.findIndex(p => p.id === pageId);
+    if (indx > -1) {
+      if (indx < pages.length - 1 && changes.isCompletion) {
+        pages.push(pages.splice(indx, 1)[0]); // put the page at the end of the pages list
+      }
+      const newIndx = pages.length;
+      const nextPage = {... pages[newIndx], ...changes };
+      pages[newIndx] = nextPage;
+      const data = { id: pageId,
+                      page: { id: pageId,
+                              name: changes.name,
+                              isCompletion: changes.isCompletion,
+                              isHidden: changes.isHidden,
+                              position: newIndx
+                             }
+                    };
+      return sendToLara({url: updatePageUrl(pageId), method: "PUT", body: data});
+    }
   };
 
   const deletePage: APIPageDeleteF = (id: PageId) => {

--- a/lara-typescript/src/section-authoring/api/lara-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/lara-api-provider.ts
@@ -92,25 +92,14 @@ export const getLaraAuthoringAPI =
 
   const updatePage: APIPageUpdateF = async (args: {pageId: PageId, changes: Partial<IPage>}) => {
     const {pageId, changes} = args;
-    const pages = await getPages();
-    const indx = pages.findIndex(p => p.id === pageId);
-    if (indx > -1) {
-      if (indx < pages.length - 1 && changes.isCompletion) {
-        pages.push(pages.splice(indx, 1)[0]); // put the page at the end of the pages list
-      }
-      const newIndx = pages.length;
-      const nextPage = {... pages[newIndx], ...changes };
-      pages[newIndx] = nextPage;
-      const data = { id: pageId,
-                      page: { id: pageId,
-                              name: changes.name,
-                              isCompletion: changes.isCompletion,
-                              isHidden: changes.isHidden,
-                              position: newIndx
-                             }
-                    };
-      return sendToLara({url: updatePageUrl(pageId), method: "PUT", body: data});
-    }
+    const data = { id: pageId,
+                   page: { id: pageId,
+                           name: changes.name,
+                           isCompletion: changes.isCompletion,
+                           isHidden: changes.isHidden,
+                         }
+                 };
+    return sendToLara({url: updatePageUrl(pageId), method: "PUT", body: data});
   };
 
   const deletePage: APIPageDeleteF = (id: PageId) => {

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -186,8 +186,8 @@ export const updatePage = (args: {pageId: PageId, changes: Partial<IPage>}) => {
     if (indx < pages.length - 1 && changes.isCompletion) {
       pages.push(pages.splice(indx, 1)[0]); // put the page at the end of the pages list
     }
-    const newIndx = pages.length - 1;
-    const nextPage = {... pages[newIndx], ...changes };
+    const newIndx = pages.findIndex(p => p.id === pageId); // we do this again because pages may have reordered
+    const nextPage = {...pages[newIndx], ...changes };
     pages[newIndx] = nextPage;
     setSectionPositions(nextPage);
     return Promise.resolve({... nextPage});

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -178,8 +178,12 @@ export const updatePage = (args: {pageId: PageId, changes: Partial<IPage>}) => {
   const {pageId, changes} = args;
   const indx = pages.findIndex(p => p.id === pageId);
   if (indx > -1) {
-    const nextPage = {... pages[indx], ...changes };
-    pages[indx] = nextPage;
+    if (indx < pages.length - 1 && changes.isCompletion) {
+      pages.push(pages.splice(indx, 1)[0]); // put the page at the end of the pages list
+    }
+    const newIndx = pages.length - 1;
+    const nextPage = {... pages[newIndx], ...changes };
+    pages[newIndx] = nextPage;
     setSectionPositions(nextPage);
     return Promise.resolve({... nextPage});
   }

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -144,7 +144,12 @@ export const createPage = () => {
     name: `Page ${pageCounter}`,
     sections: []
   };
-  pages.push(newPage);
+  // we can assume the completion page is always the last element of the array before new page was added
+  if (pages[pages.length - 1].isCompletion) {
+    pages.splice(pages.length - 1, 0, newPage);
+  } else {
+    pages.push(newPage);
+  }
   updatePositions(pages);
   return Promise.resolve(newPage);
 };

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -104,7 +104,7 @@ export const AuthoringPage: React.FC<IPageProps> = ({
   const [itemToEdit, setItemToEdit] = useState(initItemToEdit);
   const [showSettings, setShowSettings] = useState(isNew);
 
-  const { getItems, updatePage, moveSection } = usePageAPI();
+  const { getPages, getItems, updatePage, moveSection } = usePageAPI();
 
   const updateSettings = (
     updatedTitle: string | undefined,
@@ -121,6 +121,16 @@ export const AuthoringPage: React.FC<IPageProps> = ({
                  isCompletion: updatedIsCompletion,
                  isHidden: updatedIsHidden,
                });
+  };
+ /*
+  * Returns true if activity already has a completion page and it is not the completion page
+  */
+  const disableCompletionPageSetting = () => {
+    const pages = getPages.data;
+    // return !!pages?.find(p => !!p.isCompletion);
+    const isCompletionPage = pages?.find(p => p.isCompletion === true);
+    const hasCompletionPage = isCompletionPage != null;
+    return (hasCompletionPage && !isCompletion ? true : false);
   };
 
   /*
@@ -225,6 +235,7 @@ export const AuthoringPage: React.FC<IPageProps> = ({
             // hasTESidebar={pageHasTESidebar}
             updateSettingsFunction={updateSettings}
             closeDialogFunction={handleCloseDialog}
+            disableCompletionPageSetting={disableCompletionPageSetting()}
           />
         }
     </>

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -9,6 +9,7 @@ import { ICreatePageItem, IPage, ISection, ISectionItem, ISectionItemType, Secti
 import { SectionItemMoveDialog } from "./section-item-move-dialog";
 import { ItemEditDialog } from "./item-edit-dialog";
 import { DragDropContext, Droppable, Draggable, DropResult } from "react-beautiful-dnd";
+import { CompletionPage } from "./completion-page/completion-page";
 import { Add } from "../../shared/components/icons/add-icon";
 import { Cog } from "../../shared/components/icons/cog-icon";
 
@@ -168,59 +169,64 @@ export const AuthoringPage: React.FC<IPageProps> = ({
         <h2>Page: {displayTitle}</h2>
         <button onClick={pageSettingsClickHandler}><Cog height="16" width="16" /> Page Settings</button>
       </header>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="droppable">
-          {(droppableProvided, snapshot) => (
-            <div ref={droppableProvided.innerRef}
-              className="editPageContainer"
-              {...droppableProvided.droppableProps}>
-              {
-                sections.map( (sProps, index) => (
-                  <Draggable
-                    key={`section-${sProps.id}-${index}-draggable`}
-                    draggableId={`section-${sProps.id}-${index}`}
-                    index={index}>
+      {isCompletionPage
+        ? <CompletionPage />
+        : <>
+            <DragDropContext onDragEnd={onDragEnd}>
+              <Droppable droppableId="droppable">
+                {(droppableProvided, snapshot) => (
+                <div ref={droppableProvided.innerRef}
+                  className="editPageContainer"
+                  {...droppableProvided.droppableProps}>
                   {
-                    (draggableProvided) => (
-                      <div
-                        {...draggableProvided.draggableProps}
-                        ref={draggableProvided.innerRef}>
-                          <AuthoringSection {...sProps}
-                            draggableProvided={draggableProvided}
-                            key={`section-${sProps.id}-${index}`}
-                            updateFunction={changeSection}
-                            addPageItem={addPageItem}
-                            editItemFunction={handleEditItemInit}
-                          />
-                        </div>
-                      )
+                    sections.map( (sProps, index) => (
+                      <Draggable
+                        key={`section-${sProps.id}-${index}-draggable`}
+                        draggableId={`section-${sProps.id}-${index}`}
+                        index={index}>
+                      {
+                        (draggableProvided) => (
+                          <div
+                            {...draggableProvided.draggableProps}
+                            ref={draggableProvided.innerRef}>
+                              <AuthoringSection {...sProps}
+                                draggableProvided={draggableProvided}
+                                key={`section-${sProps.id}-${index}`}
+                                updateFunction={changeSection}
+                                addPageItem={addPageItem}
+                                editItemFunction={handleEditItemInit}
+                              />
+                            </div>
+                          )
+                      }
+                      </Draggable>
+                    ))
                   }
-                  </Draggable>
-                ))
-              }
-              { droppableProvided.placeholder }
-              <button className="bigButton" onClick={addSection}>
-                <Add height="16" width="16" /> <span className="lineAdjust">Add Section</span>
-              </button>
-            </div>
-          )}
-        </Droppable>
-      </DragDropContext>
-      {showSettings &&
-        <PageSettingsDialog
-          name={name}
-          isCompletion={isCompletion}
-          isHidden={isHidden}
-          hasArgBlock={hasArgBlock}
-          hasStudentSidebar={hasStudentSidebar}
-          hasTESidebar={hasTESidebar}
-          updateSettingsFunction={updateSettings}
-          closeDialogFunction={handleCloseDialog}
-        />
+                  { droppableProvided.placeholder }
+                  <button className="bigButton" onClick={addSection}>
+                    <Add height="16" width="16" /> <span className="lineAdjust">Add Section</span>
+                  </button>
+                </div>
+                )}
+              </Droppable>
+            </DragDropContext>
+            {showSettings &&
+              <PageSettingsDialog
+                title={pageTitle}
+                isCompletion={isCompletionPage}
+                isHidden={isHiddenPage}
+                hasArgBlock={pageHasArgBlock}
+                hasStudentSidebar={pageHasStudentSidebar}
+                hasTESidebar={pageHasTESidebar}
+                updateSettingsFunction={updateSettings}
+                closeDialogFunction={handleCloseDialog}
+              />
+            }
+            <SectionMoveDialog />
+            <SectionItemMoveDialog />
+            <ItemEditDialog />
+          </>
       }
-      <SectionMoveDialog />
-      <SectionItemMoveDialog />
-      <ItemEditDialog />
     </>
   );
 };

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -169,7 +169,7 @@ export const AuthoringPage: React.FC<IPageProps> = ({
         <h2>Page: {displayTitle}</h2>
         <button onClick={pageSettingsClickHandler}><Cog height="16" width="16" /> Page Settings</button>
       </header>
-      {isCompletionPage
+      {isCompletion
         ? <CompletionPage />
         : <>
             <DragDropContext onDragEnd={onDragEnd}>
@@ -210,23 +210,23 @@ export const AuthoringPage: React.FC<IPageProps> = ({
                 )}
               </Droppable>
             </DragDropContext>
-            {showSettings &&
-              <PageSettingsDialog
-                title={pageTitle}
-                isCompletion={isCompletionPage}
-                isHidden={isHiddenPage}
-                hasArgBlock={pageHasArgBlock}
-                hasStudentSidebar={pageHasStudentSidebar}
-                hasTESidebar={pageHasTESidebar}
-                updateSettingsFunction={updateSettings}
-                closeDialogFunction={handleCloseDialog}
-              />
-            }
             <SectionMoveDialog />
             <SectionItemMoveDialog />
             <ItemEditDialog />
           </>
-      }
+        }
+        {showSettings &&
+          <PageSettingsDialog
+            name={name}
+            isCompletion={isCompletion}
+            isHidden={isHidden}
+            // hasArgBlock={pageHasArgBlock}
+            // hasStudentSidebar={pageHasStudentSidebar}
+            // hasTESidebar={pageHasTESidebar}
+            updateSettingsFunction={updateSettings}
+            closeDialogFunction={handleCloseDialog}
+          />
+        }
     </>
   );
 };

--- a/lara-typescript/src/section-authoring/components/completion-page/completion-page.scss
+++ b/lara-typescript/src/section-authoring/components/completion-page/completion-page.scss
@@ -1,0 +1,23 @@
+@import "../../../vars.scss";
+
+.completion-page {
+  color: var(--dark-gray);
+  font-family: var(--font-family-default);
+
+  .completion-page-title {
+    font-size: x-large;
+    margin-bottom: 5px;
+  }
+
+  .completion-description-heading {
+    font-size: large;
+    margin: 5px 0;
+  }
+  ol {
+    margin: 0;
+  }
+  p, li {
+    font-size: small;
+    margin: 2px;
+  }
+}

--- a/lara-typescript/src/section-authoring/components/completion-page/completion-page.scss
+++ b/lara-typescript/src/section-authoring/components/completion-page/completion-page.scss
@@ -14,10 +14,10 @@
     margin: 5px 0;
   }
   ol {
-    margin: 0;
+    margin: 0 10px;
   }
   p, li {
     font-size: small;
-    margin: 2px;
+    margin: 2px 20px;
   }
 }

--- a/lara-typescript/src/section-authoring/components/completion-page/completion-page.tsx
+++ b/lara-typescript/src/section-authoring/components/completion-page/completion-page.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+import "./completion-page.scss";
+
+export const CompletionPage = () => {
+  return (
+    <div className="completion-page">
+      <h2 className="completion-page-title">Completion Page</h2>
+      <p>The completion page is intended to be used at the end of the activity.
+         Its content changes depening on how far the student is through the activity and sequence (if there is one).</p>
+      <h3 className="completion-description-heading">Here are the 7 different cases that are handled</h3>
+      <ol>
+        <li>Single activity is not completed.</li>
+        <li>Single activity is completed.</li>
+        <li>Activity is part of a sequence, it's not completed and it's not the last one in sequence.</li>
+        <li>Activity is part of a sequence, it's completed, but it's not the last one in sequence.</li>
+        <li>Activity is part of a sequence, it's not completed, but it's the last one in sequence.</li>
+        <li>Activity is part of a sequence, it's completed and it's the last one in sequence, but some other activity
+            in sequence is not completed, so the whole sequence is also not completed.</li>
+        <li>Activity is part of a sequence, it's completed and it's the last one in sequence, but some other activity
+            in sequence is not completed, so the whole sequence is also not completed.</li>
+        <li>Activity is part of a sequence, it's completed and it's the last one in sequence and all the other
+          activities in sequence are completed.</li>
+      </ol>
+    </div>
+  );
+};


### PR DESCRIPTION
When user sets page to be a completion page in page settings:
- Shows an authoring Completion Page (using existing authoring Completion Page text) 
- Moves that page to the end of the pages array so that it is now the last page of the activity.
- When a new page is added, and there is a completion page, the new page is added to the page prior to the completion page
Note that if the author changes the setting so it is no longer the completion page, that page remains at the end.