### PR TITLE
Changes found in PRs that needed to be merged before demo

### DIFF
--- a/app/models/glossary.rb
+++ b/app/models/glossary.rb
@@ -1,5 +1,5 @@
 class Glossary < ActiveRecord::Base
-  attr_accessible :name, :json, :user_id, :type
+  attr_accessible :name, :json, :user_id
   validates :name, presence: true
   validates :user_id, presence: true
 

--- a/app/views/lightweight_activities/_enable_disable_runtime_fields.html.haml
+++ b/app/views/lightweight_activities/_enable_disable_runtime_fields.html.haml
@@ -30,6 +30,8 @@
     })
 
     $view_edit_glossary.on('click', function (e) {
+      // -1 is a placeholder for the glossary id in the url generated when the page is served
+      // and is replaced at runtime below with the current selected glossary id from the select
       var edit_url = "#{edit_glossary_path(-1)}"
       e.preventDefault()
       e.stopPropagation()

--- a/spec/controllers/glossaries_controller_spec.rb
+++ b/spec/controllers/glossaries_controller_spec.rb
@@ -152,7 +152,7 @@ describe GlossariesController do
   describe "duplicate" do
     it "duplicates the requested glossary" do
       expect {
-        post :duplicate, {:id => glossary.id}
+        get :duplicate, {:id => glossary.id}
       }.to change(Glossary, :count).by(1)
       expect(assigns(:new_glossary).id).not_to eq(glossary.id)
     end
@@ -165,7 +165,7 @@ describe GlossariesController do
 
   describe "export" do
     it "exports the requested glossary" do
-      post :export, {:id => glossary.id}
+      get :export, {:id => glossary.id}
       expect(response).to be_success
       json_response = JSON.parse(response.body)
       expect(json_response["type"]).to eq("Glossary")

--- a/spec/models/glossary_spec.rb
+++ b/spec/models/glossary_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Glossary do
       let(:admin) {FactoryGirl.create(:admin)}
 
       before(:each) do
-        # make sure both glosaaries are visible in a query
+        # make sure both glossaries are visible in a query
         glossary
         glossary2
       end


### PR DESCRIPTION
- added comment about -1 placeholder in glossary view/edit button
- removed unneeded attr_accessible type in glossary model used in imports
- switched from posts to gets for duplicate and export in glossary controller spec