### PR TITLE
Add legacy_ref_id field to managed interactives.

### DIFF
--- a/app/services/lara_serialization_helper.rb
+++ b/app/services/lara_serialization_helper.rb
@@ -8,6 +8,7 @@ class LaraSerializationHelper
     results = item.export
     results[:type] = item.class.name
     results[:ref_id] = key(item)
+    results[:legacy_ref_id] = item.legacy_ref_id if item.respond_to?(:legacy_ref_id)
     if item.respond_to?(:interactive) && item.interactive
       results[:interactive_ref_id] = key(item.interactive)
     end

--- a/app/services/lara_serialization_helper.rb
+++ b/app/services/lara_serialization_helper.rb
@@ -8,7 +8,6 @@ class LaraSerializationHelper
     results = item.export
     results[:type] = item.class.name
     results[:ref_id] = key(item)
-    results[:legacy_ref_id] = item.legacy_ref_id if item.respond_to?(:legacy_ref_id)
     if item.respond_to?(:interactive) && item.interactive
       results[:interactive_ref_id] = key(item.interactive)
     end

--- a/db/migrate/20220711213558_add_legacy_ref_id_to_managed_interactives.rb
+++ b/db/migrate/20220711213558_add_legacy_ref_id_to_managed_interactives.rb
@@ -1,0 +1,5 @@
+class AddLegacyRefIdToManagedInteractives < ActiveRecord::Migration
+  def change
+    add_column :managed_interactives, :legacy_ref_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220627201532) do
+ActiveRecord::Schema.define(:version => 20220711213558) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -328,8 +328,8 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.datetime "updated_at",                                   :null => false
     t.boolean  "show_lightbox",    :default => true
     t.string   "credit_url"
-    t.boolean  "is_hidden",     :default => false
-    t.boolean  "is_half_width", :default => false
+    t.boolean  "is_hidden",        :default => false
+    t.boolean  "is_half_width",    :default => false
     t.string   "migration_status", :default => "not migrated"
   end
 
@@ -449,8 +449,8 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.string   "runtime",                                :default => "LARA"
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
-    t.integer  "glossary_id"
     t.boolean  "defunct",                                :default => false
+    t.integer  "glossary_id"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -509,6 +509,7 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.datetime "created_at",                                          :null => false
     t.datetime "updated_at",                                          :null => false
     t.string   "linked_interactive_type"
+    t.string   "legacy_ref_id"
   end
 
   create_table "mc_answer_choices", :id => false, :force => true do |t|
@@ -792,12 +793,12 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.string   "poster_url"
     t.text     "caption"
     t.text     "credit"
-    t.datetime "created_at",                       :null => false
-    t.datetime "updated_at",                       :null => false
-    t.integer  "width",         :default => 556,   :null => false
-    t.integer  "height",        :default => 240,   :null => false
-    t.boolean  "is_hidden",     :default => false
-    t.boolean  "is_half_width", :default => false
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
+    t.integer  "width",            :default => 556,            :null => false
+    t.integer  "height",           :default => 240,            :null => false
+    t.boolean  "is_hidden",        :default => false
+    t.boolean  "is_half_width",    :default => false
     t.string   "migration_status", :default => "not migrated"
   end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182657208

[#182657208]

When a built-in (aka LARA-native) question is converted to a managed interactive the built-in question's `ref_id` will be stored in this new `legacy_ref_id field`.