### PR TITLE
feat: Added font type to accessibility [PT-185336244]

### DIFF
--- a/app/helpers/interactive_run_helper.rb
+++ b/app/helpers/interactive_run_helper.rb
@@ -57,6 +57,12 @@ module InteractiveRunHelper
       data['font-size'] = run.activity.font_size
     end
 
+    # (for now) the font type is implied by the layout and not set directly on the interactive
+    data['font-type'] = 'normal'
+    if run && run.activity && run.activity.layout == LightweightActivity::LAYOUT_NOTEBOOK
+      data['font-type'] = 'notebook'
+    end
+
     opts = {
       :src => interactive.url,
       :data => data,

--- a/docs/interactive-api-client/globals.md
+++ b/docs/interactive-api-client/globals.md
@@ -93,6 +93,7 @@
 * [ITextDecorationHandlerInfo](interfaces/itextdecorationhandlerinfo.md)
 * [ITextDecorationInfo](interfaces/itextdecorationinfo.md)
 * [IThemeInfo](interfaces/ithemeinfo.md)
+* [IUseAccessibilityProps](interfaces/iuseaccessibilityprops.md)
 * [IUseReportItemOptions](interfaces/iusereportitemoptions.md)
 * [IWriteAttachmentRequest](interfaces/iwriteattachmentrequest.md)
 
@@ -1207,13 +1208,13 @@ ___
 
 ### `Const` useAccessibility
 
-▸ **useAccessibility**(`props?`: undefined | object): *[IAccessibilitySettings](interfaces/iaccessibilitysettings.md)*
+▸ **useAccessibility**(`props?`: [IUseAccessibilityProps](interfaces/iuseaccessibilityprops.md)): *[IAccessibilitySettings](interfaces/iaccessibilitysettings.md)*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`props?` | undefined &#124; object |
+`props?` | [IUseAccessibilityProps](interfaces/iuseaccessibilityprops.md) |
 
 **Returns:** *[IAccessibilitySettings](interfaces/iaccessibilitysettings.md)*
 
@@ -1361,6 +1362,10 @@ Name | Type |
 
 ### ▪ **DefaultAccessibilitySettings**: *object*
 
+###  fontFamilyForType
+
+• **fontFamilyForType**: *string* = getFamilyForFontType("normal")
+
 ###  fontSize
 
 • **fontSize**: *string* = "normal"
@@ -1368,3 +1373,7 @@ Name | Type |
 ###  fontSizeInPx
 
 • **fontSizeInPx**: *number* = 16
+
+###  fontType
+
+• **fontType**: *string* = "normal"

--- a/docs/interactive-api-client/interfaces/iaccessibilitysettings.md
+++ b/docs/interactive-api-client/interfaces/iaccessibilitysettings.md
@@ -10,10 +10,18 @@
 
 ### Properties
 
+* [fontFamilyForType](iaccessibilitysettings.md#fontfamilyfortype)
 * [fontSize](iaccessibilitysettings.md#fontsize)
 * [fontSizeInPx](iaccessibilitysettings.md#fontsizeinpx)
+* [fontType](iaccessibilitysettings.md#fonttype)
 
 ## Properties
+
+###  fontFamilyForType
+
+• **fontFamilyForType**: *string*
+
+___
 
 ###  fontSize
 
@@ -24,3 +32,9 @@ ___
 ###  fontSizeInPx
 
 • **fontSizeInPx**: *number*
+
+___
+
+###  fontType
+
+• **fontType**: *string*

--- a/docs/interactive-api-client/interfaces/iuseaccessibilityprops.md
+++ b/docs/interactive-api-client/interfaces/iuseaccessibilityprops.md
@@ -1,0 +1,19 @@
+[@concord-consortium/lara-interactive-api](../README.md) › [Globals](../globals.md) › [IUseAccessibilityProps](iuseaccessibilityprops.md)
+
+# Interface: IUseAccessibilityProps
+
+## Hierarchy
+
+* **IUseAccessibilityProps**
+
+## Index
+
+### Properties
+
+* [updateDOM](iuseaccessibilityprops.md#optional-updatedom)
+
+## Properties
+
+### `Optional` updateDOM
+
+• **updateDOM**? : *undefined | object*

--- a/docs/interactive-api-client/interfaces/iuseaccessibilityprops.md
+++ b/docs/interactive-api-client/interfaces/iuseaccessibilityprops.md
@@ -10,10 +10,24 @@
 
 ### Properties
 
-* [updateDOM](iuseaccessibilityprops.md#optional-updatedom)
+* [addBodyClass](iuseaccessibilityprops.md#optional-addbodyclass)
+* [fontFamilySelector](iuseaccessibilityprops.md#optional-fontfamilyselector)
+* [updateHtmlFontSize](iuseaccessibilityprops.md#optional-updatehtmlfontsize)
 
 ## Properties
 
-### `Optional` updateDOM
+### `Optional` addBodyClass
 
-• **updateDOM**? : *undefined | object*
+• **addBodyClass**? : *undefined | false | true*
+
+___
+
+### `Optional` fontFamilySelector
+
+• **fontFamilySelector**? : *undefined | string*
+
+___
+
+### `Optional` updateHtmlFontSize
+
+• **updateHtmlFontSize**? : *undefined | false | true*

--- a/docs/interactive-api-host/interfaces/iaccessibilitysettings.md
+++ b/docs/interactive-api-host/interfaces/iaccessibilitysettings.md
@@ -10,10 +10,18 @@
 
 ### Properties
 
+* [fontFamilyForType](iaccessibilitysettings.md#fontfamilyfortype)
 * [fontSize](iaccessibilitysettings.md#fontsize)
 * [fontSizeInPx](iaccessibilitysettings.md#fontsizeinpx)
+* [fontType](iaccessibilitysettings.md#fonttype)
 
 ## Properties
+
+###  fontFamilyForType
+
+• **fontFamilyForType**: *string*
+
+___
 
 ###  fontSize
 
@@ -24,3 +32,9 @@ ___
 ###  fontSizeInPx
 
 • **fontSizeInPx**: *number*
+
+___
+
+###  fontType
+
+• **fontType**: *string*

--- a/lara-typescript/src/interactive-api-client/hooks.spec.tsx
+++ b/lara-typescript/src/interactive-api-client/hooks.spec.tsx
@@ -324,23 +324,24 @@ describe("useAccessibility", () => {
       });
     }, 10);
 
-    // html and body should not have font updates yet
+    // the DOM should not have font updates yet
     const beforeHtml = document.getElementsByTagName("html").item(0);
     const beforeBody = document.getElementsByTagName("body").item(0);
+    const beforeStyle = document.getElementsByTagName("style").item(0);
     expect(beforeHtml?.style.getPropertyValue("font-size")).toEqual("");
-    // TODO: update test
-    // expect(beforeBody?.style.getPropertyValue("font-family")).toEqual("");
+    expect(beforeStyle).toEqual(null);
     expect(beforeBody?.classList.toString()).toBe("");
 
     await waitForNextUpdate();
     expect(result.current).toEqual(accessibility);
 
-    // html and body should now have font updates
+    // the DOM should now have font updates
     const afterHtml = document.getElementsByTagName("html").item(0);
     const afterBody = document.getElementsByTagName("body").item(0);
+    const afterStyle = document.getElementsByTagName("style").item(0);
     expect(afterHtml?.style.getPropertyValue("font-size")).toEqual("22px");
-    // TODO: update test
-    // expect(afterBody?.style.getPropertyValue("font-family")).toEqual("test-font-family, fallback-font-family");
+    expect((afterStyle?.sheet?.cssRules[0] as any).selectorText).toEqual("body");
+    expect((afterStyle?.sheet?.cssRules[0] as any).style["font-family"]).toEqual("test-font-family, fallback-font-family");
     expect(afterBody?.classList.toString()).toBe("font-size-large font-type-notebook");
   });
 });

--- a/lara-typescript/src/interactive-api-client/hooks.spec.tsx
+++ b/lara-typescript/src/interactive-api-client/hooks.spec.tsx
@@ -6,6 +6,7 @@ import * as hooks from "./hooks";
 import * as iframePhone from "iframe-phone";
 import { getClient } from "./client";
 import { IAccessibilitySettings } from "./types";
+import { getFamilyForFontType } from "../shared/accessibility";
 
 jest.mock("./in-frame", () => ({
   inIframe: () => true
@@ -303,13 +304,17 @@ describe("useAccessibility", () => {
   it("returns the accessibility settings from the initMessage", async () => {
     const accessibility: IAccessibilitySettings = {
       fontSize: "large",
-      fontSizeInPx: 22
+      fontSizeInPx: 22,
+      fontType: "notebook",
+      fontFamilyForType: "test-font-family, fallback-font-family"
     };
 
     const { waitForNextUpdate } = renderHook(() => hooks.useInitMessage());
     const { result } = renderHook(() => hooks.useAccessibility({
-      updateHtmlFontSize: true,
-      addBodyClass: true,
+      updateDOM: {
+        enabled: true,
+        fontFamilySelector: "body",
+      },
     }));
 
     setTimeout(() => {
@@ -320,15 +325,22 @@ describe("useAccessibility", () => {
     }, 10);
 
     // html and body should not have font updates yet
-    expect(document.getElementsByTagName("html").item(0)?.style.getPropertyValue("font-size")).toEqual("");
-    expect(document.getElementsByTagName("body").item(0)?.classList.toString()).toBe("");
+    const beforeHtml = document.getElementsByTagName("html").item(0);
+    const beforeBody = document.getElementsByTagName("body").item(0);
+    expect(beforeHtml?.style.getPropertyValue("font-size")).toEqual("");
+    // TODO: update test
+    // expect(beforeBody?.style.getPropertyValue("font-family")).toEqual("");
+    expect(beforeBody?.classList.toString()).toBe("");
 
     await waitForNextUpdate();
     expect(result.current).toEqual(accessibility);
 
     // html and body should now have font updates
-    expect(document.getElementsByTagName("html").item(0)?.style.getPropertyValue("font-size")).toEqual("22px");
-    expect(document.getElementsByTagName("body").item(0)?.classList.toString()).toBe("font-size-large");
-
+    const afterHtml = document.getElementsByTagName("html").item(0);
+    const afterBody = document.getElementsByTagName("body").item(0);
+    expect(afterHtml?.style.getPropertyValue("font-size")).toEqual("22px");
+    // TODO: update test
+    // expect(afterBody?.style.getPropertyValue("font-family")).toEqual("test-font-family, fallback-font-family");
+    expect(afterBody?.classList.toString()).toBe("font-size-large font-type-notebook");
   });
 });

--- a/lara-typescript/src/interactive-api-client/hooks.spec.tsx
+++ b/lara-typescript/src/interactive-api-client/hooks.spec.tsx
@@ -311,10 +311,9 @@ describe("useAccessibility", () => {
 
     const { waitForNextUpdate } = renderHook(() => hooks.useInitMessage());
     const { result } = renderHook(() => hooks.useAccessibility({
-      updateDOM: {
-        enabled: true,
-        fontFamilySelector: "body",
-      },
+      updateHtmlFontSize: true,
+      addBodyClass: true,
+      fontFamilySelector: "body",
     }));
 
     setTimeout(() => {
@@ -329,8 +328,8 @@ describe("useAccessibility", () => {
     const beforeBody = document.getElementsByTagName("body").item(0);
     const beforeStyle = document.getElementsByTagName("style").item(0);
     expect(beforeHtml?.style.getPropertyValue("font-size")).toEqual("");
-    expect(beforeStyle).toEqual(null);
     expect(beforeBody?.classList.toString()).toBe("");
+    expect(beforeStyle).toEqual(null);
 
     await waitForNextUpdate();
     expect(result.current).toEqual(accessibility);
@@ -340,8 +339,8 @@ describe("useAccessibility", () => {
     const afterBody = document.getElementsByTagName("body").item(0);
     const afterStyle = document.getElementsByTagName("style").item(0);
     expect(afterHtml?.style.getPropertyValue("font-size")).toEqual("22px");
-    expect((afterStyle?.sheet?.cssRules[0] as any).selectorText).toEqual("body");
-    expect((afterStyle?.sheet?.cssRules[0] as any).style["font-family"]).toEqual("test-font-family, fallback-font-family");
     expect(afterBody?.classList.toString()).toBe("font-size-large font-type-notebook");
+    expect((afterStyle?.sheet?.cssRules[0] as CSSPageRule).selectorText).toEqual("body");
+    expect((afterStyle?.sheet?.cssRules[0] as CSSPageRule).style["font-family" as any]).toEqual("test-font-family, fallback-font-family");
   });
 });

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -186,14 +186,13 @@ export const DefaultAccessibilitySettings: IAccessibilitySettings = {
 };
 
 export interface IUseAccessibilityProps {
-  updateDOM?: {
-    enabled: boolean;
-    fontFamilySelector?: string;
-  };
+  updateHtmlFontSize?: boolean;
+  addBodyClass?: boolean;
+  fontFamilySelector?: string;
 }
 
 export const useAccessibility = (props?: IUseAccessibilityProps) => {
-  const {updateDOM} = props || {};
+  const {updateHtmlFontSize, addBodyClass, fontFamilySelector} = props || {};
   const initMessage = useInitMessage();
   const [accessibility, setAccessibility] = useState<IAccessibilitySettings>(DefaultAccessibilitySettings);
 
@@ -206,15 +205,14 @@ export const useAccessibility = (props?: IUseAccessibilityProps) => {
 
       setAccessibility(_accessibility);
 
-      if (updateDOM) {
-        const { fontFamilySelector } = updateDOM;
+      if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
         const html = document.getElementsByTagName("html").item(0);
         const body = document.getElementsByTagName("body").item(0);
 
-        if (html) {
+        if (updateHtmlFontSize && html) {
           html.style.fontSize = `${fontSizeInPx}px`;
         }
-        if (body) {
+        if (addBodyClass && body) {
           body.classList.add(`font-size-${normalizeClass(fontSize)}`);
           body.classList.add(`font-type-${normalizeClass(fontType)}`);
         }
@@ -226,7 +224,7 @@ export const useAccessibility = (props?: IUseAccessibilityProps) => {
         }
       }
     }
-  }, [initMessage, updateDOM]);
+  }, [initMessage, updateHtmlFontSize, addBodyClass, fontFamilySelector]);
 
   return accessibility;
 };

--- a/lara-typescript/src/interactive-api-client/hooks.ts
+++ b/lara-typescript/src/interactive-api-client/hooks.ts
@@ -196,7 +196,8 @@ export const useAccessibility = (props?: IUseAccessibilityProps) => {
   const initMessage = useInitMessage();
   const [accessibility, setAccessibility] = useState<IAccessibilitySettings>(DefaultAccessibilitySettings);
 
-  const normalizeClass = (text: string) => text.toLowerCase().replace(/\s/, "-");
+  // text may be optional while font type setting is rolled out from staging to production through AP
+  const normalizeClass = (text?: string) => (text || "").toLowerCase().replace(/\s/, "-");
 
   useEffect(() => {
     if (initMessage && initMessage.mode === "runtime") {
@@ -209,7 +210,7 @@ export const useAccessibility = (props?: IUseAccessibilityProps) => {
         const html = document.getElementsByTagName("html").item(0);
         const body = document.getElementsByTagName("body").item(0);
 
-        if (updateHtmlFontSize && html) {
+        if (updateHtmlFontSize && html && fontSizeInPx) {
           html.style.fontSize = `${fontSizeInPx}px`;
         }
         if (addBodyClass && body) {
@@ -217,7 +218,7 @@ export const useAccessibility = (props?: IUseAccessibilityProps) => {
           body.classList.add(`font-type-${normalizeClass(fontType)}`);
         }
 
-        if (fontFamilySelector) {
+        if (fontFamilySelector && fontFamilyForType) {
           const style = document.createElement("style");
           document.head.appendChild(style);
           style.sheet?.insertRule(`${fontFamilySelector} { font-family: ${fontFamilyForType}; }`, 0);

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.3-pre.6",
+  "version": "1.9.3-pre.7",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.3-pre.1",
+  "version": "1.9.3-pre.5",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.3-pre.5",
+  "version": "1.9.3-pre.6",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/lara-typescript/src/interactive-api-lara-host/iframe-saver.spec.ts
+++ b/lara-typescript/src/interactive-api-lara-host/iframe-saver.spec.ts
@@ -221,6 +221,8 @@ describe("IFrameSaver", () => {
           accessibility: {
             fontSize: "normal",
             fontSizeInPx: 16,
+            fontType: "normal",
+            fontFamilyForType: "'Lato', arial, helvetica, sans-serif;",
           },
           mediaLibrary: {
             enabled: false,
@@ -278,6 +280,8 @@ describe("IFrameSaver", () => {
           accessibility: {
             fontSize: "normal",
             fontSizeInPx: 16,
+            fontType: "normal",
+            fontFamilyForType: "'Lato', arial, helvetica, sans-serif;",
           },
           mediaLibrary: {
             enabled: false,

--- a/lara-typescript/src/interactive-api-lara-host/iframe-saver.ts
+++ b/lara-typescript/src/interactive-api-lara-host/iframe-saver.ts
@@ -10,7 +10,7 @@ import {
   INavigationOptions, initializeAttachmentsManager, ISupportedFeaturesRequest, ServerMessage, IMediaLibrary
 } from "../interactive-api-host";
 import { answerMetadataToAttachmentInfoMap } from "../interactive-api-host/attachments-api/helpers";
-import { pxForFontSize } from "../shared/accessibility";
+import { getFamilyForFontType, pxForFontSize } from "../shared/accessibility";
 
 // Shutterbug is imported globally and used by the old LARA JS code.
 const Shutterbug = (window as any).Shutterbug;
@@ -560,7 +560,9 @@ export class IFrameSaver {
       attachments: answerMetadataToAttachmentInfoMap(this.metadata),
       accessibility: {
         fontSize: this.fontSize,
-        fontSizeInPx: pxForFontSize(this.fontSize)
+        fontSizeInPx: pxForFontSize(this.fontSize),
+        fontType: "normal",
+        fontFamilyForType: getFamilyForFontType("normal"),
       },
       mediaLibrary: this.mediaLibrary,
     };

--- a/lara-typescript/src/interactive-api-shared/types.ts
+++ b/lara-typescript/src/interactive-api-shared/types.ts
@@ -49,6 +49,8 @@ export interface IHostFeatures extends Record<string, IHostFeatureSupport | stri
 export interface IAccessibilitySettings {
   fontSize: string;
   fontSizeInPx: number;
+  fontType: string;
+  fontFamilyForType: string;
 }
 
 export interface IRuntimeInitInteractive<InteractiveState = {}, AuthoredState = {}, GlobalInteractiveState = {}>

--- a/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
+++ b/lara-typescript/src/page-item-authoring/common/components/interactive-authoring-preview.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import { InteractiveIframe } from "./interactive-iframe";
 import { DefaultAccessibilitySettings, IInitInteractive } from "../../../interactive-api-client";
-import { pxForFontSize } from "../../../shared/accessibility";
+import { getFamilyForFontType, pxForFontSize } from "../../../shared/accessibility";
 
 export interface IPreviewInteractive {
   id: number;
@@ -13,6 +13,7 @@ export interface IPreviewInteractive {
   authored_state: string | object;
   linked_interactives: string | object;
   font_size: string;
+  font_type: string;
 }
 
 export interface IPreviewUser {
@@ -51,6 +52,8 @@ export const InteractiveAuthoringPreview: React.FC<Props> = ({interactive, user}
   // does not need to be tested for the large font setting.
   const fontSize = interactive.font_size || DefaultAccessibilitySettings.fontSize;
   const fontSizeInPx = pxForFontSize(fontSize);
+  const fontType = interactive.font_type || DefaultAccessibilitySettings.fontType;
+  const fontFamilyForType = getFamilyForFontType(fontType);
 
   const initMsg: IInitInteractive = {
     version: 1,
@@ -86,7 +89,9 @@ export const InteractiveAuthoringPreview: React.FC<Props> = ({interactive, user}
     attachments: {},
     accessibility: {
       fontSize,
-      fontSizeInPx
+      fontSizeInPx,
+      fontType,
+      fontFamilyForType
     },
     mediaLibrary: {
       enabled: false,

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -146,6 +146,7 @@ export interface IManagedInteractiveData {
   showInFeaturedQuestionReport: boolean;
   urlFragment: string;
   fontSize: string;
+  fontType: string;
 }
 
 export interface IMWInteractiveData {
@@ -175,6 +176,7 @@ export interface IMWInteractiveData {
   showInFeaturedQuestionReport: boolean;
   url: string;
   fontSize: string;
+  fontType: string;
 }
 
 type IApprovedScript = any;

--- a/lara-typescript/src/section-authoring/components/managed-interactive-preview.tsx
+++ b/lara-typescript/src/section-authoring/components/managed-interactive-preview.tsx
@@ -16,7 +16,7 @@ export const ManagedInteractivePreview: React.FC<IManagedInteractivePreviewProps
 
   const {
     aspectRatio, authoredState, customAspectRatioMethod, id, interactiveItemId,
-    isHalfWidth, name, libraryInteractiveId, linkedInteractives, urlFragment, fontSize
+    isHalfWidth, name, libraryInteractiveId, linkedInteractives, urlFragment, fontSize, fontType
   } = pageItem.data as IManagedInteractiveData;
   const { getLibraryInteractives } = usePageAPI();
 
@@ -35,7 +35,8 @@ export const ManagedInteractivePreview: React.FC<IManagedInteractivePreviewProps
     authored_state: authoredState,
     interactive_item_id: interactiveItemId,
     linked_interactives: linkedInteractives,
-    font_size: fontSize
+    font_size: fontSize,
+    font_type: fontType,
   };
 
   const wrapperClasses = classNames("managedInteractive", {

--- a/lara-typescript/src/section-authoring/components/mw-interactive-preview.tsx
+++ b/lara-typescript/src/section-authoring/components/mw-interactive-preview.tsx
@@ -14,7 +14,7 @@ export const MWInteractivePreview: React.FC<IMWInteractivePreviewProps> = ({
   }: IMWInteractivePreviewProps) => {
   const {
     aspectRatio, aspectRatioMethod, authoredState, id, interactiveItemId,
-    isHalfWidth, name, linkedInteractives, url, fontSize
+    isHalfWidth, name, linkedInteractives, url, fontSize, fontType,
    } = pageItem.data as IMWInteractiveData;
 
   const interactive = {
@@ -26,7 +26,8 @@ export const MWInteractivePreview: React.FC<IMWInteractivePreviewProps> = ({
     authored_state: authoredState,
     interactive_item_id: interactiveItemId,
     linked_interactives: linkedInteractives,
-    font_size: fontSize
+    font_size: fontSize,
+    font_type: fontType,
   };
 
   const wrapperClasses = classNames("mwInteractive", {

--- a/lara-typescript/src/section-authoring/components/plugin-authoring.tsx
+++ b/lara-typescript/src/section-authoring/components/plugin-authoring.tsx
@@ -42,6 +42,7 @@ export const PluginAuthoring: React.FC<PluginAuthoringProps> = (
     interactive_item_id: wrappedItem?.data.interactiveItemId,
     linked_interactives: wrappedItem?.data.linkedInteractives,
     font_size: wrappedItem?.data.fontSize,
+    font_type: wrappedItem?.data.fontType,
   } : undefined;
   const wrappedEmbeddable: IEmbeddableContextOptions | null = wrappedItem?.data && wrappedDiv.current !== null
     ?  {

--- a/lara-typescript/src/shared/accessibility.ts
+++ b/lara-typescript/src/shared/accessibility.ts
@@ -4,3 +4,11 @@ export const pxForFontSize = (fontSize: string) => {
   }
   return 16;
 };
+
+export const getFamilyForFontType = (fontType: string) => {
+  const baseFontFamily = "'Lato', arial, helvetica, sans-serif;";
+  if (fontType === "notebook") {
+    return `'Andika', ${baseFontFamily}`;
+  }
+  return baseFontFamily;
+};

--- a/public/example-interactives/attachments/index.js
+++ b/public/example-interactives/attachments/index.js
@@ -37730,7 +37730,8 @@ var useAccessibility = function (props) {
     var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
     var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
-    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
+    // text may be optional while font type setting is rolled out from staging to production through AP
+    var normalizeClass = function (text) { return (text || "").toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
         if (initMessage && initMessage.mode === "runtime") {
@@ -37740,14 +37741,14 @@ var useAccessibility = function (props) {
             if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (updateHtmlFontSize && html) {
+                if (updateHtmlFontSize && html && fontSizeInPx) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
                 if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
-                if (fontFamilySelector) {
+                if (fontFamilySelector && fontFamilyForType) {
                     var style = document.createElement("style");
                     document.head.appendChild(style);
                     (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);

--- a/public/example-interactives/attachments/index.js
+++ b/public/example-interactives/attachments/index.js
@@ -37570,6 +37570,7 @@ exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useRep
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
+var accessibility_1 = __webpack_require__(/*! ../shared/accessibility */ "./src/shared/accessibility.ts");
 var handleUpdate = function (newStateOrUpdateFunc, prevState) {
     if (typeof newStateOrUpdateFunc === "function") {
         return newStateOrUpdateFunc(prevState);
@@ -37721,31 +37722,40 @@ var useReportItem = function (_a) {
 exports.useReportItem = useReportItem;
 exports.DefaultAccessibilitySettings = {
     fontSize: "normal",
-    fontSizeInPx: 16
+    fontSizeInPx: 16,
+    fontType: "normal",
+    fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
+    var updateDOM = (props || {}).updateDOM;
     var initMessage = (0, exports.useInitMessage)();
-    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
+        var _a;
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+            if (updateDOM) {
+                var fontFamilySelector = updateDOM.fontFamilySelector;
                 var html = document.getElementsByTagName("html").item(0);
+                var body = document.getElementsByTagName("body").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-            }
-            if (addBodyClass) {
-                var body = document.getElementsByTagName("body").item(0);
                 if (body) {
-                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
+                    body.classList.add("font-size-" + normalizeClass(fontSize));
+                    body.classList.add("font-type-" + normalizeClass(fontType));
+                }
+                if (fontFamilySelector) {
+                    var style = document.createElement("style");
+                    document.head.appendChild(style);
+                    (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);
                 }
             }
         }
-    }, [initMessage, updateHtmlFontSize]);
+    }, [initMessage, updateDOM]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;
@@ -37966,6 +37976,36 @@ __exportStar(__webpack_require__(/*! ../interactive-api-shared/types */ "./src/i
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+
+
+/***/ }),
+
+/***/ "./src/shared/accessibility.ts":
+/*!*************************************!*\
+  !*** ./src/shared/accessibility.ts ***!
+  \*************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getFamilyForFontType = exports.pxForFontSize = void 0;
+var pxForFontSize = function (fontSize) {
+    if (fontSize === "large") {
+        return 22;
+    }
+    return 16;
+};
+exports.pxForFontSize = pxForFontSize;
+var getFamilyForFontType = function (fontType) {
+    var baseFontFamily = "'Lato', arial, helvetica, sans-serif;";
+    if (fontType === "notebook") {
+        return "'Andika', " + baseFontFamily;
+    }
+    return baseFontFamily;
+};
+exports.getFamilyForFontType = getFamilyForFontType;
 
 
 /***/ })

--- a/public/example-interactives/attachments/index.js
+++ b/public/example-interactives/attachments/index.js
@@ -37727,9 +37727,9 @@ exports.DefaultAccessibilitySettings = {
     fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var updateDOM = (props || {}).updateDOM;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
@@ -37737,14 +37737,13 @@ var useAccessibility = function (props) {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
             var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateDOM) {
-                var fontFamilySelector = updateDOM.fontFamilySelector;
+            if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (html) {
+                if (updateHtmlFontSize && html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-                if (body) {
+                if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
@@ -37755,7 +37754,7 @@ var useAccessibility = function (props) {
                 }
             }
         }
-    }, [initMessage, updateDOM]);
+    }, [initMessage, updateHtmlFontSize, addBodyClass, fontFamilySelector]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;

--- a/public/example-interactives/linked-state/index.js
+++ b/public/example-interactives/linked-state/index.js
@@ -34290,7 +34290,8 @@ var useAccessibility = function (props) {
     var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
     var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
-    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
+    // text may be optional while font type setting is rolled out from staging to production through AP
+    var normalizeClass = function (text) { return (text || "").toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
         if (initMessage && initMessage.mode === "runtime") {
@@ -34300,14 +34301,14 @@ var useAccessibility = function (props) {
             if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (updateHtmlFontSize && html) {
+                if (updateHtmlFontSize && html && fontSizeInPx) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
                 if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
-                if (fontFamilySelector) {
+                if (fontFamilySelector && fontFamilyForType) {
                     var style = document.createElement("style");
                     document.head.appendChild(style);
                     (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);

--- a/public/example-interactives/linked-state/index.js
+++ b/public/example-interactives/linked-state/index.js
@@ -34287,9 +34287,9 @@ exports.DefaultAccessibilitySettings = {
     fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var updateDOM = (props || {}).updateDOM;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
@@ -34297,14 +34297,13 @@ var useAccessibility = function (props) {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
             var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateDOM) {
-                var fontFamilySelector = updateDOM.fontFamilySelector;
+            if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (html) {
+                if (updateHtmlFontSize && html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-                if (body) {
+                if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
@@ -34315,7 +34314,7 @@ var useAccessibility = function (props) {
                 }
             }
         }
-    }, [initMessage, updateDOM]);
+    }, [initMessage, updateHtmlFontSize, addBodyClass, fontFamilySelector]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;

--- a/public/example-interactives/linked-state/index.js
+++ b/public/example-interactives/linked-state/index.js
@@ -34130,6 +34130,7 @@ exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useRep
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
+var accessibility_1 = __webpack_require__(/*! ../shared/accessibility */ "./src/shared/accessibility.ts");
 var handleUpdate = function (newStateOrUpdateFunc, prevState) {
     if (typeof newStateOrUpdateFunc === "function") {
         return newStateOrUpdateFunc(prevState);
@@ -34281,31 +34282,40 @@ var useReportItem = function (_a) {
 exports.useReportItem = useReportItem;
 exports.DefaultAccessibilitySettings = {
     fontSize: "normal",
-    fontSizeInPx: 16
+    fontSizeInPx: 16,
+    fontType: "normal",
+    fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
+    var updateDOM = (props || {}).updateDOM;
     var initMessage = (0, exports.useInitMessage)();
-    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
+        var _a;
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+            if (updateDOM) {
+                var fontFamilySelector = updateDOM.fontFamilySelector;
                 var html = document.getElementsByTagName("html").item(0);
+                var body = document.getElementsByTagName("body").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-            }
-            if (addBodyClass) {
-                var body = document.getElementsByTagName("body").item(0);
                 if (body) {
-                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
+                    body.classList.add("font-size-" + normalizeClass(fontSize));
+                    body.classList.add("font-type-" + normalizeClass(fontType));
+                }
+                if (fontFamilySelector) {
+                    var style = document.createElement("style");
+                    document.head.appendChild(style);
+                    (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);
                 }
             }
         }
-    }, [initMessage, updateHtmlFontSize]);
+    }, [initMessage, updateDOM]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;
@@ -34526,6 +34536,36 @@ __exportStar(__webpack_require__(/*! ../interactive-api-shared/types */ "./src/i
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+
+
+/***/ }),
+
+/***/ "./src/shared/accessibility.ts":
+/*!*************************************!*\
+  !*** ./src/shared/accessibility.ts ***!
+  \*************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getFamilyForFontType = exports.pxForFontSize = void 0;
+var pxForFontSize = function (fontSize) {
+    if (fontSize === "large") {
+        return 22;
+    }
+    return 16;
+};
+exports.pxForFontSize = pxForFontSize;
+var getFamilyForFontType = function (fontType) {
+    var baseFontFamily = "'Lato', arial, helvetica, sans-serif;";
+    if (fontType === "notebook") {
+        return "'Andika', " + baseFontFamily;
+    }
+    return baseFontFamily;
+};
+exports.getFamilyForFontType = getFamilyForFontType;
 
 
 /***/ })

--- a/public/example-interactives/report-item/index.js
+++ b/public/example-interactives/report-item/index.js
@@ -37395,6 +37395,7 @@ exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useRep
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
+var accessibility_1 = __webpack_require__(/*! ../shared/accessibility */ "./src/shared/accessibility.ts");
 var handleUpdate = function (newStateOrUpdateFunc, prevState) {
     if (typeof newStateOrUpdateFunc === "function") {
         return newStateOrUpdateFunc(prevState);
@@ -37546,31 +37547,40 @@ var useReportItem = function (_a) {
 exports.useReportItem = useReportItem;
 exports.DefaultAccessibilitySettings = {
     fontSize: "normal",
-    fontSizeInPx: 16
+    fontSizeInPx: 16,
+    fontType: "normal",
+    fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
+    var updateDOM = (props || {}).updateDOM;
     var initMessage = (0, exports.useInitMessage)();
-    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
+        var _a;
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+            if (updateDOM) {
+                var fontFamilySelector = updateDOM.fontFamilySelector;
                 var html = document.getElementsByTagName("html").item(0);
+                var body = document.getElementsByTagName("body").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-            }
-            if (addBodyClass) {
-                var body = document.getElementsByTagName("body").item(0);
                 if (body) {
-                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
+                    body.classList.add("font-size-" + normalizeClass(fontSize));
+                    body.classList.add("font-type-" + normalizeClass(fontType));
+                }
+                if (fontFamilySelector) {
+                    var style = document.createElement("style");
+                    document.head.appendChild(style);
+                    (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);
                 }
             }
         }
-    }, [initMessage, updateHtmlFontSize]);
+    }, [initMessage, updateDOM]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;
@@ -37791,6 +37801,36 @@ __exportStar(__webpack_require__(/*! ../interactive-api-shared/types */ "./src/i
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+
+
+/***/ }),
+
+/***/ "./src/shared/accessibility.ts":
+/*!*************************************!*\
+  !*** ./src/shared/accessibility.ts ***!
+  \*************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getFamilyForFontType = exports.pxForFontSize = void 0;
+var pxForFontSize = function (fontSize) {
+    if (fontSize === "large") {
+        return 22;
+    }
+    return 16;
+};
+exports.pxForFontSize = pxForFontSize;
+var getFamilyForFontType = function (fontType) {
+    var baseFontFamily = "'Lato', arial, helvetica, sans-serif;";
+    if (fontType === "notebook") {
+        return "'Andika', " + baseFontFamily;
+    }
+    return baseFontFamily;
+};
+exports.getFamilyForFontType = getFamilyForFontType;
 
 
 /***/ })

--- a/public/example-interactives/report-item/index.js
+++ b/public/example-interactives/report-item/index.js
@@ -37555,7 +37555,8 @@ var useAccessibility = function (props) {
     var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
     var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
-    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
+    // text may be optional while font type setting is rolled out from staging to production through AP
+    var normalizeClass = function (text) { return (text || "").toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
         if (initMessage && initMessage.mode === "runtime") {
@@ -37565,14 +37566,14 @@ var useAccessibility = function (props) {
             if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (updateHtmlFontSize && html) {
+                if (updateHtmlFontSize && html && fontSizeInPx) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
                 if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
-                if (fontFamilySelector) {
+                if (fontFamilySelector && fontFamilyForType) {
                     var style = document.createElement("style");
                     document.head.appendChild(style);
                     (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);

--- a/public/example-interactives/report-item/index.js
+++ b/public/example-interactives/report-item/index.js
@@ -37552,9 +37552,9 @@ exports.DefaultAccessibilitySettings = {
     fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var updateDOM = (props || {}).updateDOM;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
@@ -37562,14 +37562,13 @@ var useAccessibility = function (props) {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
             var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateDOM) {
-                var fontFamilySelector = updateDOM.fontFamilySelector;
+            if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (html) {
+                if (updateHtmlFontSize && html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-                if (body) {
+                if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
@@ -37580,7 +37579,7 @@ var useAccessibility = function (props) {
                 }
             }
         }
-    }, [initMessage, updateDOM]);
+    }, [initMessage, updateHtmlFontSize, addBodyClass, fontFamilySelector]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -46205,6 +46205,7 @@ exports.useAccessibility = exports.DefaultAccessibilitySettings = exports.useRep
 var react_1 = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 var resize_observer_polyfill_1 = __webpack_require__(/*! resize-observer-polyfill */ "./node_modules/resize-observer-polyfill/dist/ResizeObserver.es.js");
 var client = __webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts");
+var accessibility_1 = __webpack_require__(/*! ../shared/accessibility */ "./src/shared/accessibility.ts");
 var handleUpdate = function (newStateOrUpdateFunc, prevState) {
     if (typeof newStateOrUpdateFunc === "function") {
         return newStateOrUpdateFunc(prevState);
@@ -46356,31 +46357,40 @@ var useReportItem = function (_a) {
 exports.useReportItem = useReportItem;
 exports.DefaultAccessibilitySettings = {
     fontSize: "normal",
-    fontSizeInPx: 16
+    fontSizeInPx: 16,
+    fontType: "normal",
+    fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass;
+    var updateDOM = (props || {}).updateDOM;
     var initMessage = (0, exports.useInitMessage)();
-    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
+    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
+        var _a;
         if (initMessage && initMessage.mode === "runtime") {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
-            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx;
+            var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateHtmlFontSize && (fontSizeInPx !== exports.DefaultAccessibilitySettings.fontSizeInPx)) {
+            if (updateDOM) {
+                var fontFamilySelector = updateDOM.fontFamilySelector;
                 var html = document.getElementsByTagName("html").item(0);
+                var body = document.getElementsByTagName("body").item(0);
                 if (html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-            }
-            if (addBodyClass) {
-                var body = document.getElementsByTagName("body").item(0);
                 if (body) {
-                    body.classList.add("font-size-" + fontSize.toLowerCase().replace(/\s/, "-"));
+                    body.classList.add("font-size-" + normalizeClass(fontSize));
+                    body.classList.add("font-type-" + normalizeClass(fontType));
+                }
+                if (fontFamilySelector) {
+                    var style = document.createElement("style");
+                    document.head.appendChild(style);
+                    (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);
                 }
             }
         }
-    }, [initMessage, updateHtmlFontSize]);
+    }, [initMessage, updateDOM]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;
@@ -46601,6 +46611,36 @@ __exportStar(__webpack_require__(/*! ../interactive-api-shared/types */ "./src/i
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+
+
+/***/ }),
+
+/***/ "./src/shared/accessibility.ts":
+/*!*************************************!*\
+  !*** ./src/shared/accessibility.ts ***!
+  \*************************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getFamilyForFontType = exports.pxForFontSize = void 0;
+var pxForFontSize = function (fontSize) {
+    if (fontSize === "large") {
+        return 22;
+    }
+    return 16;
+};
+exports.pxForFontSize = pxForFontSize;
+var getFamilyForFontType = function (fontType) {
+    var baseFontFamily = "'Lato', arial, helvetica, sans-serif;";
+    if (fontType === "notebook") {
+        return "'Andika', " + baseFontFamily;
+    }
+    return baseFontFamily;
+};
+exports.getFamilyForFontType = getFamilyForFontType;
 
 
 /***/ }),

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -46365,7 +46365,8 @@ var useAccessibility = function (props) {
     var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
     var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
-    var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
+    // text may be optional while font type setting is rolled out from staging to production through AP
+    var normalizeClass = function (text) { return (text || "").toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
         if (initMessage && initMessage.mode === "runtime") {
@@ -46375,14 +46376,14 @@ var useAccessibility = function (props) {
             if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (updateHtmlFontSize && html) {
+                if (updateHtmlFontSize && html && fontSizeInPx) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
                 if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
-                if (fontFamilySelector) {
+                if (fontFamilySelector && fontFamilyForType) {
                     var style = document.createElement("style");
                     document.head.appendChild(style);
                     (_a = style.sheet) === null || _a === void 0 ? void 0 : _a.insertRule(fontFamilySelector + " { font-family: " + fontFamilyForType + "; }", 0);

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -46362,9 +46362,9 @@ exports.DefaultAccessibilitySettings = {
     fontFamilyForType: (0, accessibility_1.getFamilyForFontType)("normal"),
 };
 var useAccessibility = function (props) {
-    var updateDOM = (props || {}).updateDOM;
+    var _a = props || {}, updateHtmlFontSize = _a.updateHtmlFontSize, addBodyClass = _a.addBodyClass, fontFamilySelector = _a.fontFamilySelector;
     var initMessage = (0, exports.useInitMessage)();
-    var _a = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _a[0], setAccessibility = _a[1];
+    var _b = (0, react_1.useState)(exports.DefaultAccessibilitySettings), accessibility = _b[0], setAccessibility = _b[1];
     var normalizeClass = function (text) { return text.toLowerCase().replace(/\s/, "-"); };
     (0, react_1.useEffect)(function () {
         var _a;
@@ -46372,14 +46372,13 @@ var useAccessibility = function (props) {
             var _accessibility = initMessage.accessibility || exports.DefaultAccessibilitySettings;
             var fontSize = _accessibility.fontSize, fontSizeInPx = _accessibility.fontSizeInPx, fontType = _accessibility.fontType, fontFamilyForType = _accessibility.fontFamilyForType;
             setAccessibility(_accessibility);
-            if (updateDOM) {
-                var fontFamilySelector = updateDOM.fontFamilySelector;
+            if (updateHtmlFontSize || addBodyClass || fontFamilySelector) {
                 var html = document.getElementsByTagName("html").item(0);
                 var body = document.getElementsByTagName("body").item(0);
-                if (html) {
+                if (updateHtmlFontSize && html) {
                     html.style.fontSize = fontSizeInPx + "px";
                 }
-                if (body) {
+                if (addBodyClass && body) {
                     body.classList.add("font-size-" + normalizeClass(fontSize));
                     body.classList.add("font-type-" + normalizeClass(fontType));
                 }
@@ -46390,7 +46389,7 @@ var useAccessibility = function (props) {
                 }
             }
         }
-    }, [initMessage, updateDOM]);
+    }, [initMessage, updateHtmlFontSize, addBodyClass, fontFamilySelector]);
     return accessibility;
 };
 exports.useAccessibility = useAccessibility;


### PR DESCRIPTION
This adds the font type to the accessibility object in the initInteractive message.

This adds a new option to the useAccessibility hook options: a css selector to use to create a font-family rule.  This allows question-interactives to target the inner runtime div.

As with the original accessibility work the LARA scripts that are no longer used have also been updated.