### PR TITLE
180788915 copy page position

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -45,10 +45,9 @@ class Api::V1::InteractivePagesController < API::APIController
     return error("Can't find activity for page") unless activity
 
     position = params[:dest_index]
-
     next_page = @interactive_page.duplicate
     next_page.lightweight_activity = activity
-    next_page.insert_at(position)
+    next_page.set_list_position(position)
     activity.reload
     next_page.reload
     render :json => generate_page_json(next_page)

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -161,6 +161,8 @@ export const deletePage = (id: PageId) => {
 
 const copyPage = (args: {pageId: PageId, destIndex: number}) => {
   const {pageId, destIndex} = args;
+  console.log(destIndex);
+  let newDestIndex;
   const page = pages.find(p => p.id === pageId);
   if (page) {
     const nextPage = {...page};
@@ -172,8 +174,14 @@ const copyPage = (args: {pageId: PageId, destIndex: number}) => {
       });
       return { ...s, items };
     });
-    pages.splice(destIndex, 0, nextPage);
+    if (destIndex === -1 || destIndex === 0) {
+      newDestIndex = destIndex + 1;
+    } else {
+      newDestIndex = destIndex;
+    }
+    pages.splice(newDestIndex, 0, nextPage);
     updatePositions(pages);
+    console.log(pages);
     return Promise.resolve(nextPage);
   }
   return Promise.reject("no source page in copy");

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -161,7 +161,6 @@ export const deletePage = (id: PageId) => {
 
 const copyPage = (args: {pageId: PageId, destIndex: number}) => {
   const {pageId, destIndex} = args;
-  console.log(destIndex);
   let newDestIndex;
   const page = pages.find(p => p.id === pageId);
   if (page) {
@@ -181,7 +180,6 @@ const copyPage = (args: {pageId: PageId, destIndex: number}) => {
     }
     pages.splice(newDestIndex, 0, nextPage);
     updatePositions(pages);
-    console.log(pages);
     return Promise.resolve(nextPage);
   }
   return Promise.reject("no source page in copy");

--- a/lara-typescript/src/section-authoring/components/page-nav-menu/page-copy-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/page-nav-menu/page-copy-dialog.tsx
@@ -13,7 +13,7 @@ export interface IPageCopyDialogProps {
   pages: IPage[];
   currentPageIndex: number | null;
   selectedPosition?: string;
-  selectedOtherPageId?: string;
+  selectedOtherPagePosition?: number;
   copyPageFunction: (destIndex: number) => void;
   closeDialogFunction: () => void;
 }
@@ -23,11 +23,11 @@ export const PageCopyDialog: React.FC<IPageCopyDialogProps> = ({
   pages,
   currentPageIndex,
   selectedPosition: initSelectedPosition = "after",
-  selectedOtherPageId: initSelectedOtherPageId = pageId,
+  selectedOtherPagePosition: initSelectedOtherPagePosition = 1,
   copyPageFunction,
   closeDialogFunction
   }: IPageCopyDialogProps) => {
-  const [selectedOtherPageId, setSelectedOtherPageId] = useState(initSelectedOtherPageId);
+  const [selectedOtherPagePosition, setSelectedOtherPagePosition] = useState(initSelectedOtherPagePosition);
   const [selectedPosition, setSelectedPosition] = useState(initSelectedPosition);
 
   const handlePositionChange = (change: React.ChangeEvent<HTMLSelectElement>) => {
@@ -35,7 +35,7 @@ export const PageCopyDialog: React.FC<IPageCopyDialogProps> = ({
   };
 
   const handleOtherPageChange = (change: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectedOtherPageId(change.target.value);
+    setSelectedOtherPagePosition(parseInt(change.target.value, 10));
   };
 
   const handleCloseDialog = () => {
@@ -44,7 +44,7 @@ export const PageCopyDialog: React.FC<IPageCopyDialogProps> = ({
 
   const handleCopyPage = () => {
     if (currentPageIndex != null && currentPageIndex > -1) {
-      let destIndex = pages.findIndex(p => p.id === selectedOtherPageId);
+      let destIndex = selectedOtherPagePosition;
       if (selectedPosition === RelativeLocation.After) {
         destIndex++;
       }
@@ -55,7 +55,7 @@ export const PageCopyDialog: React.FC<IPageCopyDialogProps> = ({
 
   const pageOptions = () => {
     return pages.map((p, index) => {
-      return <option key={`page-${index}`} value={p.id}>{index + 1}</option>;
+      return <option key={`page-${index}`} value={p.position}>{p.position}</option>;
     });
   };
 


### PR DESCRIPTION
The current implementation of the copy page uses `insert_at` from the `acts-as-list` library. This was causing the subsequent page positions to act strangely. 
ie. 
`
[{page: 1, position: 1}, {page: 2, position: 2}, {page: 3, position: 3}, {page: 4, position: 4}]`
Copy page 4 to after page 2. The result was: 
`[{page: 1, position: 1}, {page: 2, position: 2}, , {page: 4, position: 3}, {page: 3, position: 5}, {page: 4, position: 5}]
`
This was causing issues when trying to preview the correct page. When you try to preview the last page 4, sometimes you will get page 3.
There were also issue previewing items that were copied to the before page 1, as position would be set to -1, which would preview to the activity page setting. If another page is copied to after page 1, the position would be set to 0 which would also preview to activity page setting.
Changes this PR makes:
1. The method used for inserting the copied page to `set_list_position`. This inserts the copied page to the specified position and renumbers subsequent positions correctly.
2. The logic for figuring out what position to insert the page in. It now uses the position number instead of by page ids.
