### PR TITLE
feat: Added mediaLibrary to initInteractiveMessage [PT-185394064]

### DIFF
--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -63,6 +63,8 @@
 * [ILibraryInteractiveListResponseItem](interfaces/ilibraryinteractivelistresponseitem.md)
 * [ILinkedInteractive](interfaces/ilinkedinteractive.md)
 * [ILinkedInteractiveStateResponse](interfaces/ilinkedinteractivestateresponse.md)
+* [IMediaLibrary](interfaces/imedialibrary.md)
+* [IMediaLibraryItem](interfaces/imedialibraryitem.md)
 * [INavigationOptions](interfaces/inavigationoptions.md)
 * [IPortalClaims](interfaces/iportalclaims.md)
 * [IRemoveLinkedInteractiveStateListenerRequest](interfaces/iremovelinkedinteractivestatelistenerrequest.md)
@@ -112,6 +114,7 @@
 * [ICustomMessagesHandledMap](globals.md#icustommessageshandledmap)
 * [IGetReportItemAnswerHandler](globals.md#igetreportitemanswerhandler)
 * [IInitInteractive](globals.md#iinitinteractive)
+* [IMediaLibraryItemType](globals.md#imedialibraryitemtype)
 * [IReportItemAnswerItem](globals.md#ireportitemansweritem)
 * [IReportItemClientMessage](globals.md#ireportitemclientmessage)
 * [IReportItemServerMessage](globals.md#ireportitemservermessage)
@@ -312,6 +315,16 @@ ___
 ###  IInitInteractive
 
 Ƭ **IInitInteractive**: *[IRuntimeInitInteractive](interfaces/iruntimeinitinteractive.md)‹InteractiveState, AuthoredState, GlobalInteractiveState› | [IAuthoringInitInteractive](interfaces/iauthoringinitinteractive.md)‹AuthoredState› | [IReportInitInteractive](interfaces/ireportinitinteractive.md)‹InteractiveState, AuthoredState› | [IReportItemInitInteractive](interfaces/ireportiteminitinteractive.md)‹InteractiveState, AuthoredState›*
+
+___
+
+###  IMediaLibraryItemType
+
+Ƭ **IMediaLibraryItemType**: *"image"*
+
+Type of the exported media library items found in the activity or sequence.  Initially this will just
+be "image" but could be extended in the future to "video" or "audio".  The exact mime type would be
+preferable but that is not always detectable from the exported media library urls.
 
 ___
 

--- a/docs/interactive-api-client/interfaces/imedialibrary.md
+++ b/docs/interactive-api-client/interfaces/imedialibrary.md
@@ -1,0 +1,28 @@
+[@concord-consortium/lara-interactive-api](../README.md) › [Globals](../globals.md) › [IMediaLibrary](imedialibrary.md)
+
+# Interface: IMediaLibrary
+
+Interface for the media library.
+
+## Hierarchy
+
+* **IMediaLibrary**
+
+## Index
+
+### Properties
+
+* [enabled](imedialibrary.md#enabled)
+* [items](imedialibrary.md#items)
+
+## Properties
+
+###  enabled
+
+• **enabled**: *boolean*
+
+___
+
+###  items
+
+• **items**: *[IMediaLibraryItem](imedialibraryitem.md)[]*

--- a/docs/interactive-api-client/interfaces/imedialibraryitem.md
+++ b/docs/interactive-api-client/interfaces/imedialibraryitem.md
@@ -1,0 +1,35 @@
+[@concord-consortium/lara-interactive-api](../README.md) › [Globals](../globals.md) › [IMediaLibraryItem](imedialibraryitem.md)
+
+# Interface: IMediaLibraryItem
+
+Interface for the exported media library items found in the activity or sequence.
+
+## Hierarchy
+
+* **IMediaLibraryItem**
+
+## Index
+
+### Properties
+
+* [caption](imedialibraryitem.md#optional-caption)
+* [type](imedialibraryitem.md#type)
+* [url](imedialibraryitem.md#url)
+
+## Properties
+
+### `Optional` caption
+
+• **caption**? : *undefined | string*
+
+___
+
+###  type
+
+• **type**: *[IMediaLibraryItemType](../globals.md#imedialibraryitemtype)*
+
+___
+
+###  url
+
+• **url**: *string*

--- a/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-client/interfaces/iruntimeinitinteractive.md
@@ -39,6 +39,7 @@
 * [interactiveStateUrl](iruntimeinitinteractive.md#interactivestateurl)
 * [linkedInteractives](iruntimeinitinteractive.md#linkedinteractives)
 * [linkedState](iruntimeinitinteractive.md#optional-linkedstate)
+* [mediaLibrary](iruntimeinitinteractive.md#medialibrary)
 * [mode](iruntimeinitinteractive.md#mode)
 * [pageName](iruntimeinitinteractive.md#optional-pagename)
 * [pageNumber](iruntimeinitinteractive.md#optional-pagenumber)
@@ -194,6 +195,12 @@ ___
 • **linkedState**? : *undefined | object*
 
 *Inherited from [IInteractiveStateProps](iinteractivestateprops.md).[linkedState](iinteractivestateprops.md#optional-linkedstate)*
+
+___
+
+###  mediaLibrary
+
+• **mediaLibrary**: *[IMediaLibrary](imedialibrary.md)*
 
 ___
 

--- a/docs/interactive-api-host/globals.md
+++ b/docs/interactive-api-host/globals.md
@@ -57,6 +57,8 @@
 * [ILibraryInteractiveListResponseItem](interfaces/ilibraryinteractivelistresponseitem.md)
 * [ILinkedInteractive](interfaces/ilinkedinteractive.md)
 * [ILinkedInteractiveStateResponse](interfaces/ilinkedinteractivestateresponse.md)
+* [IMediaLibrary](interfaces/imedialibrary.md)
+* [IMediaLibraryItem](interfaces/imedialibraryitem.md)
 * [INavigationOptions](interfaces/inavigationoptions.md)
 * [IPortalClaims](interfaces/iportalclaims.md)
 * [IReadableAttachmentInfo](interfaces/ireadableattachmentinfo.md)
@@ -102,6 +104,7 @@
 * [ICustomMessagesHandledMap](globals.md#icustommessageshandledmap)
 * [IGetReportItemAnswerHandler](globals.md#igetreportitemanswerhandler)
 * [IInitInteractive](globals.md#iinitinteractive)
+* [IMediaLibraryItemType](globals.md#imedialibraryitemtype)
 * [IReportItemAnswerItem](globals.md#ireportitemansweritem)
 * [IReportItemClientMessage](globals.md#ireportitemclientmessage)
 * [IReportItemServerMessage](globals.md#ireportitemservermessage)
@@ -236,6 +239,16 @@ ___
 ###  IInitInteractive
 
 Ƭ **IInitInteractive**: *[IRuntimeInitInteractive](interfaces/iruntimeinitinteractive.md)‹InteractiveState, AuthoredState, GlobalInteractiveState› | [IAuthoringInitInteractive](interfaces/iauthoringinitinteractive.md)‹AuthoredState› | [IReportInitInteractive](interfaces/ireportinitinteractive.md)‹InteractiveState, AuthoredState› | [IReportItemInitInteractive](interfaces/ireportiteminitinteractive.md)‹InteractiveState, AuthoredState›*
+
+___
+
+###  IMediaLibraryItemType
+
+Ƭ **IMediaLibraryItemType**: *"image"*
+
+Type of the exported media library items found in the activity or sequence.  Initially this will just
+be "image" but could be extended in the future to "video" or "audio".  The exact mime type would be
+preferable but that is not always detectable from the exported media library urls.
 
 ___
 

--- a/docs/interactive-api-host/interfaces/imedialibrary.md
+++ b/docs/interactive-api-host/interfaces/imedialibrary.md
@@ -1,0 +1,28 @@
+[@concord-consortium/interactive-api-host](../README.md) › [Globals](../globals.md) › [IMediaLibrary](imedialibrary.md)
+
+# Interface: IMediaLibrary
+
+Interface for the media library.
+
+## Hierarchy
+
+* **IMediaLibrary**
+
+## Index
+
+### Properties
+
+* [enabled](imedialibrary.md#enabled)
+* [items](imedialibrary.md#items)
+
+## Properties
+
+###  enabled
+
+• **enabled**: *boolean*
+
+___
+
+###  items
+
+• **items**: *[IMediaLibraryItem](imedialibraryitem.md)[]*

--- a/docs/interactive-api-host/interfaces/imedialibraryitem.md
+++ b/docs/interactive-api-host/interfaces/imedialibraryitem.md
@@ -1,0 +1,35 @@
+[@concord-consortium/interactive-api-host](../README.md) › [Globals](../globals.md) › [IMediaLibraryItem](imedialibraryitem.md)
+
+# Interface: IMediaLibraryItem
+
+Interface for the exported media library items found in the activity or sequence.
+
+## Hierarchy
+
+* **IMediaLibraryItem**
+
+## Index
+
+### Properties
+
+* [caption](imedialibraryitem.md#optional-caption)
+* [type](imedialibraryitem.md#type)
+* [url](imedialibraryitem.md#url)
+
+## Properties
+
+### `Optional` caption
+
+• **caption**? : *undefined | string*
+
+___
+
+###  type
+
+• **type**: *[IMediaLibraryItemType](../globals.md#imedialibraryitemtype)*
+
+___
+
+###  url
+
+• **url**: *string*

--- a/docs/interactive-api-host/interfaces/iruntimeinitinteractive.md
+++ b/docs/interactive-api-host/interfaces/iruntimeinitinteractive.md
@@ -39,6 +39,7 @@
 * [interactiveStateUrl](iruntimeinitinteractive.md#interactivestateurl)
 * [linkedInteractives](iruntimeinitinteractive.md#linkedinteractives)
 * [linkedState](iruntimeinitinteractive.md#optional-linkedstate)
+* [mediaLibrary](iruntimeinitinteractive.md#medialibrary)
 * [mode](iruntimeinitinteractive.md#mode)
 * [pageName](iruntimeinitinteractive.md#optional-pagename)
 * [pageNumber](iruntimeinitinteractive.md#optional-pagenumber)
@@ -194,6 +195,12 @@ ___
 • **linkedState**? : *undefined | object*
 
 *Inherited from [IInteractiveStateProps](iinteractivestateprops.md).[linkedState](iinteractivestateprops.md#optional-linkedstate)*
+
+___
+
+###  mediaLibrary
+
+• **mediaLibrary**: *[IMediaLibrary](imedialibrary.md)*
 
 ___
 

--- a/lara-typescript/src/interactive-api-client/package-lock.json
+++ b/lara-typescript/src/interactive-api-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.2",
+  "version": "1.9.3-pre.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.2",
+  "version": "1.9.3-pre.1",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/lara-typescript/src/interactive-api-lara-host/iframe-saver.spec.ts
+++ b/lara-typescript/src/interactive-api-lara-host/iframe-saver.spec.ts
@@ -222,6 +222,10 @@ describe("IFrameSaver", () => {
             fontSize: "normal",
             fontSizeInPx: 16,
           },
+          mediaLibrary: {
+            enabled: false,
+            items: []
+          },
         });
       });
 
@@ -274,7 +278,11 @@ describe("IFrameSaver", () => {
           accessibility: {
             fontSize: "normal",
             fontSizeInPx: 16,
-          }
+          },
+          mediaLibrary: {
+            enabled: false,
+            items: []
+          },
         });
       });
     });

--- a/lara-typescript/src/interactive-api-lara-host/iframe-saver.ts
+++ b/lara-typescript/src/interactive-api-lara-host/iframe-saver.ts
@@ -7,7 +7,7 @@ import {
   handleGetAttachmentUrl, ClientMessage, IAnswerMetadataWithAttachmentsInfo, IAttachmentUrlRequest, IGetAuthInfoRequest,
   IGetAuthInfoResponse, IGetFirebaseJwtRequest, IGetFirebaseJwtResponse, IGetInteractiveSnapshotRequest,
   IGetInteractiveSnapshotResponse, IHintRequest, IInitInteractive, IInteractiveStateProps, ILinkedInteractive,
-  INavigationOptions, initializeAttachmentsManager, ISupportedFeaturesRequest, ServerMessage
+  INavigationOptions, initializeAttachmentsManager, ISupportedFeaturesRequest, ServerMessage, IMediaLibrary
 } from "../interactive-api-host";
 import { answerMetadataToAttachmentInfoMap } from "../interactive-api-host/attachments-api/helpers";
 import { pxForFontSize } from "../shared/accessibility";
@@ -150,6 +150,7 @@ export class IFrameSaver {
   private successCallback: SuccessCallback | null | undefined;
   private plugins: IFrameSaverPluginApi[];
   private linkedInteractives: ILinkedInteractive[];
+  private mediaLibrary: IMediaLibrary;
 
   constructor($iframe: JQuery, $dataDiv: JQuery, $deleteButton: JQuery) {
     this.$iframe = $iframe;
@@ -169,6 +170,12 @@ export class IFrameSaver {
     this.runRemoteEndpoint = $dataDiv.data("run-remote-endpoint");
     this.fontSize = $dataDiv.data("font-size");
     this.linkedInteractives = getLinkedInteractives($dataDiv);
+
+    // the media library is not filled in by default by Lara, but is in AP
+    this.mediaLibrary = {
+      enabled: false,
+      items: []
+    };
 
     this.saveIndicator = SaveIndicator.instance();
 
@@ -554,7 +561,8 @@ export class IFrameSaver {
       accessibility: {
         fontSize: this.fontSize,
         fontSizeInPx: pxForFontSize(this.fontSize)
-      }
+      },
+      mediaLibrary: this.mediaLibrary,
     };
 
     // Perhaps it would be nicer to keep `interactiveStateProps` in some separate property instead of mixing

--- a/lara-typescript/src/interactive-api-shared/types.ts
+++ b/lara-typescript/src/interactive-api-shared/types.ts
@@ -76,6 +76,7 @@ export interface IRuntimeInitInteractive<InteractiveState = {}, AuthoredState = 
   themeInfo: IThemeInfo;
   attachments?: AttachmentInfoMap;
   accessibility: IAccessibilitySettings;
+  mediaLibrary: IMediaLibrary;
 }
 
 export interface IThemeInfo {
@@ -581,3 +582,27 @@ export interface IGetInteractiveState {
   unloading?: boolean;  // set to true to tell the interactive it is getting the final state
 }
 export type OnUnloadFunction<InteractiveState = {}> = (options: IGetInteractiveState) => Promise<InteractiveState>;
+
+/**
+ * Type of the exported media library items found in the activity or sequence.  Initially this will just
+ * be "image" but could be extended in the future to "video" or "audio".  The exact mime type would be
+ * preferable but that is not always detectable from the exported media library urls.
+ */
+export type IMediaLibraryItemType = "image";
+
+/**
+ * Interface for the exported media library items found in the activity or sequence.
+ */
+export interface IMediaLibraryItem {
+  url: string;
+  type: IMediaLibraryItemType;
+  caption?: string;
+}
+
+/**
+ * Interface for the media library.
+ */
+export interface IMediaLibrary {
+  enabled: boolean;
+  items: IMediaLibraryItem[];
+}

--- a/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
@@ -87,7 +87,11 @@ export const InteractiveAuthoringPreview: React.FC<Props> = ({interactive, user}
     accessibility: {
       fontSize,
       fontSizeInPx
-    }
+    },
+    mediaLibrary: {
+      enabled: false,
+      items: []
+    },
   };
 
   return (


### PR DESCRIPTION
This is not used by the old Lara iframe-saver code but is used by AP to gather up media library items and to pass them to interactives like the lab book for use as an image source.

NOTE: there is a chore in the notebook epic to do the final release, this commit uses a pre-release version.