### PR TITLE
fix: Clicking on the empty title-container div goes to a broken link [LARA-182]

### DIFF
--- a/app/assets/stylesheets/lara-typescript.css
+++ b/app/assets/stylesheets/lara-typescript.css
@@ -663,6 +663,10 @@
   padding: 8px 10px;
   width: calc(100% - 20px);
 }
+.authoring-header .inner .header-center .title-container.empty {
+  cursor: auto !important;
+  background-color: inherit !important;
+}
 .authoring-header .inner .header-center .title-container:hover {
   background-color: var(--lt-teal);
 }

--- a/lara-typescript/src/section-authoring/components/page-header/components/page-header.scss
+++ b/lara-typescript/src/section-authoring/components/page-header/components/page-header.scss
@@ -61,6 +61,11 @@
         padding: 8px 10px;
         width: calc(100% - 20px);
 
+        &.empty {
+          cursor: auto !important;
+          background-color: inherit !important;
+        }
+
         &:hover {
           background-color: var(--lt-teal);
         }

--- a/lara-typescript/src/section-authoring/components/page-header/components/page-header.tsx
+++ b/lara-typescript/src/section-authoring/components/page-header/components/page-header.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import classNames from "classnames";
 import { APIContainer } from "../../../containers/api-container";
 import { Logo } from "./logo";
 import { AccountOwner, IUser } from "./account-owner";
@@ -23,7 +24,12 @@ export const PageHeader: React.FC<IPageHeaderProps> = ({
     userLinks
   }: IPageHeaderProps) => {
 
+  const isEmptyResourceName = (resourceName ?? "").trim().length === 0;
+
   const handleTitleClick = () => {
+    if (isEmptyResourceName) {
+      return;
+    }
     const activityPath = window.location.pathname.split("/pages")[0];
     window.location.href = activityPath + "/edit";
   };
@@ -37,7 +43,7 @@ export const PageHeader: React.FC<IPageHeaderProps> = ({
             <div className="separator" />
           </div>
           <div className="header-center">
-            <div className="title-container" onClick={handleTitleClick}>
+            <div className={classNames("title-container", { empty: isEmptyResourceName })} onClick={handleTitleClick}>
               <div className="activity-title" data-testid="activity-title">
                 {renderHTML(resourceName)}
               </div>


### PR DESCRIPTION
The title is empty when the user is not editing a resource, such as on the homepage.

Now, when the title is empty, the title-container div has no background color or cursor change on hover and it prevents any click actions.