### PR TITLE
Update GH Codespaces sample .env file

### DIFF
--- a/.env-gh-codespaces-sample
+++ b/.env-gh-codespaces-sample
@@ -11,11 +11,11 @@ COMPOSE_FILE=docker-compose.yml:docker/dev/docker-compose-gh-codespaces.yml:dock
 # to automatically set PORTAL_HOST variable.
 PORTAL_CODESPACE_NAME=
 
-PORTAL_HOST=${PORTAL_CODESPACE_NAME}-3000.preview.app.github.dev
+PORTAL_HOST=${PORTAL_CODESPACE_NAME}-3000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}
 PORTAL_PROTOCOL=https
 
 # CODESPACE_NAME is available in GitHub Codespace container.
-LARA_HOST=${CODESPACE_NAME}-3000.preview.app.github.dev
+LARA_HOST=${CODESPACE_NAME}-3000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}
 LARA_PROTOCOL=https
 
 # By default the production URL for shutterbug will be used by shutterbug.js


### PR DESCRIPTION
Recently, my GH Codespaces instances started to use `.app.github.dev` domain instead of `preview.app.github.dev`. This obviously breaks quite a few things in the Portal and LARA connection. It's the second time this has happened to me (although the previous update was a long time ago). It may be some global update in Codespaces or specific to my instances.

I was looking if there's some way to improve that and found an env variable that automatically returns the port forwarding domain: `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN`. It's documented here:

https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace

