### PR TITLE
fix: user.project_admin_of? with nil project

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ActiveRecord::Base
   end
 
   def project_admin_of?(project)
-    project && admined_projects.any? {|ap| ap.id == project.id }
+    !!(project && admined_projects.any? {|ap| ap.id == project.id })
   end
 
   def most_recent_authentication

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -514,6 +514,7 @@ describe User do
       expect(user.project_admins.length).to be(0)
       expect(user.admined_projects.length).to be(0)
 
+      expect(user.project_admin_of?(nil)).to be(false)
       expect(user.project_admin_of?(project1)).to be(false)
       expect(user.project_admin_of?(project2)).to be(false)
     end


### PR DESCRIPTION
This was returning nil instead of false which then caused nothing to be output in the glossary edit html javascript section breaking the glossary view link when the user was not a an admin or project admin.