### PR TITLE
Changed glossary visibility so that all authors and admins can see all glossaries [#181798850]

### DIFF
--- a/app/controllers/api/v1/glossaries_controller.rb
+++ b/app/controllers/api/v1/glossaries_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::GlossariesController < API::APIController
     if params[:json_only]
       render json: glossary.export_json_only.to_json
     else
-      render json: glossary.export.to_json
+      render json: glossary.export(current_user).to_json
     end
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -16,6 +16,7 @@ class HomeController < ApplicationController
     @filter.klass = Glossary
     @glossaries  = @filter.collection.includes(:user).first(10)
   end
+
   def bad_browser
     render "/home/bad_browser"
   end

--- a/app/helpers/lightweight_activity_helper.rb
+++ b/app/helpers/lightweight_activity_helper.rb
@@ -109,4 +109,19 @@ module LightweightActivityHelper
     end
     return view_activity_url
   end
+
+  def glossary_options_for_select(activity, user)
+    grouped_options_for_select([
+      ['My Glossaries', glossary_options(Glossary.by_author(user))],
+      ['Other Glossaries', glossary_options(Glossary.by_others(user))]
+    ], activity.glossary_id)
+  end
+
+  def glossary_options(glossaries)
+    if glossaries.length == 0
+      [["None", nil]]
+    else
+      glossaries.map {|g| ["#{g.name} (#{g.user.email})", g.id] }
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,7 +39,10 @@ class Ability
       can :duplicate, LightweightActivity, :is_locked => false, :publication_status => ['public', 'hidden']
       can :duplicate, Sequence, :publication_status => ['public', 'hidden']
       can :duplicate, Glossary
-      
+
+      # any authors can see the glossaries
+      can :read, Glossary
+
       # other users cannot export an activity or sequence
       cannot :export, LightweightActivity
       cannot :export, Sequence

--- a/app/models/collection_filter.rb
+++ b/app/models/collection_filter.rb
@@ -22,6 +22,9 @@ class CollectionFilter
       results = @klass.my(@user)
     elsif @user
       results = @klass.visible(@user)
+    elsif @klass.respond_to?(:public_for_user)
+      # used by glossary model to filter out glossaries when the user isn't an author or admin
+      results = @klass.public_for_user(@user)
     else
       results = @klass.public
     end

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -25,17 +25,17 @@
       .field
         = f.label :name, 'Activity Name'
         = f.text_field :name
-      .field
-        = f.label :glossary_id, 'Glossary'
-        = f.select :glossary_id, options_from_collection_for_select(Glossary.by_author(current_user), 'id', 'name', @activity.glossary_id), { :include_blank => "None" }
-        %button#view_edit_glossary{style: "margin-top: 0; margin-left: 20px;"} View/Edit
-        .hint
-          Select a glossary from the list to add to this activity. Only glossaries you have authored will show in this list. If you do not wish to associate a glossary with this activity, select "None."
       .field{:class => ("disabled" if @activity.latest_publication_portals.length > 0)}
         = f.label :runtime, "Runtime Environment"
         = f.select :runtime, options_for_select(LightweightActivity::RUNTIME_OPTIONS, @activity.runtime), :disabled => @activity.latest_publication_portals.length > 0
         .hint
           Once the activity is published, you can't change this setting.
+      .field
+        = f.label :glossary_id, 'Glossary'
+        = f.select :glossary_id, glossary_options_for_select(@activity, current_user), { :include_blank => "None" }
+        %button#view_edit_glossary{style: "margin-top: 0; margin-left: 20px;"} View or Edit
+        .hint
+          Select a glossary from the list to add to this activity. If you do not wish to associate a glossary with this activity, select "None."
       .field{:class => ("disabled" if @activity.runtime != 'Activity Player')}
         = f.label :fixed_width_layout, 'Activity Player Fixed Width Layout'
         = f.select :fixed_width_layout, options_for_select(LightweightActivity::FIXED_WIDTH_LAYOUT_OPTIONS, @activity.fixed_width_layout)

--- a/spec/controllers/api/v1/glossaries_controller_spec.rb
+++ b/spec/controllers/api/v1/glossaries_controller_spec.rb
@@ -63,6 +63,7 @@ describe Api::V1::GlossariesController do
         id: glossary.id,
         name: glossary.name,
         user_id: glossary.user_id,
+        can_edit: false,
         json: JSON.parse(stringifed_json)
       }.as_json)
     end

--- a/spec/controllers/glossaries_controller_spec.rb
+++ b/spec/controllers/glossaries_controller_spec.rb
@@ -13,8 +13,10 @@ describe GlossariesController do
   before(:each) do
     # We're testing access control in spec/models/user_spec.rb, so for this
     # suite we use a user with global permissions
-    @user = current_user
-    sign_in @user
+    if current_user
+      @user = current_user
+      sign_in @user
+    end
     glossary
     glossary2
     glossary3
@@ -24,18 +26,21 @@ describe GlossariesController do
     describe "as an admin" do
       it "assigns all glossaries as @glossaries" do
         get :index
-        expect(assigns(:glossaries)).to include(glossary)
-        expect(assigns(:glossaries)).to include(glossary2)
-        expect(assigns(:glossaries)).to include(glossary3)
+        expect(assigns(:glossaries)).to eq([glossary, glossary2, glossary3])
       end
     end
     describe "as an author" do
       let (:current_user) { author1 }
-      it "assigns glossaries owned by that author as @glossaries" do
+      it "assigns all glossaries as @glossaries" do
         get :index
-        expect(assigns(:glossaries)).not_to include(glossary)
-        expect(assigns(:glossaries)).to include(glossary2)
-        expect(assigns(:glossaries)).not_to include(glossary3)
+        expect(assigns(:glossaries)).to eq([glossary, glossary2, glossary3])
+      end
+    end
+    describe "as an anonyous user" do
+      let (:current_user) { nil }
+      it "assigns [] as @glossaries" do
+        get :index
+        expect(assigns(:glossaries)).to eq([])
       end
     end
   end

--- a/spec/models/glossary_spec.rb
+++ b/spec/models/glossary_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe Glossary do
-  let(:author)        { FactoryGirl.create(:author) }
-  let(:author2)        { FactoryGirl.create(:author) }
+  let(:author)    { FactoryGirl.create(:author) }
+  let(:author2)   { FactoryGirl.create(:author) }
+  let(:admin)     { FactoryGirl.create(:admin) }
 
   let(:glossary)      {
     glossary = FactoryGirl.create(:glossary, name: "Glossary 1", user: author)
@@ -48,49 +49,60 @@ RSpec.describe Glossary do
   }
   let(:glossary2) { FactoryGirl.create(:glossary, name: "Glossary 2", user: author2) }
 
-  it "should export itself" do
-    expect(glossary.export).to eq({
-      id: glossary.id,
-      name: glossary.name,
-      user_id: glossary.user_id,
-      json: {
-        askForUserDefinition: true,
-        autoShowMediaInPopup: true,
-        showSideBar: true,
-        enableStudentRecording: true,
-        enableStudentLanguageSwitching: true,
-        definitions: [
-          {
-            definition: "a foo",
-            image: "http://www.example.com/foo.png",
-            imageCaption: "foo image caption",
-            video: "http://www.example.com/foo.mp4",
-            videoCaption: "foo video caption",
-            word: "foo",
-            zoomImage: "http://www.example.com/foo-zoomed.png"
-          },
-          {
-            definition: "a bar",
-            image: "http://www.example.com/bar.png",
-            imageCaption: "bar image caption",
-            video: "http://www.example.com/bar.mp4",
-            videoCaption: "bar video caption",
-            word: "bar",
-            zoomImage: "http://www.example.com/bar-zoomed.png"
-          }
-        ],
-        translations: {
-          es: {
-            bar: "una bar",
-            foo: "una foo"
-          },
-          fr: {
-            bar: "les bar",
-            foo: "les foo"
+  describe "should export itself" do
+    it "as the author with can_edit as true" do
+      expect(glossary.export(author)).to eq({
+        id: glossary.id,
+        name: glossary.name,
+        user_id: glossary.user_id,
+        can_edit: true,
+        json: {
+          askForUserDefinition: true,
+          autoShowMediaInPopup: true,
+          showSideBar: true,
+          enableStudentRecording: true,
+          enableStudentLanguageSwitching: true,
+          definitions: [
+            {
+              definition: "a foo",
+              image: "http://www.example.com/foo.png",
+              imageCaption: "foo image caption",
+              video: "http://www.example.com/foo.mp4",
+              videoCaption: "foo video caption",
+              word: "foo",
+              zoomImage: "http://www.example.com/foo-zoomed.png"
+            },
+            {
+              definition: "a bar",
+              image: "http://www.example.com/bar.png",
+              imageCaption: "bar image caption",
+              video: "http://www.example.com/bar.mp4",
+              videoCaption: "bar video caption",
+              word: "bar",
+              zoomImage: "http://www.example.com/bar-zoomed.png"
+            }
+          ],
+          translations: {
+            es: {
+              bar: "una bar",
+              foo: "una foo"
+            },
+            fr: {
+              bar: "les bar",
+              foo: "les foo"
+            }
           }
         }
-      }
-    })
+      })
+    end
+
+    it "as an admin with can_edit as true" do
+      expect(glossary.export(admin)[:can_edit]).to eq(true)
+    end
+
+    it "as not the author or admin with can_edit as false" do
+      expect(glossary.export(author2)[:can_edit]).to eq(false)
+    end
   end
 
   it "should export only the json member" do
@@ -168,6 +180,53 @@ RSpec.describe Glossary do
     end
   end
 
+  describe "self.by_others" do
+    let(:other_author) { FactoryGirl.create(:author) }
+
+    it "should return an empty array if the user is nil" do
+      expect(Glossary.by_others(nil)).to eq([])
+    end
+
+    it "should return an array of glossaries by other users if the user is not nil" do
+      expect(Glossary.by_others(author)).to eq([glossary2])
+    end
+
+    describe "with a different user" do
+      it "should return an array of glossaries by the user if the user is not nil" do
+        expect(Glossary.by_others(other_author)).to eq([glossary, glossary2])
+      end
+    end
+
+    describe "with multiple glossaries" do
+      let(:glossary1)      {
+        glossary = FactoryGirl.create(:glossary, user: author, name: "ZZZ")
+        glossary.save!
+        glossary
+      }
+      let(:glossary2)      {
+        glossary = FactoryGirl.create(:glossary, user: author, name: "AAA")
+        glossary.save!
+        glossary
+      }
+
+      it "returns the list in alpha order" do
+        expect(Glossary.by_others(other_author)).to eq([glossary2, glossary1])
+      end
+    end
+  end
+
+  describe "can_edit" do
+    it "should return true for authors of glossaries" do
+      expect(glossary.can_edit(author)).to eq(true)
+    end
+    it "should return true for admins" do
+      expect(glossary.can_edit(admin)).to eq(true)
+    end
+    it "should return false for other users that are not admins" do
+      expect(glossary.can_edit(author2)).to eq(false)
+    end
+  end
+
   it "should support #to_hash" do
     expect(glossary.to_hash).to eq({
       id: glossary.id,
@@ -216,21 +275,23 @@ RSpec.describe Glossary do
       end
 
       it "should support self.can_see" do
-        expect(Glossary.can_see(author)).to eq([glossary])
+        expect(Glossary.can_see(author)).to eq([glossary, glossary2])
       end
 
       it "should support self.visible" do
-        expect(Glossary.visible(author)).to eq([glossary])
+        expect(Glossary.visible(author)).to eq([glossary, glossary2])
       end
 
       it "should support self.search" do
-        expect(Glossary.search("Glossary", author)).to eq([glossary])
+        expect(Glossary.search("Glossary", author)).to eq([glossary, glossary2])
+      end
+
+      it "should support self.public_for_user" do
+        expect(Glossary.public_for_user(author)).to eq([glossary, glossary2])
       end
     end
 
     describe "as an admin" do
-      let(:admin) {FactoryGirl.create(:admin)}
-
       before(:each) do
         # make sure both glossaries are visible in a query
         glossary
@@ -252,12 +313,16 @@ RSpec.describe Glossary do
       it "should support self.search" do
         expect(Glossary.search("Glossary", admin)).to eq([glossary, glossary2])
       end
+
+      it "should support self.public_for_user" do
+        expect(Glossary.public_for_user(author)).to eq([glossary, glossary2])
+      end
     end
   end
 
   describe "scopes" do
-    it "should support public" do
-      expect(Glossary.public).to eq ([])
+    it "should support none" do
+      expect(Glossary.none).to eq ([])
     end
 
     it "should support newest" do


### PR DESCRIPTION
This also updates the glossary selection UI in the activity editor to split glossaries into two lists and appends the email of the author to each glossary.