### PR TITLE
Fix text block default half width setting

### DIFF
--- a/db/migrate/20220107171753_change_text_block_half_width_default_to_false.rb
+++ b/db/migrate/20220107171753_change_text_block_half_width_default_to_false.rb
@@ -1,0 +1,12 @@
+class ChangeTextBlockHalfWidthDefaultToFalse < ActiveRecord::Migration
+  class Embeddable::Xhtml < ActiveRecord::Base
+  end
+
+  def up
+    change_column_default :embeddable_xhtmls, :is_half_width, false
+  end
+
+  def down
+    change_column_default :embeddable_xhtmls, :is_half_width, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20211216173613) do
+ActiveRecord::Schema.define(:version => 20220107171753) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -296,7 +296,7 @@ ActiveRecord::Schema.define(:version => 20211216173613) do
     t.datetime "created_at",                       :null => false
     t.datetime "updated_at",                       :null => false
     t.boolean  "is_hidden",     :default => false
-    t.boolean  "is_half_width", :default => true
+    t.boolean  "is_half_width", :default => false
     t.boolean  "is_callout",    :default => true
   end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180837836

[#180837836]

This migration changes the default half-width setting for text blocks to false.