### PR TITLE
add interactive idx to interactive run states

### DIFF
--- a/db/migrate/20220808120311_add_interactive_index_to_interactive_run_states.rb
+++ b/db/migrate/20220808120311_add_interactive_index_to_interactive_run_states.rb
@@ -1,0 +1,5 @@
+class AddInteractiveIndexToInteractiveRunStates < ActiveRecord::Migration
+  def change
+    add_index :interactive_run_states, [:interactive_id, :interactive_type], :name => 'interactive_run_states_interactive_idx'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20220726150351) do
+ActiveRecord::Schema.define(:version => 20220808120311) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -391,6 +391,7 @@ ActiveRecord::Schema.define(:version => 20220726150351) do
     t.text     "metadata"
   end
 
+  add_index "interactive_run_states", ["interactive_id", "interactive_type"], :name => "interactive_run_states_interactive_idx"
   add_index "interactive_run_states", ["key"], :name => "interactive_run_states_key_idx"
   add_index "interactive_run_states", ["run_id"], :name => "interactive_run_states_run_id_idx"
 
@@ -451,9 +452,9 @@ ActiveRecord::Schema.define(:version => 20220726150351) do
     t.string   "runtime",                                :default => "LARA"
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
-    t.integer  "glossary_id"
     t.boolean  "defunct",                                :default => false
     t.string   "migration_status",                       :default => "not_migrated"
+    t.integer  "glossary_id"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -517,6 +518,7 @@ ActiveRecord::Schema.define(:version => 20220726150351) do
   end
 
   add_index "managed_interactives", ["legacy_ref_id", "legacy_ref_type"], :name => "managed_interactive_legacy_idx"
+  add_index "managed_interactives", ["library_interactive_id"], :name => "managed_interactive_library_interactive_id_idx"
 
   create_table "mc_answer_choices", :id => false, :force => true do |t|
     t.integer "answer_id"


### PR DESCRIPTION
destroying a page_item was slow because it destroys
the interactive, and the interactive destroys the interactive run state
So the query to find the interactive run states was very slow without
an index.