### PR TITLE
Fixed "Edit null" showing in page editor when page name not set [#181889363]

### DIFF
--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -161,8 +161,11 @@ export const AuthoringPage: React.FC<IPageProps> = ({
   };
 
   const pageSettingsClickHandler = () => { setShowSettings(true); };
-  const displayTitle = name && name !== "" ? name : <em>(title not set)</em>;
-  useTitle("Edit " + name);
+  const trimmedName = name?.trim() || "";
+  const hasName = trimmedName.length > 0;
+  const pageName = hasName ? trimmedName : "(title not set)";
+  const displayTitle = hasName ? pageName : <em>{pageName}</em>;
+  useTitle("Edit " + pageName);
   return (
     <>
       <PageNavContainer />


### PR DESCRIPTION
I know this isn't critical but it really bugs me so I fixed it in a couple of minutes.