### PR TITLE
Script to convert all LARA runtime activities to AP runtime activities.

### DIFF
--- a/app/models/image_interactive.rb
+++ b/app/models/image_interactive.rb
@@ -3,9 +3,9 @@ class ImageInteractive < ActiveRecord::Base
 
   attr_accessible :url, :caption, :credit, :show_lightbox, :credit_url, :is_hidden, :is_full_width
 
-  has_one :page_item, :as => :embeddable, :dependent => :destroy
+  has_many :page_items, :as => :embeddable, :dependent => :destroy
   # PageItem is a join model; if this is deleted, that instance should go too
-  has_one :interactive_page, :through => :page_item
+  has_one :interactive_page, :through => :page_items
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'
 
   def self.portal_type
@@ -17,7 +17,8 @@ class ImageInteractive < ActiveRecord::Base
   end
 
   def page_section
-    page_item && page_item.section
+    # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+    page_items.count > 0 && page_items.first.section
   end
 
   def no_snapshots

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -45,6 +45,7 @@ class ManagedInteractive < ActiveRecord::Base
   has_one :labbook, :as => :interactive, :class_name => 'Embeddable::Labbook'
 
   belongs_to :linked_interactive, :polymorphic => true
+  belongs_to :converted_interactive, :polymorphic => true, :foreign_key => :legacy_ref_id, :foreign_type => :legacy_ref_type
 
   # getter for constructed url
   def url

--- a/app/models/video_interactive.rb
+++ b/app/models/video_interactive.rb
@@ -1,7 +1,7 @@
 class VideoInteractive < ActiveRecord::Base
   include Embeddable
 
-  has_one :page_item, :as => :embeddable, :dependent => :destroy
+  has_many :page_items, :as => :embeddable, :dependent => :destroy
   # PageItem is a join model; if this is deleted, that instance should go too
   has_one :interactive_page, :through => :page_item
   has_many :sources, :class_name => 'VideoSource',
@@ -53,7 +53,8 @@ class VideoInteractive < ActiveRecord::Base
   end
 
   def page_section
-    page_item && page_item.section
+    # In practice one question can't be added to multiple pages. Perhaps it should be refactored to has_one / belongs_to relation.
+    page_items.count > 0 && page_items.first.section
   end
 
   def to_hash


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/179855280

[#179855280]

Change `replace_old_embeddables` to iterate over new managed interactives instead of page items.