### PR TITLE
fix: Student rubric preview crash when no student descriptions [PT-188034293]

### DIFF
--- a/lara-typescript/src/rubric-authoring/rubric-student-preview.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-student-preview.tsx
@@ -10,7 +10,7 @@ interface IProps {
   setScoring: React.Dispatch<React.SetStateAction<Record<string, string>>>;
 }
 
-const getStringValue = (value: string, fallbackValue: string): string => {
+const getStringValue = (value: string = "", fallbackValue: string = ""): string => {
   return value.trim().length > 0 ? value : fallbackValue;
 };
 


### PR DESCRIPTION
This was caused by the use of .trim() on possibly undefined string values.