### PR TITLE
Fixed rspec error due to missing user in glossary

### DIFF
--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -233,9 +233,7 @@ describe LightweightActivity do
 
       describe "for activities that use the glossary model" do
         let(:glossary) {
-          glossary = FactoryGirl.create(:glossary)
-          glossary.user = author
-          glossary
+          glossary = FactoryGirl.create(:glossary, user: author)
         }
 
         it "has a glossary model" do


### PR DESCRIPTION
This crept in between two commits that added this test and another commit that added a validation of the user in the model