### PR TITLE
Fix state update in the interactive authoring dialog

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -452,9 +452,9 @@ ActiveRecord::Schema.define(:version => 20220808120311) do
     t.string   "runtime",                                :default => "LARA"
     t.string   "background_image"
     t.string   "fixed_width_layout",                     :default => "1100px"
+    t.integer  "glossary_id"
     t.boolean  "defunct",                                :default => false
     t.string   "migration_status",                       :default => "not_migrated"
-    t.integer  "glossary_id"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"

--- a/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
@@ -29,20 +29,9 @@ export const InteractiveAuthoringPreview: React.FC<Props> = ({interactive, user}
     ? interactive.authored_state
     : JSON.stringify(interactive.authored_state || "{}");
   const [prevAuthoredState, setPrevAuthoredState] = useState<string|null>(authoredState);
-  let linkedInteractives = typeof interactive.linked_interactives === "string"
+  const linkedInteractives = typeof interactive.linked_interactives === "string"
     ? JSON.parse(interactive.linked_interactives || "[]")
     : interactive.linked_interactives;
-  if ((linkedInteractives as any).linkedInteractives) {
-    // This is workaround of a larger issue. Usually the init message is like:
-    // `linkedInteractives: [ ... ]`
-    // as that's what LARA ManagedInteractive.to_hash returns.
-    // However, after saving the interactive edit dialog there's an unnecessary nesting:
-    // `linkedInteractives: { linkedInteractives: [ ... ] }`
-    // It happens because LARA page_item.set_linked_interactives expects linked interactives to include two separate
-    // props: linkedInteractives and linkedState (optional). And they get embedded in the edit form that is later
-    // used to generate the init message.
-    linkedInteractives = (linkedInteractives as any).linkedInteractives;
-  }
 
   const resetCount = useRef(0);
 

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
@@ -74,8 +74,9 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
 
   const handleUpdateItem = () => {
     if (pageItem) {
-      pageItem.data = {...pageItem.data, ...itemData};
-      updatePageItem(pageItem);
+      const pageItemUpdateOpts = {...pageItem};
+      pageItemUpdateOpts.data = {...pageItem.data, ...itemData};
+      updatePageItem(pageItemUpdateOpts);
     }
     handleCloseDialog();
   };


### PR DESCRIPTION
This PR fixes the root cause of the whole issue described here:
https://www.pivotaltracker.com/story/show/182710781

It also reverts the workaround from https://github.com/concord-consortium/lara/pull/1035.

The fix is a one-line change in ItemEditDialog... 🤦‍♂️ The previous version was mutating `pageItem` which should not happen. It essentially React state used to render components + this is query result returned from `react-query` `useQuery` hook: 
> Query results by default are structurally shared to detect if data has actually changed and if not, the data reference remains unchanged to better help with value stabilization with regards to useMemo and useCallback. 
(source: https://tanstack.com/query/v4/docs/guides/important-defaults)

Why was it causing issues related to the `linked_interactives` format? 
Update action / POST request expects `linked_interactibes: { linked_interactives: [], linked_state?: "int_123" }`, while GET result is `{ linked_interactives: [] }`.
Initially, I thought the problem was related to how the update is constructed (via forms). Then, I thought that it might be related to `react-query`. I thought it might automatically update the cached query result based on the update request, and since we have this mismatch, it might be breaking things. But... after reading all the react-query docs (it's actually a very cool library), I've realized that mutation and query results are fully independent. The only thing that mutation does is to invalidate query results, so they're re-fetched. So, we should be never seeing the UPDATE format of `linked_interactives` in the GET query results. So, I started looking for mutations done in place and found this one.