### PR TITLE
fix: Page settings checkboxes are not saving (PT-188545861)

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -83,7 +83,7 @@ class Api::V1::InteractivePagesController < API::APIController
   def update_page
     activity = @interactive_page.lightweight_activity
     authorize! :update, activity, @interactive_page
-    page_params = params.require("page").permit(:name, :is_completion, :is_hidden, :show_sidebar, :sidebar, :sidebar_title)
+    page_params = params.require("page").permit(:name, :isCompletion, :isHidden, :showSidebar, :sidebar, :sidebarTitle)
     return error("Missing page parameter") if page_params.nil?
 
     if page_params


### PR DESCRIPTION
[#188545861](https://www.pivotaltracker.com/story/show/188545861)

Page settings parameters are camel case. The params whitelist needed to be modified to reflect that.