### PR TITLE
188754675 Add data-testid Tags for Authoring Elements

### DIFF
--- a/app/views/home/home.html.haml
+++ b/app/views/home/home.html.haml
@@ -9,37 +9,41 @@
     .buttons-menu
       - if can? :create, LightweightActivity
         %a{ :href => new_activity_path }
-          %button=t("NEW_ACTIVITY_BUTTON")
+          %button{ "data-testid" => "new-activity-button" }= t("NEW_ACTIVITY_BUTTON")
       - if can? :create, Sequence
         %a{ :href => new_sequence_path }
-          %button=t("NEW_SEQUENCE_BUTTON")
+          %button{ "data-testid" => "new-sequence-button" }= t("NEW_SEQUENCE_BUTTON")
       - if can? :create, Glossary
         %a{ :href => new_glossary_path }
-          %button=t("NEW_GLOSSARY_BUTTON")
+          %button{ "data-testid" => "new-glossary-button" }= t("NEW_GLOSSARY_BUTTON")
       - if can? :create, Rubric
         %a{ :href => new_rubric_path }
-          %button=t("NEW_RUBRIC_BUTTON")
+          %button{ "data-testid" => "new-rubric-button" }= t("NEW_RUBRIC_BUTTON")
       - if can? :import, LightweightActivity, Sequence, Glossary
-        %a{ :href => import_status_path, 'data-remote'=>"true" }
-          %button=t("IMPORT")
+        %a{ :href => import_status_path, 'data-remote' => "true" }
+          %button{ "data-testid" => "import-button" }= t("IMPORT")
     %ul#new-menu
       %li#search
         %form
-          %input{:type => "text", :name => "search", :placeholder => "Search..." "data-testid" => "authoring-search-bar"}
-          %input{:type => "submit", :value => "Search" "data-testid" => "authoring-search-button"}
-      %li#desc-toggle= toggle_all 'descriptions'
-      %li#collection_filter= collection_filter_tag @filter
-  -if @activities || @sequences
+          %input{ :type => "text", :name => "search", :placeholder => "Search...", "data-testid" => "authoring-search-bar" }
+          %input{ :type => "submit", :value => "Search", "data-testid" => "authoring-search-button" }
+      %li#desc-toggle{ "data-testid" => "desc-toggle-button" }= toggle_all 'descriptions'
+      %li#collection_filter{ "data-testid" => "collection-filter-button" }= collection_filter_tag @filter
+  - if @activities || @sequences
     %div.bottom-header
-      %strong=t("JUMP_TO")
-      -if @activities
-        %a{ :href => "#activity_listing_head" }=t("ACTIVITIES")
-      -if @sequences
-        %a{ :href => "#sequence_listing_head" }=t("SEQUENCES")
-      -if @glossaries
-        %a{ :href => "#glossary_listing_head" }=t("GLOSSARIES")
-      -if @rubrics
-        %a{ :href => "#rubric_listing_head" }=t("RUBRICS")
+      %strong{ "data-testid" => "jump-to-label" }= t("JUMP_TO")
+      - if @activities
+        %a{ :href => "#activity_listing_head" }
+          %button{ "data-testid" => "jump-to-activities-button" }= t("ACTIVITIES")
+      - if @sequences
+        %a{ :href => "#sequence_listing_head" }
+          %button{ "data-testid" => "jump-to-sequences-button" }= t("SEQUENCES")
+      - if @glossaries
+        %a{ :href => "#glossary_listing_head" }
+          %button{ "data-testid" => "jump-to-glossaries-button" }= t("GLOSSARIES")
+      - if @rubrics
+        %a{ :href => "#rubric_listing_head" }
+          %button{ "data-testid" => "jump-to-rubrics-button" }= t("RUBRICS")
 
 
 -if @activities

--- a/app/views/home/home.html.haml
+++ b/app/views/home/home.html.haml
@@ -25,8 +25,8 @@
     %ul#new-menu
       %li#search
         %form
-          %input{:type => "text", :name => "search", :placeholder => "Search..."}
-          %input{:type => "submit", :value => "Search"}
+          %input{:type => "text", :name => "search", :placeholder => "Search..." "data-testid" => "authoring-search-bar"}
+          %input{:type => "submit", :value => "Search" "data-testid" => "authoring-search-button"}
       %li#desc-toggle= toggle_all 'descriptions'
       %li#collection_filter= collection_filter_tag @filter
   -if @activities || @sequences

--- a/app/views/lightweight_activities/_edit_header.html.haml
+++ b/app/views/lightweight_activities/_edit_header.html.haml
@@ -20,25 +20,25 @@
       = svg_icon(asset_path "/assets/images/icons/page-nav/add.svg")
     %button{ :id => "page-nav-copy", :class => "page-button disabled" }
       = svg_icon(asset_path "/assets/images/icons/page-nav/copy.svg")
-%header.edit-form-header
-  %h1 Edit Activity#{ @activity.name != "" ? ": " + @activity.name : "" }
+%header.edit-form-header{ "data-testid" => "edit-form-header" }
+  %h1{ "data-testid" => "edit-activity-title" } Edit Activity#{ @activity.name != "" ? ": " + @activity.name : "" }
   - if @editor_mode == LightweightActivity::ITSI_EDITOR_MODE
-    %div{class: "buttons-menu"}
-      %button{onclick: "window.open('#{itsi_preview_url(@activity)}', '_blank')"}
+    %div{class: "buttons-menu", "data-testid" => "preview-buttons-menu"}
+      %button{onclick: "window.open('#{itsi_preview_url(@activity)}', '_blank')", "data-testid" => "itsi-preview-button"}
         Preview
   - else
-    #preview-menu
-      %label{for: "preview-options-select"}
+    #preview-menu{ "data-testid" => "preview-menu" }
+      %label{for: "preview-options-select", "data-testid" => "preview-options-label"}
         %strong
           Preview in:
-      = select_tag :preview_options_select, options_for_select(activity_preview_options(@activity)), {id: 'preview-options-select'}
+      = select_tag :preview_options_select, options_for_select(activity_preview_options(@activity)), {id: 'preview-options-select', "data-testid" => "preview-options-select"}
 
-.edit-form-options
+.edit-form-options{ "data-testid" => "edit-form-options" }
   - if current_user.is_admin
-    = link_to "Edit in Standard Mode", "#{edit_activity_path(@activity)}?mode=standard"
-    = link_to "Edit in ITSI Mode", "#{edit_activity_path(@activity)}?mode=itsi"
+    = link_to "Edit in Standard Mode", "#{edit_activity_path(@activity)}?mode=standard", "data-testid" => "edit-standard-mode-link"
+    = link_to "Edit in ITSI Mode", "#{edit_activity_path(@activity)}?mode=itsi", "data-testid" => "edit-itsi-mode-link"
   - if (can? :export, @activity) && ENV['CONVERSION_SCRIPT_URL'].present?
-    = link_to "Convert", activity_player_conversion_url(@activity), :target => 'new'
+    = link_to "Convert", activity_player_conversion_url(@activity), :target => 'new', "data-testid" => "convert-link"
 
 - if show_publication_details
   = render :partial => "publications/publication_details", :locals =>{ :publication => @activity}

--- a/app/views/lightweight_activities/_index_item.html.haml
+++ b/app/views/lightweight_activities/_index_item.html.haml
@@ -1,28 +1,28 @@
 
 - item_class = activity.is_official ? 'item official' : 'item community'
-%li{ :id => dom_id_for(activity, :item), :class => item_class }
+%li{ :id => dom_id_for(activity, :item), :class => item_class, "data-testid" => "activity-item-#{activity.id}" }
   %div.action_menu
     %div.action_menu_header_left
-      = activity.id.to_s + '.'
-      = link_to activity.name, runtime_url(activity), :class => 'container_link', :title => 'Preview Activity'
+      %span{ "data-testid" => "activity-id" }= activity.id.to_s + '.'
+      = link_to activity.name, runtime_url(activity), :class => 'container_link', :title => 'Preview Activity', "data-testid" => "activity-preview-link"
     %div.action_menu_header_right
       %ul.menu
-        %li.export= link_to('Export', show_status_activity_path(activity), :remote => true) if can? :export, activity
+        %li.export{ "data-testid" => "export-activity-button" }= link_to('Export', show_status_activity_path(activity), :remote => true) if can? :export, activity
         - if (can? :export, activity) && ENV['CONVERSION_SCRIPT_URL'].present?
-          %li.convert= link_to('Convert', activity_player_conversion_url(activity), target: :_blank)
+          %li.convert{ "data-testid" => "convert-activity-button" }= link_to('Convert', activity_player_conversion_url(activity), target: :_blank)
         - if can? :duplicate, activity
-          %li.copy= link_to "Copy", duplicate_activity_path(activity)
+          %li.copy{ "data-testid" => "duplicate-activity-button" }= link_to "Copy", duplicate_activity_path(activity)
         - if can? :edit, activity
-          %li.edit= link_to "Edit", edit_activity_path(activity)
+          %li.edit{ "data-testid" => "edit-activity-button" }= link_to "Edit", edit_activity_path(activity)
         - if can? :destroy, activity
           - confirm_message = "Are you sure you want to delete this activity? You will lose data from #{pluralize(activity.active_runs, "learner")} that #{"has".pluralize(activity.active_runs)} attempted this activity."
-          %li.delete= link_to 'Delete', activity_path(activity), method: :delete, data: { confirm: (activity.active_runs > 0) ? confirm_message : 'Are you sure?' }
+          %li.delete{ "data-testid" => "delete-activity-button" }= link_to 'Delete', activity_path(activity), method: :delete, data: { confirm: (activity.active_runs > 0) ? confirm_message : 'Are you sure?' }
         - if can? :publish, activity
-          %li.publish= link_to('Publish', publication_show_status_path(activity.class,activity.id), :remote => true)
+          %li.publish{ "data-testid" => "publish-activity-button" }= link_to('Publish', publication_show_status_path(activity.class, activity.id), :remote => true)
         - if can? :read, activity
-          %li.print
+          %li.print{ "data-testid" => "print-activity-button" }
             = link_to "print", print_blank_activity_path(activity), :target => 'new'
-          %li.run= link_to "Run", runtime_url(activity), :target => 'new'
+          %li.run{ "data-testid" => "run-activity-button" }= link_to "Run", runtime_url(activity), :target => 'new'
 
   %div{:id => dom_id_for(activity, :details), :class => 'tiny'}
     - if (activity.active_runs > 0) && (can? :edit, activity)

--- a/app/views/sequences/edit.html.haml
+++ b/app/views/sequences/edit.html.haml
@@ -13,12 +13,12 @@
       %li
         != "/ #{@sequence.title}"
 
-%h1.title 
-  %span.title
+%h1.title{"data-testid" => "edit-sequence-header"}
+  %span.title{"data-testid" => "edit-sequence-title"}
     Edit sequence
-  #preview-menu
-    %label{for: "preview-options-select"}
-      %strong
+  #preview-menu{"data-testid" => "preview-menu"}
+    %label{for: "preview-options-select", "data-testid" => "preview-options-label"}
+      %strong{"data-testid" => "preview-options-text"}
         Preview in:
     = select_tag :preview_options_select, options_for_select(sequence_preview_options(@sequence)), {id: 'preview-options-select'}
 

--- a/lara-typescript/src/section-authoring/components/page-header/components/page-header.tsx
+++ b/lara-typescript/src/section-authoring/components/page-header/components/page-header.tsx
@@ -38,7 +38,7 @@ export const PageHeader: React.FC<IPageHeaderProps> = ({
           </div>
           <div className="header-center">
             <div className="title-container" onClick={handleTitleClick}>
-              <div className="activity-title">
+              <div className="activity-title" data-testid="activity-title">
                 {renderHTML(resourceName)}
               </div>
             </div>


### PR DESCRIPTION
[PT-188754675](https://www.pivotaltracker.com/story/show/188754675)

### Description:

This PR adds `data-testid` tags to various authoring UI elements to make them easier to locate in Cypress tests. Please check for any spacing, formatting, or syntax issues.

### Changes:
- Added data-testid tags to key elements such as buttons, input fields, and form headers (mostly in navigation areas since that's the area of code I've been looking at for [PT-188754675](https://www.pivotaltracker.com/story/show/188754675)).
- Tags follow a consistent naming convention (e.g., new-activity-button, authoring-search-bar).

### Reviewer:

@emcelroy - please review for formatting and tag placement. Let me know if I missed anything!