### PR TITLE
Snapshot content is blank

### DIFF
--- a/docs/interactive-api-client/interfaces/ireportinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/ireportinitinteractive.md
@@ -20,6 +20,7 @@
 * [authoredState](ireportinitinteractive.md#authoredstate)
 * [hostFeatures](ireportinitinteractive.md#hostfeatures)
 * [interactiveState](ireportinitinteractive.md#interactivestate)
+* [linkedInteractives](ireportinitinteractive.md#linkedinteractives)
 * [mode](ireportinitinteractive.md#mode)
 * [themeInfo](ireportinitinteractive.md#themeinfo)
 * [version](ireportinitinteractive.md#version)
@@ -48,6 +49,12 @@ ___
 ###  interactiveState
 
 • **interactiveState**: *InteractiveState*
+
+___
+
+###  linkedInteractives
+
+• **linkedInteractives**: *[ILinkedInteractive](ilinkedinteractive.md)[]*
 
 ___
 

--- a/docs/interactive-api-host/interfaces/ireportinitinteractive.md
+++ b/docs/interactive-api-host/interfaces/ireportinitinteractive.md
@@ -20,6 +20,7 @@
 * [authoredState](ireportinitinteractive.md#authoredstate)
 * [hostFeatures](ireportinitinteractive.md#hostfeatures)
 * [interactiveState](ireportinitinteractive.md#interactivestate)
+* [linkedInteractives](ireportinitinteractive.md#linkedinteractives)
 * [mode](ireportinitinteractive.md#mode)
 * [themeInfo](ireportinitinteractive.md#themeinfo)
 * [version](ireportinitinteractive.md#version)
@@ -48,6 +49,12 @@ ___
 ###  interactiveState
 
 • **interactiveState**: *InteractiveState*
+
+___
+
+###  linkedInteractives
+
+• **linkedInteractives**: *[ILinkedInteractive](ilinkedinteractive.md)[]*
 
 ___
 

--- a/lara-typescript/src/interactive-api-shared/types.ts
+++ b/lara-typescript/src/interactive-api-shared/types.ts
@@ -104,6 +104,7 @@ export interface IReportInitInteractive<InteractiveState = {}, AuthoredState = {
   interactiveState: InteractiveState;
   themeInfo: IThemeInfo;
   attachments?: AttachmentInfoMap;
+  linkedInteractives: ILinkedInteractive[];
 }
 
 export interface IReportItemInitInteractive<InteractiveState = {}, AuthoredState = {}> {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181808855

[#181808855]

Add `linkedInteractives` to `IReportInitInteractive` to support linking within the side-by-side interactive in reports/dashboard. This fixes a problem discovered by QA while testing the fix for snapshots. The changes here are required to make the changes in [this question-interactives pull request](https://github.com/concord-consortium/question-interactives/pull/182) work.