### PR TITLE
180626537 support example report item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ config/environments/local-development.rb
 # simplecov output
 coverage/
 .DS_Store
+db/backups/

--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -90,7 +90,8 @@ module BaseInteractive
       width: native_width,
       height: native_height,
       question_number: index_in_activity,
-      authored_state: parsed_authored_state
+      authored_state: parsed_authored_state,
+      report_item_url: report_item_url
     }
 
     if type === "multiple_choice"

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -105,6 +105,10 @@ class ManagedInteractive < ActiveRecord::Base
     library_interactive ? library_interactive.thumbnail_url : nil
   end
 
+  def report_item_url
+    library_interactive ? library_interactive.report_item_url : nil
+  end
+
   def self.portal_type
     "iframe interactive"
   end

--- a/spec/support/shared_examples/base_interactive.rb
+++ b/spec/support/shared_examples/base_interactive.rb
@@ -113,7 +113,9 @@ shared_examples "a base interactive" do |model_factory|
         height: interactive.native_height,
         display_in_iframe: interactive.reportable_in_iframe?,
         show_in_featured_question_report: interactive.show_in_featured_question_report,
-        question_number: interactive.index_in_activity
+        question_number: interactive.index_in_activity,
+        report_item_url: interactive.report_item_url
+
       )
     end
 


### PR DESCRIPTION
This is a small change to support report item interactives.

When we publish an activities structure we must also include the URL to the report-item-interactive for any interactives that have one. This is so the report can lookup the report-item-interactive when generating a report for it.