### PR TITLE
Fix incorrect layout strings in migration to convert activities to new sections schema.

### DIFF
--- a/db/migrate/20220628163733_convert_activities_to_new_sections_schema.rb
+++ b/db/migrate/20220628163733_convert_activities_to_new_sections_schema.rb
@@ -39,9 +39,9 @@ class ConvertActivitiesToNewSectionsSchema < ActiveRecord::Migration
         "l-full-width" => "full-width",
         "l-responsive" => "responsive-2-columns",
         "l-6040" => "40-60",
-        "l-4060" => "60-40",
+        "r-4060" => "60-40",
         "l-7030" => "30-70",
-        "l-3070" => "70-30",
+        "r-3070" => "70-30",
       }
       section_count = 0
       header_block_items = []


### PR DESCRIPTION
PT Stories:

https://www.pivotaltracker.com/story/show/182518012
https://www.pivotaltracker.com/story/show/182657008

[#182518012]
[#182657008]

The incorrect layout strings, l-4060 and l-3070, resulted in some sections' layouts being set to `nil` during the migration.