### PR TITLE
fix: Updated hide read aloud checkbox hints [PT-184688393]

### DIFF
--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -33,7 +33,7 @@
       .field
         = f.check_box :hide_read_aloud
         = f.label :hide_read_aloud,  "Hide Read-Aloud Toggle"
-        .hint Check this box if you do not want the "Tap text to listen" toggle to appear on this activity
+        .hint Check this box if you do not want the "Tap text to listen" toggle to appear on this activity.
       .field{:class => ("disabled" if @activity.runtime != 'LARA')}
         = f.label :theme_id, 'Theme'
         = f.select :theme_id, options_from_collection_for_select(Theme.all, 'id', 'name', @activity.theme_id), { :include_blank => "None (inherit from sequence, project, or site default)" }
@@ -47,7 +47,7 @@
         = f.label :runtime, "Runtime Environment"
         = f.select :runtime, options_for_select(LightweightActivity::RUNTIME_OPTIONS, selected:'Activity Player', disabled: 'LARA'), :disabled => true
         .hint
-          Runtime selection is no longer applicable. This setting will be removed in a future release..
+          Runtime selection is no longer applicable. This setting will be removed in a future release.
       .field{:class => ("disabled" if @activity.runtime != 'Activity Player')}
         = f.label :fixed_width_layout, 'Activity Player Fixed Width Layout'
         = f.select :fixed_width_layout, options_for_select(LightweightActivity::FIXED_WIDTH_LAYOUT_OPTIONS, @activity.fixed_width_layout)

--- a/app/views/lightweight_activities/new.html.haml
+++ b/app/views/lightweight_activities/new.html.haml
@@ -26,7 +26,7 @@
       = f.label :runtime, "Runtime Environment"
       = f.select :runtime, options_for_select(LightweightActivity::RUNTIME_OPTIONS, selected:'Activity Player', disabled: 'LARA'), :disabled => true
       .hint
-        Runtime selection is no longer applicable. This setting will be removed in a future release..
+        Runtime selection is no longer applicable. This setting will be removed in a future release.
     .field
       = f.label :glossary_id, 'Glossary'
       = f.select :glossary_id, glossary_options_for_select(@activity, current_user), { :include_blank => "None" }

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -25,7 +25,7 @@
     .field
       = f.check_box :hide_read_aloud
       = f.label :hide_read_aloud,  "Hide Read-Aloud Toggle"
-      .hint Check this box if you do not want the "Tap text to listen" toggle to appear on this activity
+      .hint Check this box if you do not want the "Tap text to listen" toggle to appear on activities in this sequence.
     .field
       = f.label :display_title, "Display Title"
       = f.text_field :display_title, :id => "sequence_display_title"


### PR DESCRIPTION
- Changed sequence hint to mention sequences
- Added a period at end of activity hint
- Removed (unrelated) double period in runtime hint