### PR TITLE
Update GH Codespaces URL host in sample env file

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -11,11 +11,11 @@ COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:dock
 # to automatically set PORTAL_HOST variable.
 PORTAL_CODESPACE_NAME=
 
-PORTAL_HOST=${PORTAL_CODESPACE_NAME}-3000.githubpreview.dev
+PORTAL_HOST=${PORTAL_CODESPACE_NAME}-3000.preview.app.github.dev
 PORTAL_PROTOCOL=https
 
 # CODESPACE_NAME is available in GitHub Codespace container.
-LARA_HOST=${CODESPACE_NAME}-3000.githubpreview.dev
+LARA_HOST=${CODESPACE_NAME}-3000.preview.app.github.dev
 LARA_PROTOCOL=https
 
 # By default the production URL for shutterbug will be used by shutterbug.js

--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -240,7 +240,7 @@ class Api::V1::InteractivePagesController < API::APIController
       # 1. Create a plugin with the instance of the approved_script
       # 2. Create a Embeddable::EmbeddablePlugin
       # Example: "Plugin_10::windowShade"
-      # IMPORTANT: The tip type, "windowShade" in the above example, as 
+      # IMPORTANT: The tip type, "windowShade" in the above example, as
       # the component_label is critical.
       tip_type = $2
       regex = /Plugin_(\d+)::#{tip_type}/
@@ -404,7 +404,7 @@ class Api::V1::InteractivePagesController < API::APIController
       .joins("LEFT JOIN managed_interactives ON managed_interactives.library_interactive_id = library_interactives.id")
       .group('library_interactives.id')
 
-    if !current_user.is_admin
+    if current_user && !current_user.is_admin
       library_interactives = library_interactives.where("library_interactives.official = true")
     end
 


### PR DESCRIPTION
[#184536435]

This PR updates the host to a new version used by GH Codespaces. 
There are still some problems with oauth, but this is necessary update anyway.