### PR TITLE
feat: Added project_admin model [PT-186125987]

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,7 @@ class Project < ActiveRecord::Base
   validates :project_key, uniqueness: true
   has_many :sequences
   has_many :lightweight_activities
+  has_many :project_admins, include: [:user]
 
   protected
   def self.create_default

--- a/app/models/project_admin.rb
+++ b/app/models/project_admin.rb
@@ -1,0 +1,6 @@
+class ProjectAdmin < ActiveRecord::Base
+  attr_accessible :user, :project
+
+  belongs_to :user
+  belongs_to :project
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ActiveRecord::Base
   has_many :runs
   has_many :imports
   has_many :glossaries, order: :name
+  has_many :admined_projects, :class_name => ProjectAdmin, include: [:project]
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :password, :password_confirmation, :remember_me,

--- a/db/migrate/20231113215504_add_project_admins.rb
+++ b/db/migrate/20231113215504_add_project_admins.rb
@@ -1,0 +1,12 @@
+class AddProjectAdmins < ActiveRecord::Migration
+  def change
+    create_table :project_admins do |t|
+      t.references :user, index: true
+      t.references :project, index: true
+
+      t.timestamps
+    end
+
+    add_index :project_admins, [:user_id, :project_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20230614193153) do
+ActiveRecord::Schema.define(:version => 20231113215504) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -621,6 +621,15 @@ ActiveRecord::Schema.define(:version => 20230614193153) do
   end
 
   add_index "portal_publications", ["publishable_id", "publishable_type"], :name => "index_portal_publications_on_publishable_id_and_publishable_type"
+
+  create_table "project_admins", :force => true do |t|
+    t.integer  "user_id"
+    t.integer  "project_id"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "project_admins", ["user_id", "project_id"], :name => "index_project_admins_on_user_id_and_project_id", :unique => true
 
   create_table "projects", :force => true do |t|
     t.string   "title"

--- a/spec/factories/project_admins.rb
+++ b/spec/factories/project_admins.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :project_admin do
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -63,4 +63,25 @@ describe Project do
       expect(new_project.project_key).to eq("new-project")
     end
   end
+
+  describe "Project admins" do
+    let(:project) { FactoryGirl.create(:project) }
+    let(:user1) { FactoryGirl.create(:user) }
+    let(:user2) { FactoryGirl.create(:user) }
+    let(:project_admin1) { FactoryGirl.create(:project_admin, project: project, user: user1) }
+    let(:project_admin2) { FactoryGirl.create(:project_admin, project: project, user: user2) }
+
+    it "should be empty by default" do
+      expect(project.project_admins.length).to be(0)
+    end
+
+    it "should return an array when set" do
+      project.project_admins = [project_admin1, project_admin2]
+      expect(project.project_admins.length).to be(2)
+      expect(project.project_admins[0].project.id).to be(project.id)
+      expect(project.project_admins[1].project.id).to be(project.id)
+      expect(project.project_admins[0].user.id).to be(user1.id)
+      expect(project.project_admins[1].user.id).to be(user2.id)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -268,4 +268,25 @@ describe User do
 
   end
 
+  describe "admined_projects" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:project1) { FactoryGirl.create(:project) }
+    let(:project2) { FactoryGirl.create(:project) }
+    let(:project_admin1) { FactoryGirl.create(:project_admin, project: project1, user: user) }
+    let(:project_admin2) { FactoryGirl.create(:project_admin, project: project2, user: user) }
+
+    it "should be empty by default" do
+      expect(user.admined_projects.length).to be(0)
+    end
+
+    it "should return an array when set" do
+      user.admined_projects = [project_admin1, project_admin2]
+      expect(user.admined_projects.length).to be(2)
+      expect(user.admined_projects[0].project.id).to be(project1.id)
+      expect(user.admined_projects[1].project.id).to be(project2.id)
+      expect(user.admined_projects[0].user.id).to be(user.id)
+      expect(user.admined_projects[1].user.id).to be(user.id)
+    end
+  end
+
 end


### PR DESCRIPTION
Adds a new model to track project admins and adds associations to both the user and project model.

**NOTE**: the model associations are updated in the next follow-on PR to support form edits.