### PR TITLE
ci: Add 'environment_url' to deployment

### DIFF
--- a/.github/workflows/actions/deploy-rails-app-to-aws/action.yml
+++ b/.github/workflows/actions/deploy-rails-app-to-aws/action.yml
@@ -29,15 +29,14 @@ runs:
         else
           echo "User did not select a release version to deploy."
           echo -n "Querying API for latest "
-          if [[ "${{ github.event.inputs.environment }}" == *"(Production)"* ]]; then
-            echo -n "release version"
-            latest_github_release_ver=$(gh release view --json 'tagName' --jq '.tagName[1:]' | tr -d '\n')
-          elif [[ "${{ github.event.inputs.environment }}" == *"(Staging)"* ]]; then
+          # If environment name/URL contains ".staging." subdomain
+          if [[ "${{ github.event.inputs.environment }}" == *".staging."* ]]; then
             echo -n "pre-release version"
             latest_github_release_ver=$(gh release list | grep -oP 'Pre-release\s+v\K\d+\.\d+\.\d-pre\.\d+' | sort -uVr | head -n 1 | tr -d '\n')
+          # Otherwise assume that it's a production deployment environment
           else
-            echo "Environment name must include the sub-string \"(Production)\" or \"(Staging)\" to indicate whether it is a staging or production stack"
-            test
+            echo -n "release version"
+            latest_github_release_ver=$(gh release view --json 'tagName' --jq '.tagName[1:]' | tr -d '\n')
           fi
           echo "..."
           echo "Determined latest pre-release/release version is '$latest_github_release_ver'"

--- a/.github/workflows/deploy_backend_to_aws.yml
+++ b/.github/workflows/deploy_backend_to_aws.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       environment:
         type: environment
-        default: 'Authoring (Staging) - authoring.lara.staging.concord.org'
+        default: 'authoring.lara.staging.concord.org'
         description: CloudFormation stack to deploy to
         required: true
       version:
@@ -24,7 +24,9 @@ jobs:
   deploy:
     name: 🚀 Deploy to '${{ inputs.environment }}'
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
+      url: https://${{ inputs.environment }}
     steps:
       - name: 📥 Checkout project source
         uses: actions/checkout@v4

--- a/.github/workflows/payload.json
+++ b/.github/workflows/payload.json
@@ -1,5 +1,5 @@
 {
   "inputs": {
-    "environment": "Authoring (Staging) - authoring.lara.staging.concord.org"
+    "environment": "authoring.lara.staging.concord.org"
   }
 }


### PR DESCRIPTION
This small change to the AWS app deployment workflow will add a link to the deployment environment's URL within GitHub