### PR TITLE
Fix un-editable TE question wrappers

### DIFF
--- a/app/controllers/api/v1/page_items_controller.rb
+++ b/app/controllers/api/v1/page_items_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::PageItemsController < API::APIController
     plugins = []
     page_item_plugins = Embeddable::EmbeddablePlugin.where({embeddable_id: @page_item.embeddable_id, embeddable_type: @page_item.embeddable_type})
     page_item_plugins.each do |plugin|
-      plugin_page_item = PageItem.where(embeddable_id: plugin.id).first
+      plugin_page_item = PageItem.where(embeddable_id: plugin.id, embeddable_type: "Embeddable::EmbeddablePlugin").first
       plugins.push({
         :embeddable_id => @page_item.embeddable_id,
         :id => plugin.id,


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182893380

[#182893380]

Make sure we're getting the page item of type `Embeddable::EmbeddablePlugin` with the specified `embeddable_id`. Otherwise, we may be getting a page item of a different type.