### PR TITLE
Fixes page preview to show current page

### DIFF
--- a/lara-typescript/src/section-authoring/components/preview-links.tsx
+++ b/lara-typescript/src/section-authoring/components/preview-links.tsx
@@ -13,7 +13,7 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
 
   const { previewLinks } = props;
   const [ previewLink, setPreviewLink ] = useState<string|false>(false);
-  const [ previewPageUrl, setPreviewPageUrl ] = useState<string|undefined>("");
+  const [ previewer, setPreviewer ] = useState<string|undefined>("");
 
   const getKeyOfLink = (link: string) => {
     if (previewLinks) {
@@ -30,7 +30,7 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
     const value = evt.currentTarget.value;
     if (value && value.length > 0) {
       setPreviewLink(value);
-      setPreviewPageUrl(getKeyOfLink(value));
+      setPreviewer(getKeyOfLink(value));
     }
     else {
       setPreviewLink(false);
@@ -38,8 +38,8 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
   };
 
   const handlePreviewButtonClick = () => {
-    if (previewPageUrl) {
-      const pageToPreview = getLinkFromKey(previewPageUrl);
+    if (previewer) {
+      const pageToPreview = getLinkFromKey(previewer);
       if (pageToPreview) {
         window.open(pageToPreview, "_blank");
       }

--- a/lara-typescript/src/section-authoring/components/preview-links.tsx
+++ b/lara-typescript/src/section-authoring/components/preview-links.tsx
@@ -12,12 +12,25 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
   (props: IPreviewLinksProps) => {
 
   const { previewLinks } = props;
-  const [ previewLink, setPreviewLink] = useState<string|false>(false);
+  const [ previewLink, setPreviewLink ] = useState<string|false>(false);
+  const [ previewer, setPreviewer ] = useState<string|undefined>("");
+
+  const getKeyOfLink = (link: string) => {
+    if (previewLinks) {
+      return (Object.keys(previewLinks) as string[]).find(key => previewLinks[key] === link);
+    }
+  };
+  const getLinkFromKey = (key: string) => {
+    if (previewLinks) {
+      return (previewLinks[key]);
+    }
+  };
 
   const handleLinkSelect = (evt: React.ChangeEvent<HTMLSelectElement>) => {
     const value = evt.currentTarget.value;
     if (value && value.length > 0) {
       setPreviewLink(value);
+      setPreviewer(getKeyOfLink(value));
     }
     else {
       setPreviewLink(false);
@@ -25,8 +38,11 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
   };
 
   const handlePreviewButtonClick = () => {
-    if (previewLink) {
-      window.open(previewLink, "_blank");
+    if (previewer) {
+      const pageToPreview = getLinkFromKey(previewer);
+      if (pageToPreview) {
+        window.open(pageToPreview, "_blank");
+      }
     }
   };
 

--- a/lara-typescript/src/section-authoring/components/preview-links.tsx
+++ b/lara-typescript/src/section-authoring/components/preview-links.tsx
@@ -13,7 +13,7 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
 
   const { previewLinks } = props;
   const [ previewLink, setPreviewLink ] = useState<string|false>(false);
-  const [ previewer, setPreviewer ] = useState<string|undefined>("");
+  const [ previewPageUrl, setPreviewPageUrl ] = useState<string|undefined>("");
 
   const getKeyOfLink = (link: string) => {
     if (previewLinks) {
@@ -30,7 +30,7 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
     const value = evt.currentTarget.value;
     if (value && value.length > 0) {
       setPreviewLink(value);
-      setPreviewer(getKeyOfLink(value));
+      setPreviewPageUrl(getKeyOfLink(value));
     }
     else {
       setPreviewLink(false);
@@ -38,8 +38,8 @@ export const PreviewLinks: React.FC<IPreviewLinksProps> =
   };
 
   const handlePreviewButtonClick = () => {
-    if (previewer) {
-      const pageToPreview = getLinkFromKey(previewer);
+    if (previewPageUrl) {
+      const pageToPreview = getLinkFromKey(previewPageUrl);
       if (pageToPreview) {
         window.open(pageToPreview, "_blank");
       }


### PR DESCRIPTION
Preview links were being generated by the preview selector dropdown, and were getting updated correctly when pages were changed. But the actual preview link was not getting updated because it only gets updated if the dropdown selection is changed. This gets preview link from the current preview links list instead of waiting for dropdown selection to change.