### PR TITLE
feat: Added font size setting to activities and sequences [PT-184910002]

### DIFF
--- a/app/models/accessible.rb
+++ b/app/models/accessible.rb
@@ -1,0 +1,8 @@
+module Accessible
+
+  FONT_SIZE_OPTIONS = {
+    'Normal' => 'normal',
+    'Large' => 'large'
+  }
+
+end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -2,6 +2,7 @@ class LightweightActivity < ActiveRecord::Base
   include Publishable # defines methods to publish to portals
   include PublicationStatus # defines publication status scopes and helpers
   include FixedWidthLayout # defines fixed width options
+  include Accessible # defines font options
 
   LAYOUT_MULTI_PAGE = 0
   LAYOUT_SINGLE_PAGE = 1
@@ -20,7 +21,7 @@ class LightweightActivity < ActiveRecord::Base
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :theme_id, :project_id,
                   :portal_run_count, :layout, :editor_mode, :publication_hash, :copied_from_id,
                   :student_report_enabled, :show_submit_button, :runtime, :project, :background_image,
-                  :glossary_id, :hide_read_aloud
+                  :glossary_id, :hide_read_aloud, :font_size
 
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
@@ -103,7 +104,8 @@ class LightweightActivity < ActiveRecord::Base
       student_report_enabled: student_report_enabled,
       show_submit_button: show_submit_button,
       runtime: runtime,
-      hide_read_aloud: hide_read_aloud
+      hide_read_aloud: hide_read_aloud,
+      font_size: font_size
     }
   end
 
@@ -150,7 +152,8 @@ class LightweightActivity < ActiveRecord::Base
                                         :runtime,
                                         :background_image,
                                         :defunct,
-                                        :hide_read_aloud ])
+                                        :hide_read_aloud,
+                                        :font_size ])
     activity_json[:version] = 2
     activity_json[:theme_name] = self.theme ? self.theme.name : nil
     activity_json[:project] = self.project ? self.project.export : nil
@@ -222,6 +225,7 @@ class LightweightActivity < ActiveRecord::Base
     import_activity.imported_activity_url = imported_activity_url
     import_activity.is_official = activity_json_object[:is_official]
     import_activity.hide_read_aloud = activity_json_object[:hide_read_aloud]
+    import_activity.font_size = activity_json_object[:font_size]
     import_activity.runtime = activity_json_object[:runtime]
     import_activity.project = Project.find_or_create(activity_json_object[:project]) if activity_json_object[:project]
     self.link_glossaries_on_import(activity_json_object, import_activity)

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -2,11 +2,13 @@ class Sequence < ActiveRecord::Base
 
   attr_accessible :description, :title, :theme_id, :project_id, :defunct,
     :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash,
-    :runtime, :project, :background_image, :hide_read_aloud
+    :runtime, :project, :background_image, :hide_read_aloud, :font_size
 
   include Publishable # defines methods to publish to portals
   include PublicationStatus # defines publication status scopes and helpers
   include FixedWidthLayout # defines fixed width options
+  include Accessible # defines font options
+
   has_many :lightweight_activities_sequences, :order => :position, :dependent => :destroy
   has_many :lightweight_activities, :through => :lightweight_activities_sequences, :order => :position
   belongs_to :user
@@ -57,7 +59,8 @@ class Sequence < ActiveRecord::Base
       display_title: display_title,
       thumbnail_url: thumbnail_url,
       runtime: runtime,
-      hide_read_aloud: hide_read_aloud
+      hide_read_aloud: hide_read_aloud,
+      font_size: font_size
     }
   end
 
@@ -104,7 +107,8 @@ class Sequence < ActiveRecord::Base
                                         :runtime,
                                         :background_image,
                                         :defunct,
-                                        :hide_read_aloud
+                                        :hide_read_aloud,
+                                        :font_size
     ])
     sequence_json[:project] = self.project ? self.project.export : nil
     sequence_json[:activities] = []
@@ -228,7 +232,8 @@ class Sequence < ActiveRecord::Base
       title: sequence_json_object[:title],
       runtime: sequence_json_object[:runtime],
       background_image: sequence_json_object[:background_image],
-      hide_read_aloud: sequence_json_object[:hide_read_aloud]
+      hide_read_aloud: sequence_json_object[:hide_read_aloud],
+      font_size: sequence_json_object[:font_size]
     }
 
   end

--- a/app/views/lightweight_activities/edit.html.haml
+++ b/app/views/lightweight_activities/edit.html.haml
@@ -48,6 +48,9 @@
         = f.select :runtime, options_for_select(LightweightActivity::RUNTIME_OPTIONS, selected:'Activity Player', disabled: 'LARA'), :disabled => true
         .hint
           Runtime selection is no longer applicable. This setting will be removed in a future release.
+      .field
+        = f.label :font_size, "Font Size"
+        = f.select :font_size, options_for_select(LightweightActivity::FONT_SIZE_OPTIONS, @activity.font_size)
       .field{:class => ("disabled" if @activity.runtime != 'Activity Player')}
         = f.label :fixed_width_layout, 'Activity Player Fixed Width Layout'
         = f.select :fixed_width_layout, options_for_select(LightweightActivity::FIXED_WIDTH_LAYOUT_OPTIONS, @activity.fixed_width_layout)

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -33,6 +33,9 @@
       = f.label :runtime, "Runtime Environment"
       = f.select :runtime, options_for_select(Sequence::RUNTIME_OPTIONS, selected:'Activity Player', disabled: 'LARA'), :disabled => true
       .hint Runtime selection is no longer applicable. This setting will be removed in a future release.
+    .field
+      = f.label :font_size, "Font Size"
+      = f.select :font_size, options_for_select(Sequence::FONT_SIZE_OPTIONS, @sequence.font_size)
     .field{:class => ("disabled" if @sequence.runtime != 'Activity Player')}
       = f.label :fixed_width_layout, 'Fixed Width Layout'
       = f.select :fixed_width_layout, options_for_select(LightweightActivity::FIXED_WIDTH_LAYOUT_OPTIONS, @sequence.fixed_width_layout)

--- a/db/migrate/20230418170010_add_font_size_setting.rb
+++ b/db/migrate/20230418170010_add_font_size_setting.rb
@@ -1,0 +1,6 @@
+class AddFontSizeSetting < ActiveRecord::Migration
+  def change
+    add_column :lightweight_activities, :font_size, :string, default: "normal"
+    add_column :sequences, :font_size, :string, default: "normal"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20230315103923) do
+ActiveRecord::Schema.define(:version => 20230418170010) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -456,6 +456,7 @@ ActiveRecord::Schema.define(:version => 20230315103923) do
     t.boolean  "defunct",                                :default => false
     t.string   "migration_status",                       :default => "not_migrated"
     t.boolean  "hide_read_aloud",                        :default => false
+    t.string   "font_size",                              :default => "normal"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -743,6 +744,7 @@ ActiveRecord::Schema.define(:version => 20230315103923) do
     t.boolean  "defunct",                                :default => false
     t.string   "migration_status",                       :default => "not_migrated"
     t.boolean  "hide_read_aloud",                        :default => false
+    t.string   "font_size",                              :default => "normal"
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"

--- a/spec/import_examples/valid_lightweight_activity_import_v2.json
+++ b/spec/import_examples/valid_lightweight_activity_import_v2.json
@@ -2,6 +2,7 @@
   "background_image": "",
   "defunct": false,
   "hide_read_aloud": true,
+  "font_size": "large",
   "description": "<p>Contains all page layout formats</p>",
   "editor_mode": 0,
   "id": 84,

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -4,7 +4,7 @@ describe LightweightActivity do
   let(:thumbnail_url) { "http://fake.url.com/image" }
   let(:author)        { FactoryGirl.create(:author) }
   let(:glossary)      { nil }
-  let(:act_opts)      { {thumbnail_url: thumbnail_url, glossary: glossary, hide_read_aloud: true} }
+  let(:act_opts)      { {thumbnail_url: thumbnail_url, glossary: glossary, hide_read_aloud: true, font_size: "large"} }
   let(:activity)      {
     activity = FactoryGirl.create(:activity, act_opts)
     activity.user = author
@@ -192,6 +192,7 @@ describe LightweightActivity do
         editor_mode: activity.editor_mode,
         runtime: "LARA",
         hide_read_aloud: activity.hide_read_aloud,
+        font_size: activity.font_size,
        }
       expect(activity.to_hash).to eq(expected)
     end
@@ -232,6 +233,9 @@ describe LightweightActivity do
       end
       it 'includes the hide_read_aloud setting' do
         expect(export["hide_read_aloud"]).to eq(true)
+      end
+      it 'includes the font_size setting' do
+        expect(export["font_size"]).to eq("large")
       end
 
       describe "for activity player activities" do
@@ -291,6 +295,7 @@ describe LightweightActivity do
       expect(activity.glossary_id).to eq(glossary.id)
       expect(dup.glossary_id).to eq(activity.glossary_id)
       expect(dup.hide_read_aloud).to eq(activity.hide_read_aloud)
+      expect(dup.font_size).to eq(activity.font_size)
     end
 
     describe 'describe copying the activities plugins' do
@@ -441,6 +446,7 @@ describe LightweightActivity do
       expect(act.pages.count).to eq(json[:pages].length)
       expect(act.glossary_id).to eq(nil)
       expect(act.hide_read_aloud).to eq(true)
+      expect(act.font_size).to eq("large")
     end
 
     describe "for activities that use the glossary model" do

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -246,7 +246,7 @@ describe Sequence do
   end
 
   describe '#to_hash' do
-    let(:sequence_opts) { {hide_read_aloud: true} }
+    let(:sequence_opts) { {hide_read_aloud: true, font_size: "large"} }
     it 'returns a hash with relevant values for sequence duplication' do
       expected = {
         title: sequence.title,
@@ -259,19 +259,21 @@ describe Sequence do
         display_title: sequence.display_title,
         thumbnail_url: sequence.thumbnail_url,
         runtime: "LARA",
-        hide_read_aloud: true
+        hide_read_aloud: true,
+        font_size: "large"
       }
       expect(sequence.to_hash).to eq(expected)
     end
   end
 
   describe '#export' do
-    let(:sequence_opts) { {hide_read_aloud: true} }
+    let(:sequence_opts) { {hide_read_aloud: true, font_size: "large"} }
     let(:host) { 'http://test.host' }
     it 'returns json of a sequence' do
       sequence_json = JSON.parse(sequence.export(host))
       expect(sequence_json['activities'].length).to eq(sequence.activities.count)
       expect(sequence_json['hide_read_aloud']).to eq(true)
+      expect(sequence_json['font_size']).to eq("large")
     end
 
     it 'does not include the fixed width layout option' do
@@ -300,7 +302,8 @@ describe Sequence do
     let(:thumbnail_url) { "https://concord.org/sunflower.jpg" }
     let(:title)         { "title" }
     let(:hide_read_aloud) { true }
-    let(:sequence_opts) { {logo: logo, thumbnail_url: thumbnail_url, title: title, hide_read_aloud: hide_read_aloud} }
+    let(:font_size) { "large" }
+    let(:sequence_opts) { {logo: logo, thumbnail_url: thumbnail_url, title: title, hide_read_aloud: hide_read_aloud, font_size: font_size} }
     let(:owner)         { FactoryGirl.create(:user) }
     let(:host)          { 'http://test.host' }
 
@@ -310,6 +313,7 @@ describe Sequence do
       expect(imported.thumbnail_url).to eq(thumbnail_url)
       expect(imported.logo).to eq(logo)
       expect(imported.hide_read_aloud).to eq(hide_read_aloud)
+      expect(imported.font_size).to eq(font_size)
     end
   end
   describe '#duplicate' do

--- a/spec/views/lightweight_activities/edit.html.haml_spec.rb
+++ b/spec/views/lightweight_activities/edit.html.haml_spec.rb
@@ -10,10 +10,13 @@ end
 def hide_read_aloud_checkbox
   '//*[@id="lightweight_activity_hide_read_aloud"]'
 end
+def font_size_select
+  '//*[@id="lightweight_activity_font_size"]'
+end
 
 describe "lightweight_activities/edit" do
 
-  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name', :defunct => false, :hide_read_aloud => false) }
+  let(:activity)  { stub_model(LightweightActivity, :id => 1, :name => 'Activity name', :defunct => false, :hide_read_aloud => false, :font_size => "normal") }
   let(:user)      { stub_model(User, :is_admin => false)      }
 
   before(:each) do
@@ -56,6 +59,24 @@ describe "lightweight_activities/edit" do
         it "should show the checkbox" do
           render
           expect(rendered).to have_xpath hide_read_aloud_checkbox
+        end
+      end
+    end
+
+    describe "font_size select" do
+      context "when the current user is an admin" do
+        let (:user) { stub_model(User, :is_admin => true)}
+        it "should show the select" do
+          render
+          expect(rendered).to have_xpath font_size_select
+        end
+      end
+
+      context "when the current user is not an admin" do
+        let (:user) { stub_model(User, :is_admin => false)}
+        it "should show the select" do
+          render
+          expect(rendered).to have_xpath font_size_select
         end
       end
     end

--- a/spec/views/sequences/edit.html.haml_spec.rb
+++ b/spec/views/sequences/edit.html.haml_spec.rb
@@ -22,6 +22,7 @@ describe "sequences/edit" do
         assert_select 'option'
       end
       assert_select "input#sequence_hide_read_aloud", :name => "sequence[hide_read_aloud]"
+      assert_select "select#sequence_font_size", :name => "sequence[font_size]"
     end
   end
 end


### PR DESCRIPTION
This adds a new module named Accessible that holds the font size settings, and possible future accessibility settings.

Note: the final placement of this setting in the edit forms is yet to be determined.