### PR TITLE
Fix reloading page with TE window shade causes blank page.

### DIFF
--- a/lara-typescript/src/section-authoring/components/section-column.tsx
+++ b/lara-typescript/src/section-authoring/components/section-column.tsx
@@ -132,14 +132,10 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
 
   const showItemPicker = () => setShowAddItem(true);
 
+  // TODO: Find a way to more generically identify wrapping items so this function isn't needed.
   const isWrappingItem = (itemData: any) => {
-    if (
-      itemData.componentLabel === "questionWrapper" ||
-      itemData.componentLabel === "interactives" // sharing plugin's component label
-      ) {
-      return true;
-    }
-    return false;
+    // "interactives" is the Sharing Plugin's label
+    return ["questionWrapper", "interactives"].indexOf(itemData.componentLabel) !== -1;
   };
 
   return (
@@ -161,6 +157,7 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
                     // TODO: Figure out why item.data property names are sometimes not converted
                     // to camel case, and fix it instead of using this itemData variable.
                     const itemData = snakeToCamelCaseKeys(item.data);
+                    // Wrapping items should not be rendered as separate page items
                     if (isWrappingItem(itemData)) {
                       return;
                     }

--- a/lara-typescript/src/section-authoring/components/section-column.tsx
+++ b/lara-typescript/src/section-authoring/components/section-column.tsx
@@ -132,6 +132,16 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
 
   const showItemPicker = () => setShowAddItem(true);
 
+  const isWrappingItem = (itemData: any) => {
+    if (
+      itemData.componentLabel === "questionWrapper" ||
+      itemData.componentLabel === "interactives" // sharing plugin's component label
+      ) {
+      return true;
+    }
+    return false;
+  };
+
   return (
     <>
       <DragDropContext onDragEnd={onDragEnd}>
@@ -151,14 +161,14 @@ export const SectionColumn: React.FC<ISectionColumnProps> = ({
                     // TODO: Figure out why item.data property names are sometimes not converted
                     // to camel case, and fix it instead of using this itemData variable.
                     const itemData = snakeToCamelCaseKeys(item.data);
+                    if (isWrappingItem(itemData)) {
+                      return;
+                    }
                     const sectionItemClasses = classNames("sectionItem", {
                        halfWidth: itemData.isHalfWidth,
                        pluginItem: item.type === "Embeddable::EmbeddablePlugin",
                        sideTipItem: itemData.componentLabel === "sideTip"
                     });
-                    if (itemData.componentLabel === "questionWrapper") {
-                      return;
-                    }
                     if (itemData.componentLabel === "sideTip") {
                       itemCanBeCopied = false;
                     }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182918167

[#182918167]

These changes make it so Sharing Plugin items aren't rendered as separate page items in authoring. When they were being rendered as page items, it would cause a conflict with Teacher Edition Plugin page items that led to the page crashing.