### PR TITLE
added data-testids to LARA (proof of concept)

### DIFF
--- a/app/assets/javascripts/components/itsi_authoring/publication_details.js.coffee
+++ b/app/assets/javascripts/components/itsi_authoring/publication_details.js.coffee
@@ -33,5 +33,5 @@ modulejs.define 'components/itsi_authoring/publication_details',
                 (span {className: 'message error-message', title: debugTitle}, 'not published!')
             )
         )
-        (a {href: @props.publicationDetails.publish_url, className: 'btn btn-primary', 'data-remote': true}, 'Publish to Other Portals')
+        (a {href: @props.publicationDetails.publish_url, className: 'btn btn-primary', 'data-remote': true, 'data-testid': 'publish-to-other-portals-btn'}, 'Publish to Other Portals')
       )

--- a/app/views/publications/show_status.html.haml
+++ b/app/views/publications/show_status.html.haml
@@ -1,8 +1,8 @@
 
 .publication
   .header
-    %span.title Publish #{@publishable.name} to portals:
-    %span.close.close_link
+    %span.title{'data-testid' => 'publish-title-to-portals'} Publish #{@publishable.name} to portals:
+    %span.close.close_link{'data-testid' => 'close-publish-modal-btn'}
       close (✖)
   .info
     %table


### PR DESCRIPTION
[PT-188754543](https://www.pivotaltracker.com/story/show/188754543)

This PR is a proof-of-concept to add datatest-ids in the LARA repository so that Cypress test instances will be less generic:

```
    %span.title{'data-testid' => 'publish-title-to-portals'} Publish #{@publishable.name} to portals:
    %span.close.close_link{'data-testid' => 'close-publish-modal-btn'}
```

If we like what we see we can perhaps modify this bit of code to add more datatest-ids, e.g.:

```
.publication
  .header
    %span.title{'data-testid' => 'publish-title-to-portals'} Publish #{@publishable.name} to portals:
    %span.close.close_link{'data-testid' => 'close-publish-modal-btn'}
      close (✖)
  .info
    %table{'data-testid' => 'publication-info-table'}
      %thead
        %tr
          %th{'data-testid' => 'table-header-portal'}
            Portal
          %th{'data-testid' => 'table-header-status'}
            Status
          %th{'data-testid' => 'table-header-action'}
            Action
      %tbody
        - @portals.each do |portal|
          %tr{'data-testid' => "portal-row-#{portal.url.parameterize}"}
            - case portal.status(current_user)
              - when "publish_ok"
                %td{'data-testid' => "portal-url-#{portal.url.parameterize}"}
                  = portal.url
                %td{'data-testid' => "status-added-#{portal.url.parameterize}"}
                  added
                  %span.tiny{'data-testid' => "timestamp-#{portal.url.parameterize}"}
                    = portal.date
                %td{'data-testid' => "action-disabled-#{portal.url.parameterize}"}
                  %span.disabled
                    published

              - when "publish_fail"
                %td{'data-testid' => "portal-url-#{portal.url.parameterize}"}
                  = portal.url
                %td{'data-testid' => "status-failed-#{portal.url.parameterize}"}
                  not published (failure)
                %td{'data-testid' => "action-try-again-#{portal.url.parameterize}"}
                  = link_to "Try Again", publication_publish_path(@publishable.class, @publishable.id), {:remote => true, :class => "not_published"}

              - when "add_to_fail"
                %td{'data-testid' => "portal-url-#{portal.url.parameterize}"}
                  = portal.url
                %td{'data-testid' => "status-add-failed-#{portal.url.parameterize}"}
                  not published (failure)
                %td{'data-testid' => "action-try-again-add-#{portal.url.parameterize}"}
                  = link_to "Try Again", publication_add_portal_path(@publishable.class, @publishable.id, :portal_url => portal.url), {:remote => true, :class => "not_published"}

              - when "publishable"
                %td{'data-testid' => "portal-url-#{portal.url.parameterize}"}
                  = portal.url
                %td{'data-testid' => "status-not-published-#{portal.url.parameterize}"}
                  not published
                %td{'data-testid' => "action-publish-#{portal.url.parameterize}"}
                  = link_to "Publish", publication_add_portal_path(@publishable.class, @publishable.id, :portal_url => portal.url), {:remote => true, :class => "not_published"}

              - else
                %td{'data-testid' => "portal-url-#{portal.url.parameterize}"}
                  = portal.url
                %td{'data-testid' => "status-not-published-#{portal.url.parameterize}"}
                  not published
                %td{'data-testid' => "action-login-#{portal.url.parameterize}"}
                  = link_to "Log In to Publish", user_omniauth_authorize_path(portal.name), {:class => "not_published"}

  .message{'data-testid' => 'publication-message'}
    = @message
```

although we'd probably want to make sure we like the names of the data-testids before committing (the following was just suggested by ChatGPT for now).