### PR TITLE
feat: Add rubric model [PT-187946683]

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -113,6 +113,10 @@ class Ability
     can :update, Glossary do |glossary|
       user.id == glossary.user_id || user.project_admin_of?(glossary.project)
     end
+    # Everyone (author and regular user) can update rubrics they own.
+    can :update, Rubric do |rubric|
+      user.id == rubric.user_id || user.project_admin_of?(rubric.project)
+    end
     # Everyone (author and regular user) can update activities they own.
     can :update, LightweightActivity do |activity|
       user.id == activity.user_id || user.project_admin_of?(activity.project)

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -30,7 +30,7 @@ class LightweightActivity < ActiveRecord::Base
                   :time_to_complete, :is_locked, :notes, :thumbnail_url, :project_id,
                   :portal_run_count, :layout, :editor_mode, :publication_hash, :copied_from_id,
                   :student_report_enabled, :show_submit_button, :project, :background_image,
-                  :glossary_id, :hide_read_aloud, :font_size, :hide_question_numbers
+                  :glossary_id, :hide_read_aloud, :font_size, :hide_question_numbers, :rubric_id
 
   belongs_to :user # Author
   belongs_to :changed_by, :class_name => 'User'
@@ -136,6 +136,7 @@ class LightweightActivity < ActiveRecord::Base
         new_activity.plugins.push(p.duplicate)
       end
       new_activity.glossary_id = self.glossary_id
+      new_activity.rubric_id = self.rubric_id
     end
     new_activity
   end

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -1,0 +1,117 @@
+class Rubric < ActiveRecord::Base
+  attr_accessible :name, :user_id, :project_id, :project
+  validates :name, presence: true
+  validates :user_id, presence: true
+
+  belongs_to :user
+  belongs_to :project
+  has_many :lightweight_activities
+
+  # scope :public, self.scoped # all rubrics are public
+  scope :none, where("1 = 0") # used to return "my rubrics" to no user
+  scope :newest, order("updated_at DESC")
+
+  def export(user)
+    {
+      id: self.id,
+      name: self.name,
+      project: self.project ? self.project.export : nil,
+      user_id: self.user_id,
+      can_edit: self.can_edit(user)
+    }
+  end
+
+  def to_hash
+    {
+      id: self.id,
+      name: self.name,
+      project: self.project,
+      user_id: self.user_id
+    }
+  end
+
+  def to_export_hash
+    {
+      id: self.id,
+      name: self.name,
+      project: self.project,
+      user_id: self.user_id,
+      type: "Rubric"
+    }
+  end
+
+  def duplicate(new_owner)
+    new_rubric = Rubric.new(self.to_hash)
+    new_rubric.name = "Copy of #{new_rubric.name}"
+    new_rubric.user = new_owner
+    new_rubric
+  end
+
+  def can_edit(user)
+    if user.nil?
+      false
+    else
+      user.id == self.user_id || user.admin? || user.project_admin_of?(self.project)
+    end
+  end
+
+  def self.import(rubric_json_object, new_owner)
+    imported_rubric = Rubric.new(self.extract_from_hash(rubric_json_object))
+    imported_rubric.project = Project.find_or_create(rubric_json_object[:project]) if rubric_json_object[:project]
+    imported_rubric.user = new_owner
+    imported_rubric.save!
+    imported_rubric
+  end
+
+  def self.extract_from_hash(rubric_json_object)
+    {
+      name: rubric_json_object[:name]
+    }
+  end
+
+  # helper used in lightweight activity edit to list the rubrics that can be assigned to an activity
+  def self.by_author(user)
+    if user
+      self.where(user_id: user.id).eager_load(:user).order(:name)
+    else
+      self.none
+    end
+  end
+
+  # helper used in lightweight activity edit to list the rubrics that can be assigned to an activity
+  def self.by_others(user)
+    if user
+      self.where("user_id != ?", user.id).eager_load(:user).order(:name)
+    else
+      self.scoped.eager_load(:user).order(:name)
+    end
+  end
+
+  # Class methods below are to enable rubric listing on the homepage through the collection filter
+  # These somewhat mirror the class methods injects by the PublicationStatus model, except they remove
+  # the checks for publication status
+  def self.my(user)
+    where(:user_id => user.id)
+  end
+
+  def self.can_see(user)
+    # all users can see all rubrics
+    self.scoped
+  end
+
+  def self.visible(user)
+    self.can_see(user)
+  end
+
+  def self.search(query, user)
+    self.can_see(user).where("name LIKE ?", "%#{query}%")
+  end
+
+  def self.public_for_user(user)
+    if user && (user.admin? || user.author? || user.project_admin_of?(self.project))
+      self.scoped
+    else
+      self.none
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ActiveRecord::Base
   has_many :runs
   has_many :imports
   has_many :glossaries, order: :name
+  has_many :rubrics, order: :name
   has_many :project_admins
   has_many :admined_projects, through: :project_admins, :source => :project
 

--- a/db/migrate/20240718182117_create_rubrics.rb
+++ b/db/migrate/20240718182117_create_rubrics.rb
@@ -1,0 +1,13 @@
+class CreateRubrics < ActiveRecord::Migration
+  def change
+    create_table :rubrics do |t|
+      t.string :name
+      t.integer :user_id
+      t.integer :project_id
+
+      t.timestamps
+    end
+
+    add_column :lightweight_activities, :rubric_id, :integer, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20240103135547) do
+ActiveRecord::Schema.define(:version => 20240718182117) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -457,6 +457,7 @@ ActiveRecord::Schema.define(:version => 20240103135547) do
     t.boolean  "hide_read_aloud",                        :default => false
     t.string   "font_size",                              :default => "normal"
     t.boolean  "hide_question_numbers",                  :default => false
+    t.integer  "rubric_id"
   end
 
   add_index "lightweight_activities", ["changed_by_id"], :name => "index_lightweight_activities_on_changed_by_id"
@@ -659,6 +660,14 @@ ActiveRecord::Schema.define(:version => 20240103135547) do
     t.integer "master_question_id"
     t.string  "master_question_type"
     t.integer "user_id"
+  end
+
+  create_table "rubrics", :force => true do |t|
+    t.string   "name"
+    t.integer  "user_id"
+    t.integer  "project_id"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "runs", :force => true do |t|

--- a/spec/factories/rubrics.rb
+++ b/spec/factories/rubrics.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :rubric, :class => Rubric do
+    name { generate(:name) }
+  end
+end

--- a/spec/models/rubric_spec.rb
+++ b/spec/models/rubric_spec.rb
@@ -1,0 +1,222 @@
+require 'spec_helper'
+
+RSpec.describe Rubric do
+  let(:author)    { FactoryGirl.create(:author) }
+  let(:author2)   { FactoryGirl.create(:author) }
+  let(:admin)     { FactoryGirl.create(:admin) }
+  let(:project)     { FactoryGirl.create(:project) }
+
+  let(:rubric)      {
+    rubric = FactoryGirl.create(:rubric, name: "Rubric 1", user: author, project: project)
+    rubric.save!
+    rubric
+  }
+  let(:rubric2) { FactoryGirl.create(:rubric, name: "Rubric 2", user: author2) }
+
+  describe "should export itself" do
+    it "as the author with can_edit as true" do
+      expect(rubric.export(author)).to eq({
+        id: rubric.id,
+        name: rubric.name,
+        project: project.export(),
+        user_id: rubric.user_id,
+        can_edit: true
+      })
+    end
+
+    it "as an admin with can_edit as true" do
+      expect(rubric.export(admin)[:can_edit]).to eq(true)
+    end
+
+    it "as not the author or admin with can_edit as false" do
+      expect(rubric.export(author2)[:can_edit]).to eq(false)
+    end
+
+  end
+
+  describe "self.by_author" do
+    it "should return an empty array if the user is nil" do
+      expect(Rubric.by_author(nil)).to eq([])
+    end
+
+    it "should return an array of rubrics by the user if the user is not nil" do
+      expect(Rubric.by_author(author)).to eq([rubric])
+    end
+
+    describe "with a different user" do
+      let(:other_author) { FactoryGirl.create(:author) }
+
+      it "should return an array of rubrics by the user if the user is not nil" do
+        expect(Rubric.by_author(other_author)).to eq([])
+      end
+    end
+
+    describe "with multiple rubrics" do
+      let(:rubric1)      {
+        rubric = FactoryGirl.create(:rubric, user: author, name: "ZZZ")
+        rubric.save!
+        rubric
+      }
+      let(:rubric2)      {
+        rubric = FactoryGirl.create(:rubric, user: author, name: "AAA")
+        rubric.save!
+        rubric
+      }
+
+      it "returns the list in alpha order" do
+        expect(Rubric.by_author(author)).to eq([rubric2, rubric1])
+      end
+    end
+  end
+
+  describe "self.by_others" do
+    let(:other_author) { FactoryGirl.create(:author) }
+
+    it "should return an empty array if the user is nil" do
+      expect(Rubric.by_others(nil)).to eq([])
+    end
+
+    it "should return an array of rubrics by other users if the user is not nil" do
+      expect(Rubric.by_others(author)).to eq([rubric2])
+    end
+
+    describe "with a different user" do
+      it "should return an array of rubrics by the user if the user is not nil" do
+        expect(Rubric.by_others(other_author)).to eq([rubric, rubric2])
+      end
+    end
+
+    describe "with multiple rubrics" do
+      let(:rubric1)      {
+        rubric = FactoryGirl.create(:rubric, user: author, name: "ZZZ")
+        rubric.save!
+        rubric
+      }
+      let(:rubric2)      {
+        rubric = FactoryGirl.create(:rubric, user: author, name: "AAA")
+        rubric.save!
+        rubric
+      }
+
+      it "returns the list in alpha order" do
+        expect(Rubric.by_others(other_author)).to eq([rubric2, rubric1])
+      end
+    end
+  end
+
+  describe "can_edit" do
+    it "should return true for authors of rubrics" do
+      expect(rubric.can_edit(author)).to eq(true)
+    end
+    it "should return true for admins" do
+      expect(rubric.can_edit(admin)).to eq(true)
+    end
+    it "should return false for other users that are not admins" do
+      expect(rubric.can_edit(author2)).to eq(false)
+    end
+  end
+
+  it "should support #to_hash" do
+    expect(rubric.to_hash).to eq({
+      id: rubric.id,
+      name: rubric.name,
+      project: rubric.project,
+      user_id: rubric.user_id
+    })
+  end
+
+  it "should support #to_export_hash" do
+    expect(rubric.to_export_hash).to eq({
+      id: rubric.id,
+      name: rubric.name,
+      project: rubric.project,
+      user_id: rubric.user_id,
+      type: "Rubric"
+    })
+  end
+
+  it "should support #duplicate" do
+    expect(rubric.duplicate(author2).to_hash).to eq({
+      id: nil,
+      name: "Copy of #{rubric.name}",
+      project: rubric.project,
+      user_id: author2.id
+    })
+  end
+
+  it "should support #self.import" do
+    imported_rubric = Rubric.import(rubric.to_export_hash, author2)
+    expect(imported_rubric.id).not_to eq(rubric.id)
+    expect(imported_rubric.user).to eq(author2)
+    expect(imported_rubric.project.id).to eq(project.id)
+  end
+
+  it "should support #self.extract_from_hash" do
+    expect(Rubric.extract_from_hash(rubric.to_export_hash)).to eq({
+      name: rubric.name
+    })
+  end
+
+  describe "homepage index methods" do
+    describe "as an author" do
+      it "should support self.my" do
+        expect(Rubric.my(author)).to eq([rubric])
+      end
+
+      it "should support self.can_see" do
+        expect(Rubric.can_see(author)).to eq([rubric, rubric2])
+      end
+
+      it "should support self.visible" do
+        expect(Rubric.visible(author)).to eq([rubric, rubric2])
+      end
+
+      it "should support self.search" do
+        expect(Rubric.search("Rubric", author)).to eq([rubric, rubric2])
+      end
+
+      it "should support self.public_for_user" do
+        expect(Rubric.public_for_user(author)).to eq([rubric, rubric2])
+      end
+    end
+
+    describe "as an admin" do
+      before(:each) do
+        # make sure both rubrics are visible in a query
+        rubric
+        rubric2
+      end
+
+      it "should support self.my" do
+        expect(Rubric.my(admin)).to eq([])
+      end
+
+      it "should support self.can_see" do
+        expect(Rubric.can_see(admin)).to eq([rubric, rubric2])
+      end
+
+      it "should support self.visible" do
+        expect(Rubric.visible(admin)).to eq([rubric, rubric2])
+      end
+
+      it "should support self.search" do
+        expect(Rubric.search("Rubric", admin)).to eq([rubric, rubric2])
+      end
+
+      it "should support self.public_for_user" do
+        expect(Rubric.public_for_user(author)).to eq([rubric, rubric2])
+      end
+    end
+  end
+
+  describe "scopes" do
+    it "should support none" do
+      expect(Rubric.none).to eq ([])
+    end
+
+    it "should support newest" do
+      expect(Rubric.newest).to eq ([rubric2, rubric])
+    end
+  end
+
+end


### PR DESCRIPTION
This is a mirror of the glossary model with the glossary specific attributes (like legacy glossary id, removed).