### PR TITLE
Updated linked-state example interactive to add a onOnload timeout [#182307246]

### DIFF
--- a/lara-typescript/src/example-interactives/src/linked-state/app.tsx
+++ b/lara-typescript/src/example-interactives/src/linked-state/app.tsx
@@ -5,7 +5,7 @@ import { useInitMessage, setSupportedFeatures, useAutoSetHeight } from "../../..
 import { AuthoringComponent } from "./authoring";
 import { ReportComponent } from "./report";
 import { RuntimeComponent } from "./runtime";
-import { IAuthoredState } from "../types";
+import { IAuthoredState } from "./types";
 
 interface Props {
 }

--- a/lara-typescript/src/example-interactives/src/linked-state/authoring.tsx
+++ b/lara-typescript/src/example-interactives/src/linked-state/authoring.tsx
@@ -1,16 +1,28 @@
 import * as React from "react";
-import { IAuthoringInitInteractive } from "../../../interactive-api-client";
+import { IAuthoringInitInteractive, useAuthoredState } from "../../../interactive-api-client";
+import { IAuthoredState } from "./types";
 
 interface Props {
   initMessage: IAuthoringInitInteractive<{}>;
 }
 
 export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
+  const { authoredState, setAuthoredState } = useAuthoredState<IAuthoredState>();
+
+  const handleChangeSaveTimeout = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAuthoredState({
+      onUnloadTimeout: parseInt(e.target.value, 10) || 0
+    });
+  };
+
   return (
     <div className="padded">
 
       <div className="padded">
-        <strong>NOTE: there is nothing to author for this interactive.  To use it do the following:</strong>
+        <strong>
+          NOTE: there is nothing required to author for this interactive but there are optional authoring options.
+          To use it do the following:
+        </strong>
         <ol>
           <li>Create two interactives using this interactive's url.</li>
           <li>In the "Advanced Options" tab enable saving state in both interactives.</li>
@@ -21,6 +33,19 @@ export const AuthoringComponent: React.FC<Props> = ({initMessage}) => {
               interactive state of the first interactive.</li>
           <li>Go to the second interactive and then look to see if the linked state was updated.</li>
         </ol>
+      </div>
+
+      <div className="padded">
+        <fieldset>
+          <legend>Optional Authoring Options</legend>
+          <label>
+            OnUnload Save Timeout:&nbsp;
+            <input type="number" value={authoredState?.onUnloadTimeout || 0} onChange={handleChangeSaveTimeout} />
+          </label>
+          <small className="padded">
+            Set to 0 to disable, or a positive number of seconds to wait for save on a page change.
+          </small>
+        </fieldset>
       </div>
 
       <fieldset>

--- a/lara-typescript/src/example-interactives/src/linked-state/runtime.tsx
+++ b/lara-typescript/src/example-interactives/src/linked-state/runtime.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
-import { IRuntimeInitInteractive, useInteractiveState } from "../../../interactive-api-client";
+import { useEffect } from "react";
+import { IRuntimeInitInteractive, useInteractiveState, setOnUnload, useAuthoredState, IGetInteractiveState } from "../../../interactive-api-client";
+import { IAuthoredState } from "./types";
 
 interface Props {
   initMessage: IRuntimeInitInteractive<any, {}>;
@@ -7,10 +9,31 @@ interface Props {
 
 export const RuntimeComponent: React.FC<Props> = ({initMessage}) => {
   const {interactiveState, setInteractiveState} = useInteractiveState<any>();
+  const { authoredState } = useAuthoredState<IAuthoredState>();
+  const saveTimeoutRef = React.useRef(0);
 
   const handleInteractiveStateValueChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInteractiveState(event.target.value);
   };
+
+  useEffect(() => {
+    if (authoredState?.onUnloadTimeout) {
+      setOnUnload((options: IGetInteractiveState) => {
+        return new Promise<{}>((resolve) => {
+          if (options.unloading) {
+            if (authoredState?.onUnloadTimeout) {
+              clearTimeout(saveTimeoutRef.current);
+              saveTimeoutRef.current = window.setTimeout(() => {
+                resolve(interactiveState);
+              }, authoredState.onUnloadTimeout);
+            } else {
+              resolve(interactiveState);
+            }
+          }
+        });
+      });
+    }
+  }, [interactiveState, authoredState]);
 
   return (
     <div className="padded">

--- a/lara-typescript/src/example-interactives/src/linked-state/types.ts
+++ b/lara-typescript/src/example-interactives/src/linked-state/types.ts
@@ -1,0 +1,3 @@
+export interface IAuthoredState {
+  onUnloadTimeout?: number;
+}


### PR DESCRIPTION
This optional timeout authored setting allows the page change notifications in AP to be observed by setting a timeout > 500ms for the page change and >20000ms for the page save error message.