### PR TITLE
Add GH Codespaces docs

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -1,0 +1,46 @@
+# This configuration adds the following overlays:
+#
+# docker-compose-sync: setup to speed up OSX using unison under the hood
+#
+# docker-compose-portal-proxy: a configuration to connect with a local portal running
+#   behind a docker based proxy container with the name of http-proxy.
+#   You can learn more about this at the top of docker/dev/docker-compose-portal-proxy.yml
+#
+# docker-compose-random-ports: export random exported ports, so it doesn't conflict with
+#   the portal or other apps running on portal 3000
+#
+COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:docker/dev/docker-compose-portal-proxy.yml
+
+# To connect with the portal LARA needs to know the domain of the portal. Using the dinghy
+# proxy the domain will be based on the directory name the portal is running in. Some
+# developers use a friendly name like 'portal' instead of 'rigse'
+# for automation runs we need to update the PORTAL_HOST as learn.dev.docker
+PORTAL_HOST=[PORTAL-RANDOM-GH-CODESPACES-HOST].githubpreview.dev
+PORTAL_PROTOCOL=https
+
+# Using the dinghy proxy the domain will be based on the directory name that lara is running in.
+# But for automation we need portal and lara to be in same super domain.
+# use the below naming for automation
+# LARA_HOST=authoring.dev.docker
+# Default protocol will http if we do not specify any value to below variable. If we need https
+# we need to set it up explicitly as https as the below value
+# LARA_PROTOCOL=
+LARA_HOST=[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev
+LARA_PROTOCOL=https
+
+# By default the production URL for shutterbug will be used by shutterbug.js
+# You can use this variable to switch it to staging
+# SHUTTERBUG_URI=https://dgjr6g3z30.execute-api.us-east-1.amazonaws.com/staging
+
+# To use local Activity Player
+# ACTIVITY_PLAYER_URL=http://localhost:8081
+# URL of script to create an Activity Player compatible version of resources by converting old embeddables to library interactives
+# CONVERSION_SCRIPT_URL=https://models-resources.concord.org/question-interactives/convert-old-lara/?lara_root=https://app.lara.docker&template=https://app.lara.docker/api/v1/activities/214.json
+
+#To connect to reporting service in dev we need the following variables
+REPORT_SERVICE_URL=https://us-central1-report-service-dev.cloudfunctions.net/api
+# Update to be the development token. This can be found in the Cloud Formation lara-ecs-staging stack parameters.
+#REPORT_SERVICE_TOKEN=
+
+# Report URL is used to generate student report links.
+# REPORT_URL=https://portal-report.concord.org/branch/master/index.html

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To get started quickly, run:
 
     docker-compose up
 
-You can now access LARA at http://localhost:3000  
+You can now access LARA at http://localhost:3000
 
 This will be very slow on OS X and not support a connection to the portal. So we use docker-compose override files to layer additional features onto the basic compose file. These overrides are specified in a `.env` file. To make the initial setup easier there is a `.env-osx-sample` file that contains the standard setup we use. So you can simply:
 
@@ -97,6 +97,56 @@ Installing certificates, and configuring the docker overlay:
 `COMPOSE_FILE=` entry in `.env` includes that overlay.
 6. Edit your `.env` file to include `PORTAL_PROTOCOL=https`
 
+## GitHub Codespaces
+
+Github Codespaces is a cloud-based development environment. We are currently using it to do development work on LARA and
+Portal since it’s proven difficult to do local development on those codebases on M1 MacBooks.
+
+Github’s documentation for Codespaces can be found at [here](docs.github.com/en/codespaces).
+
+You will need to set up separate codespaces for LARA and the Portal.
+
+Use of Codespaces incurs an hourly cost. The amount is not a lot, but it should be kept in mind. Codespaces will shut themselves down
+automatically after a period of inactivity, but it would be best to manually shut them down when you’re done working in order to
+minimize cost.
+
+You can use Codespaces in web browser or you can connect to selected machine from desktop Visual Studio Code if you
+install a Codespaces extension.
+
+### Basic setup
+
+- Your GitHub account needs to have Codespaces activated by the organization admin.
+- Go to the github.com page for the repository you will be working on.
+- Click on the Code button, then click the Codespaces tab, and then click the “Create codespace on master” button.
+- LARA should be fine with 2-core machine, however 4-core seems to work significantly faster.
+
+Once machine is up and running, most of the steps described for local development are still valid for GH Codespaces.
+The main difference is that you should copy `.env-gh-codespaces-sample` to `.env` (instead of `.env-osx-sample`),
+there's no need for Dinghy setup, and LARA and Portal host will be significantly different (impossible to guess
+until you make their ports visible in Visual Studio Code).
+
+Run:
+```
+  cp .env-gh-codespaces-sample .env
+  docker login
+  docker-compose up
+```
+
+Once the app has started, open "Ports" tab in Visual Studio Code. Find a process that uses port 3000 and change its
+visibility to public (right click on "Private" -> Port Visibility -> Public). You should see an updated address in
+"Local Address" column. You can open this URL in the web browser and LARA should load. It seems it's necessary to do it
+each time you run `docker-compose up`.
+
+Copy this randomly generated host and open `.env` file. Find `[LARA-RANDOM-GH-CODESPACES-HOST]` and replace it with the
+copied value. Note that you have to do it only once, as this host will stay the same in the future, even if you
+shut down and restart your Codespaces machine.
+
+Once you setup Portal and make its port public, you should open `.env` file again, find `[PORTAL-RANDOM-GH-CODESPACES-HOST]`,
+and replace it with the randomly generated host for Portal.
+
+Remember to set `REPORT_SERVICE_TOKEN` in `.env` following instructions that can be found in this file.
+
+Each time `.env` file is updated, you need stop docker-compose and start it again using `docker-compose up`.
 
 ## Editing CSS
 

--- a/docker/dev/docker-compose-gh-codespaces.yml
+++ b/docker/dev/docker-compose-gh-codespaces.yml
@@ -1,0 +1,15 @@
+# This is a docker-compose overlay with changes necessary to support GitHub Codespaces.
+# As of June 21, 2022, it only publishes the app port. More changes might be necessary in the future.
+
+# A convient way to overlay this file is to add a `.env` file with the contents:
+#  COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml
+# You can also do it manually when you run docker-compose each time with
+# docker-compose -f docker-compose.yml -f docker/dev/docker-compose-random-ports.yml
+# if you are making changes to docker-compose.yml or this file it is useful to
+# run `docker-compose config` which shows how the two files get merged together
+
+version: '3'
+services:
+  app:
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
[#182524012]

I've got `.env `and a modified `docker-compose.yml` files from @emcelroy. 
I've extracted docker-compose changes to a new overlay, and created `.env-gh-codespaces-sample`. I've also updated readme  (Ethan's doc: https://docs.google.com/document/d/1O8CQaoIBAnZLrHnrQmxY_ywKE6EUv-7scIK1Dr6-AiY/edit# has been helpful too)

I'm not sure where is the balance between having a complete guide and not repeating steps from other Readme sections (many steps are the same). But the current GH Codespaces readme provides a complete setup that enables LARA-Portal SSO, activity publications, etc., and it seems not to be too long.

Also, I could use `docker-compose.override.yml` as it also exposes Ports, but it didn't seem that clean. Do we need this file at all? I'd think it's a file for local overrides, but it's versioned in git.

Related Portal PR: https://github.com/concord-consortium/rigse/pull/1115