### PR TITLE
fix: publish options missing [LARA-149]

### DIFF
--- a/app/assets/javascripts/components/publication_ajax_mixin.js.coffee
+++ b/app/assets/javascripts/components/publication_ajax_mixin.js.coffee
@@ -1,0 +1,22 @@
+modulejs.define 'components/publication_ajax_mixin', ->
+
+  getInitialState: ->
+    last_publication_hash: @props.publicationDetails.last_publication_hash
+    latest_publication_portals: @props.publicationDetails.latest_publication_portals
+    polling: false
+
+  componentDidMount: ->
+    @poller = setInterval @pollForChanges, 5000
+
+  componentWillUnmount: ->
+    clearInterval @poller
+
+  pollForChanges: ->
+    $.ajax
+      url: @props.publicationDetails.poll_url
+      type: 'GET',
+      success: (data) =>
+        if data
+          @setState
+            last_publication_hash: data.last_publication_hash
+            latest_publication_portals: data.latest_publication_portals

--- a/app/assets/javascripts/components/publication_details.js.coffee
+++ b/app/assets/javascripts/components/publication_details.js.coffee
@@ -1,0 +1,37 @@
+{div, ul, li, span, a} = ReactFactories
+
+modulejs.define 'components/publication_details',
+['components/publication_ajax_mixin'],
+(PublicationAjaxMixin) ->
+
+  createReactClass
+
+    mixins: [PublicationAjaxMixin]
+
+    render: ->
+      numPortals = @state.latest_publication_portals.length
+      plural = if numPortals > 1 then 's' else ''
+
+      (div {className: 'publication_details'},
+        (div {className: 'summary'},
+          if numPortals > 0
+            "This item has been published to #{numPortals} portal#{plural}. Any changes will automatically be published to the portal#{plural} below."
+          else
+            "This item is not published to any of the portals. Click on the publish button to publish this item."
+        )
+        (ul {className: 'details'},
+          for portal in @state.latest_publication_portals
+            debugTitle = "Activity: #{@state.last_publication_hash} => Portal: #{portal.publication_hash}"
+            (li {className: 'detail', key: portal.url},
+              (span {className: 'detail'}, portal.domain)
+              (span {className: 'detail'}, " : (#{portal.success_count} time#{if portal.success_count is 1 then '' else 's'}) - ")
+              (span {className: 'detail'}, portal.date)
+              if portal.success
+                message = if @state.last_publication_hash is null or @state.last_publication_hash is portal.publication_hash then 'published' else 'publishing'
+                (span {className: 'message success-message', title: debugTitle}, message)
+              else
+                (span {className: 'message error-message', title: debugTitle}, 'not published!')
+            )
+        )
+        (a {href: @props.publicationDetails.publish_url, className: 'btn btn-primary', 'data-remote': true, 'data-testid': 'publish-to-other-portals-btn'}, 'Publish to Other Portals')
+      )

--- a/app/assets/javascripts/components/publication_failure.js.coffee
+++ b/app/assets/javascripts/components/publication_failure.js.coffee
@@ -1,0 +1,62 @@
+{div, ul, li, span, a} = ReactFactories
+
+modulejs.define 'components/publication_failure_alert',
+['components/publication_ajax_mixin'],
+(PublicationAjaxMixin) ->
+
+  createReactClass
+
+    mixins: [PublicationAjaxMixin]
+
+    getInitialState: ->
+      scrollTop: 0
+
+    getScrollPosition: ->
+      @setState scrollTop: @$window.scrollTop()
+
+    componentDidMount: ->
+      @$window = $ window
+      @getScrollPosition()
+      @$window.on 'scroll', @getScrollPosition
+
+    componentWillUnmount: ->
+      @$window.off 'scroll'
+
+    render: ->
+      failedPortals = []
+      for portal in @state.latest_publication_portals
+        if not portal.success
+          failedPortals.push portal
+
+      if failedPortals.length > 0
+        numPortals = failedPortals.length
+        plural = if numPortals > 1 then 's' else ''
+
+        (div {className: 'publication_details'},
+          (div {className: 'summary'}, "This item failed to publish to #{numPortals} portal#{plural}:")
+          (ul {className: 'details', style: {marginTop: 10}},
+            for portal in failedPortals
+              debugTitle = "Activity: #{@state.last_publication_hash} => Portal: #{portal.publication_hash}"
+              (li {className: 'detail', key: portal.url},
+                (span {className: 'detail', title: debugTitle}, portal.domain)
+              )
+          )
+          (div {style: {marginTop: 10}},
+            'We will try to publish this again. If it is still failing after a few minutes please email us at '
+            (a {href: 'mailto:authoring-help@concord.org'}, 'authoring-help@concord.org')
+            ". We recommend not editing further or using this activity through the failing portal#{plural}."
+          )
+          if @state.scrollTop isnt 0
+            topBarStyle =
+              position: 'fixed'
+              top: 0
+              left: 0
+              right: 0
+              padding: 5
+              color: '#fff'
+              textAlign: 'center'
+              backgroundColor: '#f00'
+            (div {style: topBarStyle}, 'Portal publication failure!  More information at the top of this page.')
+        )
+      else
+        null

--- a/app/controllers/interactive_pages_controller.rb
+++ b/app/controllers/interactive_pages_controller.rb
@@ -62,7 +62,6 @@ class InteractivePagesController < ApplicationController
   def edit
     authorize! :update, @page
     @all_pages = @activity.pages
-    gon.publication_details = PublicationDetails.new(@activity).to_json
   end
 
   def update_params

--- a/app/controllers/lightweight_activities_controller.rb
+++ b/app/controllers/lightweight_activities_controller.rb
@@ -117,6 +117,7 @@ class LightweightActivitiesController < ApplicationController
 
   def edit
     authorize! :update, @activity
+    gon.publication_details = PublicationDetails.new(@activity).to_json
     render :edit
   end
 

--- a/app/views/publications/_publication_details.html.haml
+++ b/app/views/publications/_publication_details.html.haml
@@ -1,6 +1,5 @@
 #publication-details
 
 :javascript
-  var PublicationDetails = React.createElement({publicationDetails: gon.publication_details});
+  var PublicationDetails = React.createElement(modulejs.require('components/publication_details'), {publicationDetails: gon.publication_details});
   ReactDOM.render(PublicationDetails, $('#publication-details')[0]);
-


### PR DESCRIPTION
[LARA-149](https://concord-consortium.atlassian.net/browse/LARA-149)

The "Publish to Other Portals" component previously existed only in the `itsi-authoring` CoffeeScript code. So we lost that when we removed the ITSI Authoring elements. This PR reinstates the related files, although we've placed them in the main `/app/assets/javascripts/components/` directory instead of reinstating the `itsi-authoring` sub-directory. 

While fixing that, we found that the definition of `gone.publication_details` for activities needs to be made in `LightweightActivitiesController` instead of `InteractivePagesController`. Otherwise the "Publish to Other Portals" element wouldn't render for activities. We're not 100% sure, but suspect because the app was always using the ITSI Authoring component, and there is a fallback `gon.ITSIEditor.publication_details` [here in the main branch](https://github.com/concord-consortium/lara/blob/ecf75c1e89dcd23885756826b0c4fb3ec6e4de6d/app/views/publications/_publication_details.html.haml#L4), that issue was being masked.

[LARA-149]: https://concord-consortium.atlassian.net/browse/LARA-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ