### PR TITLE
Fix author cannot upload image files

### DIFF
--- a/lara-typescript/src/page-item-authoring/common/components/interactive-iframe.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-iframe.tsx
@@ -106,7 +106,7 @@ export const InteractiveIframe: React.FC<Props> = (props) => {
       headers: {
         "Content-type": "application/json"
       },
-      body: JSON.stringify({opts})
+      body: JSON.stringify(opts)
     })
     .then(response => response.json())
     .then((data: {token: string}) => {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180963196

[#180963196]

Corrects how `firebase_app` value is sent during Firebase JWT request. Previously the request body was being set to `{opts: {firebase_app: "token-service"}}`. Now it will be set to `{firebase_app: "token-service"}`.