### PR TITLE
fix: Move section dialog capitalization error [PT-188789754]

### DIFF
--- a/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
+++ b/lara-typescript/src/section-authoring/components/section-move-dialog.tsx
@@ -55,7 +55,7 @@ export const SectionMoveDialog: React.FC = () => {
     if (sectionToMove?.name) {
       return sectionToMove.name;
     }
-    return `section ${sectionToMove?.position}`;
+    return `Section ${sectionToMove?.position}`;
   };
 
   const modalButtons = [


### PR DESCRIPTION
Changes "Move section N" to "Move Section N"