### PR TITLE
Page Settings: Hidden Page Fixes

### DIFF
--- a/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
+++ b/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
@@ -39,17 +39,28 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
   const [argBlockSettingEnabled, setargBlockSettingEnabled] = React.useState(false);
   const [studentSidebarSettingEnabled, setstudentSidebarSettingEnabled] = React.useState(false);
   const [teSidebarSettingEnabled, setTESidebarSettingEnabled] = React.useState(false);
+  const [isCompletionPage, setIsCompletionPage] = React.useState(isCompletion);
+  const [isCompletionDisabled, setIsCompletionDisabled] = React.useState(disableCompletionPageSetting);
+  const [isHiddenPage, setIsHiddenPage] = React.useState(isHidden);
+  const [isHiddenDisabled, setIsHiddenDisabled] = React.useState(isCompletion);
+
+  React.useEffect(() => {
+    setIsHiddenDisabled(isCompletionPage);
+    if (!disableCompletionPageSetting) {
+      setIsCompletionDisabled(isHiddenPage);
+    }
+  }, [isCompletionPage, isHiddenPage]);
 
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     name = event.target.value;
   };
 
   const handleIsCompletionChange = () => {
-    isCompletion = !isCompletion;
+    setIsCompletionPage(!isCompletionPage);
   };
 
   const handleIsHiddenChange = () => {
-    isHidden = !isHidden;
+    setIsHiddenPage(!isHiddenPage);
   };
 
   const handleHasArgBlockChange = () => {
@@ -67,8 +78,8 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
   const handleUpdateSettings = () => {
     updateSettingsFunction(
       name,
-      isCompletion,
-      isHidden,
+      isCompletionPage,
+      isHiddenPage,
       hasArgBlock,
       hasStudentSidebar,
       hasTESidebar
@@ -101,36 +112,36 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
               placeholder="Enter a title"
             />
           </dd>
-          <dt className={`input2 ${isCompletion ? "disabled" : ""}`}>
+          <dt className={`input2 ${isHiddenDisabled && "disabled"}`}>
             <label htmlFor="isHidden">Page is hidden from students</label>
           </dt>
-          <dd className={`input2 ${isCompletion ? "disabled" : ""}`}>
+          <dd className={`input2 ${isHiddenDisabled && "disabled"}`}>
             <input
               type="checkbox"
               id="isHidden"
               name="isHidden"
-              defaultChecked={isHidden}
+              defaultChecked={isHiddenPage}
               onChange={handleIsHiddenChange}
             />
           </dd>
-          <dt className={`input3 ${disableCompletionPageSetting ? "disabled" : ""}`}>
+          <dt className={`input3 ${isCompletionDisabled && "disabled"}`}>
             <label htmlFor="isCompletion">
               Page is a completion/summary page (An activity can only have one completion page)
             </label>
           </dt>
-          <dd className={`input3 ${disableCompletionPageSetting ? "disabled" : ""}`}>
+          <dd className={`input3 ${isCompletionDisabled && "disabled"}`}>
             <input
               type="checkbox"
               id="isCompletion"
               name="isCompletion"
-              defaultChecked={isCompletion}
+              defaultChecked={isCompletionPage}
               onChange={handleIsCompletionChange}
             />
           </dd>
-          <dt className={`input4 ${argBlockSettingEnabled ? "" : "disabled"}`}>
+          <dt className={`input4 ${!argBlockSettingEnabled && "disabled"}`}>
             <label htmlFor="hasArgBlock">Page has an argumentation block</label>
           </dt>
-          <dd className={`input4 ${argBlockSettingEnabled ? "" : "disabled"}`}>
+          <dd className={`input4 ${!argBlockSettingEnabled && "disabled"}`}>
             <input
               type="checkbox"
               id="hasArgBlock"
@@ -139,10 +150,10 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
               onChange={handleHasArgBlockChange}
             />
           </dd>
-          <dt className={`input5 ${studentSidebarSettingEnabled ? "" : "disabled"}`}>
+          <dt className={`input5 ${!studentSidebarSettingEnabled && "disabled"}`}>
             <label htmlFor="hasStudentSidebar">Page has a student sidebar menu</label>
           </dt>
-          <dd className={`input5 ${studentSidebarSettingEnabled ? "" : "disabled"}`}>
+          <dd className={`input5 ${!studentSidebarSettingEnabled && "disabled"}`}>
             <input
               type="checkbox"
               id="hasStudentSidebar"
@@ -151,10 +162,10 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
               onChange={handleHasStudentSidebarChange}
             />
           </dd>
-          <dt className={`input6 ${teSidebarSettingEnabled ? "" : "disabled"}`}>
+          <dt className={`input6 ${!teSidebarSettingEnabled && "disabled"}`}>
             <label htmlFor="hasTESidebar">Page has a Teacher Edition sidebar menu</label>
           </dt>
-          <dd className={`input6 ${teSidebarSettingEnabled ? "" : "disabled"}`}>
+          <dd className={`input6 ${!teSidebarSettingEnabled && "disabled"}`}>
             <input
               type="checkbox"
               id="hasTESidebar"

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useState } from "react";
-import { ISectionItem, ISection, SectionColumns, PageId } from "../api/api-types";
+import { ISectionItem, ISection, SectionColumns, IPage, PageId } from "../api/api-types";
 import { Modal, ModalButtons } from "../../shared/components/modal/modal";
 import { Close } from "../../shared/components/icons/close-icon";
 import { Move } from "../../shared/components/icons/move-icon";
@@ -98,7 +98,7 @@ export const SectionItemMoveDialog: React.FC = () => {
             <dd className="col1">
               <select value={selectedPageId} name="page" onChange={handlePageChange}>
                 <option value="">Select ...</option>
-                { pagesForPicking.map( (p: any, index: number) => (
+                { pagesForPicking.map( (p: Partial<IPage>, index: number) => (
                     !p.isCompletion && <option key={p.id} value={p.id}>{index + 1}{p.isHidden && ` (hidden)`}</option>
                   ))
                 }

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -6,10 +6,10 @@ import { Close } from "../../shared/components/icons/close-icon";
 import { Move } from "../../shared/components/icons/move-icon";
 import { usePageAPI } from "../hooks/use-api-provider";
 import { UserInterfaceContext } from "../containers/user-interface-provider";
-
-import "./section-item-move-dialog.scss";
 import { RelativeLocation } from "../util/move-utils";
 import { useDestinationChooser } from "../hooks/use-destination-chooser";
+
+import "./section-item-move-dialog.scss";
 
 export const SectionItemMoveDialog: React.FC = () => {
   const { moveItem, getSections  } = usePageAPI();
@@ -98,8 +98,8 @@ export const SectionItemMoveDialog: React.FC = () => {
             <dd className="col1">
               <select value={selectedPageId} name="page" onChange={handlePageChange}>
                 <option value="">Select ...</option>
-                { pagesForPicking.map( (id, index) => (
-                    <option key={id} value={id}>{index + 1}</option>
+                { pagesForPicking.map( (p: any, index: number) => (
+                    !p.isCompletion && <option key={p.id} value={p.id}>{index + 1}{p.isHidden && ` (hidden)`}</option>
                   ))
                 }
               </select>

--- a/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { IPage } from "../api/api-types";
 import { Modal, ModalButtons } from "../../shared/components/modal/modal";
 import { Close } from "../../shared/components/icons/close-icon";
 import { Move } from "../../shared/components/icons/move-icon";
@@ -68,7 +69,7 @@ export const SectionMoveDialog: React.FC = () => {
             <dd className="col1">
               <select value={selectedPageId} name="page" onChange={handlePageChange}>
                 <option >Select ...</option>
-                { pagesForPicking.map( (p: any, index: number) => (
+                { pagesForPicking.map( (p: Partial<IPage>, index: number) => (
                     !p.isCompletion && <option key={p.id} value={p.id}>{index + 1}{p.isHidden && ` (hidden)`}</option>
                   ))
                 }

--- a/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import { Modal, ModalButtons } from "../../shared/components/modal/modal";
 import { Close } from "../../shared/components/icons/close-icon";
 import { Move } from "../../shared/components/icons/move-icon";
-
-import "./section-move-dialog.scss";
 import { usePageAPI } from "../hooks/use-api-provider";
 import { UserInterfaceContext } from "../containers/user-interface-provider";
 import { ISectionDestination } from "../util/move-utils";
 import { useDestinationChooser } from "../hooks/use-destination-chooser";
+
+import "./section-move-dialog.scss";
 
 export const SectionMoveDialog: React.FC = () => {
   const { userInterface: { movingSectionId }, actions: { setMovingSectionId }} = React.useContext(UserInterfaceContext);
@@ -68,8 +68,8 @@ export const SectionMoveDialog: React.FC = () => {
             <dd className="col1">
               <select value={selectedPageId} name="page" onChange={handlePageChange}>
                 <option >Select ...</option>
-                { pagesForPicking.map( (id, index) => (
-                    <option key={id} value={id}>{index + 1}</option>
+                { pagesForPicking.map( (p: any, index: number) => (
+                    !p.isCompletion && <option key={p.id} value={p.id}>{index + 1}{p.isHidden && ` (hidden)`}</option>
                   ))
                 }
 

--- a/lara-typescript/src/section-authoring/hooks/use-destination-chooser.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-destination-chooser.ts
@@ -1,6 +1,6 @@
 import { current } from "immer";
 import * as React from "react";
-import { PageId } from "../api/api-types";
+import { IPage, PageId } from "../api/api-types";
 
 import { usePageAPI } from "../hooks/use-api-provider";
 import { RelativeLocation } from "../util/move-utils";
@@ -13,8 +13,6 @@ export const useDestinationChooser = () => {
   const [selectedPosition, setSelectedPosition] = React.useState(RelativeLocation.After);
   const [validPage, setValidPage] = React.useState(false);
   const [validSection, setValidSection] = React.useState(false);
-
-  const pagesForPicking = getPages.data ? getPages.data.map(p => p.id) : [];
 
   React.useEffect( () => {
     if (getPages.data) {
@@ -39,6 +37,19 @@ export const useDestinationChooser = () => {
       setValidSection(true);
     }
   }, [selectedSectionId]);
+
+  const setPagesForPicking = (pageData: IPage[]) => {
+    const pages = pageData.map((p: IPage) => {
+      return {
+        id: p.id,
+        isCompletion: p.isCompletion,
+        isHidden: p.isHidden
+      };
+    });
+    return pages;
+  };
+
+  const pagesForPicking = getPages.data ? setPagesForPicking(getPages.data) : [];
 
   const handlePageChange = (change: React.ChangeEvent<HTMLSelectElement>) => {
     const pageId = change.target.value;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179598005

[#179598005]

These changes address two issues identified by QA review of the original work done in [this PR](https://github.com/concord-consortium/lara/pull/870):

1) Hidden pages should be identified by adding "(hidden)" to their listing in the move dialog. Also, completion pages should not be included in the list of pages in the move dialog since completion pages do not display assessment items.

2) It should not be possible to set a page to be hidden and then also make it a completion page. Enabling the hidden option should automatically disable the completion page option, and enabling the completion page option should automatically disable the hidden option.