### PR TITLE
Add "official" flag to library interactives

### DIFF
--- a/app/models/library_interactive.rb
+++ b/app/models/library_interactive.rb
@@ -7,7 +7,7 @@ class LibraryInteractive < ActiveRecord::Base
   attr_accessible :aspect_ratio_method, :authoring_guidance, :base_url, :click_to_play, :click_to_play_prompt, :description,
                   :enable_learner_state, :full_window, :has_report_url, :image_url, :name, :native_height, :native_width,
                   :no_snapshots, :show_delete_data_button, :thumbnail_url, :export_hash, :customizable, :authorable, :data,
-                  :report_item_url
+                  :report_item_url, :official
 
   default_value_for :native_width, ASPECT_RATIO_DEFAULT_WIDTH
   default_value_for :native_height, ASPECT_RATIO_DEFAULT_HEIGHT

--- a/app/views/library_interactives/_form.html.haml
+++ b/app/views/library_interactives/_form.html.haml
@@ -4,6 +4,13 @@
     = f.text_field :name
   = field_set_tag 'Description' do
     = f.text_area :description, size: "100x4"
+  = field_set_tag 'Status' do
+    %div{:class => "option_group"}
+      = f.check_box :official
+      = f.label :official, 'Official Version'
+      %div{:class => "checkbox_note"}
+        %em Note:
+        Only set one version of a question type to be the official version.
   = field_set_tag 'Authoring Guidance' do
     = f.text_area :authoring_guidance, :rows => 5, :class => 'wysiwyg-minimal'
   = field_set_tag 'Base URL' do

--- a/app/views/library_interactives/index.html.haml
+++ b/app/views/library_interactives/index.html.haml
@@ -38,3 +38,6 @@
           Embeddables using this: #{library_interactive.use_count}
         %p
           = library_interactive.description
+        - if library_interactive.official
+          %p
+            OFFICIAL

--- a/db/migrate/20220712165650_add_official_field_to_library_interactives.rb
+++ b/db/migrate/20220712165650_add_official_field_to_library_interactives.rb
@@ -1,0 +1,5 @@
+class AddOfficialFieldToLibraryInteractives < ActiveRecord::Migration
+  def change
+    add_column :library_interactives, :official, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220627201532) do
+ActiveRecord::Schema.define(:version => 20220712165650) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -408,6 +408,7 @@ ActiveRecord::Schema.define(:version => 20220627201532) do
     t.boolean  "customizable",            :default => false
     t.boolean  "authorable",              :default => false
     t.text     "report_item_url"
+    t.boolean  "official",                :default => false
   end
 
   add_index "library_interactives", ["export_hash"], :name => "library_interactives_export_hash_idx"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182702184

[#182702184]

Adds an `official` field to library interactives. Official library interactives are the most recent, stable versions and should be used in most production activities.

The note below the field's checkbox in the form is kind of a placeholder. It should be updated when we get to the work of limiting authors to use only official library interactives.

For convenience, I added an "OFFICIAL" text label to an official library interactive's listing on the main library interactives page. We should probably update the styling of that, but for now I just put something simple.