### PR TITLE
Set lara-interactive-api version number to 1.6.1.

### DIFF
--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",


### PR DESCRIPTION
Bumping the LARA Interactive API version up to 1.6.1 in light of [these changes](https://github.com/concord-consortium/lara/pull/935).