### PR TITLE
fix: Lint issues with data-testid changes [PT-188545797]

### DIFF
--- a/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
+++ b/lara-typescript/src/page-settings/components/page-settings-dialog.tsx
@@ -76,8 +76,8 @@ export const PageSettingsDialog: React.FC<IPageSettingsDialogProps> = ({
   };
 
   const modalButtons = [
-    {classes: "cancel", clickHandler: handleCloseDialog, disabled: false, svg: <Close height="12" width="12"/>, text: "Cancel", "data-testid": "cancel-button-page-settings"},
-    {classes: "copy", clickHandler: handleUpdateSettings, disabled: false, svg: <Save height="16" width="16"/>, text: "Save & Close", "data-testid": "save-and-close-button-page-settings"}
+    {"classes": "cancel", "clickHandler": handleCloseDialog, "disabled": false, "svg": <Close height="12" width="12"/>, "text": "Cancel", "data-testid": "cancel-button-page-settings"},
+    {"classes": "copy", "clickHandler": handleUpdateSettings, "disabled": false, "svg": <Save height="16" width="16"/>, "text": "Save & Close", "data-testid": "save-and-close-button-page-settings"}
   ];
 
   return (

--- a/lara-typescript/src/section-authoring/components/authoring-page.tsx
+++ b/lara-typescript/src/section-authoring/components/authoring-page.tsx
@@ -153,8 +153,8 @@ export const AuthoringPage: React.FC<IPageProps> = ({
       <PageNavContainer />
       <header className="editPageHeader">
         <h2 data-testid="page-title">Page: {displayTitle}</h2>
-        <button 
-          data-testid="page-settings-button" 
+        <button
+          data-testid="page-settings-button"
           onClick={pageSettingsClickHandler}
         >
           <Cog height="16" width="16" /> Page Settings

--- a/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/item-edit-dialog.tsx
@@ -163,19 +163,19 @@ export const ItemEditDialog: React.FC<IItemEditDialogProps> = ({
 
   const standardModalButtons = [
     {
-      classes: "cancel",
-      clickHandler: handleCancelUpdateItem,
-      disabled: false,
-      svg: <Close height="12" width="12"/>,
-      text: "Cancel",
+      "classes": "cancel",
+      "clickHandler": handleCancelUpdateItem,
+      "disabled": false,
+      "svg": <Close height="12" width="12"/>,
+      "text": "Cancel",
       "data-testid": "cancel-item-button"
     },
     {
-      classes: "save",
-      clickHandler: handleSave,
-      disabled: false,
-      svg: <Save height="16" width="16"/>,
-      text: "Save",
+      "classes": "save",
+      "clickHandler": handleSave,
+      "disabled": false,
+      "svg": <Save height="16" width="16"/>,
+      "text": "Save",
       "data-testid": "save-item-button"
     }
   ];


### PR DESCRIPTION
The linter didn't like unquoted object keys after the quoted "data-testid" key was added.

Also adds the updated built lara-typescript.js