### PR TITLE
Simplify GH Codespaces setup

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -7,14 +7,15 @@
 #   You can learn more about this at the top of docker/dev/docker-compose-portal-proxy.yml
 COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:docker/dev/docker-compose-portal-proxy.yml
 
-# To connect with the portal LARA needs to know the domain of the Portal. GitHub Codespaces will assign a random
-# host name that can be obtained after the port is made public in the Visual Studio Code "Ports" tab.
-PORTAL_HOST=[PORTAL-RANDOM-GH-CODESPACES-HOST].githubpreview.dev
+# Run `echo ${CODESPACE_NAME}` in Portal GitHub Codespace container and copy returned value here. It'll be used
+# to automatically set PORTAL_HOST variable.
+PORTAL_CODESPACE_NAME=
+
+PORTAL_HOST=${PORTAL_CODESPACE_NAME}-3000.githubpreview.dev
 PORTAL_PROTOCOL=https
 
-# GitHub Codespaces will assign a random host name that can be obtained after the port is made public
-# in the Visual Studio Code "Ports" tab.
-LARA_HOST=[LARA-RANDOM-GH-CODESPACES-HOST].githubpreview.dev
+# CODESPACE_NAME is available in GitHub Codespace container.
+LARA_HOST=${CODESPACE_NAME}-3000.githubpreview.dev
 LARA_PROTOCOL=https
 
 # By default the production URL for shutterbug will be used by shutterbug.js

--- a/README.md
+++ b/README.md
@@ -122,31 +122,37 @@ install a Codespaces extension.
 
 Once machine is up and running, most of the steps described for local development are still valid for GH Codespaces.
 The main difference is that you should copy `.env-gh-codespaces-sample` to `.env` (instead of `.env-osx-sample`),
-there's no need for Dinghy setup, and LARA and Portal host will be significantly different (impossible to guess
-until you make their ports visible in Visual Studio Code).
+there's no need for Dinghy setup, and LARA and Portal hosts will be significantly different. However, everything
+you need to do in practice is described below.
 
-Run:
-```
-  cp .env-gh-codespaces-sample .env
-  docker login
-  docker-compose up
-```
+1. Run:
+    ```
+      cp .env-gh-codespaces-sample .env
+    ```
 
-Once the app has started, open "Ports" tab in Visual Studio Code. Find a process that uses port 3000 and change its
+2. Open Portal GitHub Codespace, run `echo ${CODESPACE_NAME}` in terminal, and set `PORTAL_CODESPACE_NAME` variable
+in LARA's `.env` file.
+
+3. Set `REPORT_SERVICE_TOKEN` in LARA's `.env` file following instructions that can be found there.
+
+4. Run
+    ```
+      docker login
+      docker-compose up
+    ```
+
+5. Once the app has started, open "Ports" tab in Visual Studio Code. Find a process that uses port 3000 and change its
 visibility to public (right click on "Private" -> Port Visibility -> Public). You should see an updated address in
 "Local Address" column. You can open this URL in the web browser and LARA should load. It seems it's necessary to do it
 each time you run `docker-compose up`.
 
-Copy this randomly generated host and open `.env` file. Find `[LARA-RANDOM-GH-CODESPACES-HOST]` and replace it with the
-copied value. Note that you have to do it only once, as this host will stay the same in the future, even if you
-shut down and restart your Codespaces machine.
-
-Once you setup Portal and make its port public, you should open `.env` file again, find `[PORTAL-RANDOM-GH-CODESPACES-HOST]`,
-and replace it with the randomly generated host for Portal.
-
-Remember to set `REPORT_SERVICE_TOKEN` in `.env` following instructions that can be found in this file.
-
-Each time `.env` file is updated, you need stop docker-compose and start it again using `docker-compose up`.
+6. Now, your LARA instance should work with Portal, Activity Player and basic reports. You can login to LARA
+through `Localhost` (Portal running on another GH Codespace) using `admin`, `password` credentials. You are now logged
+in with admin@concord.org in LARA, however this user is not actually an admin in LARA. Run the following command in
+terminal in the LARA Codespaces:
+    ```
+      docker-compose exec app bundle exec rake lightweight:admin_last_user
+    ```
 
 ## Editing CSS
 


### PR DESCRIPTION
[#182524012]

I've updated Readme and .env file to take advantage of `CODESPACE_NAME` env variable available in Codespace container. That way we don't have to start the server and make host public to guess the domain. Apparently, it's always `${CODESPACE_NAME}-{port}.githubpreview.dev`. So, the only manual part of the setup here is to go to Portal container and copy its Codespace name, and then paste into .env.

I also thought about re-defining `REPORT_SERVICE_TOOL_ID` in docker-compose-gh-codespaces.yml, so it doesn't use `USER` variable.

In practice, the report tool id / source key will look like: `${CODESPACE_NAME}-3000.githubpreview.dev.codespace`, as the username is always `codespace`. If there's no advantage of having 100% real hostname as tool id / source key, I guess this is fine. It makes this custom gh-codespaces config simpler.

UPDATE: 
> If there's no advantage of having 100% real hostname as tool id / source key, I guess this is fine. It makes this custom gh-codespaces config simpler.

Heh, I've just noticed that when Activity Player generates student report (summary), it just uses LARA host. I guess it has no better way to do it. So, apparently there's an advantage is using host / domain as report service tool ID and I guess I should change it again. I'll do it a bit later.

