### PR TITLE
Add Interactive ID information to Iframe interactive form

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -2369,6 +2369,9 @@ dl.textBlockEditForm {
   .itemEditDialog fieldset label {
     display: block;
     margin-bottom: 5px; }
+    .itemEditDialog fieldset label[for="name"] {
+      font-size: 14px;
+      font-weight: bolder; }
     .itemEditDialog fieldset label.checkboxLabel {
       display: flex;
       flex-wrap: wrap;
@@ -2383,13 +2386,9 @@ dl.textBlockEditForm {
     .itemEditDialog fieldset label input[type="checkbox"] {
       margin-right: 5px; }
   .itemEditDialog fieldset legend {
-    border-top: solid 1.5px var(--lt-gray);
-    display: block;
     font-size: 16px;
     font-weight: 700;
-    margin-bottom: 10px;
-    padding-top: 15px;
-    width: 100%; }
+    margin-bottom: 10px; }
   .itemEditDialog fieldset .customizable-label {
     font-weight: bold;
     margin: 10px 0 5px 0; }
@@ -2453,6 +2452,16 @@ dl.textBlockEditForm {
   color: var(--med-gray);
   font-size: 14px;
   font-style: italic; }
+
+.itemEditDialog .react-tabs legend {
+  border-top: solid 1.5px var(--lt-gray);
+  display: block;
+  padding-top: 15px;
+  width: 100%; }
+
+.itemEditDialog .react-tabs div fieldset:first-child legend {
+  border-top: none;
+  padding-top: 0; }
 
 @font-face {
   font-family: 'Lato-Light';

--- a/lara-typescript/src/page-item-authoring/index.tsx
+++ b/lara-typescript/src/page-item-authoring/index.tsx
@@ -11,7 +11,6 @@ import { AuthoringApiUrls } from "./common/types";
 interface IRenderManagedInteractiveAuthoringProps {
   managedInteractive: IManagedInteractive;
   libraryInteractive?: ILibraryInteractive;
-  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
 }
@@ -20,7 +19,6 @@ const renderManagedInteractiveAuthoring = (root: HTMLElement, props: IRenderMana
     <ManagedInteractiveAuthoring
       managedInteractive={props.managedInteractive}
       libraryInteractive={props.libraryInteractive}
-      interactive_item_id={props.interactive_item_id}
       defaultClickToPlayPrompt={props.defaultClickToPlayPrompt}
       authoringApiUrls={props.authoringApiUrls}
     />, root);
@@ -28,7 +26,6 @@ const renderManagedInteractiveAuthoring = (root: HTMLElement, props: IRenderMana
 
 interface IRenderMWInteractiveAuthoringProps {
   interactive: IMWInteractive;
-  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
 }
@@ -36,7 +33,6 @@ const renderMWInteractiveAuthoring = (root: HTMLElement, props: IRenderMWInterac
   return ReactDOM.render(
     <MWInteractiveAuthoring
       interactive={props.interactive}
-      interactive_item_id={props.interactive_item_id}
       defaultClickToPlayPrompt={props.defaultClickToPlayPrompt}
       authoringApiUrls={props.authoringApiUrls}
     />, root);

--- a/lara-typescript/src/page-item-authoring/index.tsx
+++ b/lara-typescript/src/page-item-authoring/index.tsx
@@ -11,6 +11,7 @@ import { AuthoringApiUrls } from "./common/types";
 interface IRenderManagedInteractiveAuthoringProps {
   managedInteractive: IManagedInteractive;
   libraryInteractive?: ILibraryInteractive;
+  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
 }
@@ -19,6 +20,7 @@ const renderManagedInteractiveAuthoring = (root: HTMLElement, props: IRenderMana
     <ManagedInteractiveAuthoring
       managedInteractive={props.managedInteractive}
       libraryInteractive={props.libraryInteractive}
+      interactive_item_id={props.interactive_item_id}
       defaultClickToPlayPrompt={props.defaultClickToPlayPrompt}
       authoringApiUrls={props.authoringApiUrls}
     />, root);
@@ -26,6 +28,7 @@ const renderManagedInteractiveAuthoring = (root: HTMLElement, props: IRenderMana
 
 interface IRenderMWInteractiveAuthoringProps {
   interactive: IMWInteractive;
+  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
 }
@@ -33,6 +36,7 @@ const renderMWInteractiveAuthoring = (root: HTMLElement, props: IRenderMWInterac
   return ReactDOM.render(
     <MWInteractiveAuthoring
       interactive={props.interactive}
+      interactive_item_id={props.interactive_item_id}
       defaultClickToPlayPrompt={props.defaultClickToPlayPrompt}
       authoringApiUrls={props.authoringApiUrls}
     />, root);

--- a/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
@@ -16,6 +16,7 @@ import "react-tabs/style/react-tabs.css";
 interface Props {
   managedInteractive: IManagedInteractive;
   libraryInteractive?: ILibraryInteractive;
+  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
   onUpdate?: (updates: Partial<IManagedInteractive>) => void;
@@ -59,7 +60,14 @@ export interface IManagedInteractive {
 }
 
 export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
-  const { libraryInteractive, managedInteractive, defaultClickToPlayPrompt, authoringApiUrls, onUpdate } = props;
+  const {
+    libraryInteractive,
+    managedInteractive,
+    interactive_item_id,
+    defaultClickToPlayPrompt,
+    authoringApiUrls,
+    onUpdate
+  } = props;
   const { name, is_half_width } = managedInteractive;
   const libraryInteractiveIdRef = useRef<HTMLInputElement|null>(null);
   const libraryInteractiveAuthoredStateRef = useRef<HTMLTextAreaElement|null>(null);
@@ -77,6 +85,9 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
     }
 
     return <>
+      <div className="interactiveItemID">
+        InteractiveID: {interactive_item_id}
+      </div>
       <fieldset>
         <label htmlFor="name">Name</label>
         <input
@@ -111,7 +122,7 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
         ? libraryInteractive.aspect_ratio_method
         : managedInteractive.custom_aspect_ratio_method,
       authored_state: managedInteractive.authored_state,
-      interactive_item_id: managedInteractive.interactive_item_id,
+      interactive_item_id,
       linked_interactives: managedInteractive.linked_interactives
     };
 

--- a/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/index.tsx
@@ -16,7 +16,6 @@ import "react-tabs/style/react-tabs.css";
 interface Props {
   managedInteractive: IManagedInteractive;
   libraryInteractive?: ILibraryInteractive;
-  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
   onUpdate?: (updates: Partial<IManagedInteractive>) => void;
@@ -63,7 +62,6 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
   const {
     libraryInteractive,
     managedInteractive,
-    interactive_item_id,
     defaultClickToPlayPrompt,
     authoringApiUrls,
     onUpdate
@@ -86,7 +84,7 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
 
     return <>
       <div className="interactiveItemID">
-        InteractiveID: {interactive_item_id}
+        InteractiveID: {managedInteractive.interactive_item_id}
       </div>
       <fieldset>
         <label htmlFor="name">Name</label>
@@ -122,7 +120,7 @@ export const ManagedInteractiveAuthoring: React.FC<Props> = (props) => {
         ? libraryInteractive.aspect_ratio_method
         : managedInteractive.custom_aspect_ratio_method,
       authored_state: managedInteractive.authored_state,
-      interactive_item_id,
+      interactive_item_id: managedInteractive.interactive_item_id,
       linked_interactives: managedInteractive.linked_interactives
     };
 

--- a/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
@@ -13,7 +13,6 @@ import { valueContainerCSS } from "react-select/src/components/containers";
 
 interface Props {
   interactive: IMWInteractive;
-  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
 }
@@ -46,7 +45,7 @@ export interface IMWInteractive {
 }
 
 export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
-  const { interactive, interactive_item_id, defaultClickToPlayPrompt, authoringApiUrls } = props;
+  const { interactive, defaultClickToPlayPrompt, authoringApiUrls } = props;
   const interactiveAuthoredStateRef = useRef<HTMLInputElement|null>(null);
   const linkedInteractivesRef = useRef<HTMLInputElement|null>(null);
   const enableLearnerStateRef = useRef<HTMLInputElement|null>(null);
@@ -121,7 +120,7 @@ export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
       aspect_ratio: interactive.aspect_ratio,
       aspect_ratio_method: interactive.aspect_ratio_method,
       authored_state: interactive.authored_state,
-      interactive_item_id,
+      interactive_item_id: interactive.interactive_item_id,
       linked_interactives: interactive.linked_interactives
     };
 
@@ -170,7 +169,7 @@ export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
   // this generates a form element that renders inside the rails popup form
   return <>
     <div className="interactiveItemID">
-      InteractiveID: {interactive_item_id}
+      InteractiveID: {interactive.interactive_item_id}
     </div>
     <fieldset>
       <legend>Iframe Interactive</legend>

--- a/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
+++ b/lara-typescript/src/page-item-authoring/mw-interactives/index.tsx
@@ -13,6 +13,7 @@ import { valueContainerCSS } from "react-select/src/components/containers";
 
 interface Props {
   interactive: IMWInteractive;
+  interactive_item_id: string;
   defaultClickToPlayPrompt: string;
   authoringApiUrls: AuthoringApiUrls;
 }
@@ -45,7 +46,7 @@ export interface IMWInteractive {
 }
 
 export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
-  const { interactive, defaultClickToPlayPrompt, authoringApiUrls } = props;
+  const { interactive, interactive_item_id, defaultClickToPlayPrompt, authoringApiUrls } = props;
   const interactiveAuthoredStateRef = useRef<HTMLInputElement|null>(null);
   const linkedInteractivesRef = useRef<HTMLInputElement|null>(null);
   const enableLearnerStateRef = useRef<HTMLInputElement|null>(null);
@@ -120,7 +121,7 @@ export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
       aspect_ratio: interactive.aspect_ratio,
       aspect_ratio_method: interactive.aspect_ratio_method,
       authored_state: interactive.authored_state,
-      interactive_item_id: interactive.interactive_item_id,
+      interactive_item_id,
       linked_interactives: interactive.linked_interactives
     };
 
@@ -168,6 +169,9 @@ export const MWInteractiveAuthoring: React.FC<Props> = (props) => {
 
   // this generates a form element that renders inside the rails popup form
   return <>
+    <div className="interactiveItemID">
+      InteractiveID: {interactive_item_id}
+    </div>
     <fieldset>
       <legend>Iframe Interactive</legend>
       <input

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.scss
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.scss
@@ -11,6 +11,11 @@
       display: block;
       margin-bottom: 5px;
 
+      &[for="name"] {
+        font-size: 14px;
+        font-weight: bolder;
+      }
+
       &.checkboxLabel {
         display: flex;
         flex-wrap: wrap;
@@ -32,13 +37,9 @@
       }
     }
     legend {
-      border-top: solid 1.5px var(--lt-gray);
-      display: block;
       font-size: 16px;
       font-weight: 700;
       margin-bottom: 10px;
-      padding-top: 15px;
-      width: 100%;
     }
 
     .customizable-label {
@@ -125,5 +126,20 @@
     color: var(--med-gray);
     font-size: 14px;
     font-style: italic;
+  }
+
+  .react-tabs {
+    legend {
+      border-top: solid 1.5px var(--lt-gray);
+      display: block;
+      padding-top: 15px;
+      width: 100%;
+    }
+    div fieldset:first-child {
+      legend {
+        border-top: none;
+        padding-top: 0;
+      }
+    }
   }
 }

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
@@ -123,6 +123,12 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
     };
   };
 
+  const interactiveFromItemToEdit = (itemToEdit: ISectionItem) => {
+    const interactive = camelToSnakeCaseKeys(itemToEdit.data);
+    interactive.interactive_item_id = `interactive_${itemToEdit.id}`;
+    return interactive;
+  };
+
   const modalButtons = [
     {
       classes: "cancel",
@@ -147,7 +153,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
         return <TextBlockEditForm pageItem={itemToEdit} />;
         break;
       case "ManagedInteractive":
-        const managedInteractive = camelToSnakeCaseKeys(itemToEdit.data);
+        const managedInteractive = interactiveFromItemToEdit(itemToEdit);
         const libraryInteractive = camelToSnakeCaseKeys(
                                      libraryInteractives?.find(
                                        li => li.id === itemToEdit.data.libraryInteractiveId
@@ -156,17 +162,15 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
         return <ManagedInteractiveAuthoring
                 managedInteractive={managedInteractive}
                 libraryInteractive={libraryInteractive}
-                interactive_item_id={`interactive_${itemToEdit.id}`}
                 defaultClickToPlayPrompt={"Click to Play"}
                 authoringApiUrls={authoringApiUrls}
                 onUpdate={handleManagedInteractiveData}
                />;
         break;
       case "MwInteractive":
-        const interactive = camelToSnakeCaseKeys(itemToEdit.data);
+        const interactive = interactiveFromItemToEdit(itemToEdit);
         return <MWInteractiveAuthoring
                 interactive={interactive}
-                interactive_item_id={`interactive_${itemToEdit.id}`}
                 defaultClickToPlayPrompt={"Click to Play"}
                 authoringApiUrls={authoringApiUrls}
                />;

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
@@ -156,6 +156,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
         return <ManagedInteractiveAuthoring
                 managedInteractive={managedInteractive}
                 libraryInteractive={libraryInteractive}
+                interactive_item_id={`interactive_${itemToEdit.id}`}
                 defaultClickToPlayPrompt={"Click to Play"}
                 authoringApiUrls={authoringApiUrls}
                 onUpdate={handleManagedInteractiveData}
@@ -165,6 +166,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
         const interactive = camelToSnakeCaseKeys(itemToEdit.data);
         return <MWInteractiveAuthoring
                 interactive={interactive}
+                interactive_item_id={`interactive_${itemToEdit.id}`}
                 defaultClickToPlayPrompt={"Click to Play"}
                 authoringApiUrls={authoringApiUrls}
                />;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180760275

[#180760275]

These changes reinstate the Interactive ID listing at the top of the iFrame and Library Interactive edit forms.

I also snuck in some minor, unrelated style fixes for an issue introduced in a separate PR that's already been merged into new-sections.