### PR TITLE
fix: Glossary image uploads [PT-188545704]

### DIFF
--- a/app/controllers/api/v1/jwt_controller.rb
+++ b/app/controllers/api/v1/jwt_controller.rb
@@ -36,7 +36,9 @@ class Api::V1::JwtController < ApplicationController
       return error(500, e.message)
     end
 
-    body = params.except(:action, :controller, :run_id).dup()
+    # NOTE: to_unsafe_h() here is used as we need to pass all the passed params (except the excepted params)
+    # but we don't know what the params are in advance so we can't use a permit list
+    body = params.except(:action, :controller, :run_id).to_unsafe_h()
 
     uri = URI.parse(remote_url)
     if run


### PR DESCRIPTION
This allows all the params to be sent in the body of the JWT request to the portal.