### PR TITLE
Fix image question conversion

### DIFF
--- a/lib/tasks/convert_embeddables.rake
+++ b/lib/tasks/convert_embeddables.rake
@@ -89,7 +89,17 @@ def image_authored_state(item)
 end
 
 def image_question_authored_state(item)
-  background_source = item.embeddable.bg_source == "Shutterbug" ? "snapshot" : item.embeddable.bg_source === "Upload" ? "upload" : nil
+  background_source =
+    if item.embeddable.bg_source == "Shutterbug"
+      "snapshot"
+    elsif item.embeddable.bg_source === "Upload"
+      "upload"
+    elsif item.embeddable.bg_url.present? # && item.embeddable.bg_source == "Drawing", but it's redundant at this point
+      "url"
+    else
+      nil
+    end
+
   target_page_item = background_source == "snapshot" ? PageItem.where(:embeddable_id => item.embeddable.interactive_id, :embeddable_type => item.embeddable.interactive_type).first : nil
   if target_page_item
     new_linked_page_item = LinkedPageItem.new(primary_id: item.id, secondary_id: target_page_item.id, label: "snapshotTarget")
@@ -102,13 +112,17 @@ def image_question_authored_state(item)
     required: item.embeddable.is_prediction,
     predictionFeedback: item.embeddable.prediction_feedback,
     backgroundImageUrl: item.embeddable.bg_url,
-    backgroundSource: background_source,
     imageFit: "shrinkBackgroundToCanvas",
     imagePosition: "center",
     answerPrompt: item.embeddable.drawing_prompt,
     prompt: item.embeddable.prompt,
     hint: item.embeddable.hint
   }
+  # Question Interactives Image Questions authoring complains about `null` or "" (empty string) values.
+  # So, if backgroundSource should not be defined if it's equal to `nil`.
+  if background_source.present?
+    authored_state[:backgroundSource] = background_source
+  end
 
   return authored_state.to_json
 end


### PR DESCRIPTION
There were two issues with IQ conversion:
- `backgroundSource` was never set to "URL", even if the background URL was provided
- `backgroundSource` was sometimes set to `null`. This was working fine in runtime, but authoring was complaining. So, I'm not setting `backgroundSource` property at all when it's undefined.

I've tested all the Image Question variants and there's one combination that is not supported by the new version (as their authored state doesn't map 1:1). LARA IQ lets the author set source to "Upload" and display an authored URL background anyway. So, students would see this background as an initial prompt. Once they upload their own background, this authored background is never displayed anymore. It's also not mixed in any way with students' uploads.

The new IQ has a concept of "backgroundSource" instead of "source". So, once it's set to "Upload", there's no way to display authored background (it'd require backgroundSource = "url" instead of "upload"). 

I think this doesn't sound like a critical issue. Also, note that it just depends on Image Question runtime / authoring logic. The data will be there, so if someone is really missing this feature, we can implement this feature later in the Question Interactives repo and things will work as they used to.