### PR TITLE
Moved glossary dropdown down in new activity form [#182051450]

### DIFF
--- a/app/views/lightweight_activities/new.html.haml
+++ b/app/views/lightweight_activities/new.html.haml
@@ -23,16 +23,16 @@
       = f.label :name, 'Activity Name'
       = f.text_field :name
     .field
-      = f.label :glossary_id, 'Glossary'
-      = f.select :glossary_id, options_from_collection_for_select(Glossary.by_author(current_user), 'id', 'name', @activity.glossary_id), { :include_blank => "None" }
-      %button#view_edit_glossary{style: "margin-top: 0; margin-left: 20px;"} View/Edit
-      .hint
-        Select a glossary from the list to add to this activity. Only glossaries you have authored will show in this list. If you do not wish to associate a glossary with this activity, select "None."
-    .field
       = f.label :runtime, "Runtime Environment"
       = f.select :runtime, options_for_select(LightweightActivity::RUNTIME_OPTIONS, @activity.runtime)
       .hint
         Once the activity is published, you can't change this setting.
+    .field
+      = f.label :glossary_id, 'Glossary'
+      = f.select :glossary_id, glossary_options_for_select(@activity, current_user), { :include_blank => "None" }
+      %button#view_edit_glossary{style: "margin-top: 0; margin-left: 20px;"} View/Edit
+      .hint
+        Select a glossary from the list to add to this activity. If you do not wish to associate a glossary with this activity, select "None."
     .field
       = f.label :theme_id, 'LARA Theme'
       = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @activity.theme_id), { :include_blank => "None (inherit from sequence, project, or site default)" }


### PR DESCRIPTION
This matches the edit form as the glossary option is only enabled for AP actvities.  This fix also changes to use the glossary_options_for_select helper.