### PR TITLE
adds back line break

### DIFF
--- a/app/views/home/home.html.haml
+++ b/app/views/home/home.html.haml
@@ -9,37 +9,45 @@
     .buttons-menu
       - if can? :create, LightweightActivity
         %a{ :href => new_activity_path }
-          %button{ "data-testid" => "new-activity-button" }= t("NEW_ACTIVITY_BUTTON")
+          %button{ "data-testid" => "new-activity-button" }=t("NEW_ACTIVITY_BUTTON")
+
       - if can? :create, Sequence
         %a{ :href => new_sequence_path }
-          %button{ "data-testid" => "new-sequence-button" }= t("NEW_SEQUENCE_BUTTON")
+          %button{ "data-testid" => "new-sequence-button" }=t("NEW_SEQUENCE_BUTTON")
+      
       - if can? :create, Glossary
         %a{ :href => new_glossary_path }
-          %button{ "data-testid" => "new-glossary-button" }= t("NEW_GLOSSARY_BUTTON")
+          %button{ "data-testid" => "new-glossary-button" }=t("NEW_GLOSSARY_BUTTON")
+
       - if can? :create, Rubric
         %a{ :href => new_rubric_path }
-          %button{ "data-testid" => "new-rubric-button" }= t("NEW_RUBRIC_BUTTON")
+          %button{ "data-testid" => "new-rubric-button" }=t("NEW_RUBRIC_BUTTON")
+
       - if can? :import, LightweightActivity, Sequence, Glossary
         %a{ :href => import_status_path, 'data-remote' => "true" }
-          %button{ "data-testid" => "import-button" }= t("IMPORT")
+          %button{ "data-testid" => "import-button" }=t("IMPORT")
     %ul#new-menu
       %li#search
         %form
           %input{ :type => "text", :name => "search", :placeholder => "Search...", "data-testid" => "authoring-search-bar" }
           %input{ :type => "submit", :value => "Search", "data-testid" => "authoring-search-button" }
+
       %li#desc-toggle{ "data-testid" => "desc-toggle-button" }= toggle_all 'descriptions'
       %li#collection_filter{ "data-testid" => "collection-filter-button" }= collection_filter_tag @filter
       - if @activities || @sequences
         %div.bottom-header
           %strong{ "data-testid" => "jump-to-label" }= t("JUMP_TO")
           - if @activities
-            %a{ :href => "#activity_listing_head", "data-testid" => "jump-to-activities" }= t("ACTIVITIES")
+            %a{ "href" => "#activity_listing_head", "data-testid" => "jump-to-activities" }= t("ACTIVITIES")
+
           - if @sequences
-            %a{ :href => "#sequence_listing_head", "data-testid" => "jump-to-sequences" }= t("SEQUENCES")
+            %a{ :href => "#sequence_listing_head", "data-testid" => "jump-to-sequences" }=t("SEQUENCES")
+
           - if @glossaries
-            %a{ :href => "#glossary_listing_head", "data-testid" => "jump-to-glossaries" }= t("GLOSSARIES")
+            %a{ :href => "#glossary_listing_head", "data-testid" => "jump-to-glossaries" }=t("GLOSSARIES")
+            
           - if @rubrics
-            %a{ :href => "#rubric_listing_head", "data-testid" => "jump-to-rubrics" }= t("RUBRICS")
+            %a{ :href => "#rubric_listing_head", "data-testid" => "jump-to-rubrics" }=t("RUBRICS")
 
 -if @activities
   #activity_listing_head

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -153,10 +153,7 @@ export const AuthoringPage: React.FC<IPageProps> = ({
       <PageNavContainer />
       <header className="editPageHeader">
         <h2 data-testid="page-title">Page: {displayTitle}</h2>
-        <button 
-          data-testid="page-settings-button" 
-          onClick={pageSettingsClickHandler}
-        >
+        <button data-testid="page-settings-button" onClick={pageSettingsClickHandler}>
           <Cog height="16" width="16" /> Page Settings
         </button>
         <PreviewLinksContainer />


### PR DESCRIPTION
There's a line break issue I introduced in [PR 1206](https://github.com/concord-consortium/lara/pull/1206) that I think created issues in the header of LARA Staging. You can compare them in the screenshots here:

---

<img width="1405" alt="Screenshot 2025-01-20 at 8 07 44 PM" src="https://github.com/user-attachments/assets/96dcd806-2171-4262-9f3d-6a299ee2ca40" />
LARA Staging

<img width="1350" alt="Screenshot 2025-01-20 at 8 07 37 PM" src="https://github.com/user-attachments/assets/51261afc-2efd-4328-ac12-16edfa0b86c1" />
LARA Production (how we want it to look)

---

The goal of this PR is to get the formatting back to where we wanted it to be. My guess is it was introduced at line 36 of `home.html.haml` since in Github this line is formatted partly in gray in the original PR: https://github.com/concord-consortium/lara/pull/1206/files#diff-ea95b1e97591bcd6c5713e60f07ff1cea51d305f84e34e08ed8dd6500fef84bb

Marking @dougmartin as reviewer in case I missed something obvious.