### PR TITLE
Fix after publishing, editing activity doesn't display content in report

### DIFF
--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -138,8 +138,8 @@ class InteractivePagesController < ApplicationController
 
   def add_section
     authorize! :update, @page
-    update_activity_changed_by
     @page.add_section
+    update_activity_changed_by
     redirect_to edit_activity_page_path(@activity, @page)
   end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182930937

[#182930937]

Call `update_activity_changed_by` from all API InteractivePages controller methods that modify activity content. The `update_activity_changed_by` will save the activity which will in turn trigger a re-publish as needed.