### PR TITLE
feat: force Rack:Cors to always return CORS headers [PT-185233166]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require_relative '../lib/middleware/inject_origin_header_middleware'
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
@@ -82,6 +83,10 @@ module LightweightStandalone
         resource '/image-proxy', :headers => :any, :methods => [:get, :options]
       end
     end
+
+    # Force Rack::Cors to always return Access-Control-Allow-Origin by injecting Origin header if it's missing.
+    # It's useful for image-proxy and image caching.
+    config.middleware.insert_before "Rack::Cors", InjectOriginHeaderMiddleware
 
     # Add a middlewere to log more info about the response
     config.middleware.insert_before 0, "Rack::ResponseLogger"

--- a/lib/middleware/inject_origin_header_middleware.rb
+++ b/lib/middleware/inject_origin_header_middleware.rb
@@ -1,0 +1,15 @@
+# See: https://github.com/cyu/rack-cors/issues/24#issuecomment-92228324
+# This is slightly modified version that sets origin to "*", so the response reuses it as
+# Access-Control-Allow-Origin value: `Access-Control-Allow-Origin: *`
+class InjectOriginHeaderMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    # Force rack-cors to always return Access-Control-Allow-Origin
+    # by always setting the "Origin:" header in the request
+    env['HTTP_ORIGIN'] ||= "*"
+    @app.call(env)
+  end
+end


### PR DESCRIPTION
I've tested that by making custom requests and it works. Origin header set in the request:
<img width="824" alt="Screenshot 2023-06-12 at 13 47 53" src="https://github.com/concord-consortium/lara/assets/767857/54ff1d66-852e-49bb-94f9-4a81d13be62f">
The provided origin is reused.

Origin header **not** set:
<img width="828" alt="Screenshot 2023-06-12 at 13 48 09" src="https://github.com/concord-consortium/lara/assets/767857/b8020393-5d82-441d-a01e-d446a7884ece">
`*` is used when Origin is not available.

The implementation is based on this suggestion:
https://github.com/cyu/rack-cors/issues/24#issuecomment-92228324
but I replaced "force-CORS" with "*", as it seemed to make more sense.

Also, note that now we don't follow the CORS specification. The official specs say that CORS headers should be returned when `Origin` header is provided. So, the previous behavior is theoretically correct.

I understand that it can cause caching issues. Apparently, we're not the only ones concerned about that:
https://github.com/cyu/rack-cors/issues/24#issuecomment-402538839

All this thread is worth reading. It's all been quite old, so I wonder if browsers don't handle that automatically if the web specs allow that to happen (eg re-requesting an image when CORS headers are necessary). I didn't try to investigate it too deeply (yet), as I could go out of my time box. :wink: But it doesn't seem that this PR would cause any issues either.