### PR TITLE
Fix moving items.

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -182,8 +182,7 @@ class Api::V1::InteractivePagesController < API::APIController
       if section && new_items
         new_items.each do |pi|
           page_item = PageItem.find(pi.delete('id'))
-          page_item&.update_attributes(
-            {
+          page_item&.update_attributes({
               column: pi['column'],
               position: pi['position'],
               section: section
@@ -259,7 +258,7 @@ class Api::V1::InteractivePagesController < API::APIController
       return error("Unknown embbeddable_type: #{embeddable_type}\nOnly library interactive embeddables, iFrame interactives, and text blocks are currently supported")
     end
 
-    @interactive_page.add_embeddable(embeddable, position, section.id, column)
+    @interactive_page.add_embeddable(embeddable, position, section, column)
     @interactive_page.reload
 
     embeddable.reload

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -203,15 +203,10 @@ class InteractivePage < ActiveRecord::Base
   def add_embeddable(embeddable, position = nil, section_identifier = nil, column = PageItem::COLUMN_PRIMARY)
 
     section_identifier ||= Section::DEFAULT_SECTION_TITLE
-    # Local function to test whether section_identifier is a numeric value
-    numeric = ->(x) { Float(x) != nil rescue false }
 
-    # look for a section specified by instance, title or ID
+    # look for a section specified by instance or title
     if section_identifier.is_a?(Section)
       section = section_identifier
-    elsif numeric.call(section_identifier)
-      section = sections.find { |s| s.id = section_identifier}  # <--- this seems like the = would blow things up
-      throw "Cant find section #{section_identifier}" unless section
     else
       section = sections.find { |s| s.title == section_identifier }
       unless section
@@ -301,12 +296,28 @@ class InteractivePage < ActiveRecord::Base
   def duplicate(helper=nil)
     helper = LaraDuplicationHelper.new if helper.nil?
     new_page = InteractivePage.new(to_hash)
-    new_sections = sections.map { |s| s.duplicate(helper) }
 
     InteractivePage.transaction do
+      new_sections = sections.map { |s| s.duplicate(helper) }
       new_page.save!(validate: false)
-      new_sections.each { |s| s.update_attribute(:interactive_page_id, new_page.id) }
+      position = 1
+      new_sections.each do |s|
+        s.interactive_page_id = new_page.id
+        s.position = position
+        s.save!(validate: false)
+        position += 1
+      end
+
+      # Original sections' positions must be reset after duplicates are moved to new page
+      sections.reload
+      position = 1
+      sections.sort_by(&:position).each do |s|
+        s.position = position
+        s.save!(validate: false)
+        position += 1
+      end
     end
+
     new_page.reload
   end
 

--- a/app/models/interactive_page.rb
+++ b/app/models/interactive_page.rb
@@ -298,24 +298,8 @@ class InteractivePage < ActiveRecord::Base
     new_page = InteractivePage.new(to_hash)
 
     InteractivePage.transaction do
-      new_sections = sections.map { |s| s.duplicate(helper) }
       new_page.save!(validate: false)
-      position = 1
-      new_sections.each do |s|
-        s.interactive_page_id = new_page.id
-        s.position = position
-        s.save!(validate: false)
-        position += 1
-      end
-
-      # Original sections' positions must be reset after duplicates are moved to new page
-      sections.reload
-      position = 1
-      sections.sort_by(&:position).each do |s|
-        s.position = position
-        s.save!(validate: false)
-        position += 1
-      end
+      new_sections = sections.map { |s| s.duplicate(helper, new_page.id) }
     end
 
     new_page.reload

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -78,11 +78,14 @@ class Section < ActiveRecord::Base
     page_items.map(&:embeddable)
   end
 
-  def duplicate(helper=nil)
+  def duplicate(helper=nil, new_page_id=nil)
     helper = LaraDuplicationHelper.new if helper.nil?
     new_section = Section.new(to_hash)
-    new_section.position = new_section.position + 1
-
+    if new_page_id.nil?
+      new_section.position = new_section.position + 1
+    else
+      new_section.interactive_page_id = new_page_id
+    end
     Section.transaction do
       new_section.save!(validate: false)
 

--- a/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-move-dialog.tsx
@@ -68,9 +68,14 @@ export const SectionItemMoveDialog: React.FC = () => {
     if (selectedSectionId) {
       const selectedSection = getSections().find(s => s.id === selectedSectionId);
       if (selectedSection?.items) {
-        itemsList = selectedSection.items
-          .filter(i => i.column === selectedColumn)
-          .filter(i => i.id !== movingItemId);
+        if (selectedSection?.layout === "full-width") {
+          itemsList = selectedSection.items
+            .filter(i => i.id !== movingItemId);
+        } else {
+          itemsList = selectedSection.items
+            .filter(i => i.column === selectedColumn)
+            .filter(i => i.id !== movingItemId);
+        }
       }
     }
     if (itemsList.length < 1) {

--- a/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
@@ -251,16 +251,13 @@ export const usePageAPI = () => {
 
   const moveItem = (itemId: string, destination: IItemDestination) => {
     if (currentPage) {
-      const updatedSections = _moveItem({itemId, destination, pages: getPages.data || []});
-      for (const updatedSection of updatedSections) {
-        if (updatedSection.items) {
-          const changes = {section: updatedSection, sectionId: updatedSection.id};
-          updateSection.mutate({pageId: currentPage.id, changes});
-          updateSectionItems({sectionId: updatedSection.id, newItems: updatedSection.items});
-        }
+      const updatedSection = _moveItem({itemId, destination, pages: getPages.data || []});
+      if (updatedSection?.items) {
+        const changes = {section: updatedSection, sectionId: updatedSection.id};
+        updateSection.mutate({pageId: currentPage.id, changes});
+        updateSectionItems({sectionId: updatedSection.id, newItems: updatedSection.items});
       }
-    }
-    else {
+    } else {
       // tslint:disable-next-line
       console.error("no page specified, cant invoke method.");
     }

--- a/lara-typescript/src/section-authoring/util/move-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/move-utils.spec.ts
@@ -163,9 +163,8 @@ describe("moveItem", () => {
       };
       const itemId = "item0";
 
-      const changedSections = moveItem({ destination, pages, itemId });
-      expect(changedSections.length).toEqual(1);
-      expect(changedSections[0].items!.map(i => i.id)).toEqual(["item1", "item2", "item0" ]);
+      const changedSection = moveItem({ destination, pages, itemId });
+      expect(changedSection?.items!.map(i => i.id)).toEqual(["item1", "item2", "item0"]);
     });
 
     it("can move an item forward from one page to another", () => {
@@ -178,9 +177,8 @@ describe("moveItem", () => {
         destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item9";
-      const changedSections = moveItem({ destination, pages, itemId });
-      expect(changedSections.length).toEqual(2);
-      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item9", "item0", "item1", "item2" ]);
+      const changedSection = moveItem({ destination, pages, itemId });
+      expect(changedSection?.items!.map(i => i.id)).toEqual(["item9", "item0", "item1", "item2"]);
     });
 
     it("can move an item backward from one page to another, not specifying item destination", () => {
@@ -192,9 +190,8 @@ describe("moveItem", () => {
         destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
-      const changedSections = moveItem({ destination, pages, itemId });
-      expect(changedSections.length).toEqual(2);
-      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item9", "item10", "item11", "item0" ]);
+      const changedSection = moveItem({ destination, pages, itemId });
+      expect(changedSection?.items!.map(i => i.id)).toEqual(["item9", "item10", "item11", "item0"]);
     });
 
     it("can move an item backward from the first section to the last not specifying item destination", () => {
@@ -206,9 +203,8 @@ describe("moveItem", () => {
         destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
-      const changedSections = moveItem({ destination, pages, itemId });
-      expect(changedSections.length).toEqual(2);
-      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item24", "item25", "item26", "item0" ]);
+      const changedSection = moveItem({ destination, pages, itemId });
+      expect(changedSection?.items!.map(i => i.id)).toEqual(["item24", "item25", "item26", "item0"]);
     });
 
     it("can move an item backward from the first section on a page to the last not specifying item destination", () => {
@@ -220,10 +216,9 @@ describe("moveItem", () => {
         destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
-      const changedSections = moveItem({ destination, pages, itemId });
-      expect(changedSections.length).toEqual(2);
-      expect(changedSections[0].items!.map(i => i.id)).toEqual(["item1", "item2" ]);
-      expect(changedSections[1].items!.map(i => i.id)).toEqual(["item6", "item7", "item8", "item0" ]);
+      const changedSection = moveItem({ destination, pages, itemId });
+      // expect(changedSection?.items!.map(i => i.id)).toEqual(["item1", "item2" ]);
+      expect(changedSection?.items!.map(i => i.id)).toEqual(["item6", "item7", "item8", "item0"]);
     });
 
     it("will update the position attributes of the sections and items that moved", () => {
@@ -235,10 +230,8 @@ describe("moveItem", () => {
         destColumn: SectionColumns.PRIMARY
       };
       const itemId = "item0";
-      const changedSections = moveItem({ destination, pages, itemId });
-      for (const section of changedSections) {
-        verifyPositions(section.items!);
-      }
+      const changedSection = moveItem({ destination, pages, itemId });
+      verifyPositions(changedSection?.items!);
     });
   });
 });

--- a/lara-typescript/src/section-authoring/util/move-utils.spec.ts
+++ b/lara-typescript/src/section-authoring/util/move-utils.spec.ts
@@ -146,7 +146,7 @@ describe("moveItem", () => {
       const itemId = "bogus";
 
       // Move failed:
-      expect(moveItem({ destination, pages, itemId })).toEqual([]);
+      expect(moveItem({ destination, pages, itemId })).toEqual(null);
     });
   });
 

--- a/spec/models/interactive_page_spec.rb
+++ b/spec/models/interactive_page_spec.rb
@@ -594,10 +594,10 @@ describe InteractivePage do
       end
     end
 
-    describe "specifying the section to add to by id" do
+    describe "specifying the section to add to" do
       it "should put everything in the same section" do
         s = page.sections.create({title: "some random section"})
-        embeddables.each { |e| page.add_embeddable(e, 0, s.id) }
+        embeddables.each { |e| page.add_embeddable(e, 0, s) }
         page.visible_embeddables.each do |e|
           expect(e.page_section).to eq(s.title)
         end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182895947

[#182895947]

* Drop support for section ID in `add_embeddable` method. Use Section object instead.
* Only use `updateSection` on target section in `moveItem` function to avoid potentially conflicting changes to moved page items. 
* Update move dialog component to properly include secondary column page items in the list of items in a full-width column. (If a two column section is changed to a single, full-width column, page items previously in the secondary column still have their column set to "secondary.")
* Fix InteractivePage's `duplicate` method to properly set and reset section positions when a page is copied.