### PR TITLE
Add legacy_ref_type field to managed interactives

### DIFF
--- a/db/migrate/20220711213558_add_legacy_ref_id_to_managed_interactives.rb
+++ b/db/migrate/20220711213558_add_legacy_ref_id_to_managed_interactives.rb
@@ -1,0 +1,5 @@
+class AddLegacyRefIdToManagedInteractives < ActiveRecord::Migration
+  def change
+    add_column :managed_interactives, :legacy_ref_id, :string
+  end
+end

--- a/db/migrate/20220711222748_add_migration_status_to_lightweight_activities_and_sequences.rb
+++ b/db/migrate/20220711222748_add_migration_status_to_lightweight_activities_and_sequences.rb
@@ -1,0 +1,6 @@
+class AddMigrationStatusToLightweightActivitiesAndSequences < ActiveRecord::Migration
+  def change
+    add_column :lightweight_activities, :migration_status, :string, default: 'not_migrated'
+    add_column :sequences, :migration_status, :string, default: 'not_migrated'
+  end
+end

--- a/db/migrate/20220721203706_add_legacy_ref_type_to_managed_interactives.rb
+++ b/db/migrate/20220721203706_add_legacy_ref_type_to_managed_interactives.rb
@@ -1,0 +1,10 @@
+class AddLegacyRefTypeToManagedInteractives < ActiveRecord::Migration
+  def up
+    change_column :managed_interactives, :legacy_ref_id, :integer
+    add_column :managed_interactives, :legacy_ref_type, :string
+  end
+  def down
+    change_column :managed_interactives, :legacy_ref_id, :string
+    remove_column :managed_interactives, :legacy_ref_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220712165650) do
+ActiveRecord::Schema.define(:version => 20220721203706) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -501,6 +501,8 @@ ActiveRecord::Schema.define(:version => 20220712165650) do
     t.datetime "created_at",                                          :null => false
     t.datetime "updated_at",                                          :null => false
     t.string   "linked_interactive_type"
+    t.integer  "legacy_ref_id"
+    t.string   "legacy_ref_type"
   end
 
   create_table "mc_answer_choices", :id => false, :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -417,8 +417,8 @@ ActiveRecord::Schema.define(:version => 20220721203706) do
     t.string   "name"
     t.integer  "user_id"
     t.string   "publication_status",                     :default => "private"
-    t.datetime "created_at",                                                    :null => false
-    t.datetime "updated_at",                                                    :null => false
+    t.datetime "created_at",                                                         :null => false
+    t.datetime "updated_at",                                                         :null => false
     t.integer  "offerings_count"
     t.text     "related"
     t.text     "description"
@@ -443,6 +443,7 @@ ActiveRecord::Schema.define(:version => 20220721203706) do
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
     t.boolean  "defunct",                                :default => false
+    t.string   "migration_status",                       :default => "not_migrated"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -691,8 +692,8 @@ ActiveRecord::Schema.define(:version => 20220721203706) do
   create_table "sequences", :force => true do |t|
     t.string   "title"
     t.text     "description"
-    t.datetime "created_at",                                                    :null => false
-    t.datetime "updated_at",                                                    :null => false
+    t.datetime "created_at",                                                         :null => false
+    t.datetime "updated_at",                                                         :null => false
     t.integer  "user_id"
     t.integer  "theme_id"
     t.integer  "project_id"
@@ -709,6 +710,7 @@ ActiveRecord::Schema.define(:version => 20220721203706) do
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
     t.boolean  "defunct",                                :default => false
+    t.string   "migration_status",                       :default => "not_migrated"
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182786659

[#182786659]

We were originally going to only add a `legacy_ref_id` field to managed interactives which would contain strings that look like `30-MultipleChoice` where "30" is the related built-in embeddable's numeric ID and "MultipleChoice" is the built-in embeddable's type. 

This change will put the two values in separate fields to provide greater flexibility.

Note: The `legacy_ref_id` migration was originally added to the `new-sections` branch of LARA (https://github.com/concord-consortium/lara/pull/984). I copied that migration file to this branch off of `master` since it turns out we are going to need to reference these values before upgrading to LARA 2. So long as the migration file name has the same ID in it (20220711213558) it won't be run again after we merge `new-sections` into `master`. That's why there are two separate migration files in this commit. In the second, we modify the type of `legacy_ref_id` from string to integer, as well as add the `legacy_ref_type` string field.