### PR TITLE
Fix adding additional item in primary column always adds at the top

### DIFF
--- a/lara-typescript/src/section-authoring/components/section-column.tsx
+++ b/lara-typescript/src/section-authoring/components/section-column.tsx
@@ -115,7 +115,8 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
   const handleShowAddItem = absorbClickThen(handleToggleShowAddItem);
 
   const handleAddItem = (itemId: string) => {
-    const position = items.length + 1;
+    const lastItemPosition = items.length > 0 ? items[items.length - 1].position : undefined;
+    const position = lastItemPosition ? lastItemPosition + 1 : 1;
     const embeddable = embeddables?.find(e => e.id === itemId);
     if (embeddable) {
       addPageItem?.({


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180760254

[#180760254]

Items' position values do not always correspond to the number of items in a column. For example, if there are two items in a column, their respective position values could be 2 and 3 instead of 1 and 2. This change makes sure to increment the actual position value of the last item in the column to determine the position value for a newly added item.