### PR TITLE
Style hidden items differently than visible items in authoring

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -989,6 +989,10 @@
 
 .sectionItemContainer {
   font-size: 12px; }
+  .sectionItemContainer.hidden {
+    opacity: .5; }
+    .sectionItemContainer.hidden h4:before {
+      content: "HIDDEN - "; }
   .sectionItemContainer .sectionItemMenu {
     background-color: var(--teal);
     color: white;

--- a/lara-typescript/src/section-authoring/components/section-item.scss
+++ b/lara-typescript/src/section-authoring/components/section-item.scss
@@ -3,6 +3,14 @@
 .sectionItemContainer {
   font-size: 12px;
 
+  &.hidden {
+    opacity: .5;
+
+    h4:before {
+      content: "HIDDEN - ";
+    }
+  }
+
   .sectionItemMenu {
     background-color: var(--teal);
     color: white;

--- a/lara-typescript/src/section-authoring/components/section-item.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
+import classNames from "classnames";
 import { usePageAPI } from "../hooks/use-api-provider";
 import { GripLines } from "../../shared/components/icons/grip-lines";
 import { UserInterfaceContext } from "../containers/user-interface-provider";
@@ -133,8 +134,13 @@ export const SectionItem: React.FC<ISectionItemProps> = ({
     }
   };
 
+  const containerClasses = classNames(
+    "sectionItemContainer",
+    pageItem?.data.isHidden ? "hidden" : "",
+  );
+
   return(
-    <div className="sectionItemContainer">
+    <div className={containerClasses}>
       <header className="sectionItemMenu">
         <div className="menuStart">
           <GripLines />


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182896332

[#182896332]

If a page item is marked as hidden in the database, it will be displayed at 50% opacity and "HIDDEN - " will be prepended to its title.

In the screenshot below, the second item in the section is a hidden page item.

<img width="1117" alt="image" src="https://user-images.githubusercontent.com/367459/182720918-f934d338-b76c-45ab-b440-f6ace4536bbc.png">
