### PR TITLE
fix: Remove scoreUsingPoints option and made "Show rating descriptions" conditional [PT-188034293]

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -3727,6 +3727,12 @@ button.bigButton svg {
   width: 750px;
   box-sizing: border-box;
 }
+.general-options input#showRatingDescriptions {
+  margin-left: 20px;
+}
+.general-options span#showRatingDescriptionsLabel.disabled {
+  color: rgba(0, 0, 0, 0.3137254902);
+}
 .rubric-panel {
   margin-bottom: 10px;
 }

--- a/lara-typescript/src/rubric-authoring/rubric-general-options.scss
+++ b/lara-typescript/src/rubric-authoring/rubric-general-options.scss
@@ -22,4 +22,13 @@
     width: 750px;
     box-sizing: border-box;
   }
+
+  input#showRatingDescriptions {
+    margin-left: 20px;
+  }
+  span#showRatingDescriptionsLabel {
+    &.disabled {
+      color:  #00000050;
+    }
+  }
 }

--- a/lara-typescript/src/rubric-authoring/rubric-general-options.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-general-options.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { useRubric } from "./use-rubric";
+import classNames from "classnames";
 
 import "./rubric-general-options.scss";
 
 type IRubricOptionKey = "referenceURL" | "criteriaLabel" | "criteriaLabelForStudent" | "feedbackLabelForStudent";
-type IRubricOptionBooleanKey = "showRatingDescriptions" | "scoreUsingPoints" | "hideRubricFromStudentsInStudentReport";
+type IRubricOptionBooleanKey = "showRatingDescriptions" | "hideRubricFromStudentsInStudentReport";
 
 export const RubricGeneralOptions = () => {
   const { rubric, setRubric } = useRubric();
@@ -65,33 +66,29 @@ export const RubricGeneralOptions = () => {
             <td className="rubric-checkbox">
               <input
                 type="checkbox"
-                name="showRatingDescriptions"
-                checked={rubric.showRatingDescriptions}
-                onChange={handleUpdateCheckbox("showRatingDescriptions")}
-              /> Show rating descriptions
-            </td>
-          </tr>
-          <tr>
-            <td/>
-            <td className="rubric-checkbox">
-              <input
-                type="checkbox"
-                name="scoreUsingPoints"
-                checked={rubric.scoreUsingPoints}
-                onChange={handleUpdateCheckbox("scoreUsingPoints")}
-              /> Score using points
-            </td>
-          </tr>
-          <tr>
-            <td/>
-            <td className="rubric-checkbox">
-              <input
-                type="checkbox"
                 name="hideRubricFromStudentsInStudentReport"
                 checked={rubric.hideRubricFromStudentsInStudentReport}
                 onChange={handleUpdateCheckbox("hideRubricFromStudentsInStudentReport")}
               />
               Hide rubric from students in Student Report
+            </td>
+          </tr>
+          <tr>
+            <td/>
+            <td className="rubric-checkbox">
+              <input
+                type="checkbox"
+                id="showRatingDescriptions"
+                name="showRatingDescriptions"
+                disabled={rubric.hideRubricFromStudentsInStudentReport}
+                checked={rubric.showRatingDescriptions}
+                onChange={handleUpdateCheckbox("showRatingDescriptions")}
+              />
+              <span
+                id="showRatingDescriptionsLabel"
+                className={classNames({disabled: rubric.hideRubricFromStudentsInStudentReport})}>
+                Show rating descriptions
+              </span>
             </td>
           </tr>
         </tbody>

--- a/lara-typescript/src/rubric-authoring/rubric-teacher-preview.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-teacher-preview.tsx
@@ -50,7 +50,7 @@ export const RubricTeacherPreview = ({scoring, setScoring}: IProps) => {
         {rubric.ratings.map((rating: any) =>
           <div className="rubricScoreHeader" key={rating.id}>
             <div className="rubricScoreLevel">{rating.label}</div>
-            {rubric.scoreUsingPoints && <div className="rubricScoreNumber">({rating.score})</div>}
+            <div className="rubricScoreNumber">({rating.score})</div>
           </div>
         )}
       </div>

--- a/lara-typescript/src/rubric-authoring/types.ts
+++ b/lara-typescript/src/rubric-authoring/types.ts
@@ -28,7 +28,6 @@ export interface IRubricV110 {
   originUrl: string;
   referenceURL: string;
   showRatingDescriptions: boolean;
-  scoreUsingPoints: boolean;
   hideRubricFromStudentsInStudentReport: boolean;
   criteriaLabel: string;
   criteriaLabelForStudent: string;

--- a/lara-typescript/src/rubric-authoring/use-rubric.ts
+++ b/lara-typescript/src/rubric-authoring/use-rubric.ts
@@ -38,7 +38,6 @@ export const useRubricValue = (authoredContentUrl: string): IRubricContext => {
             originUrl: "",
             referenceURL: "",
             showRatingDescriptions: false,
-            scoreUsingPoints: false,
             hideRubricFromStudentsInStudentReport: false,
             criteriaLabel: "",
             criteriaLabelForStudent: "",


### PR DESCRIPTION
The scoreUsingPoints option was move to the portal dashboard.  The "Show rating descriptions" option is now disabled when the "Hide rubric from students in Student Report" option is checked.