### PR TITLE
feat: Publish rubric document and json urls to portal [PT-187946772]

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -3671,7 +3671,7 @@ button.bigButton svg {
   margin: 10px 0;
 }
 .rubric-settings .rubric-settings-form label {
-  width: 150px;
+  width: 200px;
   display: inline-block;
   text-align: right;
   margin-right: 10px;
@@ -3824,7 +3824,7 @@ button.bigButton svg {
 }
 .rubricTeacherPreview .columnHeaders .rubricDescriptionHeader .rubricDescriptionTitle {
   justify-content: center;
-  width: 75%;
+  width: 100%;
 }
 .rubricTeacherPreview .columnHeaders .rubricScoreHeader {
   display: flex;

--- a/app/controllers/api/v1/rubrics_controller.rb
+++ b/app/controllers/api/v1/rubrics_controller.rb
@@ -16,6 +16,9 @@ class Api::V1::RubricsController < API::APIController
     if params[:name]
       rubric.name = params[:name]
     end
+    if params[:referenceUrl]
+      rubric.doc_url = params[:referenceUrl]
+    end
     if params.has_key?(:project)
       if params[:project].nil?
         rubric.project_id = nil
@@ -28,7 +31,7 @@ class Api::V1::RubricsController < API::APIController
     rescue => e
       error(e.message)
     else
-      render :json => {id: rubric.id, name: rubric.name, project: Project.id_and_title(rubric.project)}
+      render :json => {id: rubric.id, name: rubric.name, doc_url: rubric.doc_url, project: Project.id_and_title(rubric.project)}
     end
   end
 end

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -50,6 +50,7 @@ class LightweightActivity < ActiveRecord::Base
   has_many :runs, :foreign_key => 'activity_id', :dependent => :destroy
   belongs_to :project
   belongs_to :glossary
+  belongs_to :rubric
 
   has_many :imports, as: :import_item
 
@@ -284,6 +285,15 @@ class LightweightActivity < ActiveRecord::Base
   def serialize_for_portal_basic(host)
     local_url = "#{host}#{Rails.application.routes.url_helpers.activity_path(self)}"
 
+    rubric_url = ""
+    rubric_doc_url = ""
+    if self.rubric
+      rubric_doc_url = self.rubric.doc_url
+      if self.rubric.authored_content
+        rubric_url = self.rubric.authored_content.url
+      end
+    end
+
     data = {
       "type" => "Activity",
       "name" => self.name,
@@ -295,7 +305,9 @@ class LightweightActivity < ActiveRecord::Base
       "is_locked" => self.is_locked,
       "url" => activity_player_url(host),
       "tool_id" => "https://activity-player.concord.org",
-      "append_auth_token" => true
+      "append_auth_token" => true,
+      "rubric_url" => rubric_url,
+      "rubric_doc_url" => rubric_doc_url,
     }
 
     data

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -1,5 +1,5 @@
 class Rubric < ActiveRecord::Base
-  attr_accessible :name, :user_id, :project_id, :project, :authored_content_id, :authored_content
+  attr_accessible :name, :user_id, :project_id, :project, :authored_content_id, :authored_content, :doc_url
   validates :name, presence: true
   validates :user_id, presence: true
 
@@ -20,6 +20,7 @@ class Rubric < ActiveRecord::Base
       name: self.name,
       project: self.project ? self.project.export : nil,
       user_id: self.user_id,
+      doc_url: self.doc_url,
       can_edit: self.can_edit(user)
     }
   end
@@ -29,7 +30,8 @@ class Rubric < ActiveRecord::Base
       id: self.id,
       name: self.name,
       project: self.project,
-      user_id: self.user_id
+      user_id: self.user_id,
+      doc_url: self.doc_url
     }
   end
 
@@ -39,6 +41,7 @@ class Rubric < ActiveRecord::Base
       name: self.name,
       project: self.project,
       user_id: self.user_id,
+      doc_url: self.doc_url,
       type: "Rubric"
     }
   end

--- a/app/views/rubrics/_form.html.haml
+++ b/app/views/rubrics/_form.html.haml
@@ -11,7 +11,10 @@
 
     .field
       = f.label :name
-      = f.text_field :name, autofocus: true
+      = f.text_field :name, autofocus: true, :style => 'width: 90%'
+    .field
+      = f.label :doc_url, 'Reference URL (Scoring Guide)'
+      = f.text_field :doc_url, :style => 'width: 90%'
     .field
       = f.label :project_id, 'Project'
       = f.select :project_id, options_from_collection_for_select(Project.visible_to_user(current_user), 'id', 'title', @rubric.project_id), { :include_blank => true }

--- a/app/views/rubrics/edit.html.haml
+++ b/app/views/rubrics/edit.html.haml
@@ -23,5 +23,6 @@
       project: #{@project.to_json},
       projects: #{@projects.to_json},
       authoredContentUrl: "#{j api_v1_authored_content_url(@rubric.authored_content)}",
+      referenceURL: "#{j @rubric.doc_url}",
     });
   });

--- a/db/migrate/20240806145141_add_rubric_doc_url.rb
+++ b/db/migrate/20240806145141_add_rubric_doc_url.rb
@@ -1,0 +1,5 @@
+class AddRubricDocUrl < ActiveRecord::Migration
+  def change
+    add_column :rubrics, :doc_url, :string, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20240801164851) do
+ActiveRecord::Schema.define(:version => 20240806145141) do
 
   create_table "admin_events", :force => true do |t|
     t.string   "kind"
@@ -679,6 +679,7 @@ ActiveRecord::Schema.define(:version => 20240801164851) do
     t.datetime "created_at",          :null => false
     t.datetime "updated_at",          :null => false
     t.integer  "authored_content_id"
+    t.string   "doc_url"
   end
 
   create_table "runs", :force => true do |t|

--- a/lara-typescript/src/rubric-authoring/rubric-form.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-form.tsx
@@ -21,10 +21,12 @@ export interface IRubricFormProps {
   project: RubricProject|null;
   projects: RubricProject[];
   authoredContentUrl: string;
+  referenceURL: string;
 }
 
 export const RubricForm = (props: IRubricFormProps) => {
   const [name, setName] = useState(props.name);
+  const [referenceURL, setReferenceURL] = useState(props.referenceURL);
   const [project, setProject] = useState(props.project);
   const [showSettings, setShowSettings] = useState(false);
   const rubricContextValue = useRubricValue(props.authoredContentUrl);
@@ -49,6 +51,7 @@ export const RubricForm = (props: IRubricFormProps) => {
     }).then((resp) => {
       if (resp.status === 200) {
         setName(saveSettings.name);
+        setReferenceURL(saveSettings.referenceUrl);
         setProject(saveSettings.project);
         handleToggleShowSettings();
       } else {
@@ -73,7 +76,7 @@ export const RubricForm = (props: IRubricFormProps) => {
     return (
       <>
         <RubricPanel title="Rubric Preview" backgroundColor={"#e2f4f8"}>
-          <RubricPreview />
+          <RubricPreview referenceURL={referenceURL} />
         </RubricPanel>
 
         <RubricPanel title="General Options">
@@ -106,6 +109,7 @@ export const RubricForm = (props: IRubricFormProps) => {
         {showSettings &&
           <RubricSettings
             name={name}
+            referenceUrl={referenceURL}
             project={project}
             projects={props.projects}
             update={handleUpdateSettings}

--- a/lara-typescript/src/rubric-authoring/rubric-general-options.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-general-options.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 
 import "./rubric-general-options.scss";
 
-type IRubricOptionKey = "referenceURL" | "criteriaLabel" | "criteriaLabelForStudent" | "feedbackLabelForStudent";
+type IRubricOptionKey = "criteriaLabel" | "criteriaLabelForStudent" | "feedbackLabelForStudent";
 type IRubricOptionBooleanKey = "showRatingDescriptions" | "hideRubricFromStudentsInStudentReport";
 
 export const RubricGeneralOptions = () => {
@@ -27,10 +27,6 @@ export const RubricGeneralOptions = () => {
     <div className="general-options">
       <table>
         <tbody>
-          <tr>
-            <td><label htmlFor="referenceURL">Reference URL (Scoring Guide):</label></td>
-            <td><input name="referenceURL" type="text" value={rubric.referenceURL} onChange={handleUpdateString("referenceURL")} /></td>
-          </tr>
           <tr>
             <td><label htmlFor="criteriaLabel">Criteria Header Label for Teacher:</label></td>
             <td><input name="criteriaLabel" type="text" value={rubric.criteriaLabel} onChange={handleUpdateString("criteriaLabel")} /></td>

--- a/lara-typescript/src/rubric-authoring/rubric-preview.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-preview.tsx
@@ -8,7 +8,11 @@ import { RubricStudentPreview } from "./rubric-student-preview";
 
 import "./rubric-preview.scss";
 
-export const RubricPreview = () => {
+interface IProps {
+  referenceURL: string;
+}
+
+export const RubricPreview = ({referenceURL}: IProps) => {
   const { rubric } = useRubric();
   const [view, setView] = useState<"teacher"|"student">("teacher");
   const [scoring, setScoring] = useState<Record<string, string>>({});
@@ -45,8 +49,12 @@ export const RubricPreview = () => {
           Student View
         </div>
       </div>
-      {view === "teacher" && <RubricTeacherPreview scoring={scoring} setScoring={setScoring} />}
-      {view === "student" && <RubricStudentPreview scored={scored} scoring={scoring} setScoring={setScoring} />}
+      {view === "teacher" &&
+        <RubricTeacherPreview scoring={scoring} setScoring={setScoring} referenceURL={referenceURL} />
+      }
+      {view === "student" &&
+        <RubricStudentPreview scored={scored} scoring={scoring} setScoring={setScoring} />
+      }
     </div>
   );
 };

--- a/lara-typescript/src/rubric-authoring/rubric-settings.scss
+++ b/lara-typescript/src/rubric-authoring/rubric-settings.scss
@@ -20,7 +20,7 @@
     }
 
     label {
-      width: 150px;
+      width: 200px;
       display: inline-block;
       text-align: right;
       margin-right: 10px;

--- a/lara-typescript/src/rubric-authoring/rubric-settings.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-settings.tsx
@@ -6,11 +6,13 @@ import "./rubric-settings.scss";
 
 export interface UpdateSettingsParams {
   name: string;
+  referenceUrl: string;
   project: RubricProject|null;
 }
 
 export interface IRubricSettingsProps {
   name: string;
+  referenceUrl: string;
   project: RubricProject|null;
   projects: RubricProject[];
   update: (settings: UpdateSettingsParams) => void;
@@ -21,11 +23,16 @@ export const RubricSettings = (props: IRubricSettingsProps) => {
   const {projects, update, cancel} = props;
   const [name, setName] = useState(props.name);
   const [project, setProject] = useState(props.project);
+  const [referenceUrl, setReferenceUrl] = useState(props.referenceUrl);
 
   const formDisabled = useMemo(() => name.trim().length === 0, [name]);
 
   const handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
+  };
+
+  const handleChangeReferenceUrl = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setReferenceUrl(e.target.value);
   };
 
   const handleChangeProject = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -38,9 +45,9 @@ export const RubricSettings = (props: IRubricSettingsProps) => {
     e.preventDefault();
 
     if (!formDisabled) {
-      update({name, project});
+      update({name, project, referenceUrl});
     }
-  }, [update, formDisabled, name, project]);
+  }, [update, formDisabled, name, project, referenceUrl]);
 
   return (
     <div className="rubric-settings">
@@ -49,6 +56,10 @@ export const RubricSettings = (props: IRubricSettingsProps) => {
         <div>
           <label htmlFor="name">Name:</label>
           <input type="text" name="name" value={name} onChange={handleChangeName} autoFocus={true}/>
+        </div>
+        <div>
+          <label htmlFor="name">Reference URL (Scoring Guide):</label>
+          <input type="text" name="referenceUrl" value={referenceUrl} onChange={handleChangeReferenceUrl} />
         </div>
         <div>
           <label htmlFor="project">Project:</label>

--- a/lara-typescript/src/rubric-authoring/rubric-teacher-preview.scss
+++ b/lara-typescript/src/rubric-authoring/rubric-teacher-preview.scss
@@ -61,7 +61,7 @@
 
       .rubricDescriptionTitle {
         justify-content: center;
-        width: 75%
+        width: 100%
       }
     }
     .rubricScoreHeader {

--- a/lara-typescript/src/rubric-authoring/rubric-teacher-preview.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-teacher-preview.tsx
@@ -8,15 +8,19 @@ import { useRubric } from "./use-rubric";
 import { IRubricCriterion, IRubricRating } from "./types";
 
 import "./rubric-teacher-preview.scss";
+import { useMemo } from "react";
 
 interface IProps {
   scoring: Record<string, string>;
   setScoring: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  referenceURL: string;
 }
 
-export const RubricTeacherPreview = ({scoring, setScoring}: IProps) => {
+export const RubricTeacherPreview = ({scoring, setScoring, referenceURL}: IProps) => {
   const { rubric } = useRubric();
-  const { ratings, criteriaGroups, referenceURL } = rubric;
+  const { ratings, criteriaGroups } = rubric;
+
+  const hasReferenceUrl = useMemo(() => referenceURL.trim().length > 0, [referenceURL]);
 
   const checkReferenceUrl = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (!/^https?/.test(referenceURL)) {
@@ -33,7 +37,7 @@ export const RubricTeacherPreview = ({scoring, setScoring}: IProps) => {
     return (
       <div className="columnHeaders">
         <div className="rubricDescriptionHeader">
-          <div className="scoringGuideArea">
+          {hasReferenceUrl && <div className="scoringGuideArea">
             <a
               className="launchButton"
               href={referenceURL}
@@ -44,7 +48,7 @@ export const RubricTeacherPreview = ({scoring, setScoring}: IProps) => {
               <LaunchIcon />
             </a>
             Scoring Guide
-          </div>
+          </div>}
           <div className="rubricDescriptionTitle">{rubric.criteriaLabel}</div>
         </div>
         {rubric.ratings.map((rating: any) =>

--- a/lara-typescript/src/rubric-authoring/types.ts
+++ b/lara-typescript/src/rubric-authoring/types.ts
@@ -26,7 +26,6 @@ export interface IRubricV110 {
   versionNumber: string;
   updatedMsUTC: number;
   originUrl: string;
-  referenceURL: string;
   showRatingDescriptions: boolean;
   hideRubricFromStudentsInStudentReport: boolean;
   criteriaLabel: string;

--- a/lara-typescript/src/rubric-authoring/use-rubric.ts
+++ b/lara-typescript/src/rubric-authoring/use-rubric.ts
@@ -36,7 +36,6 @@ export const useRubricValue = (authoredContentUrl: string): IRubricContext => {
             versionNumber: "",
             updatedMsUTC: 0,
             originUrl: "",
-            referenceURL: "",
             showRatingDescriptions: false,
             hideRubricFromStudentsInStudentReport: false,
             criteriaLabel: "",

--- a/spec/controllers/publication_controller_spec.rb
+++ b/spec/controllers/publication_controller_spec.rb
@@ -1,5 +1,10 @@
 require 'spec_helper'
 describe PublicationsController do
+  let(:rubric_url)       { "https://example.com/1" }
+  let(:rubric_doc_url)   { "http://example.com/doc_url" }
+  let(:author)           { FactoryGirl.create(:author) }
+  let(:authored_content) { FactoryGirl.create(:authored_content, user: author, content_type: "application/json", url: rubric_url) }
+  let(:rubric)           { FactoryGirl.create(:rubric, user: author, name: "Test Rubric", doc_url: rubric_doc_url, authored_content: authored_content)}
   let(:act) { FactoryGirl.create(:public_activity) }
   let(:private_act) { FactoryGirl.create(:activity)}
   let(:ar)  { FactoryGirl.create(:run, :activity_id => act.id) }
@@ -29,6 +34,7 @@ describe PublicationsController do
       :description => 'Activity One Description',
       :publication_status => 'public',
       :thumbnail_url    => 'thumbnail',
+      :rubric_id => rubric.id
     })
     activity.user = @user
     activity.save
@@ -41,6 +47,7 @@ describe PublicationsController do
       :description => 'Activity Two Description',
       :publication_status => 'public',
       :thumbnail_url    => 'thumbnail',
+      :rubric_id => rubric.id
     })
     activity.user = @user
     activity.save
@@ -70,6 +77,8 @@ describe PublicationsController do
         "create_url"    =>"http://test.host/activities/#{act_one.id}",
         "author_email"  => @user.email,
         "description"   =>"Activity One Description",
+        "rubric_url"    => rubric_url,
+        "rubric_doc_url" => rubric_doc_url,
         "sections"      => [
            {"name"  => "Activity One Section",
             "pages" => []
@@ -89,7 +98,9 @@ describe PublicationsController do
         "is_locked"     =>false,
         "url"           =>"#{ENV["ACTIVITY_PLAYER_URL"]}?activity=http%3A%2F%2Ftest.host%2Fapi%2Fv1%2Factivities%2F#{act_two.id}.json",
         "tool_id"       => "https://activity-player.concord.org",
-        "append_auth_token" => true
+        "append_auth_token" => true,
+        "rubric_url"    => rubric_url,
+        "rubric_doc_url" => rubric_doc_url
       }
     end
     let(:good_body) { activity_hash.to_json }

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
 describe LightweightActivity do
-  let(:thumbnail_url) { "http://fake.url.com/image" }
-  let(:author)        { FactoryGirl.create(:author) }
-  let(:glossary)      { nil }
-  let(:act_opts)      { {thumbnail_url: thumbnail_url, glossary: glossary, hide_read_aloud: true, hide_question_numbers: true, font_size: "large"} }
-  let(:activity)      {
+  let(:thumbnail_url)    { "http://fake.url.com/image" }
+  let(:rubric_url)       { "https://example.com/1" }
+  let(:rubric_doc_url)   { "http://example.com/doc_url" }
+  let(:author)           { FactoryGirl.create(:author) }
+  let(:glossary)         { nil }
+  let(:authored_content) { FactoryGirl.create(:authored_content, user: author, content_type: "application/json", url: rubric_url) }
+  let(:rubric)           { FactoryGirl.create(:rubric, user: author, name: "Test Rubric", doc_url: rubric_doc_url, authored_content: authored_content)}
+  let(:act_opts)         { {thumbnail_url: thumbnail_url, glossary: glossary, hide_read_aloud: true, hide_question_numbers: true, font_size: "large", rubric: rubric } }
+  let(:activity)         {
     activity = FactoryGirl.create(:activity, act_opts)
     activity.user = author
     activity.save
@@ -504,6 +508,8 @@ describe LightweightActivity do
         "author_url"             => author_url,
         "print_url"              => print_url,
         "thumbnail_url"          => thumbnail_url,
+        "rubric_doc_url"         => rubric_doc_url,
+        "rubric_url"             => rubric_url,
         "student_report_enabled" => activity_player_activity.student_report_enabled,
         "show_submit_button"     => true,
         "is_locked"              => false,
@@ -531,6 +537,8 @@ describe LightweightActivity do
         "author_url"             => author_url,
         "print_url"              => print_url,
         "thumbnail_url"          => thumbnail_url,
+        "rubric_doc_url"         => rubric_doc_url,
+        "rubric_url"             => rubric_url,
         "student_report_enabled" => activity_player_activity.student_report_enabled,
         "show_submit_button"     => true,
         "is_locked"              => false,

--- a/spec/models/rubric_spec.rb
+++ b/spec/models/rubric_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Rubric do
   let(:project)     { FactoryGirl.create(:project) }
 
   let(:rubric)      {
-    rubric = FactoryGirl.create(:rubric, name: "Rubric 1", user: author, project: project)
+    rubric = FactoryGirl.create(:rubric, name: "Rubric 1", user: author, project: project, doc_url: "https://example.com")
     rubric.save!
     rubric
   }
@@ -18,6 +18,7 @@ RSpec.describe Rubric do
       expect(rubric.export(author)).to eq({
         id: rubric.id,
         name: rubric.name,
+        doc_url: rubric.doc_url,
         project: project.export(),
         user_id: rubric.user_id,
         can_edit: true
@@ -120,6 +121,7 @@ RSpec.describe Rubric do
     expect(rubric.to_hash).to eq({
       id: rubric.id,
       name: rubric.name,
+      doc_url: rubric.doc_url,
       project: rubric.project,
       user_id: rubric.user_id
     })
@@ -129,6 +131,7 @@ RSpec.describe Rubric do
     expect(rubric.to_export_hash).to eq({
       id: rubric.id,
       name: rubric.name,
+      doc_url: rubric.doc_url,
       project: rubric.project,
       user_id: rubric.user_id,
       type: "Rubric"
@@ -139,6 +142,7 @@ RSpec.describe Rubric do
     expect(rubric.duplicate(author2).to_hash).to eq({
       id: nil,
       name: "Copy of #{rubric.name}",
+      doc_url: rubric.doc_url,
       project: rubric.project,
       user_id: author2.id
     })


### PR DESCRIPTION
This required the referenceUrl to be moved from the rubric JSON to the rubric model so that it was available to post to the portal.