### PR TITLE
fix:  Allow non-admins to edit existing activities with non-official library interactives [PT-186993789]

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -404,10 +404,6 @@ class Api::V1::InteractivePagesController < API::APIController
       .joins("LEFT JOIN managed_interactives ON managed_interactives.library_interactive_id = library_interactives.id")
       .group('library_interactives.id')
 
-    if current_user && !current_user.is_admin
-      library_interactives = library_interactives.where("library_interactives.official = true")
-    end
-
     plugins = get_teacher_edition_plugins.map { |plugin| map_plugin_to_hash(plugin) }
 
     library_interactives_list = library_interactives.map do |library_interactive|

--- a/app/views/interactive_pages/edit.html.haml
+++ b/app/views/interactive_pages/edit.html.haml
@@ -63,10 +63,9 @@
       var params = {
         host: window.location.origin,
         activityId: "#{@activity.id}",
-        id: "#{@page.id}"
+        id: "#{@page.id}",
+        isAdmin: #{((current_user && current_user.is_admin) || false).to_json}
       };
-      var element;
-      console.log(params);
       var container = $("#sections-container")[0];
       LARA.SectionAuthoring.renderAuthoringPage(container, params);
     });

--- a/lara-typescript/src/projects/components/project-list-item.tsx
+++ b/lara-typescript/src/projects/components/project-list-item.tsx
@@ -32,7 +32,11 @@ export const ProjectListItem: React.FC<IProjectListItemProps> = ({
       <menu>
         <ul>
           <li><button className="textButton editButton" onClick={handleEditButtonClick}>Edit</button></li>
-          {onDelete && <li><button className="textButton deleteButton" onClick={handleDeleteButtonClick}>Delete</button></li>}
+          {onDelete && (
+            <li>
+              <button className="textButton deleteButton" onClick={handleDeleteButtonClick}>Delete</button>
+            </li>
+          )}
         </ul>
       </menu>
       <div className="projectListItem__link">

--- a/lara-typescript/src/section-authoring/api/api-types.ts
+++ b/lara-typescript/src/section-authoring/api/api-types.ts
@@ -91,6 +91,7 @@ export interface ILibraryInteractive {
   native_height: number;
   native_width: number;
   no_snapshots: boolean;
+  official: boolean;
   serializeable_id: string;
   show_delete_data_button: boolean;
   thumbnail_url: string;
@@ -368,4 +369,6 @@ export interface IAuthoringAPIProvider {
 
   pathToTinyMCE: string | null;
   pathToTinyMCECSS: string | undefined;
+
+  isAdmin: boolean;
 }

--- a/lara-typescript/src/section-authoring/api/lara-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/lara-api-provider.ts
@@ -24,14 +24,16 @@ const APIBase = "/api/v1";
 interface IGetLARAAuthoringAPIParams {
   activityId: string;
   host: string;
+  isAdmin: boolean;
 }
 
 export const getLaraAuthoringAPI =
   (authoringArgs: IGetLARAAuthoringAPIParams = {
     activityId: "",
-    host: window.location.origin
+    host: window.location.origin,
+    isAdmin: false
   }): IAuthoringAPIProvider => {
-  const { activityId, host } = authoringArgs;
+  const { activityId, host, isAdmin } = authoringArgs;
   const prefix = `${host}${APIBase}`;
   // endpoints:
 
@@ -291,6 +293,7 @@ export const getLaraAuthoringAPI =
     createSection, updateSections, updateSection, copySection, getPageItemPlugins,
     createPageItem, updatePageItem, deletePageItem, copyPageItem, getAvailablePlugins,
     getAllEmbeddables, getLibraryInteractives, getPortals, getPreviewOptions, getPageItemEmbeddableMetaData,
-    pathToTinyMCE: "/assets/tinymce.js", pathToTinyMCECSS: "/assets/tinymce-content.css"
+    pathToTinyMCE: "/assets/tinymce.js", pathToTinyMCECSS: "/assets/tinymce-content.css",
+    isAdmin
   };
 };

--- a/lara-typescript/src/section-authoring/api/lara-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/lara-api-provider.ts
@@ -261,7 +261,8 @@ export const getLaraAuthoringAPI =
           type: "MwInteractive",
           useCount: 0,
           dateAdded: 0,
-          isQuickAddItem: true
+          isQuickAddItem: true,
+          official: true,
         });
         result.allEmbeddables.push({
           id: "Embeddable::Xhtml",
@@ -270,7 +271,8 @@ export const getLaraAuthoringAPI =
           type: "Embeddable::Xhtml",
           useCount: 0,
           dateAdded: 0,
-          isQuickAddItem: true
+          isQuickAddItem: true,
+          official: true,
         });
         const plugins = (json.plugins as IPluginType[]);
         for (const plugin of plugins) {

--- a/lara-typescript/src/section-authoring/api/mock-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/mock-api-provider.ts
@@ -439,6 +439,7 @@ const getLibraryInteractives = () => {
       native_height: 435,
       native_width: 576,
       no_snapshots: false,
+      official: false,
       show_delete_data_button: false,
       thumbnail_url: "",
       updated_at: "2021-05-04T21:26:18Z"
@@ -467,6 +468,7 @@ const getLibraryInteractives = () => {
       native_height: 435,
       native_width: 576,
       no_snapshots: false,
+      official: false,
       show_delete_data_button: false,
       thumbnail_url: "",
       updated_at: "2021-05-04T21:26:18Z"
@@ -495,6 +497,7 @@ const getLibraryInteractives = () => {
       native_height: 435,
       native_width: 576,
       no_snapshots: false,
+      official: false,
       show_delete_data_button: false,
       thumbnail_url: "",
       updated_at: "2021-05-04T21:26:18Z"
@@ -523,6 +526,7 @@ const getLibraryInteractives = () => {
       native_height: 435,
       native_width: 576,
       no_snapshots: false,
+      official: false,
       show_delete_data_button: false,
       thumbnail_url: "",
       updated_at: "2021-05-04T21:26:18Z"
@@ -552,6 +556,7 @@ const getLibraryInteractives = () => {
       native_height: 435,
       native_width: 576,
       no_snapshots: false,
+      official: false,
       show_delete_data_button: false,
       thumbnail_url: "",
       updated_at: "2021-05-04T21:26:18Z"
@@ -631,5 +636,6 @@ export const API: IAuthoringAPIProvider = {
   createPageItem, updatePageItem, deletePageItem, copyPageItem,
   getAllEmbeddables, getLibraryInteractives, getAvailablePlugins, getPortals,
   getPreviewOptions, getPageItemPlugins, getPageItemEmbeddableMetaData,
-  pathToTinyMCE: "https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.10.0/tinymce.min.js", pathToTinyMCECSS: undefined
+  pathToTinyMCE: "https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.10.0/tinymce.min.js", pathToTinyMCECSS: undefined,
+  isAdmin: false
 };

--- a/lara-typescript/src/section-authoring/components/query-bound-page.tsx
+++ b/lara-typescript/src/section-authoring/components/query-bound-page.tsx
@@ -5,14 +5,14 @@ import { AuthoringPageUsingAPI, IPageProps } from "./authoring-page";
 export interface IQueryBoundPage extends IPageProps {
   host?: string;
   activityId?: string;
+  isAdmin?: boolean;
 }
 
 export const QueryBoundPage = (props: IQueryBoundPage) => {
   const host = props.host || "https://app.lara.docker";
   const activityId = props.activityId || "55";
-  const pageId = props.id;
   return (
-    <APIContainer activityId={activityId} host={host}>
+    <APIContainer activityId={activityId} host={host} isAdmin={props.isAdmin}>
       <AuthoringPageUsingAPI />
     </APIContainer>
   );

--- a/lara-typescript/src/section-authoring/components/section-item-picker.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-picker.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import classNames from "classnames";
 import { Modal, ModalButtons } from "../../shared/components/modal/modal";
 import { Add } from "../../shared/components/icons/add-icon";
 import { absorbClickThen } from "../../shared/absorb-click";
-import { ISectionItemType } from "../api/api-types";
+import { ILibraryInteractive, ISectionItemType } from "../api/api-types";
 import { usePageAPI } from "../hooks/use-api-provider";
 
 import "./section-item-picker.scss";
@@ -26,7 +26,17 @@ const SectionItemButton = ({item, disabled, className, onClick}: {
 
 export const SectionItemPicker: React.FC<IProps> = (props) => {
   const api = usePageAPI();
-  const allItems = api.getAllEmbeddables.data;
+  const allItems = useMemo(() => {
+    if (!api.getAllEmbeddables.data) {
+      return undefined;
+    }
+    // filter out non-official embeddables if the user is not an admin
+    const allEmbeddables = api.getAllEmbeddables.data.allEmbeddables.filter(em => {
+      const official = (em as unknown as ILibraryInteractive).official ?? false;
+      return api.isAdmin || official;
+    });
+    return {allEmbeddables};
+  }, [api.getAllEmbeddables.data, api.isAdmin]);
   const quickAddItems = api.getAllEmbeddables.data?.allEmbeddables.filter(e => e.isQuickAddItem);
   const { onClose, onAdd } = props;
   const modalIsVisible = true;

--- a/lara-typescript/src/section-authoring/components/section-item-picker.tsx
+++ b/lara-typescript/src/section-authoring/components/section-item-picker.tsx
@@ -37,7 +37,7 @@ export const SectionItemPicker: React.FC<IProps> = (props) => {
     });
     return {allEmbeddables};
   }, [api.getAllEmbeddables.data, api.isAdmin]);
-  const quickAddItems = api.getAllEmbeddables.data?.allEmbeddables.filter(e => e.isQuickAddItem);
+  const quickAddItems = allItems?.allEmbeddables.filter(e => e.isQuickAddItem);
   const { onClose, onAdd } = props;
   const modalIsVisible = true;
   const [currentSelectedItem, setCurrentSelectedItem]

--- a/lara-typescript/src/section-authoring/containers/api-container.tsx
+++ b/lara-typescript/src/section-authoring/containers/api-container.tsx
@@ -10,15 +10,16 @@ import { ReactQueryDevtools } from "react-query/devtools";
 export interface IAPIContainerProps {
   activityId?: string;
   host?: string;
+  isAdmin?: boolean;
 }
 
 export const APIContainer: React.FC<IAPIContainerProps> = (props) => {
-  const {activityId, host} = props;
+  const {activityId, host, isAdmin} = props;
   const queryClient = new QueryClient();
   const ui = React.useContext(UserInterfaceContext);
   let APIProvider: IAuthoringAPIProvider = mockProvider;
   if (host) {
-    APIProvider = getLaraAuthoringAPI({activityId: activityId || "", host});
+    APIProvider = getLaraAuthoringAPI({activityId: activityId || "", host, isAdmin: !!isAdmin});
   }
 
   return (

--- a/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
+++ b/lara-typescript/src/section-authoring/hooks/use-api-provider.ts
@@ -310,6 +310,7 @@ export const usePageAPI = () => {
     updateSectionItems, moveItem, getItems, getPortals,
     getAllEmbeddables, getLibraryInteractives, currentPage, deleteSectionFunction,
     getPreviewOptions,
-    pathToTinyMCE: provider.pathToTinyMCE, pathToTinyMCECSS: provider.pathToTinyMCECSS
+    pathToTinyMCE: provider.pathToTinyMCE, pathToTinyMCECSS: provider.pathToTinyMCECSS,
+    isAdmin: provider.isAdmin
   };
 };

--- a/spec/controllers/api/v1/interactive_pages_controller_spec.rb
+++ b/spec/controllers/api/v1/interactive_pages_controller_spec.rb
@@ -354,7 +354,7 @@ describe Api::V1::InteractivePagesController do
       expect(response.body).to eql(expected_response_for_admin)
     end
 
-    it "returns a list of only official library interactives including all properties for non admins" do
+    it "returns a list of all library interactives including all properties for non admins" do
       sign_in author
 
       # make sure the mocks exist
@@ -393,6 +393,35 @@ describe Api::V1::InteractivePagesController do
             thumbnail_url: library_interactive1.thumbnail_url,
             updated_at: library_interactive1.updated_at,
             use_count: 1
+          },
+          {
+            aspect_ratio_method: library_interactive2.aspect_ratio_method,
+            authorable: library_interactive2.authorable,
+            authoring_guidance: library_interactive2.authoring_guidance,
+            base_url: library_interactive2.base_url,
+            click_to_play: library_interactive2.click_to_play,
+            click_to_play_prompt: library_interactive2.click_to_play_prompt,
+            created_at: library_interactive2.created_at,
+            customizable: library_interactive2.customizable,
+            date_added: library_interactive2.created_at.to_i,
+            description: library_interactive2.description,
+            enable_learner_state: library_interactive2.enable_learner_state,
+            export_hash: library_interactive2.export_hash,
+            full_window: library_interactive2.full_window,
+            has_report_url: library_interactive2.has_report_url,
+            id: library_interactive2.id,
+            image_url: library_interactive2.image_url,
+            name: library_interactive2.name,
+            native_height: library_interactive2.native_height,
+            native_width: library_interactive2.native_width,
+            no_snapshots: library_interactive2.no_snapshots,
+            official: library_interactive2.official,
+            report_item_url: library_interactive2.report_item_url,
+            serializeable_id: library_interactive2.serializeable_id,
+            show_delete_data_button: library_interactive2.show_delete_data_button,
+            thumbnail_url: library_interactive2.thumbnail_url,
+            updated_at: library_interactive2.updated_at,
+            use_count: 0
           }
         ],
         # TODO: Add some page-level plugins to test...


### PR DESCRIPTION
With this change the server no longer filters the non-official library interactives and instead of the React UI does the filtering.

This fix was made so that project admins could edit activities with non-official library interactives included in them.

There were also some misc lint issues fixed from existing code that were highlighted when the TypeScript was rebuilt.