### PR TITLE
fix: Added max section name display length [PT-185314409]

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -1981,7 +1981,7 @@ select {
   display: flex;
   align-items: center;
   margin: 0 10px;
-  min-width: 230px;
+  width: 230px;
 }
 .sectionMenu .menuStart .sectionName form {
   display: flex;
@@ -1995,6 +1995,8 @@ select {
   display: inline;
   margin: 0 5px 0 0;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .sectionMenu .menuStart .sectionName button {
   background: transparent;

--- a/lara-typescript/src/section-authoring/components/authoring-section.scss
+++ b/lara-typescript/src/section-authoring/components/authoring-section.scss
@@ -240,7 +240,7 @@ select {
       display: flex;
       align-items: center;
       margin: 0 10px;
-      min-width: 230px;
+      width: 230px;
 
       form {
         display: flex;
@@ -256,6 +256,8 @@ select {
         display: inline;
         margin: 0 5px 0 0;
         white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
       }
 
       button {


### PR DESCRIPTION
This fix changes the section name to have a constant width with hidden overflow with ellipsis for the name when it gets too long.