### PR TITLE
feat: Add setting for override activity layout in sequences [PT-185316649]

### DIFF
--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -12,6 +12,13 @@ class LightweightActivity < ActiveRecord::Base
     ['Single-page', LAYOUT_SINGLE_PAGE],
     ['Notebook', LAYOUT_NOTEBOOK]
   ]
+  # the override uses 0 as no override and then the rest of the layout options as 1-based
+  LAYOUT_OVERRIDE_OPTIONS = [
+    ['None', 0],
+    ['Multi-page', LAYOUT_MULTI_PAGE + 1],
+    ['Single-page', LAYOUT_SINGLE_PAGE + 1],
+    ['Notebook', LAYOUT_NOTEBOOK + 1]
+  ]
   STANDARD_EDITOR_MODE = 0
   ITSI_EDITOR_MODE = 1
   EDITOR_MODE_OPTIONS = [

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -2,7 +2,7 @@ class Sequence < ActiveRecord::Base
 
   attr_accessible :description, :title, :project_id, :defunct,
     :user_id, :logo, :display_title, :thumbnail_url, :abstract, :publication_hash,
-    :project, :background_image, :hide_read_aloud, :font_size
+    :project, :background_image, :hide_read_aloud, :font_size, :layout_override
 
   include Publishable # defines methods to publish to portals
   include PublicationStatus # defines publication status scopes and helpers
@@ -57,7 +57,8 @@ class Sequence < ActiveRecord::Base
       display_title: display_title,
       thumbnail_url: thumbnail_url,
       hide_read_aloud: hide_read_aloud,
-      font_size: font_size
+      font_size: font_size,
+      layout_override: layout_override
     }
   end
 
@@ -103,7 +104,8 @@ class Sequence < ActiveRecord::Base
                                         :background_image,
                                         :defunct,
                                         :hide_read_aloud,
-                                        :font_size
+                                        :font_size,
+                                        :layout_override
     ])
     sequence_json[:project] = self.project ? self.project.export : nil
     sequence_json[:activities] = []
@@ -214,7 +216,8 @@ class Sequence < ActiveRecord::Base
       title: sequence_json_object[:title],
       background_image: sequence_json_object[:background_image],
       hide_read_aloud: sequence_json_object[:hide_read_aloud],
-      font_size: sequence_json_object[:font_size]
+      font_size: sequence_json_object[:font_size],
+      layout_override: sequence_json_object[:layout_override]
     }
 
   end

--- a/app/views/sequences/_form.html.haml
+++ b/app/views/sequences/_form.html.haml
@@ -28,6 +28,9 @@
       = f.label :hide_read_aloud,  "Hide Read-Aloud Toggle"
       .hint Check this box if you do not want the "Tap text to listen" toggle to appear on activities in this sequence.
     .field
+      = f.label :layout_override, "Activity Layout Override"
+      = f.select :layout_override, options_for_select(LightweightActivity::LAYOUT_OVERRIDE_OPTIONS, @sequence.layout_override)
+    .field
       = f.label :fixed_width_layout, 'Activity Page Fixed Width'
       = f.select :fixed_width_layout, options_for_select(LightweightActivity::FIXED_WIDTH_LAYOUT_OPTIONS, @sequence.fixed_width_layout)
       .hint This will override the "Activity Page Fixed Width" setting for any activities in this sequence.

--- a/db/migrate/20230614193153_add_sequence_layout_override.rb
+++ b/db/migrate/20230614193153_add_sequence_layout_override.rb
@@ -1,0 +1,5 @@
+class AddSequenceLayoutOverride < ActiveRecord::Migration
+  def change
+    add_column :sequences, :layout_override, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20230601143258) do
+ActiveRecord::Schema.define(:version => 20230614193153) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -739,6 +739,7 @@ ActiveRecord::Schema.define(:version => 20230601143258) do
     t.string   "migration_status",                       :default => "not_migrated"
     t.boolean  "hide_read_aloud",                        :default => false
     t.string   "font_size",                              :default => "normal"
+    t.integer  "layout_override",                        :default => 0
   end
 
   add_index "sequences", ["project_id"], :name => "index_sequences_on_project_id"

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -195,7 +195,7 @@ describe Sequence do
   end
 
   describe '#to_hash' do
-    let(:sequence_opts) { {hide_read_aloud: true, font_size: "large"} }
+    let(:sequence_opts) { {hide_read_aloud: true, font_size: "large", layout_override: 2} }
     it 'returns a hash with relevant values for sequence duplication' do
       expected = {
         title: sequence.title,
@@ -207,20 +207,22 @@ describe Sequence do
         display_title: sequence.display_title,
         thumbnail_url: sequence.thumbnail_url,
         hide_read_aloud: true,
-        font_size: "large"
+        font_size: "large",
+        layout_override: 2,
       }
       expect(sequence.to_hash).to eq(expected)
     end
   end
 
   describe '#export' do
-    let(:sequence_opts) { {hide_read_aloud: true, font_size: "large"} }
+    let(:sequence_opts) { {hide_read_aloud: true, font_size: "large", layout_override: 2} }
     let(:host) { 'http://test.host' }
     it 'returns json of a sequence' do
       sequence_json = JSON.parse(sequence.export(host))
       expect(sequence_json['activities'].length).to eq(sequence.activities.count)
       expect(sequence_json['hide_read_aloud']).to eq(true)
       expect(sequence_json['font_size']).to eq("large")
+      expect(sequence_json['layout_override']).to eq(2)
     end
 
     it 'includes the fixed width layout option' do
@@ -250,7 +252,8 @@ describe Sequence do
     let(:title)         { "title" }
     let(:hide_read_aloud) { true }
     let(:font_size) { "large" }
-    let(:sequence_opts) { {logo: logo, thumbnail_url: thumbnail_url, title: title, hide_read_aloud: hide_read_aloud, font_size: font_size} }
+    let(:layout_override) { 2 }
+    let(:sequence_opts) { {logo: logo, thumbnail_url: thumbnail_url, title: title, hide_read_aloud: hide_read_aloud, font_size: font_size, layout_override: layout_override} }
     let(:owner)         { FactoryGirl.create(:user) }
     let(:host)          { 'http://test.host' }
 
@@ -261,6 +264,7 @@ describe Sequence do
       expect(imported.logo).to eq(logo)
       expect(imported.hide_read_aloud).to eq(hide_read_aloud)
       expect(imported.font_size).to eq(font_size)
+      expect(imported.layout_override).to eq(layout_override)
     end
   end
   describe '#duplicate' do


### PR DESCRIPTION
This adds a layout override option to sequences.  The default 0 value means no override and the existing layouts option values are shifted up by 1.