### PR TITLE
Add migration_status field to activities and sequences

### DIFF
--- a/db/migrate/20220711222748_add_migration_status_to_lightweight_activities_and_sequences.rb
+++ b/db/migrate/20220711222748_add_migration_status_to_lightweight_activities_and_sequences.rb
@@ -1,0 +1,6 @@
+class AddMigrationStatusToLightweightActivitiesAndSequences < ActiveRecord::Migration
+  def change
+    add_column :lightweight_activities, :migration_status, :string, default: 'not_migrated'
+    add_column :sequences, :migration_status, :string, default: 'not_migrated'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -510,7 +510,6 @@ ActiveRecord::Schema.define(:version => 20220711222748) do
     t.datetime "created_at",                                          :null => false
     t.datetime "updated_at",                                          :null => false
     t.string   "linked_interactive_type"
-    t.string   "legacy_ref_id"
   end
 
   create_table "mc_answer_choices", :id => false, :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220627201532) do
+ActiveRecord::Schema.define(:version => 20220711222748) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -328,8 +328,8 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.datetime "updated_at",                                   :null => false
     t.boolean  "show_lightbox",    :default => true
     t.string   "credit_url"
-    t.boolean  "is_hidden",     :default => false
-    t.boolean  "is_half_width", :default => false
+    t.boolean  "is_hidden",        :default => false
+    t.boolean  "is_half_width",    :default => false
     t.string   "migration_status", :default => "not migrated"
   end
 
@@ -424,8 +424,8 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.string   "name"
     t.integer  "user_id"
     t.string   "publication_status",                     :default => "private"
-    t.datetime "created_at",                                                    :null => false
-    t.datetime "updated_at",                                                    :null => false
+    t.datetime "created_at",                                                         :null => false
+    t.datetime "updated_at",                                                         :null => false
     t.integer  "offerings_count"
     t.text     "related"
     t.text     "description"
@@ -449,8 +449,9 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.string   "runtime",                                :default => "LARA"
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
-    t.integer  "glossary_id"
     t.boolean  "defunct",                                :default => false
+    t.integer  "glossary_id"
+    t.string   "migration_status",                       :default => "not_migrated"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -509,6 +510,7 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.datetime "created_at",                                          :null => false
     t.datetime "updated_at",                                          :null => false
     t.string   "linked_interactive_type"
+    t.string   "legacy_ref_id"
   end
 
   create_table "mc_answer_choices", :id => false, :force => true do |t|
@@ -713,8 +715,8 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
   create_table "sequences", :force => true do |t|
     t.string   "title"
     t.text     "description"
-    t.datetime "created_at",                                                    :null => false
-    t.datetime "updated_at",                                                    :null => false
+    t.datetime "created_at",                                                         :null => false
+    t.datetime "updated_at",                                                         :null => false
     t.integer  "user_id"
     t.integer  "theme_id"
     t.integer  "project_id"
@@ -731,6 +733,7 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
     t.boolean  "defunct",                                :default => false
+    t.string   "migration_status",                       :default => "not_migrated"
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"
@@ -792,12 +795,12 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.string   "poster_url"
     t.text     "caption"
     t.text     "credit"
-    t.datetime "created_at",                       :null => false
-    t.datetime "updated_at",                       :null => false
-    t.integer  "width",         :default => 556,   :null => false
-    t.integer  "height",        :default => 240,   :null => false
-    t.boolean  "is_hidden",     :default => false
-    t.boolean  "is_half_width", :default => false
+    t.datetime "created_at",                                   :null => false
+    t.datetime "updated_at",                                   :null => false
+    t.integer  "width",            :default => 556,            :null => false
+    t.integer  "height",           :default => 240,            :null => false
+    t.boolean  "is_hidden",        :default => false
+    t.boolean  "is_half_width",    :default => false
     t.string   "migration_status", :default => "not migrated"
   end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/n/projects/2441249/stories/182666056

[#182666056]

Adds a `migration_status` field to lightweight activities and sequences. The field will be used to mark resources as changed during the migration process.