### PR TITLE
Disable completion page checkbox when page is not empty

### DIFF
--- a/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
+++ b/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
@@ -11,7 +11,7 @@ export interface IPageSettingsDialogProps {
   isHidden?: boolean;
   isCompletion?: boolean;
   hasStudentSidebar?: boolean;
-  disableCompletionPageSetting?: boolean;
+  disableCompletionPageSetting?: string | boolean;
   updateSettingsFunction: (changes: Partial<IPage>) => void;
   closeDialogFunction: () => void;
 }
@@ -26,9 +26,11 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
   closeDialogFunction
   }: IPageSettingsDialogProps) => {
 
+  const disableCompletionPageSettingReason = disableCompletionPageSetting ? disableCompletionPageSetting : null;
+
   const [hasStudentSidebarPage, setHasStudentSidebarPage] = React.useState(hasStudentSidebar);
   const [isCompletionPage, setIsCompletionPage] = React.useState(isCompletion);
-  const [isCompletionDisabled, setIsCompletionDisabled] = React.useState(disableCompletionPageSetting);
+  const [isCompletionDisabled, setIsCompletionDisabled] = React.useState(!!disableCompletionPageSetting);
   const [isHiddenPage, setIsHiddenPage] = React.useState(isHidden);
   const [isHiddenDisabled, setIsHiddenDisabled] = React.useState(isCompletion);
 
@@ -108,7 +110,7 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
           </dd>
           <dt className={`input3 ${isCompletionDisabled && "disabled"}`}>
             <label htmlFor="isCompletion">
-              Page is a completion/summary page (An activity can only have one completion page)
+              Page is a completion/summary page { disableCompletionPageSettingReason && `(${disableCompletionPageSettingReason})` }
             </label>
           </dt>
           <dd className={`input3 ${isCompletionDisabled && "disabled"}`}>

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -95,14 +95,25 @@ export const AuthoringPage: React.FC<IPageProps> = ({
   };
 
  /*
-  * Returns true if activity already has a completion page and it is not the completion page
+  * Returns reason for disabling completion page checkbox, false otherwise
   */
   const disableCompletionPageSetting = () => {
+    if (isCompletion) {
+      // Never block authors from turning off the completion page option.
+      return false;
+    }
     const pages = getPages.data;
-    // return !!pages?.find(p => !!p.isCompletion);
-    const isCompletionPage = pages?.find(p => p.isCompletion === true);
-    const hasCompletionPage = isCompletionPage != null;
-    return (hasCompletionPage && !isCompletion ? true : false);
+    const hasCompletionPage = pages?.find(p => p.isCompletion === true);
+    if (hasCompletionPage) {
+      return "An activity can only have one completion page";
+    }
+
+    const items = getItems();
+    if (items.length > 0) {
+      return "A completion page has to be empty";
+    }
+
+    return false;
   };
 
   /*


### PR DESCRIPTION
[[#184268545]](https://www.pivotaltracker.com/story/show/184268545)

The story description suggests not rendering the questions, but I asked on Slack and Scott confirmed that disabling the checkbox might be an easier and better solution. 