### PR TITLE
Fix state linking in Managed Interactives, let authors unlink interac…

### DIFF
--- a/app/models/base_interactive.rb
+++ b/app/models/base_interactive.rb
@@ -150,9 +150,12 @@ module BaseInteractive
 
   def linked_interactive_item_id=(val)
     matches = val.nil? ? nil : val.match(/^interactive_(.+)$/)
-    page_item = matches ? PageItem.find(matches[1]) : nil
+    page_item = matches ? PageItem.find_by_id(matches[1]) : nil
     if page_item
       self.linked_interactive = page_item.embeddable
+    else
+      # A way to unlink interactive
+      self.linked_interactive = nil
     end
   end
 

--- a/app/models/managed_interactive.rb
+++ b/app/models/managed_interactive.rb
@@ -120,7 +120,7 @@ class ManagedInteractive < ActiveRecord::Base
     "iframe interactive"
   end
 
-  # to_hash is used by the export and duplicate methods here, and the create_page_item, update_page_item, 
+  # to_hash is used by the export and duplicate methods here, and the create_page_item, update_page_item,
   # and generate_item_json methods in controllers/api/v1/interactive_pages_controller.rb
   def to_hash
     # Deliberately ignoring user (will be set in duplicate)
@@ -146,7 +146,8 @@ class ManagedInteractive < ActiveRecord::Base
       custom_click_to_play_prompt: custom_click_to_play_prompt,
       inherit_image_url: inherit_image_url,
       custom_image_url: custom_image_url,
-      linked_interactives: linked_interactives_list
+      linked_interactives: linked_interactives_list,
+      linked_interactive_item_id: linked_interactive_item_id
     }
   end
 
@@ -157,19 +158,19 @@ class ManagedInteractive < ActiveRecord::Base
     hash
   end
 
-  # to_interactive is used by the to_authoring_preview_hash method above. The to_authoring_preview_method 
+  # to_interactive is used by the to_authoring_preview_hash method above. The to_authoring_preview_method
   # is deprecated. It is not used in LARA 2 and we plan to remove it when LARA 2 is moved to production.
-  # 
+  #
   # It differs from to_hash by including:
-  # id, url, native_width, native_height, enable_learner_state, show_delete_data_button, has_report_url, 
-  # click_to_play, click_to_play_prompt, full_window, image_url, aspect_ratio, aspect_ratio_method, 
+  # id, url, native_width, native_height, enable_learner_state, show_delete_data_button, has_report_url,
+  # click_to_play, click_to_play_prompt, full_window, image_url, aspect_ratio, aspect_ratio_method,
   # no_snapshots, linked_interactive_id, linked_interactive_type
-  # 
-  # It also differs from to_hash by not including: 
-  # library_interactive_id, url_fragment, inherit_aspect_ratio_method, custom_aspect_ratio_method, 
-  # inherit_native_width, custom_native_width, inherit_native_height, custom_native_height, 
-  # inherit_click_to_play, custom_click_to_play, inherit_full_window, custom_full_window, 
-  # inherit_click_to_play_prompt, custom_click_to_play_prompt, inherit_image_url, custom_image_url, 
+  #
+  # It also differs from to_hash by not including:
+  # library_interactive_id, url_fragment, inherit_aspect_ratio_method, custom_aspect_ratio_method,
+  # inherit_native_width, custom_native_width, inherit_native_height, custom_native_height,
+  # inherit_click_to_play, custom_click_to_play, inherit_full_window, custom_full_window,
+  # inherit_click_to_play_prompt, custom_click_to_play_prompt, inherit_image_url, custom_image_url,
   # linked_interactives
 
   def to_interactive
@@ -200,7 +201,7 @@ class ManagedInteractive < ActiveRecord::Base
   end
 
   def duplicate
-    # Remove linked_interactives from the hash since it can't be mapped to a database column like the other 
+    # Remove linked_interactives from the hash since it can't be mapped to a database column like the other
     # properties in the hash can, and so causes an error when we try to create the duplicate interactive.
     new_interactive_hash = self.to_hash.except!(:linked_interactives)
     # Generate a new object with those values
@@ -218,7 +219,7 @@ class ManagedInteractive < ActiveRecord::Base
   end
 
   def export
-    # Remove linked_interactives from the hash so we don't export linked embeddables. The export method 
+    # Remove linked_interactives from the hash so we don't export linked embeddables. The export method
     # in LaraSerializationHelper provides special handling for this value. See comment there for more.
     hash = to_hash().except!(:linked_interactives)
     hash.delete(:library_interactive_id)

--- a/spec/models/managed_interactive_spec.rb
+++ b/spec/models/managed_interactive_spec.rb
@@ -65,7 +65,8 @@ describe ManagedInteractive do
         custom_click_to_play_prompt: managed_interactive.custom_click_to_play_prompt,
         inherit_image_url: managed_interactive.inherit_image_url,
         custom_image_url: managed_interactive.custom_image_url,
-        linked_interactives: []
+        linked_interactives: [],
+        linked_interactive_item_id: nil
        }
       expect(managed_interactive.to_hash).to eq(expected)
     end


### PR DESCRIPTION
[[#183759609]](https://www.pivotaltracker.com/story/show/183759609)

This PR fixes two issues:
1. Linked Interactive ID wasn't being displayed in the authoring UI
2. It was impossible for authors to unlink interactive. Removing the interactive ID or setting it to some random value was resulting in LARA API returning 404 error and the linked_interactive property wasn't updated.