### PR TITLE
Interactive API: ensure that setInteractiveState, setAuthoredState and setGlobalInteractiveState are stable

### DIFF
--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -1183,7 +1183,7 @@ ___
 
 * **authoredState**: *null | AuthoredState*
 
-* **setAuthoredState**: *handleSetAuthoredState* = handleSetAuthoredState
+* **setAuthoredState**: *(Anonymous function)* = handleSetAuthoredState
 
 ___
 
@@ -1236,7 +1236,7 @@ ___
 
 * **globalInteractiveState**: *null | GlobalInteractiveState*
 
-* **setGlobalInteractiveState**: *handleSetGlobalInteractiveState* = handleSetGlobalInteractiveState
+* **setGlobalInteractiveState**: *(Anonymous function)* = handleSetGlobalInteractiveState
 
 ___
 
@@ -1268,7 +1268,7 @@ ___
 
 * **interactiveState**: *null | InteractiveState*
 
-* **setInteractiveState**: *handleSetInteractiveState* = handleSetInteractiveState
+* **setInteractiveState**: *(Anonymous function)* = handleSetInteractiveState
 
 ___
 

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import ResizeObserver from "resize-observer-polyfill";
 
 import { ICustomMessageHandler, ICustomMessagesHandledMap, IInitInteractive, ITextDecorationHandler,
@@ -30,12 +30,13 @@ export const useInteractiveState = <InteractiveState>() => {
     };
   }, []);
 
-  const handleSetInteractiveState = (stateOrUpdateFunc: InteractiveState | UpdateFunc<InteractiveState> | null) => {
+  const handleSetInteractiveState = useCallback(
+    (stateOrUpdateFunc: InteractiveState | UpdateFunc<InteractiveState> | null) => {
     // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
     const newState = handleUpdate<InteractiveState>(stateOrUpdateFunc, client.getInteractiveState<InteractiveState>());
     setInteractiveState(newState);
     client.setInteractiveState<InteractiveState>(newState);
-  };
+  }, []);
 
   return { interactiveState, setInteractiveState: handleSetInteractiveState };
 };
@@ -63,12 +64,12 @@ export const useAuthoredState = <AuthoredState>() => {
     };
   }, []);
 
-  const handleSetAuthoredState = (stateOrUpdateFunc: AuthoredState | UpdateFunc<AuthoredState> | null) => {
+  const handleSetAuthoredState = useCallback((stateOrUpdateFunc: AuthoredState | UpdateFunc<AuthoredState> | null) => {
     // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
     const newState = handleUpdate<AuthoredState>(stateOrUpdateFunc, client.getAuthoredState<AuthoredState>());
     setAuthoredState(newState);
     client.setAuthoredState<AuthoredState>(newState);
-  };
+  }, []);
 
   return { authoredState, setAuthoredState: handleSetAuthoredState };
 };
@@ -90,14 +91,14 @@ export const useGlobalInteractiveState = <GlobalInteractiveState>() => {
   }, []);
 
   // tslint:disable-next-line:max-line-length
-  const handleSetGlobalInteractiveState = (stateOrUpdateFunc: GlobalInteractiveState | UpdateFunc<GlobalInteractiveState> | null ) => {
+  const handleSetGlobalInteractiveState = useCallback((stateOrUpdateFunc: GlobalInteractiveState | UpdateFunc<GlobalInteractiveState> | null ) => {
     // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
     const newState = handleUpdate<GlobalInteractiveState>(
       stateOrUpdateFunc, client.getGlobalInteractiveState<GlobalInteractiveState>()
     );
     setGlobalInteractiveState(newState);
     client.setGlobalInteractiveState<GlobalInteractiveState>(newState);
-  };
+  }, []);
 
   return { globalInteractiveState, setGlobalInteractiveState: handleSetGlobalInteractiveState };
 };

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/public/example-interactives/attachments/index.js
+++ b/public/example-interactives/attachments/index.js
@@ -37588,12 +37588,12 @@ var useInteractiveState = function () {
             client.removeInteractiveStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getInteractiveState());
         setInteractiveState(newState);
         client.setInteractiveState(newState);
-    };
+    }, []);
     return { interactiveState: interactiveState, setInteractiveState: handleSetInteractiveState };
 };
 exports.useInteractiveState = useInteractiveState;
@@ -37618,12 +37618,12 @@ var useAuthoredState = function () {
             client.removeAuthoredStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetAuthoredState = function (stateOrUpdateFunc) {
+    var handleSetAuthoredState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getAuthoredState());
         setAuthoredState(newState);
         client.setAuthoredState(newState);
-    };
+    }, []);
     return { authoredState: authoredState, setAuthoredState: handleSetAuthoredState };
 };
 exports.useAuthoredState = useAuthoredState;
@@ -37642,12 +37642,12 @@ var useGlobalInteractiveState = function () {
         };
     }, []);
     // tslint:disable-next-line:max-line-length
-    var handleSetGlobalInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetGlobalInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getGlobalInteractiveState());
         setGlobalInteractiveState(newState);
         client.setGlobalInteractiveState(newState);
-    };
+    }, []);
     return { globalInteractiveState: globalInteractiveState, setGlobalInteractiveState: handleSetGlobalInteractiveState };
 };
 exports.useGlobalInteractiveState = useGlobalInteractiveState;

--- a/public/example-interactives/linked-state/index.js
+++ b/public/example-interactives/linked-state/index.js
@@ -34148,12 +34148,12 @@ var useInteractiveState = function () {
             client.removeInteractiveStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getInteractiveState());
         setInteractiveState(newState);
         client.setInteractiveState(newState);
-    };
+    }, []);
     return { interactiveState: interactiveState, setInteractiveState: handleSetInteractiveState };
 };
 exports.useInteractiveState = useInteractiveState;
@@ -34178,12 +34178,12 @@ var useAuthoredState = function () {
             client.removeAuthoredStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetAuthoredState = function (stateOrUpdateFunc) {
+    var handleSetAuthoredState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getAuthoredState());
         setAuthoredState(newState);
         client.setAuthoredState(newState);
-    };
+    }, []);
     return { authoredState: authoredState, setAuthoredState: handleSetAuthoredState };
 };
 exports.useAuthoredState = useAuthoredState;
@@ -34202,12 +34202,12 @@ var useGlobalInteractiveState = function () {
         };
     }, []);
     // tslint:disable-next-line:max-line-length
-    var handleSetGlobalInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetGlobalInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getGlobalInteractiveState());
         setGlobalInteractiveState(newState);
         client.setGlobalInteractiveState(newState);
-    };
+    }, []);
     return { globalInteractiveState: globalInteractiveState, setGlobalInteractiveState: handleSetGlobalInteractiveState };
 };
 exports.useGlobalInteractiveState = useGlobalInteractiveState;

--- a/public/example-interactives/report-item/index.js
+++ b/public/example-interactives/report-item/index.js
@@ -37413,12 +37413,12 @@ var useInteractiveState = function () {
             client.removeInteractiveStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getInteractiveState());
         setInteractiveState(newState);
         client.setInteractiveState(newState);
-    };
+    }, []);
     return { interactiveState: interactiveState, setInteractiveState: handleSetInteractiveState };
 };
 exports.useInteractiveState = useInteractiveState;
@@ -37443,12 +37443,12 @@ var useAuthoredState = function () {
             client.removeAuthoredStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetAuthoredState = function (stateOrUpdateFunc) {
+    var handleSetAuthoredState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getAuthoredState());
         setAuthoredState(newState);
         client.setAuthoredState(newState);
-    };
+    }, []);
     return { authoredState: authoredState, setAuthoredState: handleSetAuthoredState };
 };
 exports.useAuthoredState = useAuthoredState;
@@ -37467,12 +37467,12 @@ var useGlobalInteractiveState = function () {
         };
     }, []);
     // tslint:disable-next-line:max-line-length
-    var handleSetGlobalInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetGlobalInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getGlobalInteractiveState());
         setGlobalInteractiveState(newState);
         client.setGlobalInteractiveState(newState);
-    };
+    }, []);
     return { globalInteractiveState: globalInteractiveState, setGlobalInteractiveState: handleSetGlobalInteractiveState };
 };
 exports.useGlobalInteractiveState = useGlobalInteractiveState;

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -46223,12 +46223,12 @@ var useInteractiveState = function () {
             client.removeInteractiveStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getInteractiveState());
         setInteractiveState(newState);
         client.setInteractiveState(newState);
-    };
+    }, []);
     return { interactiveState: interactiveState, setInteractiveState: handleSetInteractiveState };
 };
 exports.useInteractiveState = useInteractiveState;
@@ -46253,12 +46253,12 @@ var useAuthoredState = function () {
             client.removeAuthoredStateListener(handleStateUpdate);
         };
     }, []);
-    var handleSetAuthoredState = function (stateOrUpdateFunc) {
+    var handleSetAuthoredState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getAuthoredState());
         setAuthoredState(newState);
         client.setAuthoredState(newState);
-    };
+    }, []);
     return { authoredState: authoredState, setAuthoredState: handleSetAuthoredState };
 };
 exports.useAuthoredState = useAuthoredState;
@@ -46277,12 +46277,12 @@ var useGlobalInteractiveState = function () {
         };
     }, []);
     // tslint:disable-next-line:max-line-length
-    var handleSetGlobalInteractiveState = function (stateOrUpdateFunc) {
+    var handleSetGlobalInteractiveState = (0, react_1.useCallback)(function (stateOrUpdateFunc) {
         // Use client-managed state, as it should be up to date. React-managed state might not be the most recent version.
         var newState = handleUpdate(stateOrUpdateFunc, client.getGlobalInteractiveState());
         setGlobalInteractiveState(newState);
         client.setGlobalInteractiveState(newState);
-    };
+    }, []);
     return { globalInteractiveState: globalInteractiveState, setGlobalInteractiveState: handleSetGlobalInteractiveState };
 };
 exports.useGlobalInteractiveState = useGlobalInteractiveState;


### PR DESCRIPTION
[#184099334]

When a developer is using React `useState` hook, the set state function is expected to be "stable". This is not the case for our setInteractiveState, setAuthoredState and setGlobalInteractiveState functions provided by custom hooks in LARA Interactive API. It might cause infinite loops of re-renders in some cases. This PR fixes this problem by adding `useCallback`.