### PR TITLE
Fixes updating browser tab title on page nav authoring mode

### DIFF
--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { usePageAPI } from "../hooks/use-api-provider";
+import { useTitle } from "../hooks/use-title";
 import { PageNavContainer } from "../containers/page-nav-container";
 import { PageSettingsDialog } from "../../page-settings/components/page-settings-dialog";
 import { AuthoringSection } from "./authoring-section";
@@ -13,10 +14,10 @@ import { CompletionPage } from "./completion-page/completion-page";
 import { Add } from "../../shared/components/icons/add-icon";
 import { Cog } from "../../shared/components/icons/cog-icon";
 import { HiddenIcon } from "../../shared/components/icons/hidden-icon";
-
-import "./authoring-page.scss";
 import { UserInterfaceContext} from "../containers/user-interface-provider";
 import { PreviewLinksContainer } from "../containers/preview-links-container";
+
+import "./authoring-page.scss";
 
 export interface IPageProps extends IPage {
 
@@ -172,7 +173,7 @@ export const AuthoringPage: React.FC<IPageProps> = ({
 
   const pageSettingsClickHandler = () => { setShowSettings(true); };
   const displayTitle = name && name !== "" ? name : <em>(title not set)</em>;
-
+  useTitle("Edit " + name);
   return (
     <>
       <PageNavContainer />

--- a/lara-typescript/src/section-authoring/hooks/use-title.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-title.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+export function useTitle(title: string) {
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = title;
+    return () => {
+      document.title = prevTitle;
+    };
+  });
+}

--- a/lara-typescript/src/section-authoring/hooks/use-title.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-title.ts
@@ -7,5 +7,5 @@ export function useTitle(title: string) {
     return () => {
       document.title = prevTitle;
     };
-  });
+  }, [title]);
 }


### PR DESCRIPTION
Took the solution from [here](https://stackoverflow.com/questions/46160461/how-do-you-set-the-document-title-in-react)
Tried all the other simpler ways and couldn't get it to update on page change.