### PR TITLE
feat: Check if multiple copies of the lib are imported and throw an error when it happens [PT-185546697]

### DIFF
--- a/lara-typescript/src/interactive-api-client/index.ts
+++ b/lara-typescript/src/interactive-api-client/index.ts
@@ -4,3 +4,25 @@ export * from "./in-frame";
 export * from "./api";
 export * from "./hooks";
 export * from "./client";
+
+import * as packageJson from "./package.json";
+
+const version = packageJson.version;
+
+const warningMsg = (loadedVersion: string, newVersion: string) => `
+LARA Interactive API is loaded multiple times. This will lead to unexpected behavior and might break multiple features
+of the API (especially interactive state saving). Please ensure that the library is loaded only once by the main app
+and that all its dependencies specify "lara-interactive-api" as "peerDependency" in their package.json files.
+
+Already imported version: v${loadedVersion}, trying to load: v${newVersion}.
+`;
+
+if ((window as any).__LARA_INTERACTIVE_API__) {
+  const msg = warningMsg((window as any).__LARA_INTERACTIVE_API__.version, version);
+  window.alert(msg);
+  throw new Error(msg);
+} else {
+  (window as any).__LARA_INTERACTIVE_API__ = {
+    version: packageJson.version
+  };
+}

--- a/lara-typescript/src/interactive-api-client/package.json
+++ b/lara-typescript/src/interactive-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/lara-interactive-api",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "LARA Interactive API client and types",
   "main": "./index.js",
   "types": "./index-bundle.d.ts",

--- a/public/example-interactives/attachments/index.js
+++ b/public/example-interactives/attachments/index.js
@@ -37814,6 +37814,19 @@ __exportStar(__webpack_require__(/*! ./in-frame */ "./src/interactive-api-client
 __exportStar(__webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts"), exports);
 __exportStar(__webpack_require__(/*! ./hooks */ "./src/interactive-api-client/hooks.ts"), exports);
 __exportStar(__webpack_require__(/*! ./client */ "./src/interactive-api-client/client.ts"), exports);
+var packageJson = __webpack_require__(/*! ./package.json */ "./src/interactive-api-client/package.json");
+var version = packageJson.version;
+var warningMsg = function (loadedVersion, newVersion) { return "\nLARA Interactive API is loaded multiple times. This will lead to unexpected behavior and might break multiple features\nof the API (especially interactive state saving). Please ensure that the library is loaded only once by the main app\nand that all its dependencies specify \"lara-interactive-api\" as \"peerDependency\" in their package.json files.\n\nAlready imported version: v" + loadedVersion + ", trying to load: v" + newVersion + ".\n"; };
+if (window.__LARA_INTERACTIVE_API__) {
+    var msg = warningMsg(window.__LARA_INTERACTIVE_API__.version, version);
+    window.alert(msg);
+    throw new Error(msg);
+}
+else {
+    window.__LARA_INTERACTIVE_API__ = {
+        version: packageJson.version
+    };
+}
 
 
 /***/ }),
@@ -37938,6 +37951,17 @@ exports.ManagedState = ManagedState;
 // to report service and portal.
 Object.defineProperty(exports, "__esModule", { value: true });
 
+
+/***/ }),
+
+/***/ "./src/interactive-api-client/package.json":
+/*!*************************************************!*\
+  !*** ./src/interactive-api-client/package.json ***!
+  \*************************************************/
+/*! exports provided: name, version, description, main, types, repository, author, license, bugs, homepage, dependencies, peerDependencies, default */
+/***/ (function(module) {
+
+module.exports = JSON.parse("{\"name\":\"@concord-consortium/lara-interactive-api\",\"version\":\"1.9.4\",\"description\":\"LARA Interactive API client and types\",\"main\":\"./index.js\",\"types\":\"./index-bundle.d.ts\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/concord-consortium/lara.git\"},\"author\":\"Concord Consortium\",\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/concord-consortium/lara/issues\"},\"homepage\":\"https://github.com/concord-consortium/lara/tree/master/lara-typescript/src/interactive-api-client#readme\",\"dependencies\":{\"iframe-phone\":\"^1.3.1\"},\"peerDependencies\":{\"react\":\">=16.9.0\",\"react-dom\":\">=16.9.0\"}}");
 
 /***/ }),
 

--- a/public/example-interactives/linked-state/index.js
+++ b/public/example-interactives/linked-state/index.js
@@ -34374,6 +34374,19 @@ __exportStar(__webpack_require__(/*! ./in-frame */ "./src/interactive-api-client
 __exportStar(__webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts"), exports);
 __exportStar(__webpack_require__(/*! ./hooks */ "./src/interactive-api-client/hooks.ts"), exports);
 __exportStar(__webpack_require__(/*! ./client */ "./src/interactive-api-client/client.ts"), exports);
+var packageJson = __webpack_require__(/*! ./package.json */ "./src/interactive-api-client/package.json");
+var version = packageJson.version;
+var warningMsg = function (loadedVersion, newVersion) { return "\nLARA Interactive API is loaded multiple times. This will lead to unexpected behavior and might break multiple features\nof the API (especially interactive state saving). Please ensure that the library is loaded only once by the main app\nand that all its dependencies specify \"lara-interactive-api\" as \"peerDependency\" in their package.json files.\n\nAlready imported version: v" + loadedVersion + ", trying to load: v" + newVersion + ".\n"; };
+if (window.__LARA_INTERACTIVE_API__) {
+    var msg = warningMsg(window.__LARA_INTERACTIVE_API__.version, version);
+    window.alert(msg);
+    throw new Error(msg);
+}
+else {
+    window.__LARA_INTERACTIVE_API__ = {
+        version: packageJson.version
+    };
+}
 
 
 /***/ }),
@@ -34498,6 +34511,17 @@ exports.ManagedState = ManagedState;
 // to report service and portal.
 Object.defineProperty(exports, "__esModule", { value: true });
 
+
+/***/ }),
+
+/***/ "./src/interactive-api-client/package.json":
+/*!*************************************************!*\
+  !*** ./src/interactive-api-client/package.json ***!
+  \*************************************************/
+/*! exports provided: name, version, description, main, types, repository, author, license, bugs, homepage, dependencies, peerDependencies, default */
+/***/ (function(module) {
+
+module.exports = JSON.parse("{\"name\":\"@concord-consortium/lara-interactive-api\",\"version\":\"1.9.4\",\"description\":\"LARA Interactive API client and types\",\"main\":\"./index.js\",\"types\":\"./index-bundle.d.ts\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/concord-consortium/lara.git\"},\"author\":\"Concord Consortium\",\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/concord-consortium/lara/issues\"},\"homepage\":\"https://github.com/concord-consortium/lara/tree/master/lara-typescript/src/interactive-api-client#readme\",\"dependencies\":{\"iframe-phone\":\"^1.3.1\"},\"peerDependencies\":{\"react\":\">=16.9.0\",\"react-dom\":\">=16.9.0\"}}");
 
 /***/ }),
 

--- a/public/example-interactives/report-item/index.js
+++ b/public/example-interactives/report-item/index.js
@@ -37639,6 +37639,19 @@ __exportStar(__webpack_require__(/*! ./in-frame */ "./src/interactive-api-client
 __exportStar(__webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts"), exports);
 __exportStar(__webpack_require__(/*! ./hooks */ "./src/interactive-api-client/hooks.ts"), exports);
 __exportStar(__webpack_require__(/*! ./client */ "./src/interactive-api-client/client.ts"), exports);
+var packageJson = __webpack_require__(/*! ./package.json */ "./src/interactive-api-client/package.json");
+var version = packageJson.version;
+var warningMsg = function (loadedVersion, newVersion) { return "\nLARA Interactive API is loaded multiple times. This will lead to unexpected behavior and might break multiple features\nof the API (especially interactive state saving). Please ensure that the library is loaded only once by the main app\nand that all its dependencies specify \"lara-interactive-api\" as \"peerDependency\" in their package.json files.\n\nAlready imported version: v" + loadedVersion + ", trying to load: v" + newVersion + ".\n"; };
+if (window.__LARA_INTERACTIVE_API__) {
+    var msg = warningMsg(window.__LARA_INTERACTIVE_API__.version, version);
+    window.alert(msg);
+    throw new Error(msg);
+}
+else {
+    window.__LARA_INTERACTIVE_API__ = {
+        version: packageJson.version
+    };
+}
 
 
 /***/ }),
@@ -37763,6 +37776,17 @@ exports.ManagedState = ManagedState;
 // to report service and portal.
 Object.defineProperty(exports, "__esModule", { value: true });
 
+
+/***/ }),
+
+/***/ "./src/interactive-api-client/package.json":
+/*!*************************************************!*\
+  !*** ./src/interactive-api-client/package.json ***!
+  \*************************************************/
+/*! exports provided: name, version, description, main, types, repository, author, license, bugs, homepage, dependencies, peerDependencies, default */
+/***/ (function(module) {
+
+module.exports = JSON.parse("{\"name\":\"@concord-consortium/lara-interactive-api\",\"version\":\"1.9.4\",\"description\":\"LARA Interactive API client and types\",\"main\":\"./index.js\",\"types\":\"./index-bundle.d.ts\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/concord-consortium/lara.git\"},\"author\":\"Concord Consortium\",\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/concord-consortium/lara/issues\"},\"homepage\":\"https://github.com/concord-consortium/lara/tree/master/lara-typescript/src/interactive-api-client#readme\",\"dependencies\":{\"iframe-phone\":\"^1.3.1\"},\"peerDependencies\":{\"react\":\">=16.9.0\",\"react-dom\":\">=16.9.0\"}}");
 
 /***/ }),
 

--- a/public/example-interactives/testbed/index.js
+++ b/public/example-interactives/testbed/index.js
@@ -46449,6 +46449,19 @@ __exportStar(__webpack_require__(/*! ./in-frame */ "./src/interactive-api-client
 __exportStar(__webpack_require__(/*! ./api */ "./src/interactive-api-client/api.ts"), exports);
 __exportStar(__webpack_require__(/*! ./hooks */ "./src/interactive-api-client/hooks.ts"), exports);
 __exportStar(__webpack_require__(/*! ./client */ "./src/interactive-api-client/client.ts"), exports);
+var packageJson = __webpack_require__(/*! ./package.json */ "./src/interactive-api-client/package.json");
+var version = packageJson.version;
+var warningMsg = function (loadedVersion, newVersion) { return "\nLARA Interactive API is loaded multiple times. This will lead to unexpected behavior and might break multiple features\nof the API (especially interactive state saving). Please ensure that the library is loaded only once by the main app\nand that all its dependencies specify \"lara-interactive-api\" as \"peerDependency\" in their package.json files.\n\nAlready imported version: v" + loadedVersion + ", trying to load: v" + newVersion + ".\n"; };
+if (window.__LARA_INTERACTIVE_API__) {
+    var msg = warningMsg(window.__LARA_INTERACTIVE_API__.version, version);
+    window.alert(msg);
+    throw new Error(msg);
+}
+else {
+    window.__LARA_INTERACTIVE_API__ = {
+        version: packageJson.version
+    };
+}
 
 
 /***/ }),
@@ -46573,6 +46586,17 @@ exports.ManagedState = ManagedState;
 // to report service and portal.
 Object.defineProperty(exports, "__esModule", { value: true });
 
+
+/***/ }),
+
+/***/ "./src/interactive-api-client/package.json":
+/*!*************************************************!*\
+  !*** ./src/interactive-api-client/package.json ***!
+  \*************************************************/
+/*! exports provided: name, version, description, main, types, repository, author, license, bugs, homepage, dependencies, peerDependencies, default */
+/***/ (function(module) {
+
+module.exports = JSON.parse("{\"name\":\"@concord-consortium/lara-interactive-api\",\"version\":\"1.9.4\",\"description\":\"LARA Interactive API client and types\",\"main\":\"./index.js\",\"types\":\"./index-bundle.d.ts\",\"repository\":{\"type\":\"git\",\"url\":\"git+https://github.com/concord-consortium/lara.git\"},\"author\":\"Concord Consortium\",\"license\":\"MIT\",\"bugs\":{\"url\":\"https://github.com/concord-consortium/lara/issues\"},\"homepage\":\"https://github.com/concord-consortium/lara/tree/master/lara-typescript/src/interactive-api-client#readme\",\"dependencies\":{\"iframe-phone\":\"^1.3.1\"},\"peerDependencies\":{\"react\":\">=16.9.0\",\"react-dom\":\">=16.9.0\"}}");
 
 /***/ }),
 


### PR DESCRIPTION
[#185546697](https://www.pivotaltracker.com/story/show/185546697)

This PR is related to debugging and issues we had with question-interactives that for some time were importing two copies of lara-interactive-lib. A detailed description of this problem: https://concord-consortium.slack.com/archives/C0M5CM1RA/p1688581569887089

Generally, lara-interactives-api cannot be imported twice, as it uses some module-level variables as a cache/copy of the interactive state. This copy is used to automatically respond to the parent window when it requests an interactive state (so developers don't need to handle that manually) or to debounce state updates.  When two copies are defined, these state copies might be out of sync and lots of unexpected things might happen.

The code I added is very brutal - it'll display an alert and throw an error to fully break the execution. I did that, as it's very likely that a console warning would be overlooked or ignored. And leaving interactive in this state might lead to painful and time consuming debugging.

I've tested this code in the problematic version of question-interactives and it works as expected:
<img width="1207" alt="Screenshot 2023-07-06 at 13 51 04" src="https://github.com/concord-consortium/lara/assets/767857/b2c51bda-ce17-4cbb-9fa4-fecc9bf0b788">
