### PR TITLE
Fix Link Saved Work From field value not saving correctly.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ gem "chosen-rails", "~> 1.0"
 gem "safe_yaml", "~> 1.0"
 gem "will_paginate", "~> 3.0"
 gem "useragent", "~> 0.10"
-gem "ribbons-rails", "~> 0.0", {:git=>"git://github.com/concord-consortium/ribbons-rails.git"}
+gem "ribbons-rails", "~> 0.0", {:git=>"https://github.com/concord-consortium/ribbons-rails.git"}
 gem "spreadsheet", "~> 1.0"
 gem "nokogiri", ">= 1.8.5"
 gem "rack-cors","~> 0.4.1", :require => 'rack/cors'

--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ gem "omniauth", "~> 1.3.2"
 gem "omniauth-oauth2", "~> 1.1", {:git=>"https://github.com/intridea/omniauth-oauth2.git"}
 gem "default_value_for", "~> 2.0"
 gem "tinymce-rails", "~> 4.7"
-gem "yaml_db", "~> 0.2", {:git=>"git://github.com/lostapathy/yaml_db.git"}
+gem "yaml_db", "~> 0.2", {:git=>"https://github.com/lostapathy/yaml_db.git"}
 gem "aws-ses", git: "https://github.com/zebitex/aws-ses.git", ref: "78-sigv4-problem"
 gem "uuidtools", "~> 2.1"
 gem "httparty", "~> 0.12"

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :development do
   gem "webrick", "~> 1.3"
   gem "capistrano", "~> 2.15"
   gem "aws-sdk", "~> 1.66"
-  gem "capistrano-autoscaling", "~> 0.0", {:git=>"git://github.com/concord-consortium/capistrano-autoscaling.git", :branch=>"concord"}
+  gem "capistrano-autoscaling", "~> 0.0", {:git=>"https://github.com/concord-consortium/capistrano-autoscaling.git", :branch=>"concord"}
   gem "capistrano-cowboy", "~> 0.1"
   gem "lol_dba", "~> 1.6", {:require=>false}
   gem "brakeman", "~> 2.4", {:require=>false}

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -66,7 +66,8 @@ class MwInteractive < ActiveRecord::Base
       model_library_url: model_library_url,
       authored_state: authored_state,
       aspect_ratio_method: aspect_ratio_method,
-      no_snapshots: no_snapshots
+      no_snapshots: no_snapshots,
+      linked_interactive_item_id: linked_interactive_item_id
     }
   end
 

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -42,6 +42,7 @@ describe MwInteractive do
         show_in_featured_question_report: interactive.show_in_featured_question_report,
         aspect_ratio_method: interactive.aspect_ratio_method,
         no_snapshots: interactive.no_snapshots,
+        linked_interactive_item_id: interactive.linked_interactive_item_id
       }
       hash = interactive.to_hash
       expect(hash).to eq(expected)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180760275

[#180760275]

These changes add `linked_interactive_item_id` to the MWInteractive's `to_hash` method. This makes it possible for the edit form to populate the Link Saved Work From field with the saved value.

They also update some URLs in the Gemfile that were no longer working.