### PR TITLE
fix: Add auto scroll to edit preview panel [PT-182710801]

### DIFF
--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.scss
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.scss
@@ -211,6 +211,7 @@
     background: var(--ltst-teal);
     padding: 10px;
     width: calc(100% - 425px);
+    overflow: auto;
 
     @media screen and (max-width: 800px) {
       display: none;


### PR DESCRIPTION
This adds an overflow: auto directive to the item edit preview panel to allow scrolling to see the bottom of the labbook and image interactives.