### PR TITLE
fix: Unable to update/view TE Window Shades (PT-188545198)

### DIFF
--- a/app/controllers/api/v1/interactive_pages_controller.rb
+++ b/app/controllers/api/v1/interactive_pages_controller.rb
@@ -301,9 +301,11 @@ class Api::V1::InteractivePagesController < API::APIController
   def data_update_params
     params[:page_item].require(:data).permit(
       :aspect_ratio_method,
+      :author_data,
       :authored_state,
       :click_to_play,
       :click_to_play_prompt,
+      :component_label,
       :content,
       :custom_aspect_ratio_method,
       :custom_click_to_play,
@@ -329,6 +331,7 @@ class Api::V1::InteractivePagesController < API::APIController
       :is_callout,
       :is_half_width,
       :is_hidden,
+      :label,
       :legacy_ref_id,
       :legacy_ref_type,
       :library_interactive_id,


### PR DESCRIPTION
[#188545198](https://www.pivotaltracker.com/story/show/188545198)

Adds params required by the Teacher Edition window shades to the whitelist defined in `data_update_params` which is used by `update_page_item`. That allows window shade changes to be saved. It also seems to allow the window shades to appear correctly in the Activity Player Teacher Edition preview, though I'm not entirely sure why that is. Maybe the window shades don't show up until the default state/content has been edited... But, since I've had no problems viewing the window shades in Activity Player since making this change, I'm pretty sure fixing editing fixed that part of the bug as well.