### PR TITLE
Add defunct and migration status fields for deprecated items

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -16,7 +16,7 @@ class LightweightActivity < ActiveRecord::Base
     ['ITSI', ITSI_EDITOR_MODE]
   ]
 
-  attr_accessible :name, :user_id, :pages, :related, :description,
+  attr_accessible :name, :user_id, :pages, :related, :description, :defunct,
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :theme_id, :project_id,
                   :portal_run_count, :layout, :editor_mode, :publication_hash, :copied_from_id,
                   :student_report_enabled, :show_submit_button, :runtime, :project, :background_image
@@ -140,7 +140,8 @@ class LightweightActivity < ActiveRecord::Base
                                         :student_report_enabled,
                                         :show_submit_button,
                                         :runtime,
-                                        :background_image ])
+                                        :background_image,
+                                        :defunct ])
     activity_json[:version] = 1
     activity_json[:theme_name] = self.theme ? self.theme.name : nil
     activity_json[:project] = self.project ? self.project.export : nil

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -1,6 +1,6 @@
 class Sequence < ActiveRecord::Base
 
-  attr_accessible :description, :title, :theme_id, :project_id,
+  attr_accessible :description, :title, :theme_id, :project_id, :defunct, 
     :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash,
     :runtime, :project, :background_image
 
@@ -101,7 +101,8 @@ class Sequence < ActiveRecord::Base
                                         :display_title,
                                         :thumbnail_url,
                                         :runtime,
-                                        :background_image
+                                        :background_image,
+                                        :defunct
     ])
     sequence_json[:project] = self.project ? self.project.export : nil
     sequence_json[:activities] = []

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -23,6 +23,11 @@
       .field
         = f.label :name, 'Activity Name'
         = f.text_field :name, :size => 80
+      - if current_user.is_admin
+        .field
+          = f.label :defunct,  "Defunct"
+          = f.check_box :defunct
+          .hint (Check this box if the activity uses features not supported by Activity Player.)
       .field{:class => ("disabled" if @activity.runtime != 'LARA')}
         = f.label :theme_id, 'Theme'
         = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @activity.theme_id), { :include_blank => "None (inherit from sequence, project, or site default)" }

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -13,6 +13,11 @@
     .field
       = f.label :title
       = f.text_field :title
+    - if current_user.is_admin
+      .field
+        = f.label :defunct,  "Defunct"
+        = f.check_box :defunct
+        .hint (Check this box if the sequence uses features not supported by Activity Player.)
     .field
       = f.label :display_title
       = f.text_field :display_title

--- a/db/migrate/20220624201436_add_defunct_to_lightweight_activities_and_sequences.rb
+++ b/db/migrate/20220624201436_add_defunct_to_lightweight_activities_and_sequences.rb
@@ -1,0 +1,6 @@
+class AddDefunctToLightweightActivitiesAndSequences < ActiveRecord::Migration
+  def change
+    add_column :lightweight_activities, :defunct, :boolean, default: false
+    add_column :sequences, :defunct, :boolean, default: false
+  end
+end

--- a/db/migrate/20220627201532_add_migration_status_to_built_in_embeddables.rb
+++ b/db/migrate/20220627201532_add_migration_status_to_built_in_embeddables.rb
@@ -1,0 +1,9 @@
+class AddMigrationStatusToBuiltInEmbeddables < ActiveRecord::Migration
+  def change
+    add_column :embeddable_image_questions, :migration_status, :string, default: 'not migrated'
+    add_column :embeddable_multiple_choices, :migration_status, :string, default: 'not migrated'
+    add_column :embeddable_open_responses, :migration_status, :string, default: 'not migrated'
+    add_column :image_interactives, :migration_status, :string, default: 'not migrated'  
+    add_column :video_interactives, :migration_status, :string, default: 'not migrated'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220209211536) do
+ActiveRecord::Schema.define(:version => 20220627201532) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -165,8 +165,8 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
   create_table "embeddable_image_questions", :force => true do |t|
     t.string   "name"
     t.text     "prompt"
-    t.datetime "created_at",                                                 :null => false
-    t.datetime "updated_at",                                                 :null => false
+    t.datetime "created_at",                                                   :null => false
+    t.datetime "updated_at",                                                   :null => false
     t.string   "bg_source",                        :default => "Shutterbug"
     t.string   "bg_url"
     t.text     "drawing_prompt"
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
     t.boolean  "show_in_featured_question_report", :default => true
     t.integer  "interactive_id"
     t.string   "interactive_type"
+    t.string   "migration_status",                 :default => "not migrated"
   end
 
   create_table "embeddable_labbook_answers", :force => true do |t|
@@ -236,8 +237,8 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
   create_table "embeddable_multiple_choices", :force => true do |t|
     t.string   "name"
     t.text     "prompt"
-    t.datetime "created_at",                                               :null => false
-    t.datetime "updated_at",                                               :null => false
+    t.datetime "created_at",                                                   :null => false
+    t.datetime "updated_at",                                                   :null => false
     t.boolean  "custom",                           :default => false
     t.boolean  "enable_check_answer",              :default => true
     t.boolean  "multi_answer",                     :default => false
@@ -250,6 +251,7 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
     t.text     "hint"
     t.boolean  "is_full_width",                    :default => false
     t.boolean  "show_in_featured_question_report", :default => true
+    t.string   "migration_status",                 :default => "not migrated"
   end
 
   create_table "embeddable_open_response_answers", :force => true do |t|
@@ -269,8 +271,8 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
   create_table "embeddable_open_responses", :force => true do |t|
     t.string   "name"
     t.text     "prompt"
-    t.datetime "created_at",                                          :null => false
-    t.datetime "updated_at",                                          :null => false
+    t.datetime "created_at",                                                   :null => false
+    t.datetime "updated_at",                                                   :null => false
     t.boolean  "is_prediction",                    :default => false
     t.boolean  "give_prediction_feedback",         :default => false
     t.text     "prediction_feedback"
@@ -279,6 +281,7 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
     t.text     "hint"
     t.boolean  "is_full_width",                    :default => false
     t.boolean  "show_in_featured_question_report", :default => true
+    t.string   "migration_status",                 :default => "not migrated"
   end
 
   create_table "embeddable_plugins", :force => true do |t|
@@ -313,12 +316,13 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
     t.string   "url"
     t.text     "caption"
     t.text     "credit"
-    t.datetime "created_at",                       :null => false
-    t.datetime "updated_at",                       :null => false
-    t.boolean  "show_lightbox", :default => true
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
+    t.boolean  "show_lightbox",    :default => true
     t.string   "credit_url"
-    t.boolean  "is_hidden",     :default => false
-    t.boolean  "is_full_width", :default => true
+    t.boolean  "is_hidden",        :default => false
+    t.boolean  "is_full_width",    :default => true
+    t.string   "migration_status", :default => "not migrated"
   end
 
   create_table "imports", :force => true do |t|
@@ -437,6 +441,7 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
     t.string   "runtime",                                :default => "LARA"
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
+    t.boolean  "defunct",                                :default => false
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -700,6 +705,7 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
     t.string   "runtime",                                :default => "LARA"
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
+    t.boolean  "defunct",                                :default => false
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"
@@ -751,12 +757,13 @@ ActiveRecord::Schema.define(:version => 20220209211536) do
     t.string   "poster_url"
     t.text     "caption"
     t.text     "credit"
-    t.datetime "created_at",                       :null => false
-    t.datetime "updated_at",                       :null => false
-    t.integer  "width",         :default => 556,   :null => false
-    t.integer  "height",        :default => 240,   :null => false
-    t.boolean  "is_hidden",     :default => false
-    t.boolean  "is_full_width", :default => true
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
+    t.integer  "width",            :default => 556,            :null => false
+    t.integer  "height",           :default => 240,            :null => false
+    t.boolean  "is_hidden",        :default => false
+    t.boolean  "is_full_width",    :default => true
+    t.string   "migration_status", :default => "not migrated"
   end
 
   create_table "video_sources", :force => true do |t|

--- a/spec/views/lightweight_activities/edit.html.haml_spec.rb
+++ b/spec/views/lightweight_activities/edit.html.haml_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 # Chrome tip: open inspector, right-click on your HTML, copy Xpath... ## <= this is gold.
-def official_checkox
+def defunct_checkbox
+  '//*[@id="lightweight_activity_defunct"]'
+end
+def official_checkbox
   '//*[@id="lightweight_activity_is_official"]'
 end
 
 
 describe "lightweight_activities/edit" do
 
-  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name') }
+  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name', :defunct => false) }
   let(:user)      { stub_model(User, :is_admin => false)      }
 
   before(:each) do
@@ -19,12 +22,12 @@ describe "lightweight_activities/edit" do
   describe "the form" do
     let (:user) { stub_model(User, :is_admin => true)}
 
-    describe "is_official checkbox" do
+    describe "defunct checkbox" do
       context "when the current user is an admin" do
         let (:user) { stub_model(User, :is_admin => true)}
         it "should show the checkbox" do
           render
-          expect(rendered).to have_xpath official_checkox
+          expect(rendered).to have_xpath defunct_checkbox
         end
       end
 
@@ -32,7 +35,25 @@ describe "lightweight_activities/edit" do
         let (:user) { stub_model(User, :is_admin => false)}
         it "should not show the checkbox" do
           render
-          expect(rendered).not_to have_xpath official_checkox
+          expect(rendered).not_to have_xpath defunct_checkbox
+        end
+      end
+    end
+
+    describe "is_official checkbox" do
+      context "when the current user is an admin" do
+        let (:user) { stub_model(User, :is_admin => true)}
+        it "should show the checkbox" do
+          render
+          expect(rendered).to have_xpath official_checkbox
+        end
+      end
+
+      context "when the current user is not an admin" do
+        let (:user) { stub_model(User, :is_admin => false)}
+        it "should not show the checkbox" do
+          render
+          expect(rendered).not_to have_xpath official_checkbox
         end
       end
     end

--- a/spec/views/lightweight_activities/index.html.haml_spec.rb
+++ b/spec/views/lightweight_activities/index.html.haml_spec.rb
@@ -28,7 +28,8 @@ def fake_activity(official=false, is_public=true)
     changed_by: user,
     is_official: official,
     active_runs: 0,
-    portal_publications: []
+    portal_publications: [],
+    defunct: false
   )
 end
 


### PR DESCRIPTION
PT Stories:

https://www.pivotaltracker.com/story/show/182465001
https://www.pivotaltracker.com/story/show/182577639 

[#182465001]
[#182577639]

Adds a `defunct` boolean field to activities and sequences to use for identifying resources containing deprecated features.

Adds a `migration_status` string field to LARA-native multiple-choice, open response, image, image interactive, and video embeddables to use in identifying them as having been migrated. Default value is "not migrated".