### PR TITLE
Added skip of verify_authenticity_token in glossary api controller

### DIFF
--- a/app/controllers/api/v1/glossaries_controller.rb
+++ b/app/controllers/api/v1/glossaries_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::GlossariesController < API::APIController
+  skip_before_filter :verify_authenticity_token, :only => :update
+
   # GET /api/v1/glossaries/1.json
   def show
     glossary = Glossary.find(params[:id])


### PR DESCRIPTION
This was causing the new glossary editing view to log out the user after the initial save.