### PR TITLE
Fix copy section not working

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -392,14 +392,14 @@ class Api::V1::InteractivePagesController < API::APIController
   private
 
   def generate_item_json(page_item)
+    embeddable = page_item.embeddable
     {
       id: page_item.id.to_s,
       column: page_item.column,
       position: page_item.position,
       type: page_item.embeddable_type,
-      data: page_item.embeddable.to_hash
-      # using `to_interactive` here broke
-      # editing/saving by sending incorrect data back
+      data: embeddable.to_hash, # using `to_interactive` here broke editing/saving by sending incorrect data back
+      authoringApiUrls: embeddable.respond_to?(:authoring_api_urls) ? embeddable.authoring_api_urls(request.protocol, request.host_with_port) : {}
     }
   end
 
@@ -439,4 +439,5 @@ class Api::V1::InteractivePagesController < API::APIController
       render :json => { :success => false, :message => "Could not find interactive page ##{params['id']}"}
     end
   end
+
 end

--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -155,7 +155,7 @@ class Api::V1::InteractivePagesController < API::APIController
 
     item = @interactive_page.page_items.find { |i| i.id == item_id.to_i }
     duplicate = item.duplicate
-    render json:  generate_item_json(duplicate)
+    render json: generate_item_json(duplicate)
   end
 
   def update_section

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -110,6 +110,8 @@ class ManagedInteractive < ActiveRecord::Base
     "iframe interactive"
   end
 
+  # to_hash is used by the export and duplicate methods here, and the create_page_item, update_page_item, 
+  # and generate_item_json methods in controllers/api/v1/interactive_pages_controller.rb
   def to_hash
     # Deliberately ignoring user (will be set in duplicate)
     {
@@ -144,6 +146,20 @@ class ManagedInteractive < ActiveRecord::Base
     hash[:linked_interactives] = linked_interactives_list
     hash
   end
+
+  # to_interactive is used by the to_authoring_preview_hash method above. 
+  # 
+  # It differs from to_hash by including:
+  # id, url, native_width, native_height, enable_learner_state, show_delete_data_button, has_report_url, 
+  # click_to_play, click_to_play_prompt, full_window, image_url, aspect_ratio, aspect_ratio_method, 
+  # no_snapshots, linked_interactive_id, linked_interactive_type
+  # 
+  # It also differs from to_hash by not including: 
+  # library_interactive_id, url_fragment, inherit_aspect_ratio_method, custom_aspect_ratio_method, 
+  # inherit_native_width, custom_native_width, inherit_native_height, custom_native_height, 
+  # inherit_click_to_play, custom_click_to_play, inherit_full_window, custom_full_window, 
+  # inherit_click_to_play_prompt, custom_click_to_play_prompt, inherit_image_url, custom_image_url, 
+  # linked_interactives
 
   def to_interactive
     # NOTE: model_library_url is missing as there is no analog
@@ -180,7 +196,7 @@ class ManagedInteractive < ActiveRecord::Base
   end
 
   def export
-    hash = to_hash()
+    hash = to_hash().except!(:linked_interactives)
     hash.delete(:library_interactive_id)
     hash[:library_interactive] = library_interactive ? {
       data: library_interactive.to_hash()

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -133,7 +133,8 @@ class ManagedInteractive < ActiveRecord::Base
       inherit_click_to_play_prompt: inherit_click_to_play_prompt,
       custom_click_to_play_prompt: custom_click_to_play_prompt,
       inherit_image_url: inherit_image_url,
-      custom_image_url: custom_image_url
+      custom_image_url: custom_image_url,
+      linked_interactives: linked_interactives_list
     }
   end
 
@@ -172,8 +173,9 @@ class ManagedInteractive < ActiveRecord::Base
   end
 
   def duplicate
+    new_interactive_hash = self.to_hash.except!(:linked_interactives)
     # Generate a new object with those values
-    ManagedInteractive.new(self.to_hash)
+    ManagedInteractive.new(new_interactive_hash)
     # N.B. the duplicate hasn't been saved yet
   end
 

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -199,8 +199,8 @@ class ManagedInteractive < ActiveRecord::Base
   end
 
   def export
-    # Remove linked_interactives from the hash since it can't be mapped to a database column like the other 
-    # properties in the hash can, and so would cause an error on import.
+    # Remove linked_interactives from the hash so we don't export linked embeddables. The export method 
+    # in LaraSerializationHelper provides special handling for this value. See comment there for more.
     hash = to_hash().except!(:linked_interactives)
     hash.delete(:library_interactive_id)
     hash[:library_interactive] = library_interactive ? {

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -147,7 +147,8 @@ class ManagedInteractive < ActiveRecord::Base
     hash
   end
 
-  # to_interactive is used by the to_authoring_preview_hash method above. 
+  # to_interactive is used by the to_authoring_preview_hash method above. The to_authoring_preview_method 
+  # is deprecated. It is not used in LARA 2 and we plan to remove it when LARA 2 is moved to production.
   # 
   # It differs from to_hash by including:
   # id, url, native_width, native_height, enable_learner_state, show_delete_data_button, has_report_url, 
@@ -189,6 +190,8 @@ class ManagedInteractive < ActiveRecord::Base
   end
 
   def duplicate
+    # Remove linked_interactives from the hash since it can't be mapped to a database column like the other 
+    # properties in the hash can, and so causes an error when we try to create the duplicate interactive.
     new_interactive_hash = self.to_hash.except!(:linked_interactives)
     # Generate a new object with those values
     ManagedInteractive.new(new_interactive_hash)
@@ -196,6 +199,8 @@ class ManagedInteractive < ActiveRecord::Base
   end
 
   def export
+    # Remove linked_interactives from the hash since it can't be mapped to a database column like the other 
+    # properties in the hash can, and so would cause an error on import.
     hash = to_hash().except!(:linked_interactives)
     hash.delete(:library_interactive_id)
     hash[:library_interactive] = library_interactive ? {

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -77,6 +77,8 @@ class MwInteractive < ActiveRecord::Base
   end
 
   def duplicate
+    # Remove linked_interactives from the hash since it can't be mapped to a database column like the other 
+    # properties in the hash can, and so causes an error when we try to create the duplicate interactive.
     new_interactive_hash = self.to_hash.except!(:linked_interactives)
     # Generate a new object with those values
     MwInteractive.new(new_interactive_hash)

--- a/app/models/mw_interactive.rb
+++ b/app/models/mw_interactive.rb
@@ -67,7 +67,8 @@ class MwInteractive < ActiveRecord::Base
       authored_state: authored_state,
       aspect_ratio_method: aspect_ratio_method,
       no_snapshots: no_snapshots,
-      linked_interactive_item_id: linked_interactive_item_id
+      linked_interactive_item_id: linked_interactive_item_id,
+      linked_interactives: linked_interactives_list
     }
   end
 
@@ -76,8 +77,9 @@ class MwInteractive < ActiveRecord::Base
   end
 
   def duplicate
+    new_interactive_hash = self.to_hash.except!(:linked_interactives)
     # Generate a new object with those values
-    MwInteractive.new(self.to_hash)
+    MwInteractive.new(new_interactive_hash)
     # N.B. the duplicate hasn't been saved yet
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -118,8 +118,9 @@ class Section < ActiveRecord::Base
           embed.primary_linked_items.each do |pli|
             primary = helper.get_copy(embed)
             secondary = helper.get_copy(pli.secondary.embeddable)
-            if primary && secondary
-              lpi = LinkedPageItem.new(primary_id: primary.page_item.id, secondary_id: secondary.page_item.id, label: pli.label)
+            secondary_page_item = secondary.page_item ? secondary.page_item : pli.secondary.embeddable.page_item
+            if primary && secondary_page_item
+              lpi = LinkedPageItem.new(primary_id: primary.page_item.id, secondary_id: secondary_page_item.id, label: pli.label)
               lpi.save!(validate: false)
             end
           end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -81,6 +81,7 @@ class Section < ActiveRecord::Base
   def duplicate(helper=nil)
     helper = LaraDuplicationHelper.new if helper.nil?
     new_section = Section.new(to_hash)
+    new_section.position = new_section.position + 1
 
     Section.transaction do
       new_section.save!(validate: false)

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -118,6 +118,8 @@ class Section < ActiveRecord::Base
           embed.primary_linked_items.each do |pli|
             primary = helper.get_copy(embed)
             secondary = helper.get_copy(pli.secondary.embeddable)
+            # If the secondary embeddable is in a different section, it won't be copied. So in that 
+            # case, the new primary embeddable references the original secondary embeddable.
             secondary_page_item = secondary.page_item ? secondary.page_item : pli.secondary.embeddable.page_item
             if primary && secondary_page_item
               lpi = LinkedPageItem.new(primary_id: primary.page_item.id, secondary_id: secondary_page_item.id, label: pli.label)

--- a/lara-typescript/src/page-item-authoring/common/components/interactive-iframe.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-iframe.tsx
@@ -70,13 +70,13 @@ export const InteractiveIframe: React.FC<Props> = (props) => {
 
   const handleGetInteractiveList = (request: LaraInteractiveApi.IGetInteractiveListRequest, url: string) => {
     const {requestId, scope, supportsSnapshots} = request;
+    const urlWithParams = `${url}?scope=${scope}&amp;supportsSnapshots=${supportsSnapshots}`;
 
-    return fetch(url, {
+    return fetch(urlWithParams, {
       method: "GET",
       headers: {
         "Content-type": "application/json"
-      },
-      body: JSON.stringify({scope, supportsSnapshots})
+      }
     })
     .then(response => response.json())
     .then((data: {interactives: IInteractiveListResponseItem[]}) => {

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -17,6 +17,12 @@ export enum SectionColumns {
   PRIMARY =  "primary",
   SECONDARY =  "secondary"
 }
+
+interface AuthoringApiUrls {
+  get_interactive_list?: string;
+  set_linked_interactives?: string;
+}
+
 export interface ISectionItem {
   column: SectionColumns;
   data?: any;
@@ -24,6 +30,7 @@ export interface ISectionItem {
   position?: number;
   section_id?: string;
   type?: string;
+  authoringApiUrls?: AuthoringApiUrls;
 }
 
 export interface ISectionItemType {

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
@@ -30,8 +30,14 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
   const libraryInteractives = getLibraryInteractives.data?.libraryInteractives;
 
   useEffect(() => {
-    handleUpdateItem();
+    if (Object.keys(itemData).length > 0) {
+      handleUpdateItem();
+    }
   }, [itemData]);
+
+  useEffect(() => {
+    setItemData({});
+  }, [editingItemId]);
 
   const handleUpdateTextBlockData = (updates: ITextBlockData) => {
     setItemData(updates);
@@ -114,13 +120,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
 
   const handleCloseDialog = () => {
     setEditingItemId(false);
-  };
-
-  // for now, this is just a placeholder in case it's needed in the future
-  const constructAuthoringApiUrls = () => {
-    return {
-
-    };
+    setItemData({});
   };
 
   const interactiveFromItemToEdit = (itemToEdit: ISectionItem) => {
@@ -147,7 +147,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
   ];
 
   const getEditForm = (itemToEdit: ISectionItem) => {
-    const authoringApiUrls = constructAuthoringApiUrls();
+    const authoringApiUrls = itemToEdit.authoringApiUrls ? itemToEdit.authoringApiUrls : {};
     switch (itemToEdit.type) {
       case "Embeddable::Xhtml":
         return <TextBlockEditForm pageItem={itemToEdit} />;

--- a/spec/models/managed_interactive_spec.rb
+++ b/spec/models/managed_interactive_spec.rb
@@ -63,7 +63,8 @@ describe ManagedInteractive do
         inherit_click_to_play_prompt: managed_interactive.inherit_click_to_play_prompt,
         custom_click_to_play_prompt: managed_interactive.custom_click_to_play_prompt,
         inherit_image_url: managed_interactive.inherit_image_url,
-        custom_image_url: managed_interactive.custom_image_url
+        custom_image_url: managed_interactive.custom_image_url,
+        linked_interactives: []
        }
       expect(managed_interactive.to_hash).to eq(expected)
     end

--- a/spec/models/mw_interactive_spec.rb
+++ b/spec/models/mw_interactive_spec.rb
@@ -42,7 +42,8 @@ describe MwInteractive do
         show_in_featured_question_report: interactive.show_in_featured_question_report,
         aspect_ratio_method: interactive.aspect_ratio_method,
         no_snapshots: interactive.no_snapshots,
-        linked_interactive_item_id: interactive.linked_interactive_item_id
+        linked_interactive_item_id: interactive.linked_interactive_item_id,
+        linked_interactives: []
       }
       hash = interactive.to_hash
       expect(hash).to eq(expected)


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180979850

[#180979850]

These changes reinstate authoring API URL values that were not included in previous work on the `new-sections` branch. The missing authoring API URL information was preventing Image Questions' snapshot targets from being correctly set. That was in turn causing an error preventing sections that contained snapshot image questions from being duplicated.