### PR TITLE
fix: Disable deletes of glossaries and rubrics when used in an activity [PT-188116484]

### DIFF
--- a/app/controllers/glossaries_controller.rb
+++ b/app/controllers/glossaries_controller.rb
@@ -38,7 +38,9 @@ class GlossariesController < ApplicationController
 
   def destroy
     authorize! :destroy, @glossary
-    @glossary.destroy
+    if @glossary.can_delete()
+      @glossary.destroy
+    end
     redirect_to glossaries_url
   end
 

--- a/app/controllers/rubrics_controller.rb
+++ b/app/controllers/rubrics_controller.rb
@@ -37,7 +37,9 @@ class RubricsController < ApplicationController
 
   def destroy
     authorize! :destroy, @rubric
-    @rubric.destroy
+    if @rubric.can_delete()
+      @rubric.destroy
+    end
     redirect_to rubrics_url
   end
 

--- a/app/models/glossary.rb
+++ b/app/models/glossary.rb
@@ -66,6 +66,10 @@ class Glossary < ActiveRecord::Base
     end
   end
 
+  def can_delete()
+    self.lightweight_activities.length == 0
+  end
+
   def self.import(glossary_json_object, new_owner)
     imported_glossary = Glossary.new(self.extract_from_hash(glossary_json_object))
     imported_glossary.project = Project.find_or_create(glossary_json_object[:project]) if glossary_json_object[:project]

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -61,6 +61,10 @@ class Rubric < ActiveRecord::Base
     end
   end
 
+  def can_delete()
+    self.lightweight_activities.length == 0
+  end
+
   def create_authored_content
     if !self.authored_content
       self.authored_content = AuthoredContent.create_for_container(self, user, "application/json")

--- a/app/views/glossaries/_index_item.html.haml
+++ b/app/views/glossaries/_index_item.html.haml
@@ -10,11 +10,11 @@
         - if can? :duplicate, glossary
           %li.copy= link_to "Copy", duplicate_glossary_path(glossary)
         %li.edit= link_to glossary.can_edit(current_user) ? "Edit" : "View", edit_glossary_path(glossary)
-        - if can? :update, glossary
+        - if can?(:update, glossary) && glossary.can_delete()
           %li.delete= link_to 'Delete', glossary_path(glossary), method: :delete, data: { confirm: "Are you sure you want to delete this glossary? It is currently being used in #{pluralize(glossary.lightweight_activities.length, 'activity')}. You will not be able to undo this action." }
 
   %div{:id => dom_id_for(glossary, :details), :class => 'tiny'}
-    = "Used in #{pluralize(glossary.lightweight_activities.length, 'activity')}"
+    = "Used in #{pluralize(glossary.lightweight_activities.length, 'activity')} #{!glossary.can_delete() && "(thus cannot be deleted)"}"
     - if glossary.user && glossary.user.email.present?
       %p.author
         = "by #{glossary.user.email}"

--- a/app/views/rubrics/_index_item.html.haml
+++ b/app/views/rubrics/_index_item.html.haml
@@ -10,11 +10,11 @@
         - if can? :duplicate, rubric
           %li.copy= link_to "Copy", duplicate_rubric_path(rubric)
         %li.edit= link_to rubric.can_edit(current_user) ? "Edit" : "View", edit_rubric_path(rubric)
-        - if can? :update, rubric
+        - if can?(:update, rubric) && rubric.can_delete()
           %li.delete= link_to 'Delete', rubric_path(rubric), method: :delete, data: { confirm: "Are you sure you want to delete this rubric? It is currently being used in #{pluralize(rubric.lightweight_activities.length, 'activity')}. You will not be able to undo this action." }
 
   %div{:id => dom_id_for(rubric, :details), :class => 'tiny'}
-    = "Used in #{pluralize(rubric.lightweight_activities.length, 'activity')}"
+    = "Used in #{pluralize(rubric.lightweight_activities.length, 'activity')} #{!rubric.can_delete() && "(thus cannot be deleted)"}"
     - if rubric.user && rubric.user.email.present?
       %p.author
         = "by #{rubric.user.email}"


### PR DESCRIPTION
This removes the delete link and adds text next to the activity usage count.