### PR TITLE
Preview Half-Width Items in Authoring View

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -2370,8 +2370,12 @@ dl.textBlockEditForm {
     margin-bottom: 5px; }
     .itemEditDialog fieldset label.checkboxLabel {
       display: flex;
+      flex-wrap: wrap;
       font-size: 14px;
       margin: 0; }
+      .itemEditDialog fieldset label.checkboxLabel .inputNote {
+        margin-left: 25px;
+        width: 100%; }
     .itemEditDialog fieldset label input[type="checkbox"] {
       margin-right: 5px; }
   .itemEditDialog fieldset legend {

--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -2374,6 +2374,9 @@ dl.textBlockEditForm {
       flex-wrap: wrap;
       font-size: 14px;
       margin: 0; }
+      .itemEditDialog fieldset label.checkboxLabel .inputNote {
+        margin-left: 25px;
+        width: 100%; }
     .itemEditDialog fieldset label.radioLabel {
       display: inline;
       margin: 0 0 0 5px; }

--- a/lara-typescript/src/page-item-authoring/common/components/checkbox.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/checkbox.tsx
@@ -7,12 +7,13 @@ interface Props {
   checked?: boolean;
   defaultChecked?: boolean;
   label: string;
+  inputNote?: string;
   warning?: string;
   onChange?: (name: string, checked: boolean) => void;
 }
 
 export const Checkbox: React.FC<Props> = (props) => {
-  const {checkboxRef, id, name, checked, defaultChecked, label, warning, onChange} = props;
+  const {checkboxRef, id, name, checked, defaultChecked, label, inputNote, warning, onChange} = props;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (onChange) {
@@ -45,7 +46,7 @@ export const Checkbox: React.FC<Props> = (props) => {
           checked={checked}
           defaultChecked={defaultChecked}
           onChange={handleChange}
-        /> {label}
+        /> {label} {inputNote && <span className="inputNote">{inputNote}</span>}
       </label>
       {renderWarning()}
     </>

--- a/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
@@ -92,7 +92,8 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
           id="is_half_width"
           name="is_half_width"
           defaultChecked={is_half_width}
-          label="Half width (Full width layout only)"
+          label="Half Width"
+          inputNote="In full-width layout only."
         />
       </fieldset>
     </>;

--- a/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
@@ -85,7 +85,8 @@ export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
           id="is_half_width"
           name="is_half_width"
           defaultChecked={is_half_width}
-          label="Half width (Full width layout only)"
+          label="Half Width"
+          inputNote="In full-width layout only."
         />
         <br />
         <Checkbox

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.scss
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.scss
@@ -12,8 +12,14 @@
 
       &.checkboxLabel {
         display: flex;
+        flex-wrap: wrap;
         font-size: 14px;
         margin: 0;
+
+        .inputNote {
+          margin-left: 25px;
+          width: 100%;
+        }
       }
 
       input[type="checkbox"] {

--- a/lara-typescript/src/section-authoring/components/text-block-edit-form.tsx
+++ b/lara-typescript/src/section-authoring/components/text-block-edit-form.tsx
@@ -113,7 +113,7 @@ export const TextBlockEditForm: React.FC<ITextBlockEditFormProps> = ({
           type="checkbox"
           />
       </dd>
-      <dd className="inputNote row4">In full width layout only.</dd>
+      <dd className="inputNote row4">In full-width layout only.</dd>
     </dl>
     </>
   );


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180573627

[#180573627]

These changes address an issue related to work done here: https://github.com/concord-consortium/lara/pull/874

The changes make the half width option labels consistent for all assessment item types. They should all look like this:

![image](https://user-images.githubusercontent.com/367459/148114730-84270196-25f1-48e0-b171-9ebba8b31ec8.png)
