### PR TITLE
feat: Added project admin UI for user edit page [PT-186125988]

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -608,7 +608,7 @@ ul.quiet_list {
     margin: 0;
     border-bottom: dashed 1px #ddd;
     overflow: auto;
-    
+
     .action_menu {
       display: flex;
       flex-direction: row;
@@ -1187,6 +1187,9 @@ div.breadcrumbs {
 
 /* User admin stuff */
 body.admin {
+  h1 {
+    margin: 10px 0;
+  }
   td {
     padding: 7px;
     border-width: 0 1px;
@@ -1202,7 +1205,7 @@ body.admin {
     border-bottom: 1px solid #333;
   }
 }
-body.admin.edit {
+body.admin.edit, body.admin.new {
   fieldset {
     border: 1px solid #999;
     padding: 7px;
@@ -1210,9 +1213,15 @@ body.admin.edit {
       padding: 5px;
       text-align: right;
       font-weight: bold;
+      &.left {
+        text-align: left;
+      }
     }
     label {
       font-weight: bold;
+      &.normal {
+        font-weight: normal;
+      }
     }
     p {
       padding: 7px;

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,6 +32,7 @@ class Admin::UsersController < ApplicationController
   # GET /admin/users/new.json
   def new
     @user = User.new
+    @projects = Project.order(:title)
     authorize! :create, User
 
     respond_to do |format|
@@ -43,6 +44,7 @@ class Admin::UsersController < ApplicationController
   # GET /admin/users/1/edit
   def edit
     @user = User.find(params[:id])
+    @projects = Project.order(:title)
     authorize! :update, @user
   end
 
@@ -68,6 +70,10 @@ class Admin::UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     authorize! :update, @user
+
+    if !params[:user][:admined_project_ids].present?
+      params[:user][:admined_project_ids] = []
+    end
 
     respond_to do |format|
       if @user.update_attributes(params[:user])

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,7 +7,8 @@ class Project < ActiveRecord::Base
   validates :project_key, uniqueness: true
   has_many :sequences
   has_many :lightweight_activities
-  has_many :project_admins, include: [:user]
+  has_many :project_admins
+  has_many :admins, through: :project_admins, :source => :user
 
   protected
   def self.create_default

--- a/app/models/project_admin.rb
+++ b/app/models/project_admin.rb
@@ -1,5 +1,5 @@
 class ProjectAdmin < ActiveRecord::Base
-  attr_accessible :user, :project
+  attr_accessible :user, :project, :user_id, :project_id
 
   belongs_to :user
   belongs_to :project

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,12 +12,13 @@ class User < ActiveRecord::Base
   has_many :runs
   has_many :imports
   has_many :glossaries, order: :name
-  has_many :admined_projects, :class_name => ProjectAdmin, include: [:project]
+  has_many :project_admins
+  has_many :admined_projects, through: :project_admins, :source => :project
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :email, :password, :password_confirmation, :remember_me,
     :is_admin, :is_author, :first_name, :last_name,
-    :provider, :uid, :authentication_token, :api_key, :has_api_key
+    :provider, :uid, :authentication_token, :api_key, :has_api_key, :admined_project_ids
   # attr_accessible :title, :body
 
   has_many :authentications, :dependent => :delete_all
@@ -42,6 +43,10 @@ class User < ActiveRecord::Base
 
   def author?
     return is_author
+  end
+
+  def project_admin_of?(project)
+    admined_projects.any? {|ap| ap.id == project.id }
   end
 
   def most_recent_authentication

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -11,34 +11,45 @@
 <% end %>
 
 <fieldset>
-  <legend>Permissions</legend>
-  <p>
-    <label for="user_is_admin">
-      Admin?
-      <%= f.check_box :is_admin %>
+  <legend class="left">Permissions</legend>
+  <div>
+    <%= f.check_box :is_admin %>
+    <label class="normal" for="user_is_admin">
+      Admin
     </label>
-  </p>
-  <p>
-    <label for="user_is_author">
-      Author?
-      <%= f.check_box :is_author %>
+  </div>
+  <div>
+    <%= f.check_box :is_author %>
+    <label class="normal" for="user_is_author">
+      Author
     </label>
-  </p>
-  <p>
-    <label for="has_api_key">
-      Allow API access (for GET requests)?
-      <%= f.check_box :has_api_key %>
-      <% if @user.has_api_key%>
-        <p>
-          API KEY: <input type="text" size="64" readonly value="<%= @user.api_key %>">
-        </p>
-      <% end %>
+  </div>
+  <div style="margin-top: 15px;">
+    <%= f.check_box :has_api_key %>
+    <label class="normal" for="has_api_key">
+      Allow API access (for GET requests)
     </label>
-  </p>
-
-
+    <% if @user.has_api_key%>
+      <p>
+        API KEY: <input type="text" size="64" readonly value="<%= @user.api_key %>">
+      </p>
+    <% end %>
+  </div>
 </fieldset>
 
-<div class="actions">
+<fieldset>
+  <legend class="left">Project Admin for Projects</legend>
+
+  <% @projects.each do |project| %>
+    <div>
+      <%= check_box_tag "user[admined_project_ids][]", project.id, @user.project_admin_of?(project) %>
+      <label class="normal">
+        <%= project.title %>
+      </label>
+    </div>
+  <% end %>
+</fieldset>
+
+<div style="margin: 15px 0;">
   <%= f.submit %>
 </div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -4,7 +4,6 @@
   <%= render :partial => 'form', :locals => { :f => f } %>
 <%- end -%>
 
-<p>
-<%= link_to 'Show', admin_user_path(@user) %> |
-<%= link_to 'Back', admin_users_path %>
-</p>
+<div style="margin-top: 20px;">
+  <%= link_to '‹ Back to Users List', admin_users_path %>
+</div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -4,4 +4,6 @@
   <%= render :partial => 'form', :locals => { :f => f } %>
 <%- end -%>
 
-<%= link_to 'Back', admin_users_path %>
+<div style="margin-top: 20px;">
+  <%= link_to '‹ Back to Users List', admin_users_path %>
+</div>

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -64,24 +64,27 @@ describe Project do
     end
   end
 
-  describe "Project admins" do
+  describe "project_admins and admins" do
     let(:project) { FactoryGirl.create(:project) }
     let(:user1) { FactoryGirl.create(:user) }
     let(:user2) { FactoryGirl.create(:user) }
-    let(:project_admin1) { FactoryGirl.create(:project_admin, project: project, user: user1) }
-    let(:project_admin2) { FactoryGirl.create(:project_admin, project: project, user: user2) }
 
     it "should be empty by default" do
+      expect(project.admins.length).to be(0)
       expect(project.project_admins.length).to be(0)
     end
 
     it "should return an array when set" do
-      project.project_admins = [project_admin1, project_admin2]
+      project.admins = [user1, user2]
       expect(project.project_admins.length).to be(2)
       expect(project.project_admins[0].project.id).to be(project.id)
       expect(project.project_admins[1].project.id).to be(project.id)
       expect(project.project_admins[0].user.id).to be(user1.id)
       expect(project.project_admins[1].user.id).to be(user2.id)
+
+      expect(project.admins.length).to be(2)
+      expect(project.admins[0].id).to be(user1.id)
+      expect(project.admins[1].id).to be(user2.id)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -268,24 +268,36 @@ describe User do
 
   end
 
-  describe "admined_projects" do
+  describe "project_admins and admined_projects" do
     let(:user) { FactoryGirl.create(:user) }
     let(:project1) { FactoryGirl.create(:project) }
     let(:project2) { FactoryGirl.create(:project) }
-    let(:project_admin1) { FactoryGirl.create(:project_admin, project: project1, user: user) }
-    let(:project_admin2) { FactoryGirl.create(:project_admin, project: project2, user: user) }
 
     it "should be empty by default" do
+      project1
+      project2
+
+      expect(user.project_admins.length).to be(0)
       expect(user.admined_projects.length).to be(0)
+
+      expect(user.project_admin_of?(project1)).to be(false)
+      expect(user.project_admin_of?(project2)).to be(false)
     end
 
     it "should return an array when set" do
-      user.admined_projects = [project_admin1, project_admin2]
+      user.admined_projects = [project1, project2]
+      expect(user.project_admins.length).to be(2)
+      expect(user.project_admins[0].project.id).to be(project1.id)
+      expect(user.project_admins[1].project.id).to be(project2.id)
+      expect(user.project_admins[0].user.id).to be(user.id)
+      expect(user.project_admins[1].user.id).to be(user.id)
+
       expect(user.admined_projects.length).to be(2)
-      expect(user.admined_projects[0].project.id).to be(project1.id)
-      expect(user.admined_projects[1].project.id).to be(project2.id)
-      expect(user.admined_projects[0].user.id).to be(user.id)
-      expect(user.admined_projects[1].user.id).to be(user.id)
+      expect(user.admined_projects[0].id).to be(project1.id)
+      expect(user.admined_projects[1].id).to be(project2.id)
+
+      expect(user.project_admin_of?(project1)).to be(true)
+      expect(user.project_admin_of?(project2)).to be(true)
     end
   end
 

--- a/spec/views/admin/users/edit.html.erb_spec.rb
+++ b/spec/views/admin/users/edit.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe "admin/users/edit" do
   before(:each) do
     @user = assign(:user, stub_model(User))
+    @projects = assign(:project, [stub_model(Project)])
   end
 
   it "renders the edit user form" do

--- a/spec/views/admin/users/new.html.erb_spec.rb
+++ b/spec/views/admin/users/new.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe "admin/users/new" do
   before(:each) do
     assign(:user, stub_model(User).as_new_record)
+    @projects = assign(:project, [stub_model(Project)])
   end
 
   it "renders new user form" do


### PR DESCRIPTION
This adds a list of checkboxes, one per project, on the user edit page that can be checked/unchecked to set the projects the user is the admin of.

This also updates the user and project models to have a second project admin has_many association that only holds the user or project.  This allows the standard Rails update_attributes method to update the association based on the checkboxes checked in the form.

Finally, this also updates the styling of the user form, for both the edit and the (unused) new form.