### PR TITLE
feat: Add accessibility object to initInterative message [PT-184987026]

### DIFF
--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -51,6 +51,12 @@ module InteractiveRunHelper
     data['interactive-name'] = interactive.name
     data['linked-interactives'] = interactive.linked_interactives_list.to_json
 
+    # default to normal size unless set in activity
+    data['font-size'] = 'normal'
+    if run && run.activity && run.activity.font_size
+      data['font-size'] = run.activity.font_size
+    end
+
     opts = {
       :src => interactive.url,
       :data => data,

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -182,6 +182,7 @@
 * [setOnUnload](globals.md#const-setonunload)
 * [setSupportedFeatures](globals.md#const-setsupportedfeatures)
 * [showModal](globals.md#const-showmodal)
+* [useAccessibility](globals.md#const-useaccessibility)
 * [useAuthoredState](globals.md#const-useauthoredstate)
 * [useAutoSetHeight](globals.md#const-useautosetheight)
 * [useCustomMessages](globals.md#const-usecustommessages)
@@ -191,6 +192,10 @@
 * [useInteractiveState](globals.md#const-useinteractivestate)
 * [useReportItem](globals.md#const-usereportitem)
 * [writeAttachment](globals.md#const-writeattachment)
+
+### Object literals
+
+* [DefaultAccessibilitySettings](globals.md#const-defaultaccessibilitysettings)
 
 ## Type aliases
 
@@ -1187,6 +1192,20 @@ Name | Type |
 
 ___
 
+### `Const` useAccessibility
+
+▸ **useAccessibility**(`props?`: undefined | object): *[IAccessibilitySettings](interfaces/iaccessibilitysettings.md)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`props?` | undefined &#124; object |
+
+**Returns:** *[IAccessibilitySettings](interfaces/iaccessibilitysettings.md)*
+
+___
+
 ### `Const` useAuthoredState
 
 ▸ **useAuthoredState**‹**AuthoredState**›(): *object*
@@ -1322,3 +1341,17 @@ Name | Type |
 `params` | [WriteAttachmentParams](globals.md#writeattachmentparams) |
 
 **Returns:** *Promise‹Response›*
+
+## Object literals
+
+### `Const` DefaultAccessibilitySettings
+
+### ▪ **DefaultAccessibilitySettings**: *object*
+
+###  fontSize
+
+• **fontSize**: *string* = "normal"
+
+###  fontSizeInPx
+
+• **fontSizeInPx**: *number* = 16

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -10,6 +10,7 @@
 
 ### Interfaces
 
+* [IAccessibilitySettings](interfaces/iaccessibilitysettings.md)
 * [IAddLinkedInteractiveStateListenerOptions](interfaces/iaddlinkedinteractivestatelisteneroptions.md)
 * [IAddLinkedInteractiveStateListenerRequest](interfaces/iaddlinkedinteractivestatelistenerrequest.md)
 * [IAttachmentInfo](interfaces/iattachmentinfo.md)

--- a/docs/interactive-api-client/interfaces/iaccessibilitysettings.md
+++ b/docs/interactive-api-client/interfaces/iaccessibilitysettings.md
@@ -1,0 +1,26 @@
+[@concord-consortium/lara-interactive-api](../README.md) › [Globals](../globals.md) › [IAccessibilitySettings](iaccessibilitysettings.md)
+
+# Interface: IAccessibilitySettings
+
+## Hierarchy
+
+* **IAccessibilitySettings**
+
+## Index
+
+### Properties
+
+* [fontSize](iaccessibilitysettings.md#fontsize)
+* [fontSizeInPx](iaccessibilitysettings.md#fontsizeinpx)
+
+## Properties
+
+###  fontSize
+
+• **fontSize**: *string*
+
+___
+
+###  fontSizeInPx
+
+• **fontSizeInPx**: *number*

--- a/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
@@ -20,6 +20,7 @@
 
 ### Properties
 
+* [accessibility](iruntimeinitinteractive.md#accessibility)
 * [activityName](iruntimeinitinteractive.md#optional-activityname)
 * [allLinkedStates](iruntimeinitinteractive.md#optional-alllinkedstates)
 * [attachments](iruntimeinitinteractive.md#optional-attachments)
@@ -47,6 +48,12 @@
 * [version](iruntimeinitinteractive.md#version)
 
 ## Properties
+
+###  accessibility
+
+• **accessibility**: *[IAccessibilitySettings](iaccessibilitysettings.md)*
+
+___
 
 ### `Optional` activityName
 

--- a/docs/interactive-api-host/globals.md
+++ b/docs/interactive-api-host/globals.md
@@ -6,6 +6,7 @@
 
 ### Interfaces
 
+* [IAccessibilitySettings](interfaces/iaccessibilitysettings.md)
 * [IAddLinkedInteractiveStateListenerOptions](interfaces/iaddlinkedinteractivestatelisteneroptions.md)
 * [IAddLinkedInteractiveStateListenerRequest](interfaces/iaddlinkedinteractivestatelistenerrequest.md)
 * [IAnswerMetadataWithAttachmentsInfo](interfaces/ianswermetadatawithattachmentsinfo.md)

--- a/docs/interactive-api-host/interfaces/iaccessibilitysettings.md
+++ b/docs/interactive-api-host/interfaces/iaccessibilitysettings.md
@@ -1,0 +1,26 @@
+[@concord-consortium/interactive-api-host](../README.md) › [Globals](../globals.md) › [IAccessibilitySettings](iaccessibilitysettings.md)
+
+# Interface: IAccessibilitySettings
+
+## Hierarchy
+
+* **IAccessibilitySettings**
+
+## Index
+
+### Properties
+
+* [fontSize](iaccessibilitysettings.md#fontsize)
+* [fontSizeInPx](iaccessibilitysettings.md#fontsizeinpx)
+
+## Properties
+
+###  fontSize
+
+• **fontSize**: *string*
+
+___
+
+###  fontSizeInPx
+
+• **fontSizeInPx**: *number*

--- a/docs/interactive-api-host/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-host/interfaces/iruntimeinitinteractive.md
@@ -20,6 +20,7 @@
 
 ### Properties
 
+* [accessibility](iruntimeinitinteractive.md#accessibility)
 * [activityName](iruntimeinitinteractive.md#optional-activityname)
 * [allLinkedStates](iruntimeinitinteractive.md#optional-alllinkedstates)
 * [attachments](iruntimeinitinteractive.md#optional-attachments)
@@ -47,6 +48,12 @@
 * [version](iruntimeinitinteractive.md#version)
 
 ## Properties
+
+###  accessibility
+
+• **accessibility**: *[IAccessibilitySettings](iaccessibilitysettings.md)*
+
+___
 
 ### `Optional` activityName
 

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import ResizeObserver from "resize-observer-polyfill";
 
 import { ICustomMessageHandler, ICustomMessagesHandledMap, IInitInteractive, ITextDecorationHandler,
-  IReportItemHandlerMetadata, IGetReportItemAnswerHandler } from "./types";
+  IReportItemHandlerMetadata, IGetReportItemAnswerHandler, IAccessibilitySettings } from "./types";
 import * as client from "./api";
 
 type UpdateFunc<S> = (prevState: S | null) => S;
@@ -175,4 +175,33 @@ export const useReportItem = <InteractiveState, AuthoredState>({ metadata, handl
 
     return () => client.removeGetReportItemAnswerListener();
   }, []);
+};
+
+export const DefaultAccessibilitySettings: IAccessibilitySettings = {
+  fontSize: "normal",
+  fontSizeInPx: 16
+};
+
+export const useAccessibility = (props?: {updateHtmlFontSize?: boolean}) => {
+  const {updateHtmlFontSize} = props || {};
+  const initMessage = useInitMessage();
+  const [accessibility, setAccessibility] = useState<IAccessibilitySettings>(DefaultAccessibilitySettings);
+
+  useEffect(() => {
+    if (initMessage && initMessage.mode === "runtime") {
+      const _accessibility = initMessage.accessibility || DefaultAccessibilitySettings;
+      const {fontSizeInPx} = _accessibility;
+
+      setAccessibility(_accessibility);
+
+      if (updateHtmlFontSize && (fontSizeInPx !== DefaultAccessibilitySettings.fontSizeInPx)) {
+        const html = document.getElementsByTagName("html").item(0);
+        if (html) {
+          html.style.fontSize = `${fontSizeInPx}px`;
+        }
+      }
+    }
+  }, [initMessage, updateHtmlFontSize]);
+
+  return accessibility;
 };

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -182,15 +182,15 @@ export const DefaultAccessibilitySettings: IAccessibilitySettings = {
   fontSizeInPx: 16
 };
 
-export const useAccessibility = (props?: {updateHtmlFontSize?: boolean}) => {
-  const {updateHtmlFontSize} = props || {};
+export const useAccessibility = (props?: {updateHtmlFontSize?: boolean, addBodyClass?: boolean}) => {
+  const {updateHtmlFontSize, addBodyClass} = props || {};
   const initMessage = useInitMessage();
   const [accessibility, setAccessibility] = useState<IAccessibilitySettings>(DefaultAccessibilitySettings);
 
   useEffect(() => {
     if (initMessage && initMessage.mode === "runtime") {
       const _accessibility = initMessage.accessibility || DefaultAccessibilitySettings;
-      const {fontSizeInPx} = _accessibility;
+      const {fontSize, fontSizeInPx} = _accessibility;
 
       setAccessibility(_accessibility);
 
@@ -198,6 +198,13 @@ export const useAccessibility = (props?: {updateHtmlFontSize?: boolean}) => {
         const html = document.getElementsByTagName("html").item(0);
         if (html) {
           html.style.fontSize = `${fontSizeInPx}px`;
+        }
+      }
+
+      if (addBodyClass) {
+        const body = document.getElementsByTagName("body").item(0);
+        if (body) {
+          body.classList.add(`font-size-${fontSize.toLowerCase().replace(/\s/, "-")}`);
         }
       }
     }

--- a/lara-typescript/src/interactive-api-client/package-lock.json
+++ b/lara-typescript/src/interactive-api-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.0",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lara-typescript/src/interactive-api-client/package-lock.json
+++ b/lara-typescript/src/interactive-api-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.7.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.0",
+  "version": "1.9.2",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/lara-typescript/src/interactive-api-lara-host/iframe-saver.spec.ts
+++ b/lara-typescript/src/interactive-api-lara-host/iframe-saver.spec.ts
@@ -74,6 +74,7 @@ describe("IFrameSaver", () => {
               data-user-email="user@example.com"
               data-loggedin="true"
               data-linked-interactives='{"1":{"label":"one"}}'
+              data-font-size="normal"
           >
           </div>
           <button class="delete_interactive_data">Clear & start over</button>
@@ -217,6 +218,10 @@ describe("IFrameSaver", () => {
               contentType: "text/plain",
             },
           },
+          accessibility: {
+            fontSize: "normal",
+            fontSizeInPx: 16,
+          },
         });
       });
 
@@ -265,7 +270,11 @@ describe("IFrameSaver", () => {
               colorB: "green"
             }
           },
-          attachments: {}
+          attachments: {},
+          accessibility: {
+            fontSize: "normal",
+            fontSizeInPx: 16,
+          }
         });
       });
     });

--- a/lara-typescript/src/interactive-api-lara-host/iframe-saver.ts
+++ b/lara-typescript/src/interactive-api-lara-host/iframe-saver.ts
@@ -10,6 +10,7 @@ import {
   INavigationOptions, initializeAttachmentsManager, ISupportedFeaturesRequest, ServerMessage
 } from "../interactive-api-host";
 import { answerMetadataToAttachmentInfoMap } from "../interactive-api-host/attachments-api/helpers";
+import { pxForFontSize } from "../shared/accessibility";
 
 // Shutterbug is imported globally and used by the old LARA JS code.
 const Shutterbug = (window as any).Shutterbug;
@@ -143,6 +144,7 @@ export class IFrameSaver {
   private metadata: object | undefined;
   private savedState: object | string | null;
   private autoSaveIntervalId: number | null;
+  private fontSize: string;
   private alreadySetup: boolean;
   private iframePhone: ParentEndpoint;
   private successCallback: SuccessCallback | null | undefined;
@@ -165,6 +167,7 @@ export class IFrameSaver {
     this.getFirebaseJWTUrl = $dataDiv.data("get-firebase-jwt-url");
     this.runKey = $dataDiv.data("run-key");
     this.runRemoteEndpoint = $dataDiv.data("run-remote-endpoint");
+    this.fontSize = $dataDiv.data("font-size");
     this.linkedInteractives = getLinkedInteractives($dataDiv);
 
     this.saveIndicator = SaveIndicator.instance();
@@ -547,7 +550,11 @@ export class IFrameSaver {
           colorB: "green"
         }
       },
-      attachments: answerMetadataToAttachmentInfoMap(this.metadata)
+      attachments: answerMetadataToAttachmentInfoMap(this.metadata),
+      accessibility: {
+        fontSize: this.fontSize,
+        fontSizeInPx: pxForFontSize(this.fontSize)
+      }
     };
 
     // Perhaps it would be nicer to keep `interactiveStateProps` in some separate property instead of mixing

--- a/lara-typescript/src/interactive-api-shared/types.ts
+++ b/lara-typescript/src/interactive-api-shared/types.ts
@@ -46,6 +46,11 @@ export interface IHostFeatures extends Record<string, IHostFeatureSupport | stri
   domain?: string;
 }
 
+export interface IAccessibilitySettings {
+  fontSize: string;
+  fontSizeInPx: number;
+}
+
 export interface IRuntimeInitInteractive<InteractiveState = {}, AuthoredState = {}, GlobalInteractiveState = {}>
        extends IInteractiveStateProps<InteractiveState> {
   version: 1;
@@ -70,6 +75,7 @@ export interface IRuntimeInitInteractive<InteractiveState = {}, AuthoredState = 
   linkedInteractives: ILinkedInteractive[];
   themeInfo: IThemeInfo;
   attachments?: AttachmentInfoMap;
+  accessibility: IAccessibilitySettings;
 }
 
 export interface IThemeInfo {

--- a/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import { InteractiveIframe } from "./interactive-iframe";
 import { IInitInteractive } from "../../../interactive-api-client";
+import { pxForFontSize } from "../../../shared/accessibility";
 
 export interface IPreviewInteractive {
   id: number;
@@ -11,6 +12,7 @@ export interface IPreviewInteractive {
   aspect_ratio_method: string;
   authored_state: string | object;
   linked_interactives: string | object;
+  font_size: string;
 }
 
 export interface IPreviewUser {
@@ -74,7 +76,11 @@ export const InteractiveAuthoringPreview: React.FC<Props> = ({interactive, user}
         colorB: "green"
       }
     },
-    attachments: {}
+    attachments: {},
+    accessibility: {
+      fontSize: interactive.font_size,
+      fontSizeInPx: pxForFontSize(interactive.font_size)
+    }
   };
 
   return (

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -145,6 +145,7 @@ export interface IManagedInteractiveData {
   showDeleteDataButton: boolean;
   showInFeaturedQuestionReport: boolean;
   urlFragment: string;
+  fontSize: string;
 }
 
 export interface IMWInteractiveData {
@@ -173,6 +174,7 @@ export interface IMWInteractiveData {
   showDeleteDataButton: boolean;
   showInFeaturedQuestionReport: boolean;
   url: string;
+  fontSize: string;
 }
 
 type IApprovedScript = any;

--- a/lara-typescript/src/section-authoring/components/managed-interactive-preview.tsx
+++ b/lara-typescript/src/section-authoring/components/managed-interactive-preview.tsx
@@ -16,7 +16,7 @@ export const ManagedInteractivePreview: React.FC<IManagedInteractivePreviewProps
 
   const {
     aspectRatio, authoredState, customAspectRatioMethod, id, interactiveItemId,
-    isHalfWidth, name, libraryInteractiveId, linkedInteractives, urlFragment
+    isHalfWidth, name, libraryInteractiveId, linkedInteractives, urlFragment, fontSize
   } = pageItem.data as IManagedInteractiveData;
   const { getLibraryInteractives } = usePageAPI();
 
@@ -34,7 +34,8 @@ export const ManagedInteractivePreview: React.FC<IManagedInteractivePreviewProps
     aspect_ratio_method: customAspectRatioMethod ? customAspectRatioMethod : "",
     authored_state: authoredState,
     interactive_item_id: interactiveItemId,
-    linked_interactives: linkedInteractives
+    linked_interactives: linkedInteractives,
+    font_size: fontSize
   };
 
   const wrapperClasses = classNames("managedInteractive", {

--- a/lara-typescript/src/section-authoring/components/mw-interactive-preview.tsx
+++ b/lara-typescript/src/section-authoring/components/mw-interactive-preview.tsx
@@ -14,7 +14,7 @@ export const MWInteractivePreview: React.FC<IMWInteractivePreviewProps> = ({
   }: IMWInteractivePreviewProps) => {
   const {
     aspectRatio, aspectRatioMethod, authoredState, id, interactiveItemId,
-    isHalfWidth, name, linkedInteractives, url
+    isHalfWidth, name, linkedInteractives, url, fontSize
    } = pageItem.data as IMWInteractiveData;
 
   const interactive = {
@@ -25,7 +25,8 @@ export const MWInteractivePreview: React.FC<IMWInteractivePreviewProps> = ({
     aspect_ratio_method: aspectRatioMethod,
     authored_state: authoredState,
     interactive_item_id: interactiveItemId,
-    linked_interactives: linkedInteractives
+    linked_interactives: linkedInteractives,
+    font_size: fontSize
   };
 
   const wrapperClasses = classNames("mwInteractive", {

--- a/lara-typescript/src/section-authoring/components/plugin-authoring.tsx
+++ b/lara-typescript/src/section-authoring/components/plugin-authoring.tsx
@@ -40,7 +40,8 @@ export const PluginAuthoring: React.FC<PluginAuthoringProps> = (
     aspect_ratio_method: wrappedItem?.data.customAspectRatioMethod ? wrappedItem?.data.customAspectRatioMethod : "",
     authored_state: wrappedItem?.data.authoredState,
     interactive_item_id: wrappedItem?.data.interactiveItemId,
-    linked_interactives: wrappedItem?.data.linkedInteractives
+    linked_interactives: wrappedItem?.data.linkedInteractives,
+    font_size: wrappedItem?.data.fontSize,
   } : undefined;
   const wrappedEmbeddable: IEmbeddableContextOptions | null = wrappedItem?.data && wrappedDiv.current !== null
     ?  {

--- a/lara-typescript/src/shared/accessibility.ts
+++ b/lara-typescript/src/shared/accessibility.ts
@@ -1,0 +1,6 @@
+export const pxForFontSize = (fontSize: string) => {
+  if (fontSize === "large") {
+    return 22;
+  }
+  return 16;
+};

--- a/public/example-interactives/attachments/index.js
+++ b/public/example-interactives/attachments/index.js
@@ -37047,7 +37047,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
+exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
@@ -37200,6 +37200,30 @@ var useReportItem = function (_a) {
     }, []);
 };
 exports.useReportItem = useReportItem;
+exports.DefaultAccessibilitySettings = {
+    fontSize: "normal",
+    fontSizeInPx: 16
+};
+var useAccessibility = function (props) {
+    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var initMessage = (0, exports.useInitMessage)();
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    (0, react_1.useEffect)(function () {
+        if (initMessage && initMessage.mode === "runtime") {
+            var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
+            var fontSizeInPx = _accessibility.fontSizeInPx;
+            setAccessibility(_accessibility);
+            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+                var html = document.getElementsByTagName("html").item(0);
+                if (html) {
+                    html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+        }
+    }, [initMessage, updateHtmlFontSize]);
+    return accessibility;
+};
+exports.useAccessibility = useAccessibility;
 
 
 /***/ }),

--- a/public/example-interactives/attachments/index.js
+++ b/public/example-interactives/attachments/index.js
@@ -37205,18 +37205,24 @@ exports.DefaultAccessibilitySettings = {
     fontSizeInPx: 16
 };
 var useAccessibility = function (props) {
-    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     (0, react_1.useEffect)(function () {
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
             setAccessibility(_accessibility);
             if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
                 var html = document.getElementsByTagName("html").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+            if (addBodyClass) {
+                var body = document.getElementsByTagName("body").item(0);
+                if (body) {
+                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
                 }
             }
         }

--- a/public/example-interactives/linked-state/index.js
+++ b/public/example-interactives/linked-state/index.js
@@ -33607,7 +33607,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
+exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
@@ -33760,6 +33760,30 @@ var useReportItem = function (_a) {
     }, []);
 };
 exports.useReportItem = useReportItem;
+exports.DefaultAccessibilitySettings = {
+    fontSize: "normal",
+    fontSizeInPx: 16
+};
+var useAccessibility = function (props) {
+    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var initMessage = (0, exports.useInitMessage)();
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    (0, react_1.useEffect)(function () {
+        if (initMessage && initMessage.mode === "runtime") {
+            var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
+            var fontSizeInPx = _accessibility.fontSizeInPx;
+            setAccessibility(_accessibility);
+            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+                var html = document.getElementsByTagName("html").item(0);
+                if (html) {
+                    html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+        }
+    }, [initMessage, updateHtmlFontSize]);
+    return accessibility;
+};
+exports.useAccessibility = useAccessibility;
 
 
 /***/ }),

--- a/public/example-interactives/linked-state/index.js
+++ b/public/example-interactives/linked-state/index.js
@@ -33765,18 +33765,24 @@ exports.DefaultAccessibilitySettings = {
     fontSizeInPx: 16
 };
 var useAccessibility = function (props) {
-    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     (0, react_1.useEffect)(function () {
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
             setAccessibility(_accessibility);
             if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
                 var html = document.getElementsByTagName("html").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+            if (addBodyClass) {
+                var body = document.getElementsByTagName("body").item(0);
+                if (body) {
+                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
                 }
             }
         }

--- a/public/example-interactives/report-item/index.js
+++ b/public/example-interactives/report-item/index.js
@@ -37030,18 +37030,24 @@ exports.DefaultAccessibilitySettings = {
     fontSizeInPx: 16
 };
 var useAccessibility = function (props) {
-    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     (0, react_1.useEffect)(function () {
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
             setAccessibility(_accessibility);
             if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
                 var html = document.getElementsByTagName("html").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+            if (addBodyClass) {
+                var body = document.getElementsByTagName("body").item(0);
+                if (body) {
+                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
                 }
             }
         }

--- a/public/example-interactives/report-item/index.js
+++ b/public/example-interactives/report-item/index.js
@@ -36872,7 +36872,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
+exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
@@ -37025,6 +37025,30 @@ var useReportItem = function (_a) {
     }, []);
 };
 exports.useReportItem = useReportItem;
+exports.DefaultAccessibilitySettings = {
+    fontSize: "normal",
+    fontSizeInPx: 16
+};
+var useAccessibility = function (props) {
+    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var initMessage = (0, exports.useInitMessage)();
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    (0, react_1.useEffect)(function () {
+        if (initMessage && initMessage.mode === "runtime") {
+            var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
+            var fontSizeInPx = _accessibility.fontSizeInPx;
+            setAccessibility(_accessibility);
+            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+                var html = document.getElementsByTagName("html").item(0);
+                if (html) {
+                    html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+        }
+    }, [initMessage, updateHtmlFontSize]);
+    return accessibility;
+};
+exports.useAccessibility = useAccessibility;
 
 
 /***/ }),

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -45840,18 +45840,24 @@ exports.DefaultAccessibilitySettings = {
     fontSizeInPx: 16
 };
 var useAccessibility = function (props) {
-    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     (0, react_1.useEffect)(function () {
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
             setAccessibility(_accessibility);
             if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
                 var html = document.getElementsByTagName("html").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+            if (addBodyClass) {
+                var body = document.getElementsByTagName("body").item(0);
+                if (body) {
+                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
                 }
             }
         }

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -45682,7 +45682,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
+exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useReportItem = exports.useAutoSetHeight = exports.useDecorateContent = exports.useCustomMessages = exports.useInitMessage = exports.useGlobalInteractiveState = exports.useAuthoredState = exports.useInteractiveState = void 0;
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
@@ -45835,6 +45835,30 @@ var useReportItem = function (_a) {
     }, []);
 };
 exports.useReportItem = useReportItem;
+exports.DefaultAccessibilitySettings = {
+    fontSize: "normal",
+    fontSizeInPx: 16
+};
+var useAccessibility = function (props) {
+    var updateHtmlFontSize = (props || {}).updateHtmlFontSize;
+    var initMessage = (0, exports.useInitMessage)();
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    (0, react_1.useEffect)(function () {
+        if (initMessage && initMessage.mode === "runtime") {
+            var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
+            var fontSizeInPx = _accessibility.fontSizeInPx;
+            setAccessibility(_accessibility);
+            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+                var html = document.getElementsByTagName("html").item(0);
+                if (html) {
+                    html.style.fontSize = fontSizeInPx + "px";
+                }
+            }
+        }
+    }, [initMessage, updateHtmlFontSize]);
+    return accessibility;
+};
+exports.useAccessibility = useAccessibility;
 
 
 /***/ }),


### PR DESCRIPTION
This adds an accessibility object to the initInteractive message that currently contains both the name of the required font size (normal or large) and the font size in pixels.

The two font settings allow interactives to either directly set the font size by value or use the font name in their css files.