### PR TITLE
LARA 178 changed tags from data-cy to data-testid

### DIFF
--- a/cypress.save/e2e/experiment/iframe.cy.js
+++ b/cypress.save/e2e/experiment/iframe.cy.js
@@ -4,18 +4,18 @@ context.skip("Test Authoring Preview", () => {
             cy.visit("https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring-migrate.concord.org%2Fapi%2Fv1%2Factivities%2F13056.json");
         });
         it("Verify MCQ", () => {
-            cy.get("[data-cy=activity-nav-header] [data-cy=nav-pages-button]").contains("1").eq(0).click();
+            cy.get("[data-testid=activity-nav-header] [data-testid=nav-pages-button]").contains("1").eq(0).click();
             cy.get(".page-content .name").should("contain", "MCQ");
             cy.pause();
         })
         it("Verify CODAP", () => {
             
-            cy.get("[data-cy=activity-nav-header] [data-cy=nav-pages-button]").contains("2").eq(0).click();
+            cy.get("[data-testid=activity-nav-header] [data-testid=nav-pages-button]").contains("2").eq(0).click();
             cy.get(".page-content .name").should("contain", "CODAP");
             cy.pause();
         })
         it("Verify Sage Modeler", () => {
-            cy.get("[data-cy=activity-nav-header] [data-cy=nav-pages-button]").contains("3").eq(0).click();
+            cy.get("[data-testid=activity-nav-header] [data-testid=nav-pages-button]").contains("3").eq(0).click();
             cy.get(".page-content .name").should("contain", "Sage Modeler");
             cy.pause();
         })

--- a/cypress.save/support/activity-player-preview.cy.js
+++ b/cypress.save/support/activity-player-preview.cy.js
@@ -1,6 +1,6 @@
 class ActivityPlayerPreview {
   getActivitySummary() {
-    return cy.get('[data-cy=activity-summary]');
+    return cy.get('[data-testid=activity-summary]');
   }
   getActivityTitle() {
     return this.getActivitySummary().find('h1 div');
@@ -18,23 +18,23 @@ class ActivityPlayerPreview {
     return this.getActivitySummary().find('.activity-content.intro-txt img').invoke("attr", "src").should("contain", url);
   }
   getEstimatedTime() {
-    return this.getActivitySummary().find('[data-cy=estimated-time] .estimate');
+    return this.getActivitySummary().find('[data-testid=estimated-time] .estimate');
   }
   getPagesHeader() {
-    return cy.get('[data-cy=activity-page-links] .pages div')
+    return cy.get('[data-testid=activity-page-links] .pages div')
   }
   getPageItemNo() {
-    return cy.get('[data-cy=activity-page-links] .page-item span').eq(0);
+    return cy.get('[data-testid=activity-page-links] .page-item span').eq(0);
   }
   getPageItemLink() {
-    return cy.get('[data-cy=activity-page-links] .page-item span').eq(1);
+    return cy.get('[data-testid=activity-page-links] .page-item span').eq(1);
   }
   clickPageItem(index) {
-    return cy.get('[data-cy=activity-page-links] .page-item').eq(index).click();
+    return cy.get('[data-testid=activity-page-links] .page-item').eq(index).click();
   }
 
   getPageContent() {
-    return cy.get('[data-cy=page-content]');
+    return cy.get('[data-testid=page-content]');
   }
   getPageContentHeader() {
     return this.getPageContent().find('.name  div');
@@ -43,7 +43,7 @@ class ActivityPlayerPreview {
     return this.getPageContent().find('.name  div').should("contain", header);
   }
   getInteractive() {
-    return cy.get('[data-cy=managed-interactive]');
+    return cy.get('[data-testid=managed-interactive]');
   }
   getQuestionHeader() {
     return this.getInteractive().find('.header div').eq(0);
@@ -52,7 +52,7 @@ class ActivityPlayerPreview {
     this.getQuestionHeader().should("contain", header);
   }
   openHint() {
-    this.getInteractive().find('[data-cy=open-hint]').eq(0).click();
+    this.getInteractive().find('[data-testid=open-hint]').eq(0).click();
   }
   getHintText() {
     return this.getInteractive().find('.hint.question-txt');
@@ -60,10 +60,10 @@ class ActivityPlayerPreview {
 
   //Sequence Home Page
   getSequenceActivityTitle() {
-    return cy.get('[data-cy=activity-title]');
+    return cy.get('[data-testid=activity-title]');
   }
   getSequenceContent() {
-    return cy.get('[data-cy=sequence-page-content]')
+    return cy.get('[data-testid=sequence-page-content]')
   }
   getSequenceTitle() {
     return this.getSequenceContent().find('.sequence-title div');

--- a/cypress.save/support/bar-graph-authoring.cy.js
+++ b/cypress.save/support/bar-graph-authoring.cy.js
@@ -74,25 +74,25 @@ class BarGraphAuthoringPage {
   verifyAuthoringPreviewTitle(title) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=title]').should("contain", title);
+            cy.wrap($body).find('[data-testid=title]').should("contain", title);
     });
   }
   verifyAuthoringPreviewXAxisLabel(label) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=xAxisLabel]').should("contain", label);
+            cy.wrap($body).find('[data-testid=xAxisLabel]').should("contain", label);
     });
   }
   verifyAuthoringPreviewYAxisLabel(label) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=yAxisLabel]').should("contain", label);
+            cy.wrap($body).find('[data-testid=yAxisLabel]').should("contain", label);
     });
   }
   verifyAuthoringPreviewBarValue(index, value) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=barValue'+index+']').should("contain", value);
+            cy.wrap($body).find('[data-testid=barValue'+index+']').should("contain", value);
     });
   }
   
@@ -111,25 +111,25 @@ class BarGraphAuthoringPage {
   verifyEditItemPreviewTitle(title) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=title]').should("contain", title);
+            cy.wrap($body).find('[data-testid=title]').should("contain", title);
     });
   }
   verifyEditItemPreviewXAxisLabel(label) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=xAxisLabel]').should("contain", label);
+            cy.wrap($body).find('[data-testid=xAxisLabel]').should("contain", label);
     });
   }
   verifyEditItemPreviewYAxisLabel(label) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=yAxisLabel]').should("contain", label);
+            cy.wrap($body).find('[data-testid=yAxisLabel]').should("contain", label);
     });
   }
   verifyEditItemPreviewBarValue(index, value) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=barValue'+index+']').should("contain", value);
+            cy.wrap($body).find('[data-testid=barValue'+index+']').should("contain", value);
     });
   }
   

--- a/cypress.save/support/carousel-authoring.cy.js
+++ b/cypress.save/support/carousel-authoring.cy.js
@@ -30,7 +30,7 @@ class CarouselAuthoringPage {
   clickItemPreviewSlideButton(index) {
   return  this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=carousel-nav] [title]').eq(index).click();
+            cy.wrap($body).find('[data-testid=carousel-nav] [title]').eq(index).click();
     });
   }
   getChoice(choice) {
@@ -38,7 +38,7 @@ class CarouselAuthoringPage {
       const $body = $iframe.contents().find('#app')
       cy.get($iframe.contents()).find('.runtime--runtime--question-int').find('iframe').then($iframe1 => {
         const $body1 = $iframe1.contents().find('#app')
-            cy.wrap($body1).find('[data-cy=choices-container]').should("contain", choice);
+            cy.wrap($body1).find('[data-testid=choices-container]').should("contain", choice);
           })
     });
   }
@@ -74,13 +74,13 @@ class CarouselAuthoringPage {
   selectInteractive(value, index) {
     this.getEditItemForm().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=select-subquestion]').eq(index).select(value);
+            cy.wrap($body).find('[data-testid=select-subquestion]').eq(index).select(value);
     });
   }
   selectAuthoring(index) {
     this.getEditItemForm().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=subquestion-authoring]').eq(index).click();
+            cy.wrap($body).find('[data-testid=subquestion-authoring]').eq(index).click();
     });
   }
   getPrompt(prompt, index) {
@@ -112,7 +112,7 @@ class CarouselAuthoringPage {
   clickSlideButton(index) {
   return  this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=carousel-nav] [title]').eq(index).click();
+            cy.wrap($body).find('[data-testid=carousel-nav] [title]').eq(index).click();
     });
   }
   getAuthoringPreviewPrompt(prompt) {
@@ -138,7 +138,7 @@ class CarouselAuthoringPage {
       const $body = $iframe.contents().find('#app')
     cy.get($iframe.contents()).find('.runtime--runtime--question-int').find('iframe').then($iframe1 => {
       const $body1 = $iframe1.contents().find('#app')
-            cy.wrap($body1).find('[data-cy=choices-container]').should("contain", choice);
+            cy.wrap($body1).find('[data-testid=choices-container]').should("contain", choice);
           })
     });
   }

--- a/cypress.save/support/commands.js
+++ b/cypress.save/support/commands.js
@@ -7,18 +7,18 @@ Cypress.Commands.add("login", (username, password) => {
 
 Cypress.Commands.add("loginLARAWithSSO", (username, password) => {
   cy.log("Logging in as user : " + username);
-  cy.get("[data-cy=header-menu] .login-link").click();
+  cy.get("[data-testid=header-menu] .login-link").click();
   cy.wait(2000);
-  cy.get("[data-cy=header-menu] .header-menu-links.show a").eq(0).click();
+  cy.get("[data-testid=header-menu] .header-menu-links.show a").eq(0).click();
   cy.wait(2000);
   cy.login(username, password);
 })
 
 Cypress.Commands.add("loginLARA", (username) => {
   cy.log("Logging in as user : " + username);
-  cy.get("[data-cy=header-menu] .login-link").click();
+  cy.get("[data-testid=header-menu] .login-link").click();
   cy.wait(1000);
-  cy.get("[data-cy=header-menu] .header-menu-links.show a").eq(0).click();
+  cy.get("[data-testid=header-menu] .header-menu-links.show a").eq(0).click();
   cy.wait(2000);
 })
 
@@ -277,8 +277,8 @@ Cypress.Commands.add("previewNotebookActivty", () => {
 
 Cypress.Commands.add("logoutLARA", (username) => {
   cy.log("Logout user : " + username);
-  cy.get("[data-cy=header-menu] .icon").click();
+  cy.get("[data-testid=header-menu] .icon").click();
   cy.wait(2000);
-  cy.get("[data-cy=header-menu] .header-menu-links.show a").last().click();
+  cy.get("[data-testid=header-menu] .header-menu-links.show a").last().click();
   cy.wait(2000);
 })

--- a/cypress.save/support/glossary/glossary-settings.cy.js
+++ b/cypress.save/support/glossary/glossary-settings.cy.js
@@ -76,17 +76,17 @@ class GlossarySettings {
     return this.getTermPopupPreviewInnerPopup().find("[class^=glossary-popup--answerTextarea]");
   }
   getAnswerTextAreaRecordButton() {
-    return this.getTermPopupPreviewAnswerTextArea().find("[data-cy=recordButton]");
+    return this.getTermPopupPreviewAnswerTextArea().find("[data-testid=recordButton]");
   }
   getAnswerTextAreaReadAloud() {
     return this.getTermPopupPreviewAnswerTextArea().find("[title^=Read]");
   }
 
   getTermPopupPreviewSubmitButton() {
-    return this.getTermPopupPreviewInnerPopup().find("[data-cy=submit]");
+    return this.getTermPopupPreviewInnerPopup().find("[data-testid=submit]");
   }
   getTermPopupPreviewIDontKnowYetButton() {
-    return this.getTermPopupPreviewInnerPopup().find("[data-cy=cancel]");
+    return this.getTermPopupPreviewInnerPopup().find("[data-testid=cancel]");
   }
 
   getTermPopupLanguageSelector() {

--- a/cypress.save/support/glossary/preview-term.cy.js
+++ b/cypress.save/support/glossary/preview-term.cy.js
@@ -80,10 +80,10 @@ class PreviewTerm {
   }
 
   getTermPopupPreviewSubmitButton() {
-    return this.getTermPopupPreviewInnerPopup().find("[data-cy=submit]");
+    return this.getTermPopupPreviewInnerPopup().find("[data-testid=submit]");
   }
   getTermPopupPreviewIDontKnowYetButton() {
-    return this.getTermPopupPreviewInnerPopup().find("[data-cy=cancel]");
+    return this.getTermPopupPreviewInnerPopup().find("[data-testid=cancel]");
   }
   getTermPopupPreviewUserDefinition() {
     return this.getTermPopupPreviewInnerPopup().find("[class^=user-definitions--userDefinition]");

--- a/cypress.save/support/mcq-authoring.cy.js
+++ b/cypress.save/support/mcq-authoring.cy.js
@@ -13,38 +13,38 @@ class MCQAuthoringPage {
   getCheckAnswerButton() {
   return  this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=check-answer-button]');
+            cy.wrap($body).find('[data-testid=check-answer-button]');
     });
   }
   getChoice(choice) {
     this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container]').should("contain", choice);
+            cy.wrap($body).find('[data-testid=choices-container]').should("contain", choice);
     });
   }
   getChoiceDisabled() {
     this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] .radio-choice  input').eq(0).should("be.disabled");
+            cy.wrap($body).find('[data-testid=choices-container] .radio-choice  input').eq(0).should("be.disabled");
     });
   }
   selectChoice(choice) {
     const option = [ "1", "2", "3", "4"];
     this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] [type=radio]').eq(option.indexOf(choice)).click();
+            cy.wrap($body).find('[data-testid=choices-container] [type=radio]').eq(option.indexOf(choice)).click();
     });
   }
   getIncorrectFeedback() {
   return  this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-false]');
+            cy.wrap($body).find('[data-testid=feedback-false]');
     });
   }
   getCorrectFeedback() {
   return  this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-true]');
+            cy.wrap($body).find('[data-testid=feedback-true]');
     });
   }
 //***************************************************************************************************************
@@ -83,38 +83,38 @@ class MCQAuthoringPage {
   getAuthoringPreviewChoice(choice) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container]').should("contain", choice);
+            cy.wrap($body).find('[data-testid=choices-container]').should("contain", choice);
     });
   }
   getAuthoringPreviewCheckAnswerButton() {
   return  this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=check-answer-button]');
+            cy.wrap($body).find('[data-testid=check-answer-button]');
     });
   }
   selectAuthoringPreviewChoice(choice) {
     const option = [ "1", "2", "3", "4"];
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] [type=radio]').eq(option.indexOf(choice)).click();
+            cy.wrap($body).find('[data-testid=choices-container] [type=radio]').eq(option.indexOf(choice)).click();
     });
   }
   getAuthoringPreviewIncorrectFeedback() {
   return  this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-false]');
+            cy.wrap($body).find('[data-testid=feedback-false]');
     });
   }
   getAuthoringPreviewCorrectFeedback() {
   return  this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-true]');
+            cy.wrap($body).find('[data-testid=feedback-true]');
     });
   }
   getAuthoringPreviewChoiceDisabled() {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] .radio-choice  input').eq(0).should("be.disabled");
+            cy.wrap($body).find('[data-testid=choices-container] .radio-choice  input').eq(0).should("be.disabled");
     });
   }
 

--- a/cypress.save/support/multi-select-authoring.cy.js
+++ b/cypress.save/support/multi-select-authoring.cy.js
@@ -13,44 +13,44 @@ class MultiSelectAuthoringPage {
   getCheckAnswerButton() {
   return  this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=check-answer-button]');
+            cy.wrap($body).find('[data-testid=check-answer-button]');
     });
   }
   getChoice(choice) {
     this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container]').should("contain", choice);
+            cy.wrap($body).find('[data-testid=choices-container]').should("contain", choice);
     });
   }
   getChoiceType() {
     this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] input').eq(0).invoke("attr", "type").should("contain", "checkbox");
+            cy.wrap($body).find('[data-testid=choices-container] input').eq(0).invoke("attr", "type").should("contain", "checkbox");
     });
   }
   getChoiceDisabled() {
     this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] .radio-choice  input').eq(0).should("be.disabled");
+            cy.wrap($body).find('[data-testid=choices-container] .radio-choice  input').eq(0).should("be.disabled");
     });
   }
   selectChoice(choice) {
     const option = [ "1", "2", "3", "4"];
     this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] [type=checkbox]').eq(option.indexOf(choice)).click();
+            cy.wrap($body).find('[data-testid=choices-container] [type=checkbox]').eq(option.indexOf(choice)).click();
     });
   }
   getIncorrectFeedback() {
   return  this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-false]');
+            cy.wrap($body).find('[data-testid=feedback-false]');
     });
   }
   getCorrectFeedback() {
   return  this.getEditItemPreview().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-true]');
+            cy.wrap($body).find('[data-testid=feedback-true]');
     });
   }
 //***************************************************************************************************************
@@ -96,44 +96,44 @@ class MultiSelectAuthoringPage {
   getAuthoringPreviewChoice(choice) {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container]').should("contain", choice);
+            cy.wrap($body).find('[data-testid=choices-container]').should("contain", choice);
     });
   }
   getAuthoringPreviewChoiceType() {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] input').eq(0).invoke("attr", "type").should("contain", "checkbox");
+            cy.wrap($body).find('[data-testid=choices-container] input').eq(0).invoke("attr", "type").should("contain", "checkbox");
     });
   }
   getAuthoringPreviewCheckAnswerButton() {
   return  this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=check-answer-button]');
+            cy.wrap($body).find('[data-testid=check-answer-button]');
     });
   }
   selectAuthoringPreviewChoice(choice) {
     const option = [ "1", "2", "3", "4"];
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] [type=checkbox]').eq(option.indexOf(choice)).click();
+            cy.wrap($body).find('[data-testid=choices-container] [type=checkbox]').eq(option.indexOf(choice)).click();
     });
   }
   getAuthoringPreviewIncorrectFeedback() {
   return  this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-false]');
+            cy.wrap($body).find('[data-testid=feedback-false]');
     });
   }
   getAuthoringPreviewCorrectFeedback() {
   return  this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=feedback-true]');
+            cy.wrap($body).find('[data-testid=feedback-true]');
     });
   }
   getAuthoringPreviewChoiceDisabled() {
     this.getInteractive().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=choices-container] .radio-choice  input').eq(0).should("be.disabled");
+            cy.wrap($body).find('[data-testid=choices-container] .radio-choice  input').eq(0).should("be.disabled");
     });
   }
 

--- a/cypress.save/support/notebook-layout.cy.js
+++ b/cypress.save/support/notebook-layout.cy.js
@@ -1,9 +1,9 @@
 class NotebookLayout {
   getPreviousPageButton() {
-    return cy.get("[data-cy=previous-page-button");
+    return cy.get("[data-testid=previous-page-button");
   }
   getNextPageButton() {
-    return cy.get("[data-cy=next-page-button");
+    return cy.get("[data-testid=next-page-button");
   }
   getActivityNavHeader(index) {
     return cy.get("[data-cy=activity-nav-header]").eq(index);

--- a/cypress.save/support/project.cy.js
+++ b/cypress.save/support/project.cy.js
@@ -1,6 +1,6 @@
 class Projects {
   getHeaderMenu() {
-    return cy.get("[data-cy='header-menu']");
+    return cy.get("[data-testid='header-menu']");
   }
   clickHeaderMenu() {
     this.getHeaderMenu().click();
@@ -8,11 +8,11 @@ class Projects {
   }
   launchUserAdmin() {
     this.clickHeaderMenu();
-    cy.get("[data-cy=header-menu] .header-menu-links.show a").contains("User Admin").click();
+    cy.get("[data-testid=header-menu] .header-menu-links.show a").contains("User Admin").click();
   }
   launchProjects() {
     this.clickHeaderMenu();
-    cy.get("[data-cy=header-menu] .header-menu-links.show a").contains("Projects").click();
+    cy.get("[data-testid=header-menu] .header-menu-links.show a").contains("Projects").click();
   }
 
 // Projects

--- a/cypress.save/support/run-time-preview.cy.js
+++ b/cypress.save/support/run-time-preview.cy.js
@@ -1,7 +1,7 @@
 class RunTimePreview {
 
   getSequenceContent() {
-    return cy.get('[data-cy=sequence-page-content]');
+    return cy.get('[data-testid=sequence-page-content]');
   }
   getSequenceTitle() {
     return this.getSequenceContent().find('.sequence-title');

--- a/cypress.save/support/scaffolded-authoring.cy.js
+++ b/cypress.save/support/scaffolded-authoring.cy.js
@@ -38,7 +38,7 @@ class ScaffoldedAuthoringPage {
       const $body = $iframe.contents().find('#app')
       cy.get($iframe.contents()).find('.runtime--runtime--question-int').find('iframe').then($iframe1 => {
         const $body1 = $iframe1.contents().find('#app')
-            cy.wrap($body1).find('[data-cy=choices-container]').should("contain", choice);
+            cy.wrap($body1).find('[data-testid=choices-container]').should("contain", choice);
           })
     });
   }
@@ -74,13 +74,13 @@ class ScaffoldedAuthoringPage {
   selectInteractive(value, index) {
     this.getEditItemForm().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=select-subquestion]').eq(index).select(value);
+            cy.wrap($body).find('[data-testid=select-subquestion]').eq(index).select(value);
     });
   }
   selectAuthoring(index) {
     this.getEditItemForm().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=subquestion-authoring]').eq(index).click();
+            cy.wrap($body).find('[data-testid=subquestion-authoring]').eq(index).click();
     });
   }
   getPrompt(prompt, index) {

--- a/cypress.save/support/side-by-side-authoring.cy.js
+++ b/cypress.save/support/side-by-side-authoring.cy.js
@@ -26,13 +26,13 @@ class SideBySideAuthoringPage {
   selectInteractive(value, index) {
     this.getEditItemForm().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=select-subquestion]').eq(index).select(value);
+            cy.wrap($body).find('[data-testid=select-subquestion]').eq(index).select(value);
     });
   }
   selectAuthoring(index) {
     this.getEditItemForm().find('iframe').then($iframe => {
       const $body = $iframe.contents().find('#app')
-            cy.wrap($body).find('[data-cy=subquestion-authoring]').eq(index).click();
+            cy.wrap($body).find('[data-testid=subquestion-authoring]').eq(index).click();
     });
   }
   getPrompt(prompt, index) {

--- a/cypress.save/support/teacher-edition-question-wrapper-authoring.cy.js
+++ b/cypress.save/support/teacher-edition-question-wrapper-authoring.cy.js
@@ -19,7 +19,7 @@ class TEQuestionWrapperAuthoringPage {
   }
 
   clickHeader(form) {
-    this.getEditItemForm().find('.authoring-app--preview--TETipsPluginV1 [data-cy='+form+']').click();
+    this.getEditItemForm().find('.authoring-app--preview--TETipsPluginV1 [data-testid='+form+']').click();
   }
 
   verifyQuestionWrapperContent(content) {

--- a/cypress/cypress/e2e/homepage.cy.js
+++ b/cypress/cypress/e2e/homepage.cy.js
@@ -6,7 +6,7 @@ describe('homepage spec', () => {
   it('should render the homepage', () => {
     cy.contains('Authoring');
     // check the header
-    cy.get('[data-cy="authoring-header"]')
+    cy.get('[data-testid="authoring-header"]')
       .should('exist')
       .and('be.visible')
       .within(() => {

--- a/cypress/cypress/support/commands.js
+++ b/cypress/cypress/support/commands.js
@@ -18,9 +18,9 @@ Cypress.Commands.add("login", (options) => {
   const useSSO = Cypress.env('useSSO') || false;
   if (useSSO) {
     cy.log("Login using SSO as user : " + username);
-    cy.get("[data-cy=header-menu] .login-link").click();
+    cy.get("[data-testid=header-menu] .login-link").click();
     cy.wait(2000);
-    cy.get("[data-cy=header-menu] .header-menu-links.show a").eq(0).click();
+    cy.get("[data-testid=header-menu] .header-menu-links.show a").eq(0).click();
     cy.wait(2000);
     cy.origin('https://learn.portal.staging.concord.org', { args: { username, password } }, ({ username, password }) => {
       cy.get('#username').type(username);
@@ -41,11 +41,11 @@ Cypress.Commands.add("login", (options) => {
 
 Cypress.Commands.add("logout", () => {
   cy.log("Logout");
-  cy.get("[data-cy=header-menu] .icon").click();
+  cy.get("[data-testid=header-menu] .icon").click();
   cy.wait(500);
-  cy.get("[data-cy=header-menu] .header-menu-links.show a").last().click();
+  cy.get("[data-testid=header-menu] .header-menu-links.show a").last().click();
   cy.wait(500);
 });
 Cypress.Commands.add('getAccountOwnerName', () => {
-  return cy.get('#header .account-owner-name');
+  return cy.get('[data-testid=account-owner] .account-owner-name');
 });

--- a/lara-typescript/src/rubric-authoring/rubric-preview.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-preview.tsx
@@ -36,7 +36,7 @@ export const RubricPreview = ({referenceURL}: IProps) => {
   const handleSetStudentView = () => setView("student");
 
   return (
-    <div className="rubricPreview" data-cy="rubric-preview">
+    <div className="rubricPreview" data-testid="rubric-preview">
       <div className="rubricPreviewSwitcher">
         <div
           className={classNames({rubricPreviewActive: view === "teacher"})}

--- a/lara-typescript/src/rubric-authoring/rubric-student-preview.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-student-preview.tsx
@@ -103,7 +103,7 @@ export const RubricStudentPreview = ({scored, scoring, setScoring}: IProps) => {
   };
 
   return (
-    <div className="rubricStudentPreview" data-cy="rubric-student-preview">
+    <div className="rubricStudentPreview" data-testid="rubric-student-preview">
       {hide ? renderHidden() : (scored ? renderScored() : renderUnscored())}
     </div>
   );

--- a/lara-typescript/src/rubric-authoring/rubric-teacher-preview.tsx
+++ b/lara-typescript/src/rubric-authoring/rubric-teacher-preview.tsx
@@ -42,7 +42,7 @@ export const RubricTeacherPreview = ({scoring, setScoring, referenceURL}: IProps
               className="launchButton"
               href={referenceURL}
               target="_blank"
-              data-cy="scoring-guide-launch-icon"
+              data-testid="scoring-guide-launch-icon"
               onClick={checkReferenceUrl}
             >
               <LaunchIcon />
@@ -114,12 +114,12 @@ export const RubricTeacherPreview = ({scoring, setScoring, referenceURL}: IProps
     ));
 
     return (
-      <button className={classNames("outerCircle", {selected})} data-cy="rating-radio-button" onClick={handleClick} />
+      <button className={classNames("outerCircle", {selected})} data-testid="rating-radio-button" onClick={handleClick} />
     );
   };
 
   return (
-    <div className="rubricTeacherPreview" data-cy="rubric-teacher-preview">
+    <div className="rubricTeacherPreview" data-testid="rubric-teacher-preview">
       {renderColumnHeaders()}
       <div className="rubricTable">
         {criteriaGroups.map((criteriaGroup, index) => (

--- a/lara-typescript/src/section-authoring/components/page-header/components/account-owner.tsx
+++ b/lara-typescript/src/section-authoring/components/page-header/components/account-owner.tsx
@@ -39,7 +39,7 @@ export const AccountOwner: React.FC<IAccountOwnerProps> = ({
 
   const accountOwnerContent = currentUser ? renderLoggedInUserContent() : null;
   return (
-    <div className="account-owner" data-cy="account-owner">
+    <div className="account-owner" data-testid="account-owner">
       {accountOwnerContent}
     </div>
   );

--- a/lara-typescript/src/section-authoring/components/page-header/components/logo.tsx
+++ b/lara-typescript/src/section-authoring/components/page-header/components/logo.tsx
@@ -12,7 +12,7 @@ export const Logo: React.FC<ILogoProps> = ({
     logoPath
   }: ILogoProps) => {
   const logo = logoPath
-                 ? <img data-cy="logo-img" className="logo-img" src={logoPath} alt="Authoring Home"/>
+                 ? <img data-testid="logo-img" className="logo-img" src={logoPath} alt="Authoring Home"/>
                  : <CCLogo/>;
 
   const handleClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {

--- a/lara-typescript/src/section-authoring/components/page-header/components/page-header-menu.tsx
+++ b/lara-typescript/src/section-authoring/components/page-header/components/page-header-menu.tsx
@@ -121,7 +121,7 @@ export const PageHeaderMenu: React.FC<IAccountOwnerProps> = ({
 
   const menuLinks = logOutURL !== "" ? renderLoggedInUserLinks() : renderAnonymousUserLinks();
   return (
-    <div className={`header-menu ${showHeaderMenu ? "active" : ""}`} onClick={handleMenuClick} data-cy="header-menu">
+    <div className={`header-menu ${showHeaderMenu ? "active" : ""}`} onClick={handleMenuClick} data-testid="header-menu">
       {menuLinks}
     </div>
   );

--- a/lara-typescript/src/section-authoring/components/page-header/components/page-header.tsx
+++ b/lara-typescript/src/section-authoring/components/page-header/components/page-header.tsx
@@ -30,7 +30,7 @@ export const PageHeader: React.FC<IPageHeaderProps> = ({
 
   return (
     <APIContainer host={host}>
-      <div className="authoring-header" data-cy="authoring-header">
+      <div className="authoring-header" data-testid="authoring-header">
         <div className="inner">
           <div className="header-left">
             <Logo />

--- a/lara-typescript/src/section-authoring/components/page-nav-menu/page-nav-menu.tsx
+++ b/lara-typescript/src/section-authoring/components/page-nav-menu/page-nav-menu.tsx
@@ -161,7 +161,7 @@ export const PageNavMenu: React.FC<IPageNavMenuProps> = ({
                 className={pageButtonClasses}
                 onClick={clickHandler}
                 key={`page ${pageNum}`}
-                data-cy={`${page.isCompletion ? "nav-pages-completion-page-button" : "nav-pages-button"}`}
+                data-testid={`${page.isCompletion ? "nav-pages-completion-page-button" : "nav-pages-button"}`}
                 aria-label={`Page ${pageNum}`}
               >
                 {buttonContent}
@@ -196,8 +196,8 @@ export const PageNavMenu: React.FC<IPageNavMenuProps> = ({
 
   return (
     <>
-      <nav className="activity-nav" data-cy="activity-nav">
-        <div className="nav-pages" data-cy="nav-pages">
+      <nav className="activity-nav" data-testid="activity-nav">
+        <div className="nav-pages" data-testid="nav-pages">
           {renderPreviousButton()}
           {renderHomePageButton()}
           {renderPageButtons()}

--- a/lara-typescript/src/section-authoring/components/page-sidebar/sidebar-panel.tsx
+++ b/lara-typescript/src/section-authoring/components/page-sidebar/sidebar-panel.tsx
@@ -82,18 +82,18 @@ export const SidebarPanel = (props: ISidebarPanelProps) => {
   return (
     <div className={`sidebar-panel ${props.show ? "visible " : "hidden"}`}>
       <div className="sidebar-header">
-        <div className="sidebar-title" data-cy="sidebar-title">
+        <div className="sidebar-title" data-testid="sidebar-title">
           <Title />
         </div>
-        <div className="sidebar-menu" data-cy="sidebar-menu">
+        <div className="sidebar-menu" data-testid="sidebar-menu">
           <MenuItems />
         </div>
         <div className="icon" onClick={handleCloseButton}
-              data-cy="sidebar-close-button" tabIndex={0}>
+              data-testid="sidebar-close-button" tabIndex={0}>
           <IconClose />
         </div>
       </div>
-      <div className="sidebar-content help-content" data-cy="sidebar-content">
+      <div className="sidebar-content help-content" data-testid="sidebar-content">
         <Content />
       </div>
     </div>

--- a/lara-typescript/src/section-authoring/components/page-sidebar/sidebar-tab.tsx
+++ b/lara-typescript/src/section-authoring/components/page-sidebar/sidebar-tab.tsx
@@ -18,11 +18,11 @@ export class SidebarTab extends React.PureComponent<IProps>{
   public render() {
     return (
       <div className="sidebar-tab" onClick={this.handleSidebarShow} onKeyDown={this.handleSidebarShow}
-           data-cy="sidebar-tab" tabIndex={0}>
+           data-testid="sidebar-tab" tabIndex={0}>
         <div className={`icon ${this.props.sidebarOpen ? "open" : ""}`}>
           <IconArrow />
         </div>
-        <div className="tab-name" data-cy="sidebar-tab-title">{this.props.title}</div>
+        <div className="tab-name" data-testid="sidebar-tab-title">{this.props.title}</div>
       </div>
     );
   }

--- a/lara-typescript/src/section-authoring/components/page-sidebar/sidebar.tsx
+++ b/lara-typescript/src/section-authoring/components/page-sidebar/sidebar.tsx
@@ -34,7 +34,7 @@ export class Sidebar extends React.PureComponent<IProps, IState> {
     const { content, index, style, title, updateSettingsFunction } = this.props;
     const { showSidebarContent } = this.state;
     return (
-      <div className={`sidebar-container ${showSidebarContent ? "expanded" : ""}`} style={style} data-cy="sidebar">
+      <div className={`sidebar-container ${showSidebarContent ? "expanded" : ""}`} style={style} data-testid="sidebar">
         <SidebarTab
           handleShowSidebarContent={this.toggleShow}
           index={index}


### PR DESCRIPTION
[LARA-178](https://concord-consortium.atlassian.net/browse/LARA-178)

As part of our efforts to rebuild the LARA automation suite to integrate with CI (and down the line, Playwright), we need to update attributes to `data-testid` throughout the repository. This is a good modernization since `data-testid` is now the more widely adopted standard for test selectors.

This may break CI for awhile, but hopefully it's an easy fix when I go to do the next story ([LARA-183](https://concord-consortium.atlassian.net/browse/LARA-183)).

[LARA-178]: https://concord-consortium.atlassian.net/browse/LARA-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LARA-183]: https://concord-consortium.atlassian.net/browse/LARA-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ