### PR TITLE
Fix change page layout doesn’t work as expected -- image outside column

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -704,7 +704,11 @@
   .textBlock.callout .textBlockContent {
     background: #f4f4f4;
     margin: 0;
+    overflow: hidden;
     padding: 5px 20px 20px 20px; }
+    .textBlock.callout .textBlockContent img {
+      height: auto;
+      max-width: 100%; }
   .textBlock p {
     margin: 0 10px 20px; }
   .textBlock .textBlockName {

--- a/lara-typescript/src/section-authoring/components/text-block-preview.scss
+++ b/lara-typescript/src/section-authoring/components/text-block-preview.scss
@@ -15,7 +15,13 @@
     .textBlockContent {
       background: #f4f4f4;
       margin: 0;
+      overflow: hidden;
       padding: 5px 20px 20px 20px;
+
+      img {
+        height: auto;
+        max-width: 100%;
+      }
     }
   }
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180980286

[#180980286]

This change adds a limit on how wide an image within a text block can be so it won't extend outside the boundary of its containing column. (The problem identified by the PT story doesn't actually require a layout change to manifest. Simply adding a largish image to a text block that's within a secondary column will reveal the bug.)

There's an additional CSS tweak that ensures an image in a text block also doesn't extend beyond the bottom boundary of the text block.