### PR TITLE
Fix interactive authoring preview to show updated linked interactives array

### DIFF
--- a/lara-typescript/src/page-item-authoring/common/hooks/use-authoring-preview.ts
+++ b/lara-typescript/src/page-item-authoring/common/hooks/use-authoring-preview.ts
@@ -1,0 +1,72 @@
+import { ILinkedInteractive, ISetLinkedInteractives } from "@concord-consortium/interactive-api-host";
+import { RefObject, useCallback, useEffect, useState } from "react";
+import { debounce } from "ts-debounce";
+
+interface IInteractiveBase {
+  url?: string | null;
+  authored_state: string;
+  linked_interactives: ILinkedInteractive[];
+}
+
+interface IPreviewUpdate {
+  newAuthoredState: string | object;
+  newUrl?: string | null;
+  newLinkedInteractives?: ILinkedInteractive[];
+}
+
+interface IOptions {
+  interactive: IInteractiveBase;
+  interactiveAuthoredStateRef: RefObject<HTMLTextAreaElement>;
+  linkedInteractivesRef: RefObject<HTMLTextAreaElement>;
+  handleUpdateItemPreview?: (updates: Record<string, any>) => void;
+}
+
+export const useAuthoringPreview = (options: IOptions) => {
+  const { interactive, handleUpdateItemPreview, interactiveAuthoredStateRef, linkedInteractivesRef } = options;
+
+  const [url, setUrl] = useState(interactive.url);
+  const [authoredState, setAuthoredState] = useState(interactive.authored_state);
+  const [linkedInteractives, setLinkedInteractives] =
+    useState<ILinkedInteractive[] | undefined>(interactive.linked_interactives);
+
+  const _updatePreview = ({ newAuthoredState, newLinkedInteractives, newUrl }: IPreviewUpdate) => {
+    handleUpdateItemPreview?.({
+      authoredState: typeof newAuthoredState === "string" ? newAuthoredState : JSON.stringify(newAuthoredState),
+      linkedInteractives: newLinkedInteractives,
+      url: newUrl
+    });
+  };
+
+  const updatePreview = useCallback(debounce(_updatePreview, 500), []);
+
+  useEffect(() => {
+    updatePreview({ newAuthoredState: authoredState, newLinkedInteractives: linkedInteractives, newUrl: url });
+  }, [authoredState, linkedInteractives, url]);
+
+  const handleUrlChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const interactiveUrl = e.target.value;
+    setUrl(interactiveUrl);
+  };
+
+  const handleAuthoredStateChange = (newAuthoredState: string | object) => {
+    if (interactiveAuthoredStateRef.current) {
+      const jsonValue = typeof newAuthoredState === "string" ? newAuthoredState : JSON.stringify(newAuthoredState);
+      interactiveAuthoredStateRef.current.value = jsonValue;
+      setAuthoredState(jsonValue);
+    }
+  };
+
+  const handleLinkedInteractivesChange = (newLinkedInteractives: ISetLinkedInteractives) => {
+    if (linkedInteractivesRef.current) {
+      linkedInteractivesRef.current.value = JSON.stringify(newLinkedInteractives);
+      setLinkedInteractives(newLinkedInteractives.linkedInteractives);
+    }
+  };
+
+  return {
+    url,
+    handleUrlChange,
+    handleAuthoredStateChange,
+    handleLinkedInteractivesChange
+  };
+};

--- a/lara-typescript/src/page-item-authoring/managed-interactives/customize.tsx
+++ b/lara-typescript/src/page-item-authoring/managed-interactives/customize.tsx
@@ -26,7 +26,6 @@ export const CustomizeManagedInteractive: React.FC<Props> = (props) => {
     custom_native_height,
     inherit_click_to_play,
     custom_click_to_play,
-    inherit_click_to_play_prompt,
     custom_click_to_play_prompt,
     inherit_full_window,
     custom_full_window,
@@ -44,7 +43,6 @@ export const CustomizeManagedInteractive: React.FC<Props> = (props) => {
   });
   const [inheritClickToPlay, setInheritClickToPlay] = useState(inherit_click_to_play);
   const [customClickToPlay, setCustomClickToPlay] = useState(custom_click_to_play);
-  const [inheritClickToPlayPrompt, setInheritClickToPlayPrompt] = useState(inherit_click_to_play_prompt);
   const [customClickToPlayPrompt, setCustomClickToPlayPrompt] = useState(custom_click_to_play_prompt);
   const [inheritFullWindow, setInheritFullWindow] = useState(inherit_full_window);
   const [inheritImageUrl, setInheritImageUrl] = useState(inherit_image_url);

--- a/lara-typescript/src/page-item-authoring/mw-interactives/customize.tsx
+++ b/lara-typescript/src/page-item-authoring/mw-interactives/customize.tsx
@@ -33,8 +33,6 @@ export const CustomizeMWInteractive: React.FC<Props> = (props) => {
     image_url,
     show_in_featured_question_report,
     aspect_ratio_method,
-    linked_interactive_id,
-    linked_interactive_type,
     linked_interactive_item_id,
     report_item_url
   } = interactive;

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { ISectionItem, ITextBlockData } from "../api/api-types";
 import { Modal, ModalButtons } from "../../shared/components/modal/modal";
 import { TextBlockEditForm } from "./text-block-edit-form";
@@ -34,7 +34,6 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
   const pageItem = pageItems.find(pi => pi.id === editingItemId);
   const wrappedItem = pageItems.find(pi => pi.id === wrappedItemId);
   const [previewPageItem, setPreviewPageItem] = useState<ISectionItem>();
-  const [modalVisibility, setModalVisibility] = useState(true);
   const [itemData, setItemData] = useState({});
   const libraryInteractives = getLibraryInteractives.data?.libraryInteractives;
 
@@ -81,7 +80,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
     handleCloseDialog();
   };
 
-  const handleUpdateItemPreview = (updates: Record<string, any> | Partial<IManagedInteractive>) => {
+  const handleUpdateItemPreview = useCallback((updates: Record<string, any> | Partial<IManagedInteractive>) => {
     if (previewPageItem) {
       const data = {...previewPageItem.data, ...updates};
       setPreviewPageItem({...previewPageItem, data});
@@ -89,7 +88,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
       const data = {...pageItem.data, ...updates};
       setPreviewPageItem({...pageItem, data});
     }
-  };
+  }, [pageItem, previewPageItem]);
 
   const handleBooleanElement = (element: HTMLInputElement) => {
     // boolean value form fields are of type radio or of type hidden
@@ -272,7 +271,7 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
         title="Edit"
         className="itemEditDialog"
         closeFunction={handleCancelUpdateItem}
-        visibility={modalVisibility}
+        visibility={true}
       >
         <div id="itemEditDialog">
           {errorMessage &&


### PR DESCRIPTION
[[#183641151]](https://www.pivotaltracker.com/story/show/183641151)

This PR fixes interactive authoring preview. It wasn't handling updates of the linked interactives, so in some cases, authors could get confused. PT story describes that nicely using the image question example.

I've extracted the preview update functionality to `useAuthoringPreview` hook and used that in both MwInteractive and MangedInteractive classes to avoid code duplication.

