### PR TITLE
Update glossary json column to store more than 64kb [#182141060]

### DIFF
--- a/db/migrate/20220511144104_change_glossary_json_size.rb
+++ b/db/migrate/20220511144104_change_glossary_json_size.rb
@@ -1,0 +1,9 @@
+class ChangeGlossaryJsonSize < ActiveRecord::Migration
+  def up
+    change_column :glossaries, :json, :text, :limit => 16777215
+  end
+
+  def down
+    change_column :glossaries, :json, :text, :limit => 65535
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220509142509) do
+ActiveRecord::Schema.define(:version => 20220511144104) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -311,10 +311,10 @@ ActiveRecord::Schema.define(:version => 20220509142509) do
 
   create_table "glossaries", :force => true do |t|
     t.string   "name"
-    t.text     "json"
+    t.text     "json",       :limit => 16777215
     t.integer  "user_id"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",                     :null => false
+    t.datetime "updated_at",                     :null => false
   end
 
   create_table "image_interactives", :force => true do |t|


### PR DESCRIPTION
The json column now maxes out at 16777215 (MySQL's mediumtext)