### PR TITLE
fix: Missing edit link on glossaries for project admins [PT-186530973]

### DIFF
--- a/app/models/glossary.rb
+++ b/app/models/glossary.rb
@@ -62,7 +62,7 @@ class Glossary < ActiveRecord::Base
     if user.nil?
       false
     else
-      user.id == self.user_id || user.admin?
+      user.id == self.user_id || user.admin? || user.project_admin_of?(self.project)
     end
   end
 


### PR DESCRIPTION
The glossary used a method outside of cancan to set the editing ability.