### PR TITLE
fix: Added modal title truncation [PT-185369384]

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -1337,7 +1337,11 @@
   font-weight: 700;
   line-height: 1;
   margin: 0;
-  padding: 0;
+  padding: 0 5px 0 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 5px;
 }
 .modalContainer .modalBody header .modalClose {
   align-self: center;

--- a/lara-typescript/src/shared/components/modal/modal.scss
+++ b/lara-typescript/src/shared/components/modal/modal.scss
@@ -50,7 +50,12 @@
         font-weight: 700;
         line-height: 1;
         margin: 0;
-        padding: 0;
+        // the rest of these rules allow long modal titles to be truncated with an ellipsis with padding between the close X
+        padding: 0 5px 0 0;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        padding-right: 5px;
       }
       .modalClose {
         align-self: center;
@@ -66,7 +71,7 @@
         text-indent: 100%;
         white-space: nowrap;
         width: 12px;
-      
+
         &:before {
           content: "\2716";
           cursor: pointer;


### PR DESCRIPTION
This truncates long modal titles so they don't overflow to the next line.