### PR TITLE
Fix iframes not rendered in the authoring preview.

### DIFF
--- a/lara-typescript/src/section-authoring/components/text-block-preview.tsx
+++ b/lara-typescript/src/section-authoring/components/text-block-preview.tsx
@@ -1,6 +1,4 @@
 import * as React from "react";
-import * as DOMPurify from "dompurify";
-import parse from "html-react-parser";
 import classNames from "classnames";
 import { ISectionItem, ITextBlockData } from "../api/api-types";
 

--- a/lara-typescript/src/shared/render-html.ts
+++ b/lara-typescript/src/shared/render-html.ts
@@ -2,5 +2,5 @@ import * as DOMPurify from "dompurify";
 import parse from "html-react-parser";
 
 export function renderHTML(html: string) {
-  return parse(DOMPurify.sanitize(html || ""));
+  return parse(DOMPurify.sanitize(html || "", {ADD_TAGS: ["iframe"], ADD_ATTR: ["allowfullscreen", "frameborder", "scrolling", "target"]}));
 }

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -46585,7 +46585,7 @@ exports.renderHTML = void 0;
 var DOMPurify = __webpack_require__(/*! dompurify */ "./node_modules/dompurify/dist/purify.js");
 var html_react_parser_1 = __webpack_require__(/*! html-react-parser */ "./node_modules/html-react-parser/index.mjs");
 function renderHTML(html) {
-    return (0, html_react_parser_1.default)(DOMPurify.sanitize(html || ""));
+    return (0, html_react_parser_1.default)(DOMPurify.sanitize(html || "", { ADD_TAGS: ["iframe"], ADD_ATTR: ["allowfullscreen", "frameborder", "scrolling", "target"] }));
 }
 exports.renderHTML = renderHTML;
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182908649

[#182908649]

Adds `iframe` to the default set of allowed HTML tags, and adds some related attributes to the set of allowed attributes. Also removes some unnecessary/unused imports from the text block preview component. 