### PR TITLE
180626565 auto deploy of example-interactives

### DIFF
--- a/.github/workflows/deploy-example-interactives.yml
+++ b/.github/workflows/deploy-example-interactives.yml
@@ -1,0 +1,25 @@
+name: Deploy Example Interactives
+
+on: push
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install Dependencies
+        run: npm ci
+        working-directory: lara-typescript
+      - uses: concord-consortium/s3-deploy-action@v1
+        with:
+          bucket: models-resources
+          prefix: lara-example-interactives
+          awsAccessKeyId: ${{ secrets.EXAMPLE_INTERACTIVES_DEPLOY_ACCESS_KEY }}
+          awsSecretAccessKey: ${{ secrets.EXAMPLE_INTERACTIVES_DEPLOY_SECRET_ACCESS_KEY }}
+          workingDirectory: lara-typescript
+          build: npm run build:webpack:no-copy-to-rails
+          folderToDeploy: dist/example-interactives

--- a/lara-typescript/package.json
+++ b/lara-typescript/package.json
@@ -13,6 +13,7 @@
     "publish:interactive-api-host:yalc": "npm run build && cd dist/interactive-api-host && npx yalc publish",
     "build": "npm-run-all lint:build clean build:webpack build:types build:docs",
     "build:webpack": "webpack --devtool false && npm run build:copy-to-rails",
+    "build:webpack:no-copy-to-rails": "webpack --devtool false",
     "build:types": "rollup -c",
     "build:docs": "npm-run-all build:docs:plugin-api build:docs:interactive-api-client build:docs:interactive-api-host",
     "build:docs:plugin-api": "typedoc --readme src/plugin-api/README.md --out ../docs/lara-plugin-api src/plugin-api/index.ts",


### PR DESCRIPTION

- add target in package.json for build:webpack:no-copy-rails
- add deploy-example-interactives.yml

See example deployment:
https://models-resources.concord.org/lara-example-interactives/branch/auto-deploy-example-interactives/index.html

[#180626565] https://www.pivotaltracker.com/story/show/180626565
auto deploy of example-interactives