### PR TITLE
Added admin settings interface to set current glossary [#181884477]

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -1221,6 +1221,12 @@ body.admin.edit {
   }
 }
 
+.settings-table {
+  td {
+    padding: 5px 10px 5px 0;
+  }
+}
+
 .multiple_choice {
   .answer {
     label {

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,28 @@
+class SettingsController < ApplicationController
+  def view
+    authorize! :manage, Setting
+
+    @glossary_approved_scripts = ApprovedScript.where(label: "glossary")
+    @glossary_approved_script_id = Setting.get("glossary_approved_script_id")
+
+    # when adding other settings here, make sure to add them to the view
+    # the update action should handle any new settings added here automatically
+  end
+
+  def update
+    authorize! :manage, Setting
+
+    settings = params["settings"]
+    if settings.present?
+      settings.each do |key, value|
+        Setting.set(key, value)
+      end
+
+      flash[:notice] = "Settings updated"
+    else
+      flash[:error] = "Settings not found!"
+    end
+
+    redirect_to '/settings'
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,7 @@ class Ability
       can :report, QuestionTracker
       can :manage, ApprovedScript
       can :manage, LibraryInteractive
+      can :manage, Setting
     elsif user.author?
       # Authors can create new items and manage those they created
       can :create, Sequence

--- a/app/models/approved_script.rb
+++ b/app/models/approved_script.rb
@@ -64,4 +64,8 @@ class ApprovedScript < ActiveRecord::Base
       authoring_metadata: authoring_metadata
     }
   end
+
+  def option_value
+    "##{self.id}: #{self.json_url}"
+  end
 end

--- a/app/models/glossary.rb
+++ b/app/models/glossary.rb
@@ -73,9 +73,11 @@ class Glossary < ActiveRecord::Base
   end
 
   def self.get_glossary_approved_script()
-    # for now we just return the first approved script named glossary, this should be
-    # changed before the final delivery to add an admin setting for the approved glossary script
-    ApprovedScript.find_by_label("glossary")
+    # if no glossary is selected in the settings, return the first one found
+    approved_script_id = Setting.get("glossary_approved_script_id")
+    selected_glossary = ApprovedScript.find_by_id(approved_script_id) if approved_script_id
+    default_glossary = ApprovedScript.find_by_label("glossary") unless selected_glossary
+    selected_glossary || default_glossary
   end
 
   # helper used in lightweight activity edit to list the glossaries that can be assigned to an activity

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,21 @@
+class Setting < ActiveRecord::Base
+  attr_accessible :key, :value
+  validates :key, presence: true
+  # value may be empty so no validation needed
+
+  def self.get(key, default_value = nil)
+    setting = Setting.find_by_key(key)
+    setting ? setting.value : default_value
+  end
+
+  def self.set(key, value)
+    setting = Setting.find_by_key(key)
+    if setting
+      setting.value = value
+    else
+      setting = Setting.new({:key => key, :value => value})
+    end
+    setting.save
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,6 +170,9 @@ class User < ActiveRecord::Base
     if can? :manage, LibraryInteractive
       links.push({text: "Library Interactives", path: Rails.application.routes.url_helpers.library_interactives_path})
     end
+    if can? :manage, Setting
+      links.push({text: "Settings", path: Rails.application.routes.url_helpers.settings_path})
+    end
 
     return links
   end

--- a/app/views/approved_scripts/index.html.haml
+++ b/app/views/approved_scripts/index.html.haml
@@ -24,7 +24,7 @@
     %li{ :id => dom_id_for(approved_script, :item), :class => 'item' }
       %div.action_menu
         %div.action_menu_header_left
-          = link_to approved_script.label, edit_approved_script_path(approved_script), :class => 'container_link'
+          = link_to "#{approved_script.label} (##{approved_script.id})", edit_approved_script_path(approved_script), :class => 'container_link'
         %div.action_menu_header_right.themes
           %ul.menu
             %li.edit= link_to "Edit", edit_approved_script_path(approved_script) if can? :update, approved_script

--- a/app/views/library_interactives/index.html.haml
+++ b/app/views/library_interactives/index.html.haml
@@ -24,7 +24,7 @@
     %li{ :id => dom_id_for(library_interactive, :item), :class => 'item' }
       %div.action_menu
         %div.action_menu_header_left
-          = link_to library_interactive.name, edit_library_interactive_path(library_interactive), :class => 'container_link'
+          = link_to "#{library_interactive.name} (##{library_interactive.id})", edit_library_interactive_path(library_interactive), :class => 'container_link'
         %div.action_menu_header_right.themes
           %ul.menu
             %li.edit= link_to "Edit", edit_library_interactive_path(library_interactive) if can? :update, library_interactive

--- a/app/views/settings/view.html.haml
+++ b/app/views/settings/view.html.haml
@@ -1,0 +1,24 @@
+= content_for :title do
+  = "Settings"
+= content_for :nav do
+  .breadcrumbs
+    %ul
+      %li= link_to "Home", root_path
+      %li Settings
+
+#official_listing_heading
+  %h1 Settings
+
+= form_for(:settings, {:url => settings_path(@setting), :method => 'post'}) do |f|
+  %table.settings-table
+    %tr
+      %td
+        = f.label :glossary_approved_script_id, "Glossary Approved Script", {style: "font-weight: bold;"}
+      %td
+        = f.select :glossary_approved_script_id, options_from_collection_for_select(@glossary_approved_scripts, 'id', 'option_value', @glossary_approved_script_id), { :include_blank => "Not set (use first one found)" }
+    %tr
+      %td
+      %td This setting controls which glossary approved script is used to render the glossary model editing and runtime.
+
+  %p{style: "margin-top: 20px;"}
+    = f.submit "Save Settings"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,9 @@ LightweightStandalone::Application.routes.draw do
     resources :users
   end
 
+  get :settings, to: 'settings#view'
+  post :settings, to: 'settings#update'
+
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
 
   resources :sections, :controller => 'sections', :constraints => { :id => /\d+/ }

--- a/db/migrate/20220509142509_add_settings_model.rb
+++ b/db/migrate/20220509142509_add_settings_model.rb
@@ -1,0 +1,12 @@
+class AddSettingsModel < ActiveRecord::Migration
+  def change
+    create_table :settings do |t|
+      t.string :key
+      t.text :value
+
+      t.timestamps
+    end
+
+    add_index :settings, [:key], uniq: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220406135335) do
+ActiveRecord::Schema.define(:version => 20220509142509) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -729,6 +729,15 @@ ActiveRecord::Schema.define(:version => 20220406135335) do
   add_index "sequences", ["theme_id"], :name => "index_sequences_on_theme_id"
   add_index "sequences", ["updated_at"], :name => "sequences_updated_at_idx"
   add_index "sequences", ["user_id"], :name => "index_sequences_on_user_id"
+
+  create_table "settings", :force => true do |t|
+    t.string   "key"
+    t.text     "value"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "settings", ["key"], :name => "index_settings_on_key"
 
   create_table "themes", :force => true do |t|
     t.string   "name"

--- a/spec/factories/setting.rb
+++ b/spec/factories/setting.rb
@@ -1,0 +1,8 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :setting do
+    key { generate(:name) }
+    value { generate(:name) }
+  end
+end

--- a/spec/models/glossary_spec.rb
+++ b/spec/models/glossary_spec.rb
@@ -330,4 +330,33 @@ RSpec.describe Glossary do
     end
   end
 
+  describe "self.get_glossary_approved_script" do
+    it "should return nil with no glossary approved script" do
+      expect(Glossary.get_glossary_approved_script).to eq nil
+    end
+
+    describe "with glossary approved scripts" do
+      let(:approved_script1) { FactoryGirl.create(:approved_script, label: "glossary") }
+      let(:approved_script2) { FactoryGirl.create(:approved_script, label: "glossary") }
+
+      before :each do
+        approved_script1
+        approved_script2
+      end
+
+      it "should return the first glossary approved script if no setting is set" do
+        expect(Glossary.get_glossary_approved_script).to eq approved_script1
+      end
+
+      describe "with glossary approved script setting" do
+        let(:glossary_setting) { FactoryGirl.create(:setting, key: "glossary_approved_script_id", value: "#{approved_script2.id}") }
+
+        it "should return the glossary approved in the settings" do
+          glossary_setting
+          expect(Glossary.get_glossary_approved_script).to eq approved_script2
+        end
+      end
+    end
+  end
+
 end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe Setting do
+  let(:glossary_setting) { FactoryGirl.create(:setting, key: "glossary_approved_script_id", value: "1") }
+
+  it "should provide a self.get method with defaults" do
+    glossary_setting
+    expect(Setting.get("glossary_approved_script_id")).to eq("1")
+    expect(Setting.get("UNKNOWN_SETTING")).to eq(nil)
+    expect(Setting.get("UNKNOWN_SETTING", "foo")).to eq("foo")
+  end
+
+  it "should provide a self.set method" do
+    Setting.set("glossary_approved_script_id", "1000")
+    Setting.set("NEW_SETTING", "bar")
+
+    expect(Setting.get("glossary_approved_script_id")).to eq("1000")
+    expect(Setting.get("NEW_SETTING")).to eq("bar")
+  end
+end


### PR DESCRIPTION
This adds a generic key/value settings model with a concrete setting controller that currently only sets the approved glossary script id.  It is designed to be extensible to other settings.

To make id mapping more visible the ids have been added to both the plugin list and library interactive list.