### PR TITLE
feat: Added UI for showing/removing admins of a project [PT-186428490]

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -4097,13 +4097,57 @@ button.bigButton svg {
 .projectSettingsForm {
   padding-bottom: 20px;
 }
+.projectSettingsForm .titleContainer {
+  padding: 1% 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.projectSettingsForm .titleContainer h1, .projectSettingsForm .titleContainer button {
+  margin: 0;
+}
 .projectSettingsForm h2 {
   color: var(--teal);
   font-family: var(--font-family-bold);
   font-size: 20px;
   line-height: 1.2;
-  margin: 30px 0 20px;
+  margin: 20px 0;
   padding: 0;
+}
+.projectSettingsForm .splitForm {
+  display: flex;
+  gap: 20px;
+}
+.projectSettingsForm .splitForm dl {
+  flex-grow: 1;
+  width: 100%;
+}
+.projectSettingsForm .splitForm .projectAdmins {
+  flex-grow: 1;
+  width: 25%;
+}
+.projectSettingsForm .splitForm .projectAdmins label {
+  font-size: 16px;
+  font-weight: 900;
+}
+.projectSettingsForm .splitForm .projectAdmins table {
+  margin: 10px 0;
+  width: 100%;
+  border-spacing: 10px;
+}
+.projectSettingsForm .splitForm .projectAdmins table button {
+  background: transparent;
+  border: none;
+  color: var(--dark-gray);
+  display: inline-block;
+  font-size: 12px;
+  margin: 0;
+  padding: 0;
+  text-transform: uppercase;
+}
+.projectSettingsForm .splitForm .projectAdmins .emphasis {
+  margin: 10px 0;
+  font-style: italic;
 }
 .projectSettingsForm .slateContainer {
   border: solid 1.5px var(--med-gray);
@@ -4142,8 +4186,8 @@ button.bigButton svg {
   border-radius: 4px;
   font-family: var(--font-family-default);
   font-size: 16px;
-  padding: 5px 10px 7px;
-  width: calc(50% - 23px);
+  padding: 5px 10px;
+  width: calc(100% - 23px);
   -webkit-appearance: none;
 }
 .projectSettingsForm textarea {
@@ -4151,7 +4195,7 @@ button.bigButton svg {
   width: calc(100% - 23px);
 }
 .projectSettingsForm dl {
-  margin: 0 0 20px;
+  margin: 0;
   padding: 0;
 }
 .projectSettingsForm dl dt {

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -1227,6 +1227,11 @@ body.admin.edit, body.admin.new {
       padding: 7px;
     }
   }
+  input[type=checkbox] {
+    vertical-align: middle;
+    position: relative;
+    bottom: 1px;
+  }
   div.actions {
     padding: 7px;
     input {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,7 +3,7 @@ class Project < ActiveRecord::Base
   DefaultKey = 'default-project'
 
   attr_accessible :footer, :logo_lara, :logo_ap, :title, :url, :about, :project_key, :copyright,
-                  :copyright_image_url, :collaborators, :funders_image_url, :collaborators_image_url, :contact_email
+                  :copyright_image_url, :collaborators, :funders_image_url, :collaborators_image_url, :contact_email, :admin_ids
   validates :project_key, uniqueness: true
   has_many :sequences
   has_many :lightweight_activities

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -15,7 +15,7 @@
   <div>
     <%= f.check_box :is_admin %>
     <label class="normal" for="user_is_admin">
-      Admin
+      Site Admin
     </label>
   </div>
   <div>

--- a/lara-typescript/src/projects/components/project-settings-form.scss
+++ b/lara-typescript/src/projects/components/project-settings-form.scss
@@ -3,14 +3,65 @@
 .projectSettingsForm {
   padding-bottom: 20px;
 
+  .titleContainer {
+    padding: 1% 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    h1, button {
+      margin: 0;
+    }
+  }
+
   h2 {
     color: var(--teal);
     font-family: var(--font-family-bold);
     font-size: 20px;
     line-height: 1.2;
-    margin: 30px 0 20px;
+    margin: 20px 0;
     padding: 0;
   }
+
+  .splitForm {
+    display: flex;
+    gap: 20px;
+
+    dl {
+      flex-grow: 1;
+      width: 100%;
+    }
+    .projectAdmins {
+      flex-grow: 1;
+      width: 25%;
+
+      label {
+        font-size: 16px;
+        font-weight: 900;
+      }
+      table {
+        margin: 10px 0;
+        width: 100%;
+        border-spacing: 10px;
+
+        button {
+          background: transparent;
+          border: none;
+          color: var(--dark-gray);
+          display: inline-block;
+          font-size: 12px;
+          margin: 0;
+          padding: 0;
+          text-transform: uppercase;
+        }
+      }
+      .emphasis {
+        margin: 10px 0;
+        font-style: italic;
+      }
+    }
+  }
+
 
   .slateContainer {
     border: solid 1.5px var(--med-gray);
@@ -46,8 +97,8 @@
     border-radius: 4px;
     font-family: var(--font-family-default);
     font-size: 16px;
-    padding: 5px 10px 7px;
-    width: calc(50% - 23px); // 20px padding + 3px border = 23
+    padding: 5px 10px;
+    width: calc(100% - 23px); // 20px padding + 3px border = 23
     -webkit-appearance: none;
   }
   textarea {
@@ -56,7 +107,7 @@
   }
 
   dl {
-    margin: 0 0 20px;
+    margin: 0;
     padding: 0;
 
     dt {

--- a/lara-typescript/src/projects/components/project-settings-form.spec.tsx
+++ b/lara-typescript/src/projects/components/project-settings-form.spec.tsx
@@ -58,7 +58,7 @@ describe("ProjectSettingsForm", () => {
   });
 
   it("renders a form with options for project settings", async () => {
-    fetch.mockResponse(JSON.stringify({project}));
+    fetch.mockResponse(JSON.stringify({project, admins: []}));
     await act(async () => {
       ReactDOM.render(<ProjectSettingsForm id={project1Id} />, container);
     });
@@ -90,14 +90,14 @@ describe("ProjectSettingsForm", () => {
   });
 
   it("saves changes to project settings", async () => {
-    fetch.mockResponse(JSON.stringify({project}));
+    fetch.mockResponse(JSON.stringify({project, admins: []}));
     await act(async () => {
       ReactDOM.render(<ProjectSettingsForm id={project1Id} />, container);
     });
     const titleInput = container.querySelector("#project-title") as HTMLInputElement;
     const urlInput = container.querySelector("#project-url") as HTMLInputElement;
-    const saveButton = container.querySelector("#save-button") as HTMLButtonElement;
-    const updatedProject = {...project, title: "Test Project A", url: "https://concord.org/new-path"};
+    const saveButton = container.querySelector(".save-button") as HTMLButtonElement;
+    const updatedProject = {...project, title: "Test Project A", url: "https://concord.org/new-path", admins: []};
     fetch.mockResponse(JSON.stringify({project: updatedProject, success: true}));
     await act(async () => {
       fireEvent.change(titleInput, { target: { value: "Test Project A"} });
@@ -132,7 +132,7 @@ describe("ProjectSettingsForm", () => {
       ReactDOM.render(<ProjectSettingsForm id={null} />, container);
     });
     const titleInput = container.querySelector("#project-title") as HTMLInputElement;
-    const saveButton = container.querySelector("#save-button") as HTMLButtonElement;
+    const saveButton = container.querySelector(".save-button") as HTMLButtonElement;
     await act(async () => {
       fireEvent.change(titleInput, { target: { value: "New Project Title"} });
       fireEvent.blur(titleInput);

--- a/lara-typescript/src/projects/types.ts
+++ b/lara-typescript/src/projects/types.ts
@@ -14,3 +14,7 @@ export interface IProject {
   title: string;
   url?: string;
 }
+export interface IProjectAdmin {
+  id: number;
+  email: string;
+}


### PR DESCRIPTION
Adds list of admins in the project edit form and allows users to remove project admins.

Due to the concern of leaking emails only site admins can add project admins to projects.

This also updates some styling of the main admin ui.