### PR TITLE
[LARA 175] added a log in and log out spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           nix develop -c npm run test
         working-directory: ./lara-typescript/
       - name: Create CI admin user
-        run: nix develop -c bundle exec rake create_ci_admin_user
+        run: nix develop -c bundle exec rake lightweight:create_ci_admin_user
       - name: Start Rails server
         run: nix develop -c bundle exec rails server -b 0.0.0.0 -p 3000 &
       - name: Run Cypress Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
           nix develop -c npm ci
           nix develop -c npm run test
         working-directory: ./lara-typescript/
+      - name: Create CI admin user
+        run: nix develop -c bundle exec create_ci_admin_user
       - name: Start Rails server
-        run: |-
-          nix develop -c bundle exec rails server -b 0.0.0.0 -p 3000 &
-          #     cp config/user-config.github-ci.json config/user-config.json
+        run: nix develop -c bundle exec rails server -b 0.0.0.0 -p 3000 &
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           nix develop -c npm run test
         working-directory: ./lara-typescript/
       - name: Create CI admin user
-        run: nix develop -c bundle exec create_ci_admin_user
+        run: nix develop -c bundle exec rake create_ci_admin_user
       - name: Start Rails server
         run: nix develop -c bundle exec rails server -b 0.0.0.0 -p 3000 &
       - name: Run Cypress Tests

--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ If it was working you could run
 
     docker-compose run --rm app bundle exec rake jasmine:ci
 
+## Cypress
+
+### Running tests
+In the dev environment:
+
+- `npm run test:dev`
+
+In the staging environment:
+
+- `CYPRESS_password=<password> npm run test:cypress:open:staging``
+
 
 ## Adding Embeddable support
 _This may be obsolete as of April 2013_

--- a/cypress/cypress.config.github.js
+++ b/cypress/cypress.config.github.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
   },
   env: {
     baseUrl: "http://localhost:3000",
-    username: "dev_test_user@test.email",
+    email: "dev_test_user@test.email",
     password: "password",
   }
 });

--- a/cypress/cypress.config.github.js
+++ b/cypress/cypress.config.github.js
@@ -8,6 +8,7 @@ module.exports = defineConfig({
     baseUrl: "http://localhost:3000",
   },
   env: {
+    useSSO: false,
     baseUrl: "http://localhost:3000",
     email: "ci_test_user@test.email",
     password: "password",

--- a/cypress/cypress.config.github.js
+++ b/cypress/cypress.config.github.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
   },
   env: {
     baseUrl: "http://localhost:3000",
-    email: "dev_test_user@test.email",
+    email: "ci_test_user@test.email",
     password: "password",
   }
 });

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -1,9 +1,19 @@
 const { defineConfig } = require("cypress");
 
+const baseUrl = process.env.CYPRESS_BASE_URL || "http://localhost:3000";
+const email = process.env.CYPRESS_EMAIL || "dev_test_user@test.email";
+const password = process.env.CYPRESS_PASSWORD || "password";
+
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
+    baseUrl,
   },
+  env: {
+    baseUrl,
+    email,
+    password,
+  }
 });

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -12,6 +12,7 @@ module.exports = defineConfig({
     baseUrl,
   },
   env: {
+    useSSO: false,
     baseUrl,
     email,
     password,

--- a/cypress/cypress.config.staging.js
+++ b/cypress/cypress.config.staging.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
   },
   env: {
     baseUrl: "https://authoring.lara.staging.concord.org/",
-    username: "sara_teacher1",
+    email: "sara.teacher1@mailinator.com",
     // password should NOT be stored here!
     portalBaseUrl: "https://learn.portal.staging.concord.org"
   }

--- a/cypress/cypress.config.staging.js
+++ b/cypress/cypress.config.staging.js
@@ -10,6 +10,7 @@ module.exports = defineConfig({
   env: {
     baseUrl: "https://authoring.lara.staging.concord.org/",
     username: "sara_teacher1",
-    password: "password1",
+    // password should NOT be stored here!
+    portalBaseUrl: "https://learn.portal.staging.concord.org"
   }
 });

--- a/cypress/cypress.config.staging.js
+++ b/cypress/cypress.config.staging.js
@@ -1,5 +1,7 @@
 const { defineConfig } = require("cypress");
 
+const password = process.env.CYPRESS_PASSWORD || "password";
+
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
@@ -8,9 +10,11 @@ module.exports = defineConfig({
     baseUrl: "https://authoring.lara.staging.concord.org/",
   },
   env: {
+    useSSO: true,
     baseUrl: "https://authoring.lara.staging.concord.org/",
+    username: "sara_teacher1",
     email: "sara.teacher1@mailinator.com",
-    // password should NOT be stored here!
+    password,
     portalBaseUrl: "https://learn.portal.staging.concord.org"
   }
 });

--- a/cypress/cypress/e2e/homepage.cy.js
+++ b/cypress/cypress/e2e/homepage.cy.js
@@ -1,41 +1,15 @@
-// context("Test Admin User Role", () => {
-//   before(() => {
-//     cy.visit("")
-//     // cy.loginLARAWithSSO(Cypress.config().username, Cypress.env("password"));
-//   })
-
 describe('homepage spec', () => {
-  it('should log in and out with an account"', () => {
-    const username = Cypress.env('username');
-    const password = Cypress.env('password');
-    const portalUrl = Cypress.env('portalBaseUrl');
-    cy.log(`Username: ${username}`);
-    cy.log(`Base URL: ${Cypress.env('baseUrl')}`);
+  it('should render the homepage', () => {
     cy.visit("");
     cy.contains('Authoring');
+  })
 
-    cy.get('.login-link').click();
-    cy.get("[data-cy=header-menu] .login-link")
-      .as('loginLink')
-      .click();
-    cy.wait(2000);
-    cy.get("[data-cy=header-menu] .header-menu-links.show a").eq(0).click();
-    cy.wait(2000);
-    // Use dynamic origin from config
-    cy.origin(portalUrl, () => {
-      cy.get('form#login-form p')
-      .should('contain', 'Log in with your');
-      cy.get('#username').type(Cypress.env('username'));
-      cy.get('#password').type(Cypress.env('password'), { log: false });
-      cy.get("#submit").click({ force: true });
-      cy.wait(500);
-    });
-    cy.url().should('include', Cypress.env('baseUrl'));
-    cy.get('@loginLink').should('not.exist');
-
-    cy.get('[data-cy="header-menu"]').click();
-    cy.get('[data-testid="logout-link"]').should('be.visible').click();
-    cy.get('@loginLink').should('be.visible');
-
+  it('should allow log in and out with an account', () => {
+    const email = Cypress.env('email');
+    cy.getAccountOwnerName().should('not.exist');
+    cy.login(email);
+    cy.getAccountOwnerName().should('contain', email);
+    cy.logout();
+    cy.getAccountOwnerName().should('not.exist');
   })
 })

--- a/cypress/cypress/e2e/homepage.cy.js
+++ b/cypress/cypress/e2e/homepage.cy.js
@@ -1,6 +1,42 @@
+/// <reference types="Cypress" />
+// context("Test Admin User Role", () => {
+//   before(() => {
+//     cy.visit("")
+//     // cy.loginLARAWithSSO(Cypress.config().username, Cypress.env("password"));
+//   })
+
 describe('homepage spec', () => {
-  it('contains the text "Authoring"', () => {
-    cy.visit('/')
-    cy.contains('Authoring')
+  it('should log in and out with an account"', () => {
+    const username = Cypress.env('username');
+    const password = Cypress.env('password');
+    const portalUrl = Cypress.env('portalBaseUrl');
+    cy.log(`Username: ${username}`);
+    cy.log(`Base URL: ${Cypress.env('baseUrl')}`);
+    cy.visit("");
+    cy.contains('Authoring');
+
+    cy.get('.login-link').click();
+    cy.get("[data-cy=header-menu] .login-link")
+      .as('loginLink')
+      .click();
+    cy.wait(2000);
+    cy.get("[data-cy=header-menu] .header-menu-links.show a").eq(0).click();
+    cy.wait(2000);
+    // Use dynamic origin from config
+    cy.origin(portalUrl, () => {
+      cy.get('form#login-form p')
+      .should('contain', 'Log in with your');
+      cy.get('#username').type(Cypress.env('username'));
+      cy.get('#password').type(Cypress.env('password'), { log: false });
+      cy.get("#submit").click({ force: true });
+      cy.wait(500);
+    });
+    cy.url().should('include', Cypress.env('baseUrl'));
+    cy.get('@loginLink').should('not.exist');
+
+    cy.get('[data-cy="header-menu"]').click();
+    cy.get('[data-testid="logout-link"]').should('be.visible').click();
+    cy.get('@loginLink').should('be.visible');
+
   })
 })

--- a/cypress/cypress/e2e/homepage.cy.js
+++ b/cypress/cypress/e2e/homepage.cy.js
@@ -5,7 +5,23 @@ describe('homepage spec', () => {
 
   it('should render the homepage', () => {
     cy.contains('Authoring');
-  })
+    // check the header
+    cy.get('[data-cy="authoring-header"]')
+      .should('exist')
+      .and('be.visible')
+      .within(() => {
+        cy.get('.project-logo').should('exist');
+        cy.get('.login-link').should('exist');
+      });
+    
+    // Check the bottom header section
+    cy.get('.bottom-header').should('exist').within(() => {
+      cy.get('[data-testid="jump-to-label"]').should('have.text', 'Jump to:');
+      cy.get('[data-testid="jump-to-sequences"]').should('have.text', 'Sequences');
+      cy.get('[data-testid="jump-to-glossaries"]').should('have.text', 'Glossaries');
+      cy.get('[data-testid="jump-to-rubrics"]').should('have.text', 'Rubrics');
+    });
+  });
 
   it('should allow log in and out with an account', () => {
     cy.getAccountOwnerName().should('not.exist');

--- a/cypress/cypress/e2e/homepage.cy.js
+++ b/cypress/cypress/e2e/homepage.cy.js
@@ -1,4 +1,3 @@
-/// <reference types="Cypress" />
 // context("Test Admin User Role", () => {
 //   before(() => {
 //     cy.visit("")

--- a/cypress/cypress/e2e/homepage.cy.js
+++ b/cypress/cypress/e2e/homepage.cy.js
@@ -1,14 +1,16 @@
 describe('homepage spec', () => {
-  it('should render the homepage', () => {
+  beforeEach(() => {
     cy.visit("");
+  });
+
+  it('should render the homepage', () => {
     cy.contains('Authoring');
   })
 
   it('should allow log in and out with an account', () => {
-    const email = Cypress.env('email');
     cy.getAccountOwnerName().should('not.exist');
-    cy.login(email);
-    cy.getAccountOwnerName().should('contain', email);
+    cy.login();
+    cy.getAccountOwnerName().should('contain', Cypress.env('email'));
     cy.logout();
     cy.getAccountOwnerName().should('not.exist');
   })

--- a/cypress/cypress/support/commands.js
+++ b/cypress/cypress/support/commands.js
@@ -9,21 +9,23 @@
 // ***********************************************
 //
 //
-Cypress.Commands.add("loginLARAWithSSO", (username, password) => {
-    cy.log("Logging in as user : " + username);
-    cy.get("[data-cy=header-menu] .login-link").click();
-    cy.wait(2000);
-    cy.get("[data-cy=header-menu] .header-menu-links.show a").eq(0).click();
-    cy.wait(2000);
-    cy.login(username, password);
-  })
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+Cypress.Commands.add("login", (email, password) => {
+  email = email ?? Cypress.env('email');
+  password = password ?? Cypress.env('password');
+  cy.log(`Login user: ${email}`);
+  cy.visit("/users/sign_in");
+  cy.get('#user_email').type(email);
+  cy.get('#user_password').type(password, { log: false });
+  cy.get("input[type=submit]").click( {force: true} );
+  cy.wait(500)
+});
+Cypress.Commands.add("logout", () => {
+  cy.log("Logout");
+  cy.get("[data-cy=header-menu] .icon").click();
+  cy.wait(500);
+  cy.get("[data-cy=header-menu] .header-menu-links.show a").last().click();
+  cy.wait(500);
+});
+Cypress.Commands.add('getAccountOwnerName', () => {
+  return cy.get('#header .account-owner-name');
+});

--- a/cypress/cypress/support/commands.js
+++ b/cypress/cypress/support/commands.js
@@ -9,10 +9,14 @@
 // ***********************************************
 //
 //
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
+Cypress.Commands.add("loginLARAWithSSO", (username, password) => {
+    cy.log("Logging in as user : " + username);
+    cy.get("[data-cy=header-menu] .login-link").click();
+    cy.wait(2000);
+    cy.get("[data-cy=header-menu] .header-menu-links.show a").eq(0).click();
+    cy.wait(2000);
+    cy.login(username, password);
+  })
 // -- This is a child command --
 // Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
 //

--- a/lib/tasks/lightweight_tasks.rake
+++ b/lib/tasks/lightweight_tasks.rake
@@ -25,4 +25,12 @@ namespace :lightweight do
     end
   end
 
+  desc "Create an admin user for testing in continuous integration environment."
+  task create_ci_admin_user: :environment do
+    u = User.create(
+      email: "ci_test_user@test.email",
+      password: "password",
+      is_admin: true
+    )
+  end
 end

--- a/lib/tasks/lightweight_tasks.rake
+++ b/lib/tasks/lightweight_tasks.rake
@@ -25,12 +25,17 @@ namespace :lightweight do
     end
   end
 
-  desc "Create an admin user for testing in continuous integration environment."
+  desc "Create an admin user for testing in GitHub CI environment."
   task create_ci_admin_user: :environment do
-    u = User.create(
-      email: "ci_test_user@test.email",
-      password: "password",
-      is_admin: true
-    )
+    begin
+      raise SecurityError unless ENV['GITHUB_ACTIONS'] == 'true'
+        u = User.create(
+          email: "ci_test_user@test.email",
+          password: "password",
+          is_admin: true
+        )
+    rescue SecurityError
+      puts "This script only runs in the GitHub CI environment."
+    end
   end
 end


### PR DESCRIPTION
### Description:
This PR adds a working Cypress spec that successfully logs in and out of LARA in the staging environment. The code is currently in draft mode with a couple of open questions for @dougmartin and some potential enhancements:

---

#### ✅ Summary of Changes:
- Added a login/logout test for LARA Staging.
- Configured portalBaseUrl for staging environment.

---

#### 🚀 Open Questions:
#### 1. Commands.js:
We could move the login/logout logic into the `commands.js` file for cleaner test code.
- ➡️ The tradeoff I see is that if we switch to Playwright in the future, refactoring custom commands may be more complex.
#### 2. Secure Password Storage:
Do we need to worry about securing the password in the dev environment for LARA? Currently, it’s passed via CYPRESS_password at runtime, which seems fine for staging but might need tightening up for dev.
#### 3. Configuration in Dev Environment:
In the current setup, I added:

> `portalBaseUrl: "https://learn.portal.staging.concord.org"`

Where would this live in the dev environment? Is there an existing config pattern we should follow?

#### 4. Switching from `data-cy` to `data-testid`:
There are several data-cy selectors currently used in the tests.
✅ Playwright works more reliably with `data-testid`, and it’s also more secure for production environments.
✅ To migrate, I’d need to update the tags in staging, which is a bit annoying but necessary.
💡 Should I create a separate GitHub branch just for migrating the tags? That way, we can isolate that change from the main spec work.

---

#### ✅ Next Steps:

- [x] Feedback from Doug on the questions above.

If the direction looks good, we can:
- [x] Refactor into commands.js
- [x] Set up secure password storage if needed
- [ ] Create a new branch for the data-testid migration