### PR TITLE
fix: Plugins not showing in add item UI for non-admins [PT-187056636]

### DIFF
--- a/lara-typescript/src/section-authoring/api/lara-api-provider.ts
+++ b/lara-typescript/src/section-authoring/api/lara-api-provider.ts
@@ -209,7 +209,10 @@ export const getLaraAuthoringAPI =
           type: `Plugin::${plugin.label}`,
           useCount: 0,
           dateAdded: 0,
-          isQuickAddItem: false
+          isQuickAddItem: false,
+          // since there is no official column for plugins in the model
+          // we force it to true here so it shows in the item picker for non-admins
+          official: true,
         });
       }
     }


### PR DESCRIPTION
This fix adds the official flag to all embeddable plugins so they shown to non-admins in the add item UI.  There is no official flag in the plugin server side model so it needs to be set on the client side.