### PR TITLE
fix: Add non-author role glossary updates frm owner [PT-186126069]

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -105,6 +105,10 @@ class Ability
       can :manage, Sequence, :user_id => user.id
     end
 
+    # Everyone (author and regular user) can update glossaries they own.
+    can :update, Glossary do |glossary|
+      user.id == glossary.user_id || user.project_admin_of?(glossary.project)
+    end
     # Everyone (author and regular user) can update activities they own.
     can :update, LightweightActivity do |activity|
       user.id == activity.user_id || user.project_admin_of?(activity.project)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -288,6 +288,13 @@ describe User do
       let(:other_collaborating_run) { FactoryGirl.create(:run, user: other_user, collaboration_run: other_collaboration_run, activity: other_collaboration_activity) }
       let(:other_collaboration_irs) { FactoryGirl.create(:interactive_run_state, run: other_collaborating_run) }
 
+      let(:glossary) { FactoryGirl.create(:glossary, user: other_user) }
+      let(:own_glossary) { FactoryGirl.create(:glossary, user: user) }
+
+      it { is_expected.not_to be_able_to(:create, Glossary) }
+      it { is_expected.to be_able_to(:update, own_glossary) }
+      it { is_expected.not_to be_able_to(:update, glossary) }
+
       it { is_expected.not_to be_able_to(:create, LightweightActivity) }
       it { is_expected.to be_able_to(:read, archive_activity) }
       it { is_expected.to be_able_to(:read, hidden_activity) }


### PR DESCRIPTION
Added a ability rule that creators of glossaries, even if they do not have an author role, can update glossaries they create.