### PR TITLE
fix: Hide rubric export/import/copy links

### DIFF
--- a/app/views/import/import.html.haml
+++ b/app/views/import/import.html.haml
@@ -1,6 +1,6 @@
 .import_activity_sequence
   .header
-    %span.title Import Activity/Sequence/Glossary/Rubric
+    %span.title Import Activity/Sequence/Glossary
     %span.close.close_link
       close (✖)
 
@@ -13,8 +13,8 @@
             =file_field 'import', 'import', accept: 'application/json', class: 'import_file'
     .buttons
       -#= link_to "Import", import_activities_path, {:remote => true, :class => 'btn btn-primary'}
-      =submit_tag "import", class: "import btn btn-primary"
+      =submit_tag "Import", class: "import btn btn-primary"
       %a.btn.btn-primary.close
-        cancel
+        Cancel
     .message
       =@message

--- a/app/views/rubrics/_index_item.html.haml
+++ b/app/views/rubrics/_index_item.html.haml
@@ -5,10 +5,11 @@
       = rubric.name
     %div.action_menu_header_right
       %ul.menu
-        - if can? :export, rubric
-          %li.copy= link_to "Export", export_rubric_path(rubric)
-        - if can? :duplicate, rubric
-          %li.copy= link_to "Copy", duplicate_rubric_path(rubric)
+        -# disable export and copy for now since the underlying S3 file is not exported or copied
+        -#- if can? :export, rubric
+        -#  %li.copy= link_to "Export", export_rubric_path(rubric)
+        -# - if can? :duplicate, rubric
+        -#  %li.copy= link_to "Copy", duplicate_rubric_path(rubric)
         %li.edit= link_to rubric.can_edit(current_user) ? "Edit" : "View", edit_rubric_path(rubric)
         - if can?(:update, rubric) && rubric.can_delete()
           %li.delete= link_to 'Delete', rubric_path(rubric), method: :delete, data: { confirm: "Are you sure you want to delete this rubric? It is currently being used in #{pluralize(rubric.lightweight_activities.length, 'activity')}. You will not be able to undo this action." }

--- a/app/views/rubrics/index.html.haml
+++ b/app/views/rubrics/index.html.haml
@@ -15,9 +15,10 @@
   - if can? :create, Rubric
     %a{ :href => new_rubric_path }
       %button=t("NEW_RUBRIC_BUTTON")
-  - if can? :import, Rubric
-    %a{ :href => import_status_path, 'data-remote'=>"true" }
-      %button=t("IMPORT")
+  -# import disabled as export doesn't contain the S3 file info to import
+  -#- if can? :import, Rubric
+  -#  %a{ :href => import_status_path, 'data-remote'=>"true" }
+  -#    %button=t("IMPORT")
 
 #official_listing_heading.pagination_heading
   %h1 Rubrics


### PR DESCRIPTION
Neither export, import or copy currently contains a reference to the S3 authored content data so only the metadata is exported, imported or copied which is not really useful at all.

For now these options are hidden until we have time in the future to correctly implement the actions.