### PR TITLE
Added glossary setting to activity new/edit pages [#181798850]

### DIFF
--- a/app/models/glossary.rb
+++ b/app/models/glossary.rb
@@ -17,4 +17,12 @@ class Glossary < ActiveRecord::Base
     JSON.parse(json, symbolize_names: true)
   end
 
+  def self.by_author(user)
+    if user
+      self.where(user_id: user.id).order(:name)
+    else
+      []
+    end
+  end
+
 end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -129,6 +129,10 @@ class LightweightActivity < ActiveRecord::Base
     new_activity
   end
 
+  def fake_glossary_plugin_id
+    self.glossary_id * 1_000_000_000 + self.id
+  end
+
   def export(host)
     activity_json = self.as_json(only: [:id,
                                         :name,
@@ -162,7 +166,7 @@ class LightweightActivity < ActiveRecord::Base
       activity_json[:plugins].delete_if { |plugin| plugin[:component_label] == "glossary" }
 
       fake_glossary_plugin = {
-        id: 0,
+        id: fake_glossary_plugin_id(),
         description: nil,
         author_data: JSON.generate({
           version:"1.0",

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -169,8 +169,8 @@ class LightweightActivity < ActiveRecord::Base
           glossaryResourceId: "this-is-a-fake-glossary-resource-id",
           s3Url: Rails.application.routes.url_helpers.api_v1_glossary_url(self.glossary_id, host: host, json_only: true)
         }),
-        approved_script_label: "fakeglossary",
-        component_label: "fakeglossary",
+        approved_script_label: "glossary",
+        component_label: "glossary",
         approved_script: approved_glossary_script.to_hash
       }
       activity_json[:plugins] << fake_glossary_plugin

--- a/app/views/lightweight_activities/_enable_disable_runtime_fields.html.haml
+++ b/app/views/lightweight_activities/_enable_disable_runtime_fields.html.haml
@@ -1,0 +1,39 @@
+:javascript
+  // toggle enabled/disabled fields based on runtime environment
+  $(function() {
+    var $glossary_id = $("#lightweight_activity_glossary_id")
+    var $theme_id = $("#lightweight_activity_theme_id")
+    var $runtime = $('#lightweight_activity_runtime')
+    var $view_edit_glossary = $('#view_edit_glossary')
+
+    function toggleFields(isLara) {
+      $glossary_id.attr("disabled", isLara);
+      $theme_id.attr("disabled", !isLara)
+      $view_edit_glossary.attr("disabled", isLara || !$glossary_id.val());
+
+      // reset the dropdowns to "None"
+      if (isLara) {
+        $glossary_id.val(null)
+      } else {
+        $theme_id.val(null)
+      }
+    }
+
+    $runtime.on('change', function(e) {
+      var isLara = e.target.value === "LARA";
+      toggleFields(isLara)
+    })
+
+    $glossary_id.on('change', function(e) {
+      var isNone = !e.target.value;
+      $view_edit_glossary.attr("disabled", isNone);
+    })
+
+    $view_edit_glossary.on('click', function (e) {
+      e.preventDefault()
+      e.stopPropagation()
+      alert("TODO AFTER AVAILABLE: jump to view/edit glossary" + $glossary_id.val());
+    })
+
+    toggleFields($runtime.val() === "LARA")
+  });

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -71,6 +71,12 @@
         = f.label :time_to_complete,  'Estimated Completion Time (in minutes)'
         = f.text_field :time_to_complete
       .field
+        = f.label :glossary_id, 'Glossary'
+        = f.select :glossary_id, options_from_collection_for_select(Glossary.by_author(current_user), 'id', 'name', @activity.glossary_id), { :include_blank => "None" }
+        %button#view_edit_glossary{style: "margin-top: 0; margin-left: 20px;"} View/Edit
+        .hint
+          Select a glossary from the list to add to this activity. Only glossaries you have authored will show in this list. If you do not wish to associate a glossary with this activity, select "None."
+      .field
         = f.label :related, 'Related Content'
         = f.text_area :related, :class => 'wysiwyg'
       .field
@@ -115,7 +121,7 @@
       %ul.sortable-list#sort-pages
         - @activity.pages.each.with_index(1) do |p, index|
           %li{ :id => dom_id_for(p, :item), :class => 'item' }
-            #{index}. 
+            #{index}.
             -if p.is_completion
               %i.fa.fa-flag-checkered
             = truncate(p.name, :length => 23, :omission => "…")
@@ -127,8 +133,6 @@
               %li.drag_handle
                 &nbsp;
         %li#add= link_to "Add Page", new_activity_page_path(@activity), :class => "btn-primary"
-    #plugins
-      =render partial: 'plugins/list', locals: {activity: @activity}
 
 :javascript
   $(function() {
@@ -143,3 +147,5 @@
       }
     })
   });
+
+= render :partial => 'enable_disable_runtime_fields'

--- a/app/views/lightweight_activities/new.html.haml
+++ b/app/views/lightweight_activities/new.html.haml
@@ -54,6 +54,12 @@
       = f.label :time_to_complete,  'Estimated Completion Time (in minutes)'
       = f.text_field :time_to_complete
     .field
+      = f.label :glossary_id, 'Glossary'
+      = f.select :glossary_id, options_from_collection_for_select(Glossary.by_author(current_user), 'id', 'name', @activity.glossary_id), { :include_blank => "None" }
+      %button#view_edit_glossary{style: "margin-top: 0; margin-left: 20px;"} View/Edit
+      .hint
+        Select a glossary from the list to add to this activity. Only glossaries you have authored will show in this list. If you do not wish to associate a glossary with this activity, select "None."
+    .field
       = f.label :related, 'Related Content'
       = f.text_area :related, :class => 'wysiwyg'
     .field
@@ -69,3 +75,5 @@
       .hint The notes area is for storing information for other authors, e.g. source material or usage restrictions, and is not intended to be displayed in the runtime.
 
     = edit_menu_for(@activity, f)
+
+= render :partial => 'enable_disable_runtime_fields'

--- a/spec/models/glossary_spec.rb
+++ b/spec/models/glossary_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Glossary do
         }
       }
     })
+    glossary.save!
     glossary
   }
 
@@ -128,5 +129,40 @@ RSpec.describe Glossary do
         }
       }
     })
+  end
+
+  describe "self.by_author" do
+    it "should return an empty array if the user is nil" do
+      expect(Glossary.by_author(nil)).to eq([])
+    end
+
+    it "should return an array of glossaries by the user if the user is not nil" do
+      expect(Glossary.by_author(author)).to eq([glossary])
+    end
+
+    describe "with a different user" do
+      let(:other_author) { FactoryGirl.create(:author) }
+
+      it "should return an array of glossaries by the user if the user is not nil" do
+        expect(Glossary.by_author(other_author)).to eq([])
+      end
+    end
+
+    describe "with multiple glossaries" do
+      let(:glossary1)      {
+        glossary = FactoryGirl.create(:glossary, user: author, name: "ZZZ")
+        glossary.save!
+        glossary
+      }
+      let(:glossary2)      {
+        glossary = FactoryGirl.create(:glossary, user: author, name: "AAA")
+        glossary.save!
+        glossary
+      }
+
+      it "returns the list in alpha order" do
+        expect(Glossary.by_author(author)).to eq([glossary2, glossary1])
+      end
+    end
   end
 end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -243,12 +243,12 @@ describe LightweightActivity do
         end
 
         it "drops the existing glossary plugin" do
-          expect(activity.plugins[0].component_label).to eq("glossary")
-          expect(activity.plugins[1].component_label).to eq("notaglossary")
+          expect(activity.plugins[0].id).to eq(plugins[0].id)
+          expect(activity.plugins[1].id).to eq(plugins[1].id)
 
           expect(export[:plugins].length).to eq(activity.plugins.count)
-          expect(export[:plugins][0][:component_label]).to eq("notaglossary")
-          expect(export[:plugins][1][:component_label]).to eq("fakeglossary")
+          expect(export[:plugins][0][:id]).to eq(plugins[1].id)
+          expect(export[:plugins][1][:id]).to eq(0)
         end
       end
     end

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -248,7 +248,7 @@ describe LightweightActivity do
 
           expect(export[:plugins].length).to eq(activity.plugins.count)
           expect(export[:plugins][0][:id]).to eq(plugins[1].id)
-          expect(export[:plugins][1][:id]).to eq(0)
+          expect(export[:plugins][1][:id]).to eq(activity.fake_glossary_plugin_id())
         end
       end
     end


### PR DESCRIPTION
Also changed:

- Fixed glossary labels in faked plugin, they need to be "glossary"
- Added Javascript to enable/disable glossary and lara theme based on runtime environtment