### PR TITLE
Add hidden label to Copy Page dialog.

### DIFF
--- a/lara-typescript/src/section-authoring/components/page-nav-menu/page-copy-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/page-nav-menu/page-copy-dialog.tsx
@@ -4,9 +4,10 @@ import { Modal, ModalButtons } from "../../../shared/components/modal/modal";
 import { Add } from "../../../shared/components/icons/add-icon";
 import { Close } from "../../../shared/components/icons/close-icon";
 import { IPage } from "../../api/api-types";
+import { RelativeLocation } from "../../util/move-utils";
+import { useDestinationChooser } from "../../hooks/use-destination-chooser";
 
 import "./page-copy-dialog.scss";
-import { RelativeLocation } from "../../util/move-utils";
 
 export interface IPageCopyDialogProps {
   pageId: string;
@@ -29,6 +30,7 @@ export const PageCopyDialog: React.FC<IPageCopyDialogProps> = ({
   }: IPageCopyDialogProps) => {
   const [selectedOtherPagePosition, setSelectedOtherPagePosition] = useState(initSelectedOtherPagePosition);
   const [selectedPosition, setSelectedPosition] = useState(initSelectedPosition);
+  const { pagesForPicking } = useDestinationChooser();
 
   const handlePositionChange = (change: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedPosition(change.target.value);
@@ -78,7 +80,11 @@ export const PageCopyDialog: React.FC<IPageCopyDialogProps> = ({
           <dt className="col2">Page</dt>
           <dd className="col2">
             <select name="otherItem" onChange={handleOtherPageChange}>
-              {pageOptions()}
+              <option value="">Select ...</option>
+              { pagesForPicking.map( (p: Partial<IPage>, index: number) => (
+                  !p.isCompletion && <option key={p.id} value={p.id}>{index + 1}{p.isHidden && ` (hidden)`}</option>
+                ))
+              }
             </select>
           </dd>
         </dl>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179598005

[#179598005]

These changes add the " (hidden)" label to hidden pages listed in the Page Copy dialog's page selection options, something I missed in [these changes](https://github.com/concord-consortium/lara/pull/876).

