### PR TITLE
Add UI for marking a section as hidden

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -1672,6 +1672,8 @@ select {
           width: calc(50% - 6px); }
   .edit-page-grid-container.col-2 {
     margin-left: 0; }
+  .edit-page-grid-container.hidden {
+    opacity: .5; }
 
 .teal-label {
   color: var(--teal);

--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -478,11 +478,12 @@ class Api::V1::InteractivePagesController < API::APIController
 
   def generate_section_json(section)
     {
+      can_collapse_small: section.can_collapse_small,
       id: section.id.to_s,
+      items: section.page_items.map { |pi| generate_item_json(pi) },
       layout: section.layout,
       position: section.position,
-      can_collapse_small: section.can_collapse_small,
-      items: section.page_items.map { |pi| generate_item_json(pi) }
+      show: section.show
     }
   end
 

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -232,7 +232,7 @@ export interface ISection {
   items?: ISectionItem[];
 
   /**
-   * Items in this section
+   * Should the section be shown in runtime?
    */
   show?: boolean;
 }

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -230,6 +230,11 @@ export interface ISection {
    * Items in this section
    */
   items?: ISectionItem[];
+
+  /**
+   * Items in this section
+   */
+  show?: boolean;
 }
 
 export interface IPage {

--- a/lara-typescript/src/section-authoring/components/authoring-section.scss
+++ b/lara-typescript/src/section-authoring/components/authoring-section.scss
@@ -146,6 +146,9 @@ select {
   &.col-2 {
     margin-left: 0;
   }
+  &.hidden {
+    opacity: .5;
+  }
 }
 
 .teal-label {

--- a/lara-typescript/src/section-authoring/components/authoring-section.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-section.tsx
@@ -74,6 +74,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
   position,
   collapsed: initCollapsed = false,
   title,
+  show: initShow = true,
   moveItemFunction,
   editItemFunction,
   draggableProvided,
@@ -85,6 +86,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
   const { deleteSectionFunction, copySection } = usePageAPI();
   const [layout, setLayout] = useState(initLayout);
   const [collapsed, setCollapsed] = useState(initCollapsed);
+  const [show, setShow] = useState(initShow);
 
   React.useEffect(() => {
     setLayout(initLayout);
@@ -106,6 +108,12 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
     const nextCollapsed = !collapsed;
     setCollapsed(nextCollapsed);
     updateFunction?.({section: {collapsed: nextCollapsed, id}});
+  };
+
+  const toggleShow = () => {
+    const nextShow = !show;
+    setShow(nextShow);
+    updateFunction?.({section: {show: nextShow, id}});
   };
 
   const handleDelete = () => {
@@ -193,7 +201,13 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
 
   const sectionClassNames = () => {
     const layoutClass = "section-" + layout.toLowerCase().replace(/ /g, "-");
-    return `edit-page-grid-container sectionContainer ${layoutClass}`;
+    const sectionClasses = classNames(
+      "edit-page-grid-container",
+      "sectionContainer",
+      layoutClass,
+      !show ? "hidden" : "",
+    );
+    return sectionClasses;
   };
 
   const toggleSecondaryColumnDisabled = layout === SectionLayouts.LAYOUT_FULL_WIDTH ||
@@ -242,6 +256,7 @@ export const AuthoringSection: React.FC<ISectionProps> = ({
             <li><button onClick={toggleCollapse}>Collapse</button></li>
             <li><button onClick={handleMoveSection}>Move</button></li>
             <li><button onClick={handleCopy}>Copy</button></li>
+            <li><button onClick={toggleShow}>{ show ? "Hide" : "Show" }</button></li>
             <li><button onClick={handleDelete}>Delete</button></li>
           </ul>
         </div>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182613081

[#182613081]

Adds a toggle option in authoring to set a section's `show` property. The `show` property is used by Activity Player to determine if a section should be shown. When section is hidden, its opacity is set to 50% in authoring.