### PR TITLE
feat: Add search by id number [LARA-187]

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,7 @@ class HomeController < ApplicationController
     attributes = (params[:filter] || {})
     if params.has_key?('search')
       attributes[:search] = params[:search]
+      @search = params[:search]
     end
     @filter  = CollectionFilter.new(current_user, LightweightActivity, attributes)
     # TODO: Add 'oficial' to the criteron?

--- a/app/models/glossary.rb
+++ b/app/models/glossary.rb
@@ -129,7 +129,11 @@ class Glossary < ApplicationRecord
   end
 
   def self.search(query, user)
-    self.can_see(user).where("name LIKE ?", "%#{query}%")
+    if query.to_s =~ /^\d+$/ && query.to_i > 0
+      self.can_see(user).where("name LIKE ? OR id = ?", "%#{query}%", query.to_i)
+    else
+      self.can_see(user).where("name LIKE ?", "%#{query}%")
+    end
   end
 
   def self.public_for_user(user)

--- a/app/models/lightweight_activity.rb
+++ b/app/models/lightweight_activity.rb
@@ -418,7 +418,11 @@ class LightweightActivity < ApplicationRecord
   end
 
   def self.search(query, _user)  # user not used
-    where("name LIKE ?", "%#{query}%")
+    if query.to_s =~ /^\d+$/ && query.to_i > 0
+      where("name LIKE ? OR id = ?", "%#{query}%", query.to_i)
+    else
+      where("name LIKE ?", "%#{query}%")
+    end
   end
 
   def activity_player_url(host, page: nil, preview: false, mode: nil)

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -122,7 +122,11 @@ class Rubric < ApplicationRecord
   end
 
   def self.search(query, user)
-    self.can_see(user).where("name LIKE ?", "%#{query}%")
+    if query.to_s =~ /^\d+$/ && query.to_i > 0
+      self.can_see(user).where("name LIKE ? OR id = ?", "%#{query}%", query.to_i)
+    else
+      self.can_see(user).where("name LIKE ?", "%#{query}%")
+    end
   end
 
   def self.public_for_user(user)

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -243,7 +243,11 @@ class Sequence < ApplicationRecord
   end
 
   def self.search(query, _user)  # user not used
-    where("title LIKE ?", "%#{query}%")
+    if query.to_s =~ /^\d+$/ && query.to_i > 0
+      where("title LIKE ? OR id = ?", "%#{query}%", query.to_i)
+    else
+      where("title LIKE ?", "%#{query}%")
+    end
   end
 
   private

--- a/app/views/home/home.html.haml
+++ b/app/views/home/home.html.haml
@@ -29,7 +29,7 @@
           %input{ :type => "submit", :value => "Search", "data-testid" => "authoring-search-button" }
       %li#desc-toggle{ "data-testid" => "desc-toggle-button" }= toggle_all 'descriptions'
       %li#collection_filter{ "data-testid" => "collection-filter-button" }= collection_filter_tag @filter
-  - if @activities || @sequences
+  - if @activities || @sequences || @glossaries || @rubrics
     %div.bottom-header
       %strong{ "data-testid" => "jump-to-label" }= t("JUMP_TO")
       - if @activities
@@ -40,6 +40,10 @@
         %a{ :href => "#glossary_listing_head", "data-testid" => "jump-to-glossaries" }= t("GLOSSARIES")
       - if @rubrics
         %a{ :href => "#rubric_listing_head", "data-testid" => "jump-to-rubrics" }= t("RUBRICS")
+
+- if @search
+  %div{ style: "padding: 1em 0; font-style: italic;" }
+    Search results for <span style="font-weight: bold;">#{@search}</span> ...
 
 -if @activities
   #activity_listing_head

--- a/spec/models/glossary_spec.rb
+++ b/spec/models/glossary_spec.rb
@@ -300,6 +300,8 @@ RSpec.describe Glossary do
 
       it "should support self.search" do
         expect(Glossary.search("Glossary", author)).to eq([glossary, glossary2])
+        expect(Glossary.search(glossary.id.to_s, author)).to eq([glossary])
+        expect(Glossary.search(glossary2.id, author)).to eq([glossary2])
       end
 
       it "should support self.public_for_user" do
@@ -328,6 +330,8 @@ RSpec.describe Glossary do
 
       it "should support self.search" do
         expect(Glossary.search("Glossary", admin)).to eq([glossary, glossary2])
+        expect(Glossary.search(glossary.id.to_s, admin)).to eq([glossary])
+        expect(Glossary.search(glossary2.id, admin)).to eq([glossary2])
       end
 
       it "should support self.public_for_user" do

--- a/spec/models/lightweight_activity_spec.rb
+++ b/spec/models/lightweight_activity_spec.rb
@@ -718,4 +718,18 @@ describe LightweightActivity do
       end
     end
   end
+
+  describe "#search" do
+    let!(:activity1) { FactoryBot.create(:activity, name: "Alpha Activity") }
+    let!(:activity2) { FactoryBot.create(:activity, name: "Beta Activity") }
+
+    it "finds by name substring" do
+      expect(LightweightActivity.search("Alpha", nil)).to include(activity1)
+      expect(LightweightActivity.search("Beta", nil)).to include(activity2)
+    end
+    it "finds by id (string and integer)" do
+      expect(LightweightActivity.search(activity1.id.to_s, nil)).to eq([activity1])
+      expect(LightweightActivity.search(activity2.id, nil)).to eq([activity2])
+    end
+  end
 end

--- a/spec/models/rubric_spec.rb
+++ b/spec/models/rubric_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rubric do
     rubric.update_column(:updated_at, 1.day.ago)
     rubric
   }
-  let(:rubric2) { 
+  let(:rubric2) {
     rubric = FactoryBot.create(:rubric, name: "Rubric 2", user: author2)
     rubric.update_column(:updated_at, Time.now)
     rubric
@@ -182,6 +182,8 @@ RSpec.describe Rubric do
 
       it "should support self.search" do
         expect(Rubric.search("Rubric", author)).to eq([rubric, rubric2])
+        expect(Rubric.search(rubric.id.to_s, author)).to eq([rubric])
+        expect(Rubric.search(rubric2.id, author)).to eq([rubric2])
       end
 
       it "should support self.public_for_user" do
@@ -210,6 +212,8 @@ RSpec.describe Rubric do
 
       it "should support self.search" do
         expect(Rubric.search("Rubric", admin)).to eq([rubric, rubric2])
+        expect(Rubric.search(rubric.id.to_s, admin)).to eq([rubric])
+        expect(Rubric.search(rubric2.id, admin)).to eq([rubric2])
       end
 
       it "should support self.public_for_user" do

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -380,4 +380,17 @@ describe Sequence do
     end
   end
 
+  describe "#search" do
+    let!(:sequence1) { FactoryBot.create(:sequence, title: "Alpha Sequence") }
+    let!(:sequence2) { FactoryBot.create(:sequence, title: "Beta Sequence") }
+
+    it "finds by title substring" do
+      expect(Sequence.search("Alpha", nil)).to include(sequence1)
+      expect(Sequence.search("Beta", nil)).to include(sequence2)
+    end
+    it "finds by id (string and integer)" do
+      expect(Sequence.search(sequence1.id.to_s, nil)).to eq([sequence1])
+      expect(Sequence.search(sequence2.id, nil)).to eq([sequence2])
+    end
+  end
 end


### PR DESCRIPTION
Adds functionality to the search box on the home page that allows searching by id number.

If a positive integer is entered, the search will return any activities, sequences, glossaries, or rubrics with that id number along with name/title matches of that number.

This also adds a line above the listings that shows what the current search term is.